### PR TITLE
TlsContext/TlsSession: document lifetime, tighten AttachSocket

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsContext.cs
@@ -19,13 +19,23 @@ namespace System.Net.Security
     /// allocated lazily on the first handshake call.
     /// </para>
     /// <para>
-    /// Lifetime: it is safe to dispose the <see cref="TlsContext"/> while
-    /// <see cref="TlsSession"/> instances created from it are still in use.
-    /// The underlying native TLS context (e.g. OpenSSL <c>SSL_CTX</c>, SChannel
-    /// credentials handle) is reference-counted at the native layer, so each
-    /// live session keeps it alive until the session itself is disposed.
-    /// After the context is disposed, however, attempts to create new sessions
-    /// from it throw <see cref="ObjectDisposedException"/>.
+    /// Ownership: the <see cref="TlsContext"/> retains any
+    /// <see cref="SslStreamCertificateContext"/> it built internally &#8212; i.e.
+    /// when the caller supplied a raw <see cref="System.Security.Cryptography.X509Certificates.X509Certificate2"/>
+    /// via <see cref="SslServerAuthenticationOptions.ServerCertificate"/> rather
+    /// than a prebuilt <see cref="SslStreamCertificateContext"/>. A prebuilt
+    /// certificate context passed via <see cref="SslServerAuthenticationOptions.ServerCertificateContext"/>
+    /// remains owned by the caller.
+    /// </para>
+    /// <para>
+    /// Lifetime: callers must keep the <see cref="TlsContext"/> alive for as long
+    /// as any <see cref="TlsSession"/> derived from it is still in use. Native
+    /// handles (OpenSSL <c>SSL_CTX</c>, SChannel credentials) are ref-counted at
+    /// the native layer and stay valid for each live session, but the managed
+    /// certificate chain retained by the context is not, mirroring the ownership
+    /// model used by <see cref="SslStream"/>. After the context is disposed,
+    /// attempts to create new sessions from it throw
+    /// <see cref="ObjectDisposedException"/>.
     /// </para>
     /// </remarks>
     [Experimental(Experimentals.LowLevelTlsDiagId, UrlFormat = Experimentals.SharedUrlFormat)]

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.cs
@@ -128,14 +128,20 @@ namespace System.Net.Security
         {
         }
 
-        // Called by TlsSocketSession's constructor to bind a socket handle before the
-        // session receives any TlsContext. The socket is taken to ownership and disposed
-        // with the session. Platforms with a native fd-binding fast path (OpenSSL) take
-        // the socket directly; otherwise the socket is wrapped in a managed Socket for
-        // the buffered I/O path.
-        internal void AttachSocket(SafeSocketHandle socket)
+        // Called from TlsSocketSession.OnContextInitialized (right after the base
+        // InitializeFromContext runs) to bind a socket handle for the socket-bound I/O
+        // path. Must be called exactly once per session, and only before any
+        // Handshake / Read / Write / Shutdown call has touched the PAL. The socket is
+        // taken to ownership and disposed with the session. Platforms with a native
+        // fd-binding fast path (OpenSSL) take the socket directly; otherwise the
+        // socket is wrapped in a managed Socket for the buffered I/O path.
+        private protected void AttachSocket(SafeSocketHandle socket)
         {
             Debug.Assert(socket != null);
+            Debug.Assert(!_disposed, "AttachSocket called on a disposed session");
+            Debug.Assert(_socketHandle is null, "AttachSocket called twice on the same session");
+            Debug.Assert(_socket is null, "AttachSocket called after the managed Socket wrapper was already created");
+            Debug.Assert(_securityContext is null, "AttachSocket called after the PAL security context was already allocated");
             _socketHandle = socket;
 
             bool nativeBindingEnabled = false;


### PR DESCRIPTION
Follow-up on #130366 — small, safe cleanup driven by post-merge review feedback. The larger `SslStream`/`TlsSession` unification (turning `SslStream` into a thin adapter over `TlsBufferSession` and retiring the parallel PAL glue) will land as its own dedicated PR — that discussion had already outgrown this one.

**Changes**

- **`TlsContext` XML remarks** — drop the promise that it is safe to `Dispose` the context while sessions are still in use. Native handles (`SSL_CTX`, SChannel credentials) are ref-counted, but `SslStreamCertificateContext` is not `IDisposable` and has no refcount, so an internally-built cert chain gets released on the context's `Dispose` even when live sessions still hold a reference. The revised docs make the ownership contract explicit — the context retains cert contexts it built itself (raw `ServerCertificate`), caller-supplied `ServerCertificateContext` stays caller-owned, and the caller keeps the context alive for as long as any session derived from it is in use. This mirrors the ownership model used by `SslStream` today (r3624718621).

- **`TlsSession.AttachSocket`** — tighten from `internal` to `private protected`, add `Debug.Assert`s that the session is fresh at the call site (no prior socket handle, no managed `Socket` wrapper, no PAL security context, not disposed), and update the leading comment to reflect that it's called from `OnContextInitialized` after the base `InitializeFromContext` runs, not from `TlsSocketSession`'s constructor as the old comment claimed (bartonjs r3562414767).

No public API change. No behavior change outside `Debug.Assert`s.

> [!NOTE]
> This PR description was drafted with GitHub Copilot assistance.
