### PR TITLE
Use native SDK for arm64 Apple simulator tests

### DIFF
--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -237,6 +237,7 @@
     <DotNetCliVersion>$([System.Text.RegularExpressions.Regex]::Match($(GlobalJsonContent), '(%3F&lt;="dotnet": ").*(%3F=")'))</DotNetCliVersion>
     <!-- Apple mobile test runs need to use the host OS DotnetCliRuntime -->
     <DotNetCliRuntime>osx-x64</DotNetCliRuntime>
+    <DotNetCliRuntime Condition="'$(TargetArchitecture)' == 'arm64' and ('$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'tvossimulator' or '$(TargetOS)' == 'maccatalyst')">osx-arm64</DotNetCliRuntime>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsMobile)' == 'true'">


### PR DESCRIPTION
Use the `osx-arm64` .NET SDK when Apple simulator and Mac Catalyst tests target arm64. These jobs run on `OSX.26.Arm64` Helix machines, so using the native SDK avoids running MSBuild and crossgen2 under Rosetta.

The x64 simulator legs and physical iOS/tvOS device legs continue using `osx-x64` because their Helix hosts are Intel.

This addresses the Rosetta hang in [runtime-extra-platforms build 1527467](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1527467&view=logs&j=747d7729-4383-5624-d8f7-8c866d58f280).

Validated the evaluated `DotNetCliRuntime` for all affected Apple target/architecture combinations.

> [!NOTE]
> This pull request was created with GitHub Copilot.