### PR TITLE
Add null checks for interactPtr and defaultsPtr parameters in SaslInteractionProcedure

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -189,7 +189,7 @@ namespace System.DirectoryServices.Protocols
         /// <returns></returns>
         internal static int SaslInteractionProcedure(IntPtr ldapHandle, uint flags, IntPtr defaultsPtr, IntPtr interactPtr)
         {
-            if (ldapHandle == IntPtr.Zero)
+            if (ldapHandle == IntPtr.Zero || defaultsPtr == IntPtr.Zero || interactPtr == IntPtr.Zero) 
             {
                 return -9; // Parameter Error
             }


### PR DESCRIPTION
PtrToStructure may return null if currentInteractPtr equals IntPtr.Zero, resulting in dereferencing null in interactChallenge.saslChallengeType. The SaslInteractionProcedure is a callback invoked by native LDAP library, so pointer parameters may be IntPtr.Zero in error scenarios. Add null checks for interactPtr, currentInteractPtr, and interactChallenge before member access to prevent NullReferenceException.

Found by Linux Verification Center (linuxtesting.org) with SVACE.