### PR TITLE
[release/10.0] Fix EH - throw from catch in UnmanagedCallersOnly

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3932,14 +3932,20 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
     if (pThis->GetFrameState() == StackFrameIterator::SFITER_NATIVE_MARKER_FRAME)
     {
         EECodeInfo codeInfo(preUnwindControlPC);
+        // If we are unwinding from a funclet, we don't care about the reverse pinvoke frame of the parent method
+        // that we would get from the GC info. It applies to the parent method only. The funclet itself cannot be
+        // invoked via a reverse pinvoke.
+        if (!doingFuncletUnwind)
+        {
 #ifdef USE_GC_INFO_DECODER
-        GcInfoDecoder gcInfoDecoder(codeInfo.GetGCInfoToken(), DECODE_REVERSE_PINVOKE_VAR);
-        isPropagatingToNativeCode = gcInfoDecoder.GetReversePInvokeFrameStackSlot() != NO_REVERSE_PINVOKE_FRAME;
+            GcInfoDecoder gcInfoDecoder(codeInfo.GetGCInfoToken(), DECODE_REVERSE_PINVOKE_VAR);
+            isPropagatingToNativeCode = gcInfoDecoder.GetReversePInvokeFrameStackSlot() != NO_REVERSE_PINVOKE_FRAME;
 #else // USE_GC_INFO_DECODER
-        hdrInfo *hdrInfoBody;
-        codeInfo.DecodeGCHdrInfo(&hdrInfoBody);
-        isPropagatingToNativeCode = hdrInfoBody->revPInvokeOffset != INVALID_REV_PINVOKE_OFFSET;
+            hdrInfo *hdrInfoBody;
+            codeInfo.DecodeGCHdrInfo(&hdrInfoBody);
+            isPropagatingToNativeCode = hdrInfoBody->revPInvokeOffset != INVALID_REV_PINVOKE_OFFSET;
 #endif // USE_GC_INFO_DECODER
+        }
         bool isPropagatingToExternalNativeCode = false;
 
         EH_LOG((LL_INFO100, "SfiNext: reached native frame at IP=%p, SP=%p, isPropagatingToNativeCode=%d\n",

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
@@ -258,6 +258,7 @@ public unsafe static class ExceptionInterop
         Assert.False(reportedUnhandledException, "Exception should not be reported as unhandled");
     }
 
+    [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
     public static void ThrowNativeExceptionFromCatchInUnmanagedCallersOnlyCallback()
@@ -278,6 +279,7 @@ public unsafe static class ExceptionInterop
         Assert.IsType<SEHException>(exception);
     }
 
+    [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
     public static void ThrowManagedExceptionFromCatchInUnmanagedCallersOnlyCallback()

--- a/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
+++ b/src/tests/baseservices/exceptions/exceptioninterop/ExceptionInterop.cs
@@ -21,6 +21,9 @@ internal unsafe static class ExceptionInteropNative
 
 public unsafe static class ExceptionInterop
 {
+    private static int s_nativeExceptionFromCatchCount;
+    private static int s_managedExceptionFromCatchCount;
+
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
@@ -179,6 +182,46 @@ public unsafe static class ExceptionInterop
         }
     }
 
+    [UnmanagedCallersOnly]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void ThrowNativeExceptionFromCatchInUnmanagedCallersOnly()
+    {
+        try
+        {
+            throw new Exception("This one is handled");
+        }
+        catch
+        {
+            s_nativeExceptionFromCatchCount++;
+            if (s_nativeExceptionFromCatchCount > 1)
+            {
+                return;
+            }
+
+            ThrowException();
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void ThrowManagedExceptionFromCatchInUnmanagedCallersOnly()
+    {
+        try
+        {
+            throw new Exception("This one is handled");
+        }
+        catch
+        {
+            s_managedExceptionFromCatchCount++;
+            if (s_managedExceptionFromCatchCount > 1)
+            {
+                return;
+            }
+
+            throw new ApplicationException();
+        }
+    }
+
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Exception interop not supported on Mono.")]
@@ -213,5 +256,45 @@ public unsafe static class ExceptionInterop
         InvokeCallbackOnNewThread(&CallPInvoke);
         AppDomain.CurrentDomain.UnhandledException -= handler;
         Assert.False(reportedUnhandledException, "Exception should not be reported as unhandled");
+    }
+
+    [PlatformSpecific(TestPlatforms.Windows)]
+    [SkipOnMono("Exception interop not supported on Mono.")]
+    public static void ThrowNativeExceptionFromCatchInUnmanagedCallersOnlyCallback()
+    {
+        s_nativeExceptionFromCatchCount = 0;
+
+        Exception exception = null;
+        try
+        {
+            CallCallback(&ThrowNativeExceptionFromCatchInUnmanagedCallersOnly);
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        Assert.Equal(1, s_nativeExceptionFromCatchCount);
+        Assert.IsType<SEHException>(exception);
+    }
+
+    [PlatformSpecific(TestPlatforms.Windows)]
+    [SkipOnMono("Exception interop not supported on Mono.")]
+    public static void ThrowManagedExceptionFromCatchInUnmanagedCallersOnlyCallback()
+    {
+        s_managedExceptionFromCatchCount = 0;
+
+        Exception exception = null;
+        try
+        {
+            CallCallback(&ThrowManagedExceptionFromCatchInUnmanagedCallersOnly);
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+
+        Assert.Equal(1, s_managedExceptionFromCatchCount);
+        Assert.IsType<ApplicationException>(exception);
     }
 }


### PR DESCRIPTION
Backport of #131163 to release/10.0

## Customer Impact

- [x] Customer reported - #123579
- [ ] Found internally

There is an issue when an exception is thrown from catch in a method marked as `UnmanagedCallersOnly` on Windows. When such exception escapes the catch, it is not detected as going into CallEHFunclet, but it is thought to be escaping the `UnmanagedCallersOnly` method itself, thus going through a reverse pinvoke transition. That results in an incorrect handling of that exception. We don't detect the unwind is colliding with previous exception and we end up calling the same catch again. This results in an infinite loop and a stack overflow after a while.

## Regression

- [x]  Yes - in .NET 9 when new exception handling was enabled by default
- [ ] No

## Testing

Directed repro from the customer, regular coreclr / libraries tests. 

## Risk

Low. The change just fixes a condition that was incorrect for UnmanagedCallersOnly case.