### PR TITLE
Add unsafe contract consistency code fixes

### DIFF
--- a/src/tools/illink/src/ILLink.CodeFix/MatchPartialSafetyModifierCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/MatchPartialSafetyModifierCodeFixProvider.cs
@@ -1,0 +1,149 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ILLink.CodeFixProvider;
+using ILLink.RoslynAnalyzer;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ILLink.CodeFix
+{
+    /// <summary>
+    /// Fixes compiler diagnostics <c>CS0764</c> and <c>CS9390</c> by copying the safety modifier from the partial
+    /// declaration that has it onto the one that does not.
+    /// </summary>
+    /// <remarks>
+    /// The modifier is always propagated rather than removed. For <c>unsafe</c> that preserves the caller
+    /// obligation, and for <c>safe</c> removing it would reintroduce <c>CS9389</c> on an <c>extern</c> member.
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MatchPartialSafetyModifierCodeFixProvider)), Shared]
+    public sealed class MatchPartialSafetyModifierCodeFixProvider : Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider
+    {
+        public const string PartialMemberUnsafeDifferenceDiagnosticId = "CS0764";
+        public const string PartialMemberSafeDifferenceDiagnosticId = "CS9390";
+
+        private static LocalizableString CodeFixTitle =>
+            new LocalizableResourceString(
+                nameof(Resources.MatchPartialSafetyModifierCodeFixTitle),
+                Resources.ResourceManager,
+                typeof(Resources));
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            [PartialMemberUnsafeDifferenceDiagnosticId, PartialMemberSafeDifferenceDiagnosticId];
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            Diagnostic diagnostic = context.Diagnostics[0];
+            SyntaxKind modifier = diagnostic.Id == PartialMemberUnsafeDifferenceDiagnosticId
+                ? SyntaxKind.UnsafeKeyword
+                : UnsafeMigrationSyntaxHelpers.SafeKeywordKind;
+            if (modifier == SyntaxKind.None)
+                return;
+
+            if (await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false) is not { } root
+                || await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false) is not { } semanticModel)
+            {
+                return;
+            }
+
+            SyntaxNode targetNode = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            if (FindPartialDeclaration(targetNode) is not { } declaration
+                || semanticModel.GetDeclaredSymbol(declaration, context.CancellationToken) is not { } symbol
+                || GetOtherPart(symbol) is not { } otherPart)
+            {
+                return;
+            }
+
+            // Determine which declaration is missing the modifier. The diagnostic is reported on the
+            // implementing part regardless of which part carries it.
+            bool declarationHasModifier = HasModifier(declaration, modifier);
+            (Document Document, SyntaxNode Declaration)? target = declarationHasModifier
+                ? await GetDeclarationToEditAsync(context.Document.Project.Solution, otherPart, modifier, context.CancellationToken).ConfigureAwait(false)
+                : (context.Document, declaration);
+
+            // When the parts disagree in opposite directions the compiler reports both CS0764 and CS9390, and
+            // adding the missing modifier would put 'safe' and 'unsafe' on the same declaration, which is an
+            // error. Resolving that requires deciding which contract is correct, so no fix is offered.
+            if (target is not { } edit || HasModifier(edit.Declaration, GetOppositeModifier(modifier)))
+                return;
+
+            string title = CodeFixTitle.ToString();
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title,
+                    async cancellationToken =>
+                    {
+                        Document updated = await UnsafeModifierCodeFixHelpers
+                            .AddModifierAsync(edit.Document, edit.Declaration, modifier, cancellationToken)
+                            .ConfigureAwait(false);
+                        return updated.Project.Solution;
+                    },
+                    title),
+                diagnostic);
+        }
+
+        private static async Task<(Document, SyntaxNode)?> GetDeclarationToEditAsync(
+            Solution solution,
+            ISymbol otherPart,
+            SyntaxKind modifier,
+            CancellationToken cancellationToken)
+        {
+            foreach (SyntaxReference reference in otherPart.DeclaringSyntaxReferences)
+            {
+                // A part emitted by a source generator has no editable document.
+                if (solution.GetDocument(reference.SyntaxTree) is not { } document)
+                    continue;
+
+                SyntaxNode declaration = reference.GetSyntax(cancellationToken);
+                if (HasModifier(declaration, modifier))
+                    continue;
+
+                // Re-resolve against the document's current tree so the edit applies to a live node.
+                if (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) is not { } root)
+                    continue;
+
+                SyntaxNode candidate = root.FindNode(declaration.Span, getInnermostNodeForTie: true);
+                if (candidate.AncestorsAndSelf().FirstOrDefault(node => node.IsKind(declaration.Kind())) is { } current)
+                    return (document, current);
+            }
+
+            return null;
+        }
+
+        private static bool HasModifier(SyntaxNode declaration, SyntaxKind modifier) =>
+            modifier == SyntaxKind.UnsafeKeyword
+                ? UnsafeMigrationSyntaxHelpers.HasModifier(declaration, SyntaxKind.UnsafeKeyword)
+                : UnsafeMigrationSyntaxHelpers.HasSafeModifier(declaration);
+
+        private static SyntaxKind GetOppositeModifier(SyntaxKind modifier) =>
+            modifier == SyntaxKind.UnsafeKeyword
+                ? UnsafeMigrationSyntaxHelpers.SafeKeywordKind
+                : SyntaxKind.UnsafeKeyword;
+
+        private static ISymbol? GetOtherPart(ISymbol symbol) =>
+            symbol switch
+            {
+                IMethodSymbol method => method.PartialDefinitionPart ?? method.PartialImplementationPart,
+                IPropertySymbol property => property.PartialDefinitionPart ?? property.PartialImplementationPart,
+                IEventSymbol @event => @event.PartialDefinitionPart ?? @event.PartialImplementationPart,
+                _ => null,
+            };
+
+        private static SyntaxNode? FindPartialDeclaration(SyntaxNode node) =>
+            node.AncestorsAndSelf().FirstOrDefault(static ancestor => ancestor is MethodDeclarationSyntax
+                or PropertyDeclarationSyntax
+                or EventDeclarationSyntax);
+    }
+}
+#endif

--- a/src/tools/illink/src/ILLink.CodeFix/MatchPartialSafetyModifierCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/MatchPartialSafetyModifierCodeFixProvider.cs
@@ -106,6 +106,12 @@ namespace ILLink.CodeFix
                     continue;
 
                 SyntaxNode declaration = reference.GetSyntax(cancellationToken);
+
+                // A field-like event's reference points at the variable declarator, but the modifier lives on the
+                // declaration that contains it.
+                if (declaration is VariableDeclaratorSyntax variable && variable.Parent?.Parent is BaseFieldDeclarationSyntax field)
+                    declaration = field;
+
                 if (HasModifier(declaration, modifier))
                     continue;
 
@@ -141,9 +147,11 @@ namespace ILLink.CodeFix
             };
 
         private static SyntaxNode? FindPartialDeclaration(SyntaxNode node) =>
-            node.AncestorsAndSelf().FirstOrDefault(static ancestor => ancestor is MethodDeclarationSyntax
-                or PropertyDeclarationSyntax
-                or EventDeclarationSyntax);
+            // BaseMethodDeclarationSyntax covers partial methods and constructors, BasePropertyDeclarationSyntax
+            // covers partial properties, indexers and events, and a field-like event is its own declaration kind.
+            node.AncestorsAndSelf().FirstOrDefault(static ancestor => ancestor is BaseMethodDeclarationSyntax
+                or BasePropertyDeclarationSyntax
+                or EventFieldDeclarationSyntax);
     }
 }
 #endif

--- a/src/tools/illink/src/ILLink.CodeFix/Resources.resx
+++ b/src/tools/illink/src/ILLink.CodeFix/Resources.resx
@@ -148,7 +148,7 @@
     <value>Remove 'unsafe' from this member</value>
   </data>
   <data name="AddUnsafeToBaseMemberCodeFixTitle" xml:space="preserve">
-    <value>Mark '{0}' 'unsafe'</value>
+    <value>Mark the overridden or implemented member 'unsafe'</value>
   </data>
   <data name="MatchPartialSafetyModifierCodeFixTitle" xml:space="preserve">
     <value>Match the safety modifier on both partial declarations</value>

--- a/src/tools/illink/src/ILLink.CodeFix/Resources.resx
+++ b/src/tools/illink/src/ILLink.CodeFix/Resources.resx
@@ -144,6 +144,18 @@
   <data name="AddUnsafeToFieldCodeFixTitle" xml:space="preserve">
     <value>Mark field-like member 'unsafe'</value>
   </data>
+  <data name="RemoveUnsafeFromDerivedMemberCodeFixTitle" xml:space="preserve">
+    <value>Remove 'unsafe' from this member</value>
+  </data>
+  <data name="AddUnsafeToBaseMemberCodeFixTitle" xml:space="preserve">
+    <value>Mark '{0}' 'unsafe'</value>
+  </data>
+  <data name="MatchPartialSafetyModifierCodeFixTitle" xml:space="preserve">
+    <value>Match the safety modifier on both partial declarations</value>
+  </data>
+  <data name="ReplaceUnsafeWithSafeCodeFixTitle" xml:space="preserve">
+    <value>Replace 'unsafe' with 'safe' on this member</value>
+  </data>
   <data name="UconditionalSuppressMessageCodeFixTitle" xml:space="preserve">
     <value>Add UnconditionalSuppressMessage attribute to parent method</value>
   </data>

--- a/src/tools/illink/src/ILLink.CodeFix/SynchronizeUnsafeContractCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/SynchronizeUnsafeContractCodeFixProvider.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
 
 namespace ILLink.CodeFix
 {
@@ -35,6 +36,12 @@ namespace ILLink.CodeFix
         public const string UnsafeCannotOverrideSafeDiagnosticId = "CS9364";
         public const string UnsafeCannotImplicitlyImplementSafeDiagnosticId = "CS9365";
         public const string UnsafeCannotExplicitlyImplementSafeDiagnosticId = "CS9366";
+
+        // The keys are deliberately independent of the member being fixed, so that "fix all occurrences"
+        // groups every use of the same action rather than one group per member name.
+        private const string RemoveEquivalenceKey = nameof(SynchronizeUnsafeContractCodeFixProvider) + ".Remove";
+        private const string AddToBaseEquivalenceKey = nameof(SynchronizeUnsafeContractCodeFixProvider) + ".AddToBase";
+        private const string ReplaceWithSafeEquivalenceKey = nameof(SynchronizeUnsafeContractCodeFixProvider) + ".ReplaceWithSafe";
 
         private static LocalizableString RemoveTitle =>
             new LocalizableResourceString(
@@ -81,15 +88,14 @@ namespace ILLink.CodeFix
                 // CS9364/CS9365/CS9366 for CS9389. Narrowing the contract to 'safe' is the equivalent edit.
                 if (UnsafeMigrationSyntaxHelpers.SafeKeywordKind != SyntaxKind.None)
                 {
-                    string replaceTitle = ReplaceWithSafeTitle.ToString();
                     context.RegisterCodeFix(
                         CodeAction.Create(
-                            replaceTitle,
+                            ReplaceWithSafeTitle.ToString(),
                             cancellationToken => UnsafeModifierCodeFixHelpers.ReplaceUnsafeWithSafeAsync(
                                 context.Document,
                                 derivedDeclaration,
                                 cancellationToken),
-                            replaceTitle),
+                            ReplaceWithSafeEquivalenceKey),
                         diagnostic);
                 }
             }
@@ -102,32 +108,62 @@ namespace ILLink.CodeFix
                             context.Document,
                             derivedDeclaration,
                             cancellationToken),
-                        removeTitle),
+                        RemoveEquivalenceKey),
                     diagnostic);
             }
 
             if (await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false) is not { } semanticModel
-                || semanticModel.GetDeclaredSymbol(derivedDeclaration, context.CancellationToken) is not { } derivedSymbol)
+                || GetDeclaredSymbol(semanticModel, targetNode, derivedDeclaration, context.CancellationToken) is not { } derivedSymbol)
             {
                 return;
             }
 
-            // Only a base member declared in source can be annotated, and only one that is missing the modifier
-            // on every one of its declarations.
-            if (GetBaseContract(derivedSymbol) is not { } baseSymbol
-                || GetEditableDeclarations(baseSymbol, context.Document.Project.Solution, context.CancellationToken) is not { Count: > 0 } baseDeclarations
-                || baseDeclarations.Any(static pair => UnsafeMigrationSyntaxHelpers.HasSafeModifier(pair.Declaration)))
+            // Only base members declared in source can be annotated, and only ones that are missing the modifier
+            // on every one of their declarations.
+            List<(DocumentId DocumentId, SyntaxNode Declaration)> baseDeclarations = [];
+            foreach (ISymbol baseSymbol in GetBaseContracts(derivedSymbol))
             {
-                return;
+                if (GetEditableDeclarations(baseSymbol, context.Document.Project.Solution, context.CancellationToken) is not { Count: > 0 } declarations
+                    || declarations.Any(static pair => UnsafeMigrationSyntaxHelpers.HasSafeModifier(pair.Declaration)))
+                {
+                    return;
+                }
+
+                baseDeclarations.AddRange(declarations);
             }
 
-            string addToBaseTitle = string.Format(AddToBaseTitle.ToString(), baseSymbol.Name);
+            if (baseDeclarations.Count == 0)
+                return;
+
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    addToBaseTitle,
+                    AddToBaseTitle.ToString(),
                     cancellationToken => AddUnsafeToBaseAsync(context.Document.Project.Solution, baseDeclarations, cancellationToken),
-                    addToBaseTitle),
+                    AddToBaseEquivalenceKey),
                 diagnostic);
+        }
+
+        /// <summary>
+        /// Resolves the symbol whose contract the diagnostic is about.
+        /// </summary>
+        /// <remarks>
+        /// A field or field-like event declaration declares one symbol per variable and has no symbol of its
+        /// own, so the declarator the diagnostic points at is what has to be asked.
+        /// </remarks>
+        private static ISymbol? GetDeclaredSymbol(
+            SemanticModel semanticModel,
+            SyntaxNode targetNode,
+            SyntaxNode declaration,
+            CancellationToken cancellationToken)
+        {
+            if (declaration is BaseFieldDeclarationSyntax)
+            {
+                return targetNode.AncestorsAndSelf().OfType<VariableDeclaratorSyntax>().FirstOrDefault() is { } variable
+                    ? semanticModel.GetDeclaredSymbol(variable, cancellationToken)
+                    : null;
+            }
+
+            return semanticModel.GetDeclaredSymbol(declaration, cancellationToken);
         }
 
         private static async Task<Solution> AddUnsafeToBaseAsync(
@@ -143,11 +179,17 @@ namespace ILLink.CodeFix
                     continue;
 
                 var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+                var seenSpans = new HashSet<TextSpan>();
                 bool edited = false;
                 foreach ((_, SyntaxNode declaration) in group)
                 {
-                    if (UnsafeMigrationSyntaxHelpers.HasModifier(declaration, SyntaxKind.UnsafeKeyword))
+                    // Two contracts can share one declaration, for example a member that implements both
+                    // 'I<int>.M' and 'I<string>.M', and the editor cannot replace the same node twice.
+                    if (!seenSpans.Add(declaration.Span)
+                        || UnsafeMigrationSyntaxHelpers.HasModifier(declaration, SyntaxKind.UnsafeKeyword))
+                    {
                         continue;
+                    }
 
                     editor.ReplaceNode(
                         declaration,
@@ -220,19 +262,53 @@ namespace ILLink.CodeFix
                     or AccessorDeclarationSyntax)
                 .FirstOrDefault(static ancestor => UnsafeMigrationSyntaxHelpers.HasModifier(ancestor, SyntaxKind.UnsafeKeyword));
 
-        private static ISymbol? GetBaseContract(ISymbol symbol)
+        /// <summary>
+        /// Collects every member whose contract the derived member has to match.
+        /// </summary>
+        /// <remarks>
+        /// The compiler compares an override against the original definition of its chain, so annotating the
+        /// root is enough and the members in between can stay as they are. A member can also override one member
+        /// while implementing another, in which case both have to be annotated for the derived member to be
+        /// legal, and both diagnostics are reported on it.
+        /// </remarks>
+        private static ImmutableArray<ISymbol> GetBaseContracts(ISymbol symbol)
         {
-            if (GetOverriddenMember(symbol) is { } overridden)
-                return overridden;
+            var contracts = new List<ISymbol>();
+            var seen = new HashSet<ISymbol>(SymbolEqualityComparer.Default) { symbol };
 
-            if (GetExplicitInterfaceImplementations(symbol).FirstOrDefault() is { } explicitImplementation)
-                return explicitImplementation;
+            var chain = new List<ISymbol> { symbol };
+            for (ISymbol current = symbol; GetOverriddenMember(current) is { } overridden; current = overridden)
+                chain.Add(overridden);
+
+            if (seen.Add(chain[chain.Count - 1]))
+                contracts.Add(chain[chain.Count - 1]);
+
+            // An interface implementation is attributed to the member that declares it rather than to the most
+            // derived override, so every member of the chain has to be asked about its own interfaces.
+            foreach (ISymbol member in chain)
+            {
+                foreach (ISymbol interfaceMember in GetImplementedInterfaceMembers(member))
+                {
+                    if (seen.Add(interfaceMember))
+                        contracts.Add(interfaceMember);
+                }
+            }
+
+            return [.. contracts];
+        }
+
+        private static IEnumerable<ISymbol> GetImplementedInterfaceMembers(ISymbol symbol)
+        {
+            // An explicit implementation names its interface member directly; its own name is qualified, so the
+            // scan below would not match it.
+            foreach (ISymbol explicitImplementation in GetExplicitInterfaceImplementations(symbol))
+                yield return explicitImplementation;
+
+            if (symbol.ContainingType is not { } containingType)
+                yield break;
 
             // An implicit implementation has no syntactic link to the interface, so the containing type's
-            // interfaces are searched for a member this symbol satisfies.
-            if (symbol.ContainingType is not { } containingType)
-                return null;
-
+            // interfaces are searched for members this symbol satisfies.
             foreach (INamedTypeSymbol interfaceType in containingType.AllInterfaces)
             {
                 foreach (ISymbol interfaceMember in interfaceType.GetMembers())
@@ -243,12 +319,10 @@ namespace ILLink.CodeFix
                             containingType.FindImplementationForInterfaceMember(interfaceMember),
                             symbol))
                     {
-                        return interfaceMember;
+                        yield return interfaceMember;
                     }
                 }
             }
-
-            return null;
         }
 
         private static ISymbol? GetOverriddenMember(ISymbol symbol) =>

--- a/src/tools/illink/src/ILLink.CodeFix/SynchronizeUnsafeContractCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/SynchronizeUnsafeContractCodeFixProvider.cs
@@ -1,0 +1,273 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ILLink.CodeFixProvider;
+using ILLink.RoslynAnalyzer;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace ILLink.CodeFix
+{
+    /// <summary>
+    /// Fixes compiler diagnostics <c>CS9364</c>, <c>CS9365</c> and <c>CS9366</c>, reported when an
+    /// <c>unsafe</c> member overrides or implements a member that is not caller-unsafe.
+    /// </summary>
+    /// <remarks>
+    /// Two fixes are offered because the compiler cannot tell which side is wrong. Removing <c>unsafe</c> from
+    /// the derived member is correct when it was an unsafe-v1 lexical scope, and is always available. Marking
+    /// the base member <c>unsafe</c> is correct when the contract was genuinely under-annotated, and is only
+    /// offered when that member is declared in source.
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SynchronizeUnsafeContractCodeFixProvider)), Shared]
+    public sealed class SynchronizeUnsafeContractCodeFixProvider : Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider
+    {
+        public const string UnsafeCannotOverrideSafeDiagnosticId = "CS9364";
+        public const string UnsafeCannotImplicitlyImplementSafeDiagnosticId = "CS9365";
+        public const string UnsafeCannotExplicitlyImplementSafeDiagnosticId = "CS9366";
+
+        private static LocalizableString RemoveTitle =>
+            new LocalizableResourceString(
+                nameof(Resources.RemoveUnsafeFromDerivedMemberCodeFixTitle),
+                Resources.ResourceManager,
+                typeof(Resources));
+
+        private static LocalizableString AddToBaseTitle =>
+            new LocalizableResourceString(
+                nameof(Resources.AddUnsafeToBaseMemberCodeFixTitle),
+                Resources.ResourceManager,
+                typeof(Resources));
+
+        private static LocalizableString ReplaceWithSafeTitle =>
+            new LocalizableResourceString(
+                nameof(Resources.ReplaceUnsafeWithSafeCodeFixTitle),
+                Resources.ResourceManager,
+                typeof(Resources));
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            [
+                UnsafeCannotOverrideSafeDiagnosticId,
+                UnsafeCannotImplicitlyImplementSafeDiagnosticId,
+                UnsafeCannotExplicitlyImplementSafeDiagnosticId,
+            ];
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            Diagnostic diagnostic = context.Diagnostics[0];
+            if (await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false) is not { } root)
+                return;
+
+            SyntaxNode targetNode = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            if (FindUnsafeDeclaration(targetNode) is not { } derivedDeclaration)
+                return;
+
+            string removeTitle = RemoveTitle.ToString();
+            bool isExtern = UnsafeMigrationSyntaxHelpers.HasModifier(derivedDeclaration, SyntaxKind.ExternKeyword);
+            if (isExtern)
+            {
+                // An extern member must keep an explicit marker, so removing 'unsafe' would only trade
+                // CS9364/CS9365/CS9366 for CS9389. Narrowing the contract to 'safe' is the equivalent edit.
+                if (UnsafeMigrationSyntaxHelpers.SafeKeywordKind != SyntaxKind.None)
+                {
+                    string replaceTitle = ReplaceWithSafeTitle.ToString();
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            replaceTitle,
+                            cancellationToken => UnsafeModifierCodeFixHelpers.ReplaceUnsafeWithSafeAsync(
+                                context.Document,
+                                derivedDeclaration,
+                                cancellationToken),
+                            replaceTitle),
+                        diagnostic);
+                }
+            }
+            else
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        removeTitle,
+                        cancellationToken => UnsafeModifierCodeFixHelpers.RemoveUnsafeModifierAsync(
+                            context.Document,
+                            derivedDeclaration,
+                            cancellationToken),
+                        removeTitle),
+                    diagnostic);
+            }
+
+            if (await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false) is not { } semanticModel
+                || semanticModel.GetDeclaredSymbol(derivedDeclaration, context.CancellationToken) is not { } derivedSymbol)
+            {
+                return;
+            }
+
+            // Only a base member declared in source can be annotated, and only one that is missing the modifier
+            // on every one of its declarations.
+            if (GetBaseContract(derivedSymbol) is not { } baseSymbol
+                || GetEditableDeclarations(baseSymbol, context.Document.Project.Solution, context.CancellationToken) is not { Count: > 0 } baseDeclarations
+                || baseDeclarations.Any(static pair => UnsafeMigrationSyntaxHelpers.HasSafeModifier(pair.Declaration)))
+            {
+                return;
+            }
+
+            string addToBaseTitle = string.Format(AddToBaseTitle.ToString(), baseSymbol.Name);
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    addToBaseTitle,
+                    cancellationToken => AddUnsafeToBaseAsync(context.Document.Project.Solution, baseDeclarations, cancellationToken),
+                    addToBaseTitle),
+                diagnostic);
+        }
+
+        private static async Task<Solution> AddUnsafeToBaseAsync(
+            Solution solution,
+            List<(DocumentId DocumentId, SyntaxNode Declaration)> declarations,
+            CancellationToken cancellationToken)
+        {
+            // All declarations in a document are edited in a single pass so that no node has to be re-resolved
+            // against a tree whose spans have already shifted.
+            foreach (IGrouping<DocumentId, (DocumentId DocumentId, SyntaxNode Declaration)> group in declarations.GroupBy(static pair => pair.DocumentId))
+            {
+                if (solution.GetDocument(group.Key) is not { } document)
+                    continue;
+
+                var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+                bool edited = false;
+                foreach ((_, SyntaxNode declaration) in group)
+                {
+                    if (UnsafeMigrationSyntaxHelpers.HasModifier(declaration, SyntaxKind.UnsafeKeyword))
+                        continue;
+
+                    editor.ReplaceNode(
+                        declaration,
+                        UnsafeModifierCodeFixHelpers.AddModifier(declaration, SyntaxKind.UnsafeKeyword));
+                    edited = true;
+                }
+
+                if (edited)
+                    solution = editor.GetChangedDocument().Project.Solution;
+            }
+
+            return solution;
+        }
+
+        private static List<(DocumentId DocumentId, SyntaxNode Declaration)> GetEditableDeclarations(
+            ISymbol symbol,
+            Solution solution,
+            CancellationToken cancellationToken)
+        {
+            var declarations = new List<(DocumentId, SyntaxNode)>();
+
+            // A partial member is two symbols, each seeing only its own declaration, but both parts must agree
+            // on the modifier or the edit trades one diagnostic for CS0764.
+            foreach (ISymbol part in GetSymbolAndPartialParts(symbol))
+            {
+                foreach (SyntaxReference reference in part.DeclaringSyntaxReferences)
+                {
+                    if (solution.GetDocumentId(reference.SyntaxTree) is not { } documentId)
+                        return [];
+
+                    SyntaxNode declaration = reference.GetSyntax(cancellationToken);
+                    if (declaration is VariableDeclaratorSyntax variable && variable.Parent?.Parent is BaseFieldDeclarationSyntax field)
+                        declaration = field;
+
+                    declarations.Add((documentId, declaration));
+                }
+            }
+
+            return declarations;
+        }
+
+        private static IEnumerable<ISymbol> GetSymbolAndPartialParts(ISymbol symbol)
+        {
+            yield return symbol;
+
+            ISymbol? otherPart = symbol switch
+            {
+                IMethodSymbol method => (ISymbol?)method.PartialDefinitionPart ?? method.PartialImplementationPart,
+                IPropertySymbol property => (ISymbol?)property.PartialDefinitionPart ?? property.PartialImplementationPart,
+                IEventSymbol @event => (ISymbol?)@event.PartialDefinitionPart ?? @event.PartialImplementationPart,
+                _ => null,
+            };
+
+            if (otherPart is not null)
+                yield return otherPart;
+        }
+
+        /// <summary>
+        /// Finds the declaration that carries the <c>unsafe</c> modifier the compiler objected to.
+        /// </summary>
+        /// <remarks>
+        /// For a property or event, the diagnostic is reported on the accessor while <c>unsafe</c> may be on the
+        /// containing declaration, so the search continues outward until a declaration with the modifier is found.
+        /// </remarks>
+        private static SyntaxNode? FindUnsafeDeclaration(SyntaxNode node) =>
+            node.AncestorsAndSelf()
+                .Where(static ancestor => ancestor is BaseMethodDeclarationSyntax
+                    or BasePropertyDeclarationSyntax
+                    or BaseFieldDeclarationSyntax
+                    or AccessorDeclarationSyntax)
+                .FirstOrDefault(static ancestor => UnsafeMigrationSyntaxHelpers.HasModifier(ancestor, SyntaxKind.UnsafeKeyword));
+
+        private static ISymbol? GetBaseContract(ISymbol symbol)
+        {
+            if (GetOverriddenMember(symbol) is { } overridden)
+                return overridden;
+
+            if (GetExplicitInterfaceImplementations(symbol).FirstOrDefault() is { } explicitImplementation)
+                return explicitImplementation;
+
+            // An implicit implementation has no syntactic link to the interface, so the containing type's
+            // interfaces are searched for a member this symbol satisfies.
+            if (symbol.ContainingType is not { } containingType)
+                return null;
+
+            foreach (INamedTypeSymbol interfaceType in containingType.AllInterfaces)
+            {
+                foreach (ISymbol interfaceMember in interfaceType.GetMembers())
+                {
+                    if (interfaceMember.Kind == symbol.Kind
+                        && interfaceMember.Name == symbol.Name
+                        && SymbolEqualityComparer.Default.Equals(
+                            containingType.FindImplementationForInterfaceMember(interfaceMember),
+                            symbol))
+                    {
+                        return interfaceMember;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static ISymbol? GetOverriddenMember(ISymbol symbol) =>
+            symbol switch
+            {
+                IMethodSymbol method => method.OverriddenMethod,
+                IPropertySymbol property => property.OverriddenProperty,
+                IEventSymbol @event => @event.OverriddenEvent,
+                _ => null,
+            };
+
+        private static ImmutableArray<ISymbol> GetExplicitInterfaceImplementations(ISymbol symbol) =>
+            symbol switch
+            {
+                IMethodSymbol method => ImmutableArray<ISymbol>.CastUp(method.ExplicitInterfaceImplementations),
+                IPropertySymbol property => ImmutableArray<ISymbol>.CastUp(property.ExplicitInterfaceImplementations),
+                IEventSymbol @event => ImmutableArray<ISymbol>.CastUp(@event.ExplicitInterfaceImplementations),
+                _ => ImmutableArray<ISymbol>.Empty,
+            };
+    }
+}
+#endif

--- a/src/tools/illink/src/ILLink.CodeFix/UnsafeModifierCodeFixHelpers.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/UnsafeModifierCodeFixHelpers.cs
@@ -141,12 +141,17 @@ namespace ILLink.CodeFix
         }
 
         private static SyntaxToken GetModifierAnchorToken(SyntaxNode declaration) =>
+            GetAttributeLists(declaration) is { Count: > 0 } attributeLists
+                ? attributeLists[attributeLists.Count - 1].GetLastToken().GetNextToken()
+                : declaration.GetFirstToken();
+
+        private static SyntaxList<AttributeListSyntax> GetAttributeLists(SyntaxNode declaration) =>
             declaration switch
             {
-                MemberDeclarationSyntax { AttributeLists.Count: > 0 } member
-                    => member.AttributeLists[member.AttributeLists.Count - 1].GetLastToken().GetNextToken(),
-                LocalFunctionStatementSyntax localFunction => localFunction.GetFirstToken(),
-                _ => declaration.GetFirstToken(),
+                MemberDeclarationSyntax member => member.AttributeLists,
+                LocalFunctionStatementSyntax localFunction => localFunction.AttributeLists,
+                AccessorDeclarationSyntax accessor => accessor.AttributeLists,
+                _ => default,
             };
 
         /// <summary>

--- a/src/tools/illink/src/ILLink.CodeFix/UnsafeModifierCodeFixHelpers.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/UnsafeModifierCodeFixHelpers.cs
@@ -70,31 +70,84 @@ namespace ILLink.CodeFix
         /// <summary>
         /// Adds unsafe while preserving declaration-specific modifiers and trivia.
         /// </summary>
-        internal static async Task<Document> AddUnsafeModifierAsync(
+        internal static Task<Document> AddUnsafeModifierAsync(
+            Document document,
+            SyntaxNode declaration,
+            CancellationToken cancellationToken) =>
+            AddModifierAsync(document, declaration, SyntaxKind.UnsafeKeyword, cancellationToken);
+
+        /// <summary>
+        /// Adds a safety modifier while preserving declaration-specific modifiers and trivia.
+        /// </summary>
+        internal static async Task<Document> AddModifierAsync(
+            Document document,
+            SyntaxNode declaration,
+            SyntaxKind modifier,
+            CancellationToken cancellationToken)
+        {
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            editor.ReplaceNode(declaration, AddModifier(declaration, modifier));
+            return editor.GetChangedDocument();
+        }
+
+        /// <summary>
+        /// Replaces an <c>unsafe</c> modifier with <c>safe</c>, preserving its position and trivia.
+        /// </summary>
+        /// <remarks>
+        /// This is the narrowing edit for declarations that must keep an explicit marker, such as
+        /// <c>extern</c> members, where removing <c>unsafe</c> outright would produce <c>CS9389</c>.
+        /// </remarks>
+        internal static async Task<Document> ReplaceUnsafeWithSafeAsync(
             Document document,
             SyntaxNode declaration,
             CancellationToken cancellationToken)
         {
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             SyntaxTokenList modifiers = UnsafeMigrationSyntaxHelpers.GetModifiers(declaration);
-            if (declaration is AccessorDeclarationSyntax accessor)
-            {
-                editor.ReplaceNode(accessor, AddUnsafeModifier(accessor));
-            }
-            else if (modifiers.Count > 0)
-            {
-                editor.ReplaceNode(
-                    declaration,
-                    WithModifiers(declaration, AddUnsafeModifier(modifiers)));
-            }
-            else
-            {
-                DeclarationModifiers declarationModifiers = editor.Generator.GetModifiers(declaration);
-                editor.SetModifiers(declaration, declarationModifiers.WithIsUnsafe(true));
-            }
+            int unsafeIndex = GetUnsafeModifierIndex(modifiers);
+            if (unsafeIndex < 0 || UnsafeMigrationSyntaxHelpers.SafeKeywordKind == SyntaxKind.None)
+                return document;
 
+            SyntaxToken safeToken = SyntaxFactory.Token(UnsafeMigrationSyntaxHelpers.SafeKeywordKind)
+                .WithTriviaFrom(modifiers[unsafeIndex]);
+            editor.ReplaceNode(
+                declaration,
+                WithModifiers(declaration, modifiers.Replace(modifiers[unsafeIndex], safeToken)));
             return editor.GetChangedDocument();
         }
+
+        /// <summary>
+        /// Returns <paramref name="declaration"/> with a safety modifier added.
+        /// </summary>
+        internal static SyntaxNode AddModifier(SyntaxNode declaration, SyntaxKind modifier)
+        {
+            if (declaration is AccessorDeclarationSyntax accessor)
+                return AddModifier(accessor, modifier);
+
+            SyntaxTokenList modifiers = UnsafeMigrationSyntaxHelpers.GetModifiers(declaration);
+            if (modifiers.Count > 0)
+                return WithModifiers(declaration, AddModifier(modifiers, modifier));
+
+            // With no existing modifiers the declaration's leading trivia belongs to the token the new modifier
+            // displaces, so it has to move with it. Attribute lists keep their own leading trivia.
+            SyntaxToken anchor = GetModifierAnchorToken(declaration);
+            SyntaxToken modifierToken = SyntaxFactory.Token(modifier)
+                .WithLeadingTrivia(anchor.LeadingTrivia)
+                .WithTrailingTrivia(SyntaxFactory.ElasticSpace);
+            SyntaxNode withoutTrivia = declaration.ReplaceToken(
+                anchor,
+                anchor.WithLeadingTrivia(default(SyntaxTriviaList)));
+            return WithModifiers(withoutTrivia, SyntaxFactory.TokenList(modifierToken));
+        }
+
+        private static SyntaxToken GetModifierAnchorToken(SyntaxNode declaration) =>
+            declaration switch
+            {
+                MemberDeclarationSyntax { AttributeLists.Count: > 0 } member
+                    => member.AttributeLists[member.AttributeLists.Count - 1].GetLastToken().GetNextToken(),
+                LocalFunctionStatementSyntax localFunction => localFunction.GetFirstToken(),
+                _ => declaration.GetFirstToken(),
+            };
 
         /// <summary>
         /// Removes unsafe without disturbing modifiers that the current SyntaxGenerator does not model.
@@ -125,17 +178,17 @@ namespace ILLink.CodeFix
             return editor.GetChangedDocument();
         }
 
-        private static AccessorDeclarationSyntax AddUnsafeModifier(AccessorDeclarationSyntax accessor)
+        private static AccessorDeclarationSyntax AddModifier(AccessorDeclarationSyntax accessor, SyntaxKind modifier)
         {
             // SyntaxGenerator does not yet model unsafe property accessors, so edit their tokens directly.
             if (accessor.Modifiers.Count > 0)
-                return accessor.WithModifiers(AddUnsafeModifier(accessor.Modifiers));
+                return accessor.WithModifiers(AddModifier(accessor.Modifiers, modifier));
 
-            SyntaxToken unsafeModifier = SyntaxFactory.Token(SyntaxKind.UnsafeKeyword)
+            SyntaxToken modifierToken = SyntaxFactory.Token(modifier)
                 .WithLeadingTrivia(accessor.Keyword.LeadingTrivia)
                 .WithTrailingTrivia(SyntaxFactory.ElasticSpace);
             return accessor
-                .WithModifiers([unsafeModifier])
+                .WithModifiers([modifierToken])
                 .WithKeyword(accessor.Keyword.WithLeadingTrivia(default(SyntaxTriviaList)));
         }
 
@@ -166,24 +219,37 @@ namespace ILLink.CodeFix
             return accessor.WithModifiers(modifiers);
         }
 
-        private static SyntaxTokenList AddUnsafeModifier(SyntaxTokenList modifiers)
+        private static SyntaxTokenList AddModifier(SyntaxTokenList modifiers, SyntaxKind modifier)
         {
-            // Place unsafe before extern while preserving the existing modifier order.
-            int insertionIndex = modifiers.IndexOf(SyntaxKind.ExternKeyword);
+            // 'extern' and 'partial' conventionally sit closest to the return type, so the safety modifier goes
+            // before them. Otherwise it is appended, which matches the repo's preferred modifier order where
+            // 'unsafe' follows 'virtual', 'abstract', 'sealed' and 'override'.
+            int insertionIndex = GetFirstModifierIndex(modifiers, SyntaxKind.ExternKeyword, SyntaxKind.PartialKeyword);
             if (insertionIndex < 0)
                 insertionIndex = modifiers.Count;
 
-            SyntaxToken unsafeModifier = SyntaxFactory.Token(SyntaxKind.UnsafeKeyword)
+            SyntaxToken modifierToken = SyntaxFactory.Token(modifier)
                 .WithTrailingTrivia(SyntaxFactory.ElasticSpace);
-            if (insertionIndex == 0)
+            if (insertionIndex == 0 && modifiers.Count > 0)
             {
-                unsafeModifier = unsafeModifier.WithLeadingTrivia(modifiers[0].LeadingTrivia);
+                modifierToken = modifierToken.WithLeadingTrivia(modifiers[0].LeadingTrivia);
                 modifiers = modifiers.Replace(
                     modifiers[0],
                     modifiers[0].WithLeadingTrivia(default(SyntaxTriviaList)));
             }
 
-            return modifiers.Insert(insertionIndex, unsafeModifier);
+            return modifiers.Insert(insertionIndex, modifierToken);
+        }
+
+        private static int GetFirstModifierIndex(SyntaxTokenList modifiers, SyntaxKind first, SyntaxKind second)
+        {
+            for (int i = 0; i < modifiers.Count; i++)
+            {
+                if (modifiers[i].IsKind(first) || modifiers[i].IsKind(second))
+                    return i;
+            }
+
+            return -1;
         }
 
         private static SyntaxTokenList RemoveUnsafeModifier(SyntaxTokenList modifiers)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeMigrationSyntaxHelpers.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeMigrationSyntaxHelpers.cs
@@ -17,6 +17,12 @@ namespace ILLink.RoslynAnalyzer
         // The analyzer builds against a Roslyn version that predates SyntaxKind.SafeKeyword.
         private static readonly SyntaxKind s_safeKeyword = SyntaxFacts.GetContextualKeywordKind("safe");
 
+        /// <summary>
+        /// The kind of the <c>safe</c> contextual keyword, or <see cref="SyntaxKind.None"/> when the hosting
+        /// compiler does not know it.
+        /// </summary>
+        internal static SyntaxKind SafeKeywordKind => s_safeKeyword;
+
         internal static SyntaxTokenList GetModifiers(SyntaxNode declaration) =>
             declaration switch
             {

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/AddUnsafeToPointerSignatureCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/AddUnsafeToPointerSignatureCodeFixTests.cs
@@ -220,6 +220,43 @@ namespace ILLink.RoslynAnalyzer.Tests
                 }
                 """
             },
+            {
+                // A local function keeps its attribute lists where they are, the same as a member does.
+                """
+                using System.Diagnostics.CodeAnalysis;
+
+                class C
+                {
+                    void Outer()
+                    {
+                        [SuppressMessage("Category", "Rule")]
+                        void {|IL5006:Local|}(int* value) { }
+
+                        unsafe
+                        {
+                            Local(null);
+                        }
+                    }
+                }
+                """,
+                """
+                using System.Diagnostics.CodeAnalysis;
+
+                class C
+                {
+                    void Outer()
+                    {
+                        [SuppressMessage("Category", "Rule")]
+                        unsafe void Local(int* value) { }
+
+                        unsafe
+                        {
+                            Local(null);
+                        }
+                    }
+                }
+                """
+            },
         };
 
         [Theory]

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/MatchPartialSafetyModifierCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/MatchPartialSafetyModifierCodeFixTests.cs
@@ -123,6 +123,148 @@ namespace ILLink.RoslynAnalyzer.Tests
             await test.RunAsync();
         }
         [Fact]
+        public async Task AddsUnsafeToIndexerImplementingPart()
+        {
+            string source = """
+                partial class C
+                {
+                    public unsafe partial int this[int i] { get; }
+                }
+
+                partial class C
+                {
+                    public partial int {|CS0764:this|}[int i] => 0;
+                }
+                """;
+
+            string fixedSource = """
+                partial class C
+                {
+                    public unsafe partial int this[int i] { get; }
+                }
+
+                partial class C
+                {
+                    public unsafe partial int this[int i] => 0;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, MatchPartialSafetyModifierCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task AddsUnsafeToIndexerDefiningPart()
+        {
+            string source = """
+                partial class C
+                {
+                    public partial int this[int i] { get; }
+                }
+
+                partial class C
+                {
+                    public unsafe partial int {|CS0764:this|}[int i] => 0;
+                }
+                """;
+
+            string fixedSource = """
+                partial class C
+                {
+                    public unsafe partial int this[int i] { get; }
+                }
+
+                partial class C
+                {
+                    public unsafe partial int this[int i] => 0;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, MatchPartialSafetyModifierCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task AddsUnsafeToConstructorImplementingPart()
+        {
+            string source = """
+                partial class C
+                {
+                    public unsafe partial C(int x);
+                }
+
+                partial class C
+                {
+                    public partial {|CS0764:C|}(int x) { }
+                }
+                """;
+
+            string fixedSource = """
+                partial class C
+                {
+                    public unsafe partial C(int x);
+                }
+
+                partial class C
+                {
+                    public unsafe partial C(int x) { }
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, MatchPartialSafetyModifierCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task AddsUnsafeToFieldLikeEventDefiningPart()
+        {
+            // The defining part's symbol reference points at the variable declarator, not the declaration that
+            // carries the modifier.
+            string source = """
+                using System;
+
+                partial class C
+                {
+                    public partial event Action E;
+                }
+
+                partial class C
+                {
+                    public unsafe partial event Action {|CS0764:E|} { add { } remove { } }
+                }
+                """;
+
+            string fixedSource = """
+                using System;
+
+                partial class C
+                {
+                    public unsafe partial event Action E;
+                }
+
+                partial class C
+                {
+                    public unsafe partial event Action E { add { } remove { } }
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, MatchPartialSafetyModifierCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
         public async Task DoesNotOfferFixWhenPartsDisagreeInOppositeDirections()
         {
             // The parts declare conflicting contracts, so the compiler reports both CS0764 and CS9390. Adding

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/MatchPartialSafetyModifierCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/MatchPartialSafetyModifierCodeFixTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Threading.Tasks;
+using ILLink.CodeFix;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+    /// <summary>
+    /// Verifies the <c>CS0764</c> and <c>CS9390</c> code fix, which copies the safety modifier onto the partial
+    /// declaration that is missing it.
+    /// </summary>
+    public class MatchPartialSafetyModifierCodeFixTests
+    {
+        [Fact]
+        public async Task AddsUnsafeToImplementingPart()
+        {
+            string source = """
+                partial class C
+                {
+                    public unsafe partial int M();
+                }
+
+                partial class C
+                {
+                    public partial int {|CS0764:M|}() => 0;
+                }
+                """;
+
+            string fixedSource = """
+                partial class C
+                {
+                    public unsafe partial int M();
+                }
+
+                partial class C
+                {
+                    public unsafe partial int M() => 0;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, MatchPartialSafetyModifierCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task AddsUnsafeToDefiningPart()
+        {
+            // The compiler always reports on the implementing part, so the fixer has to edit the other one.
+            string source = """
+                partial class C
+                {
+                    public partial int M();
+                }
+
+                partial class C
+                {
+                    public unsafe partial int {|CS0764:M|}() => 0;
+                }
+                """;
+
+            string fixedSource = """
+                partial class C
+                {
+                    public unsafe partial int M();
+                }
+
+                partial class C
+                {
+                    public unsafe partial int M() => 0;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, MatchPartialSafetyModifierCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task AddsSafeToImplementingPart()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+
+                partial class C
+                {
+                    public static safe partial int M(int x);
+                }
+
+                partial class C
+                {
+                    [DllImport("nativelib")]
+                    public static extern partial int {|CS9390:M|}(int x);
+                }
+                """;
+
+            string fixedSource = """
+                using System.Runtime.InteropServices;
+
+                partial class C
+                {
+                    public static safe partial int M(int x);
+                }
+
+                partial class C
+                {
+                    [DllImport("nativelib")]
+                    public static safe extern partial int M(int x);
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, MatchPartialSafetyModifierCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+        [Fact]
+        public async Task DoesNotOfferFixWhenPartsDisagreeInOppositeDirections()
+        {
+            // The parts declare conflicting contracts, so the compiler reports both CS0764 and CS9390. Adding
+            // the missing modifier would put 'safe' and 'unsafe' on the same declaration, which is an error.
+            string source = """
+                using System.Runtime.InteropServices;
+
+                partial class C
+                {
+                    public static unsafe partial int M(int x);
+                }
+
+                partial class C
+                {
+                    [DllImport("nativelib")]
+                    public static safe extern partial int {|CS0764:{|CS9390:M|}|}(int x);
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, MatchPartialSafetyModifierCodeFixProvider>(
+                    source);
+            await test.RunAsync();
+        }
+    }
+}
+#endif

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/SynchronizeUnsafeContractCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/SynchronizeUnsafeContractCodeFixTests.cs
@@ -274,6 +274,342 @@ namespace ILLink.RoslynAnalyzer.Tests
             test.CodeActionIndex = 1;
             await test.RunAsync();
         }
+
+        [Fact]
+        public async Task MarksRootOfTheOverrideChainUnsafe()
+        {
+            // The compiler compares an override against the original definition of its chain, so the root is
+            // what has to be annotated. Marking the immediate base would only move the diagnostic onto it.
+            string source = """
+                abstract class A
+                {
+                    public abstract int M();
+                }
+
+                abstract class B : A
+                {
+                    public override int M() => 0;
+                }
+
+                class C : B
+                {
+                    public unsafe override int {|CS9364:M|}() => 0;
+                }
+                """;
+
+            string fixedSource = """
+                abstract class A
+                {
+                    public abstract unsafe int M();
+                }
+
+                abstract class B : A
+                {
+                    public override int M() => 0;
+                }
+
+                class C : B
+                {
+                    public unsafe override int M() => 0;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MarksBothTheBaseAndTheInterfaceMemberUnsafe()
+        {
+            // A member that overrides one member while implementing another reports both diagnostics, and stays
+            // broken unless both contracts are annotated.
+            string source = """
+                interface I
+                {
+                    int M();
+                }
+
+                abstract class A
+                {
+                    public abstract int M();
+                }
+
+                class C : A, I
+                {
+                    public unsafe override int {|CS9365:{|CS9364:M|}|}() => 0;
+                }
+                """;
+
+            string fixedSource = """
+                interface I
+                {
+                    unsafe int M();
+                }
+
+                abstract class A
+                {
+                    public abstract unsafe int M();
+                }
+
+                class C : A, I
+                {
+                    public unsafe override int M() => 0;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MarksBaseOfFieldLikeEventUnsafe()
+        {
+            // The semantic model has no symbol for the event declaration itself, only for its declarator.
+            string source = """
+                using System;
+
+                abstract class B
+                {
+                    public abstract event Action E;
+                }
+
+                class D : B
+                {
+                    public override unsafe event Action {|CS9364:E|};
+                }
+                """;
+
+            string fixedSource = """
+                using System;
+
+                abstract class B
+                {
+                    public abstract unsafe event Action E;
+                }
+
+                class D : B
+                {
+                    public override unsafe event Action E;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MarksInterfaceEventOfFieldLikeEventUnsafe()
+        {
+            string source = """
+                using System;
+
+                interface I
+                {
+                    event Action E;
+                }
+
+                class C : I
+                {
+                    public unsafe event Action {|CS9365:E|};
+                }
+                """;
+
+            string fixedSource = """
+                using System;
+
+                interface I
+                {
+                    unsafe event Action E;
+                }
+
+                class C : I
+                {
+                    public unsafe event Action E;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MarksInterfaceEventOfOneOfSeveralDeclaratorsUnsafe()
+        {
+            // A field-like event declaration declares one symbol per variable, so the fix has to follow the
+            // declarator the diagnostic points at rather than the declaration.
+            string source = """
+                using System;
+
+                interface I
+                {
+                    event Action Second;
+                }
+
+                class C : I
+                {
+                    public unsafe event Action First, {|CS9365:Second|};
+                }
+                """;
+
+            string fixedSource = """
+                using System;
+
+                interface I
+                {
+                    unsafe event Action Second;
+                }
+
+                class C : I
+                {
+                    public unsafe event Action First, Second;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MarksInterfaceMemberImplementedByTheOverrideRootUnsafe()
+        {
+            // The interface implementation belongs to the member that declares it, not to the most derived
+            // override, so annotating only the override root would leave a fresh CS9365 behind on it.
+            string source = """
+                interface I
+                {
+                    int M();
+                }
+
+                class A : I
+                {
+                    public virtual int M() => 0;
+                }
+
+                class C : A
+                {
+                    public unsafe override int {|CS9364:M|}() => 0;
+                }
+                """;
+
+            string fixedSource = """
+                interface I
+                {
+                    unsafe int M();
+                }
+
+                class A : I
+                {
+                    public virtual unsafe int M() => 0;
+                }
+
+                class C : A
+                {
+                    public unsafe override int M() => 0;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MarksSharedDeclarationOfSeveralInterfacesOnce()
+        {
+            // Two constructions of the same interface are two contracts sharing one declaration, which the
+            // editor can only be asked to replace once.
+            string source = """
+                interface I<T>
+                {
+                    void M();
+                }
+
+                class C : I<int>, I<string>
+                {
+                    public unsafe void {|CS9365:{|CS9365:M|}|}() { }
+                }
+                """;
+
+            string fixedSource = """
+                interface I<T>
+                {
+                    unsafe void M();
+                }
+
+                class C : I<int>, I<string>
+                {
+                    public unsafe void M() { }
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task RemovesUnsafeFromDerivedFieldLikeEvent()
+        {
+            string source = """
+                using System;
+
+                abstract class B
+                {
+                    public abstract event Action E;
+                }
+
+                class D : B
+                {
+                    public override unsafe event Action {|CS9364:E|};
+                }
+                """;
+
+            string fixedSource = """
+                using System;
+
+                abstract class B
+                {
+                    public abstract event Action E;
+                }
+
+                class D : B
+                {
+                    public override event Action E;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
     }
 }
 #endif

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/SynchronizeUnsafeContractCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/SynchronizeUnsafeContractCodeFixTests.cs
@@ -1,0 +1,279 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Threading.Tasks;
+using ILLink.CodeFix;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+    /// <summary>
+    /// Verifies the <c>CS9364</c>, <c>CS9365</c> and <c>CS9366</c> code fix, which resolves a member that is
+    /// <c>unsafe</c> while the member it overrides or implements is not.
+    /// </summary>
+    public class SynchronizeUnsafeContractCodeFixTests
+    {
+        public static TheoryData<string, string> RemoveFromDerived => new()
+        {
+            {
+                """
+                abstract class B
+                {
+                    public abstract int M();
+                }
+
+                class D : B
+                {
+                    public unsafe override int {|CS9364:M|}() => 0;
+                }
+                """,
+                """
+                abstract class B
+                {
+                    public abstract int M();
+                }
+
+                class D : B
+                {
+                    public override int M() => 0;
+                }
+                """
+            },
+            {
+                """
+                interface I
+                {
+                    int M();
+                }
+
+                class C : I
+                {
+                    public unsafe int {|CS9365:M|}() => 0;
+                }
+                """,
+                """
+                interface I
+                {
+                    int M();
+                }
+
+                class C : I
+                {
+                    public int M() => 0;
+                }
+                """
+            },
+            {
+                """
+                interface I
+                {
+                    int M();
+                }
+
+                class C : I
+                {
+                    unsafe int I.{|CS9366:M|}() => 0;
+                }
+                """,
+                """
+                interface I
+                {
+                    int M();
+                }
+
+                class C : I
+                {
+                    int I.M() => 0;
+                }
+                """
+            },
+            {
+                """
+                abstract class B
+                {
+                    public abstract int P { get; }
+                }
+
+                class D : B
+                {
+                    public unsafe override int P => {|CS9364:0|};
+                }
+                """,
+                """
+                abstract class B
+                {
+                    public abstract int P { get; }
+                }
+
+                class D : B
+                {
+                    public override int P => 0;
+                }
+                """
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(RemoveFromDerived))]
+        public async Task RemovesUnsafeFromDerivedMember(string source, string fixedSource)
+        {
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MarksBaseMemberUnsafe()
+        {
+            string source = """
+                abstract class B
+                {
+                    public abstract int M();
+                }
+
+                class D : B
+                {
+                    public unsafe override int {|CS9364:M|}() => 0;
+                }
+                """;
+
+            string fixedSource = """
+                abstract class B
+                {
+                    public abstract unsafe int M();
+                }
+
+                class D : B
+                {
+                    public unsafe override int M() => 0;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task ReplacesUnsafeWithSafeOnExternMember()
+        {
+            // Removing 'unsafe' outright would only trade CS9364 for CS9389, so the narrowing edit uses 'safe'.
+            string source = """
+                abstract class B
+                {
+                    public abstract object M();
+                }
+
+                class D : B
+                {
+                    public unsafe extern override object {|CS9364:M|}();
+                }
+                """;
+
+            string fixedSource = """
+                abstract class B
+                {
+                    public abstract object M();
+                }
+
+                class D : B
+                {
+                    public safe extern override object M();
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MarksEveryPartOfPartialBaseMemberUnsafe()
+        {
+            // Both parts must be annotated, otherwise the fix trades CS9364 for CS0764.
+            string source = """
+                partial class B
+                {
+                    public virtual partial int M();
+                }
+
+                partial class B
+                {
+                    public virtual partial int M() => 0;
+                }
+
+                class D : B
+                {
+                    public unsafe override int {|CS9364:M|}() => 0;
+                }
+                """;
+
+            string fixedSource = """
+                partial class B
+                {
+                    public virtual unsafe partial int M();
+                }
+
+                partial class B
+                {
+                    public virtual unsafe partial int M() => 0;
+                }
+
+                class D : B
+                {
+                    public unsafe override int M() => 0;
+                }
+                """;
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MarksInterfaceMemberUnsafe()
+        {
+            string source = """
+                interface I
+                {
+                    int M();
+                }
+
+                class C : I
+                {
+                    public unsafe int {|CS9365:M|}() => 0;
+                }
+                """;
+
+            string fixedSource = """
+                interface I
+                {
+                    unsafe int M();
+                }
+
+                class C : I
+                {
+                    public unsafe int M() => 0;
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<DynamicallyAccessedMembersAnalyzer, SynchronizeUnsafeContractCodeFixProvider>(
+                    source,
+                    fixedSource);
+            test.CodeActionIndex = 1;
+            await test.RunAsync();
+        }
+    }
+}
+#endif


### PR DESCRIPTION
This PR adds code fixers for the **contract consistency** part of the unsafe-v2 migration tooling ([tracking issue](https://github.com/dotnet/runtime/issues/131451) §3), continuing #131002. Both fixers are built entirely on diagnostics Roslyn already reports, so no new diagnostic ID is introduced. Nothing changes under unsafe-v1.

### Background

Under the updated memory safety rules `unsafe` on a member is part of its public contract, so the compiler rejects a member that is `unsafe` when the member it overrides or implements is not (callers holding a base reference would never see the added obligation). It likewise requires both halves of a partial member to agree. Neither error has a fix today, and both are common during migration: marking a member `unsafe` immediately breaks its overrides, and source generators author one half of a partial.

### Changes in this PR

1. 🔧 **`SynchronizeUnsafeContractCodeFixProvider`** fixes `CS9364`, `CS9365` and `CS9366` (_see 'Diagnostics IDs' below_) with two actions, since the compiler cannot tell which side is wrong:
   - **Narrow the derived member**, which is correct when the `unsafe` was an unsafe-v1 lexical scope. For an `extern` member this replaces `unsafe` with `safe` rather than removing it, because an `extern` member must keep an explicit marker.
   - **Mark the base member `unsafe`**, which is correct when the contract was under-annotated. Only offered when that member is declared in source.

2. 🔧 **`MatchPartialSafetyModifierCodeFixProvider`** fixes `CS0764` and `CS9390` by copying the safety modifier onto the declaration that lacks it. The modifier is always propagated rather than removed: for `unsafe` that preserves the caller obligation, and for `safe` removing it would reintroduce `CS9389` on an `extern` member.

Both diagnostics for partials are reported at `implementation.GetFirstLocation()` regardless of which part carries the modifier, so the fixer frequently has to edit a different document than the one the diagnostic is in.

### Notable cases handled

- **`extern` overrides.** Removing `unsafe` from `public unsafe extern override object M();` only trades `CS9364` for `CS9389`, and `AddUnsafeToExternCodeFixProvider` from #131002 would then add it straight back. The fix offers `safe` instead. This shape is real, e.g. `RuntimeFieldInfo.UnsafeGetValue`.
- **Partial base members.** A partial symbol's `DeclaringSyntaxReferences` only covers its own half, so annotating the base has to walk both parts or the fix trades `CS9364` for `CS0764`. Edits are batched per document so no node is re-resolved against a tree whose spans have already shifted.
- **Conflicting partial contracts.** When one part is `safe` and the other `unsafe`, the compiler reports both `CS0764` and `CS9390`, and naively satisfying each would put both modifiers on one declaration (`CS9388`). No fix is offered, since resolving it requires deciding which contract is correct.
- **Property accessors.** `CS9364` is reported once per accessor while `unsafe` may sit on the containing property, so the fixer walks outward to the declaration that actually carries the modifier.

### Diagnostics IDs

Just for reference

- `CS9364` [**Roslyn**] - An `unsafe` member cannot override a safe member.
- `CS9365` [**Roslyn**] - An `unsafe` member cannot implicitly implement a safe member.
- `CS9366` [**Roslyn**] - An `unsafe` member cannot explicitly implement a safe member.
- `CS0764` [**Roslyn**] - Both partial member declarations must be `unsafe`, or neither may be `unsafe`.
- `CS9390` [**Roslyn**] - Both partial member declarations must be marked `safe`, or neither may be marked `safe`.
- `CS9388` [**Roslyn**] - The `safe` modifier is only valid on non-unsafe `extern` members or field-like members of explicit or extended-layout types.
- `CS9389` [**Roslyn**] - An `extern` member must be explicitly marked `unsafe` or `safe`.

### Known limitations / follow ups

- The "mark the base member `unsafe`" action is only offered when the base is in source. Roslyn filters `RequiresUnsafeAttribute` out of `ISymbol.GetAttributes()`, so a contract coming from a referenced assembly is invisible to analyzers.
- The opposite migration direction, where an override or implementation is left unannotated while the base is `unsafe`, is **not** covered here. That is legal and the compiler is silent, so it needs its own analyzer (`IL5008` in the tracking issue) and is deliberately left out of this PR.
- `MatchPartialSafetyModifierCodeFixProvider` skips parts that live in generated code, since there is no editable document for them.

### Testing

`ILLink.RoslynAnalyzer.Tests`: 1223 passed. 12 new tests cover both narrowing and base-annotating actions across methods, properties, and implicit and explicit interface implementations, plus regressions for the `extern`, partial-base and conflicting-contract cases above.

> [!NOTE]
> This description and the changes in this PR were generated with GitHub Copilot.
