### PR TITLE
Update winget install instructions in windows-requirements.md

### DIFF
--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -97,10 +97,6 @@ winget install -e --id Ninja-build.Ninja
 winget install -e --id Microsoft.VisualStudio.Community --override "--passive --wait --config $PWD\.vsconfig"
 ```
 
-Passing the repo's [`.vsconfig`](https://github.com/dotnet/runtime/blob/main/.vsconfig) file to the Visual Studio installer ensures all the components required by the repo get installed, including the Arm64 build tools and the C++/CLI support needed to build the tests. The last command assumes it is run from the root of your runtime clone. `$PWD` is expanded by *Powershell* before the arguments are handed over, which is required because the installer is launched from a temporary directory and would not resolve a relative path.
-
-**NOTE for Arm64 machines:** The Visual Studio winget manifest only publishes an x64 bootstrapper. `winget` runs it under emulation, and it installs the native Arm64 Visual Studio, so the command above works as-is. If `winget` reports that no applicable installer was found, add `-a x64` to the command. All the other packages listed above have native Arm64 installers.
-
 ## Setting Environment Variables on Windows
 
 As mentioned in the sections above, the commands that run the development tools have to be in your `PATH` environment variable. Their installers usually have the option to do it automatically for you enabled by the default, but if for any reason you need to set them yourself, here is how you can do it. There are two options. You can make them last only for that terminal instance, or you can set them directly to the system to make them permanent.

--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -91,11 +91,15 @@ This will set the `DOTNET_ROOT` and `PATH` environment variables to point to the
 All the tools mentioned above can be installed with the [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/winget/):
 ```ps1
 winget install -e --id Kitware.CMake
-winget install -e --id Python.Python.3.11
+winget install -e --id Python.Python.3.14
 winget install -e --id Git.Git
 winget install -e --id Ninja-build.Ninja
-winget install -e --id Microsoft.VisualStudio.2022.Community --override "--add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.ManagedDesktop --includeRecommended"
+winget install -e --id Microsoft.VisualStudio.Community --override "--passive --wait --config <path-to-runtime-repo>\.vsconfig"
 ```
+
+Passing the repo's [`.vsconfig`](https://github.com/dotnet/runtime/blob/main/.vsconfig) file to the Visual Studio installer ensures all the components required by the repo get installed, including the Arm64 build tools and the C++/CLI support needed to build the tests.
+
+**NOTE for Arm64 machines:** The Visual Studio winget manifest only publishes an x64 bootstrapper. `winget` runs it under emulation, and it installs the native Arm64 Visual Studio, so the command above works as-is. If `winget` reports that no applicable installer was found, add `-a x64` to the command. All the other packages listed above have native Arm64 installers.
 
 ## Setting Environment Variables on Windows
 

--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -97,6 +97,8 @@ winget install -e --id Ninja-build.Ninja
 winget install -e --id Microsoft.VisualStudio.Community --override "--passive --wait --config $PWD\.vsconfig"
 ```
 
+The last command installs the components listed in the repo's [`.vsconfig`](https://github.com/dotnet/runtime/blob/main/.vsconfig), so run it from the root of your clone.
+
 ## Setting Environment Variables on Windows
 
 As mentioned in the sections above, the commands that run the development tools have to be in your `PATH` environment variable. Their installers usually have the option to do it automatically for you enabled by the default, but if for any reason you need to set them yourself, here is how you can do it. There are two options. You can make them last only for that terminal instance, or you can set them directly to the system to make them permanent.

--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -94,10 +94,10 @@ winget install -e --id Kitware.CMake
 winget install -e --id Python.Python.3.14
 winget install -e --id Git.Git
 winget install -e --id Ninja-build.Ninja
-winget install -e --id Microsoft.VisualStudio.Community --override "--passive --wait --config <path-to-runtime-repo>\.vsconfig"
+winget install -e --id Microsoft.VisualStudio.Community --override "--passive --wait --config $PWD\.vsconfig"
 ```
 
-Passing the repo's [`.vsconfig`](https://github.com/dotnet/runtime/blob/main/.vsconfig) file to the Visual Studio installer ensures all the components required by the repo get installed, including the Arm64 build tools and the C++/CLI support needed to build the tests.
+Passing the repo's [`.vsconfig`](https://github.com/dotnet/runtime/blob/main/.vsconfig) file to the Visual Studio installer ensures all the components required by the repo get installed, including the Arm64 build tools and the C++/CLI support needed to build the tests. The last command assumes it is run from the root of your runtime clone. `$PWD` is expanded by *Powershell* before the arguments are handed over, which is required because the installer is launched from a temporary directory and would not resolve a relative path.
 
 **NOTE for Arm64 machines:** The Visual Studio winget manifest only publishes an x64 bootstrapper. `winget` runs it under emulation, and it installs the native Arm64 Visual Studio, so the command above works as-is. If `winget` reports that no applicable installer was found, add `-a x64` to the command. All the other packages listed above have native Arm64 installers.
 


### PR DESCRIPTION
Small refresh of the `winget` section in `docs/workflow/requirements/windows-requirements.md`.

Tested on a real clean win-arm64 machine.
