### PR TITLE
Use an explicit allow list for SIMD types in getTypeLayout

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2671,6 +2671,39 @@ namespace Internal.JitInterface
             throw new InvalidOperationException();
         }
 
+        //------------------------------------------------------------------------
+        // IsSimdIntrinsicType: Check whether a type is one of the SIMD types that the
+        // JIT considers to be a primitive.
+        //
+        // Arguments:
+        //   type - The type to check.
+        //
+        // Return Value:
+        //   True if the type is a SIMD type; otherwise false.
+        //
+        // Remarks:
+        //   This is an explicit allow list mirroring the types recognized by
+        //   Compiler::getBaseTypeAndSizeOfSIMDType. The other intrinsic types in these
+        //   namespaces (Decimal32/Decimal64/Decimal128, Matrix3x2/Matrix4x4) are laid
+        //   out like any other struct, so the JIT needs their fields reported.
+        //
+        private static bool IsSimdIntrinsicType(MetadataType type)
+        {
+            if (VectorFieldLayoutAlgorithm.IsVectorType(type) || VectorOfTFieldLayoutAlgorithm.IsVectorOfTType(type))
+            {
+                return true;
+            }
+
+            if (!type.IsIntrinsic || type.Namespace != "System.Numerics"u8)
+            {
+                return false;
+            }
+
+            Utf8Span name = type.Name;
+            return name == "Vector2"u8 || name == "Vector3"u8 || name == "Vector4"u8 ||
+                   name == "Quaternion"u8 || name == "Plane"u8;
+        }
+
         private GetTypeLayoutResult GetTypeLayoutHelper(MetadataType type, uint parentIndex, uint baseOffs, FieldDesc field, CORINFO_TYPE_LAYOUT_NODE* treeNodes, nuint maxTreeNodes, nuint* numTreeNodes)
         {
             if (*numTreeNodes >= maxTreeNodes)
@@ -2711,37 +2744,31 @@ namespace Internal.JitInterface
 #endif
 
             // The intrinsic SIMD/HW SIMD types have a lot of fields that the JIT does
-            // not care about since they are considered primitives by the JIT. The IEEE 754
-            // decimal floating-point types are the System.Numerics intrinsics that are not
-            // SIMD, so the JIT lays them out like any other struct and needs their fields.
-            if (type.IsIntrinsic && !type.IsDecimalFloatingPointOrHasDecimalFloatingPointFields)
+            // not care about since they are considered primitives by the JIT.
+            if (IsSimdIntrinsicType(type))
             {
-                Utf8Span ns = type.Namespace;
-                if (ns == "System.Runtime.Intrinsics"u8 || ns == "System.Numerics"u8)
+                parNode->simdTypeHnd = ObjectToHandle(type);
+                if (parentIndex != uint.MaxValue)
                 {
-                    parNode->simdTypeHnd = ObjectToHandle(type);
-                    if (parentIndex != uint.MaxValue)
-                    {
 #if READYTORUN
-                        if (NeedsTypeLayoutCheck(type))
-                        {
-                            // We cannot allow the JIT to call getClassSize for
-                            // arbitrary types of fields as it will insert a fixup
-                            // that we may not be able to encode. We could skip the
-                            // field, but that will make prejit promotion different
-                            // from the runtime promotion. We could also change the
-                            // JIT to avoid calling getClassSize and just use the
-                            // size from the returned node, but for that we would
-                            // need to be sure that the type layout check fixup
-                            // added in getTypeLayout is sufficient to guarantee
-                            // the size of all these intrinsically handled SIMD
-                            // types.
-                            return GetTypeLayoutResult.Failure;
-                        }
+                    if (NeedsTypeLayoutCheck(type))
+                    {
+                        // We cannot allow the JIT to call getClassSize for
+                        // arbitrary types of fields as it will insert a fixup
+                        // that we may not be able to encode. We could skip the
+                        // field, but that will make prejit promotion different
+                        // from the runtime promotion. We could also change the
+                        // JIT to avoid calling getClassSize and just use the
+                        // size from the returned node, but for that we would
+                        // need to be sure that the type layout check fixup
+                        // added in getTypeLayout is sufficient to guarantee
+                        // the size of all these intrinsically handled SIMD
+                        // types.
+                        return GetTypeLayoutResult.Failure;
+                    }
 #endif
 
-                        return GetTypeLayoutResult.Success;
-                    }
+                    return GetTypeLayoutResult.Success;
                 }
             }
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1993,6 +1993,62 @@ CEEInfo::getFieldInClass(CORINFO_CLASS_HANDLE clsHnd, INT num)
     return result;
 }
 
+//------------------------------------------------------------------------
+// IsSimdIntrinsicType: Check whether a type is one of the SIMD types that the
+// JIT considers to be a primitive.
+//
+// Arguments:
+//   pMT - The type to check.
+//
+// Return Value:
+//   True if the type is a SIMD type; otherwise false.
+//
+// Remarks:
+//   This is an explicit allow list mirroring the types recognized by
+//   Compiler::getBaseTypeAndSizeOfSIMDType. The other intrinsic types in these
+//   namespaces (Decimal32/Decimal64/Decimal128, Matrix3x2/Matrix4x4) are laid
+//   out like any other struct, so the JIT needs their fields reported.
+//
+static bool IsSimdIntrinsicType(MethodTable* pMT)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        FORBID_FAULT;
+    }
+    CONTRACTL_END;
+
+    if (!pMT->IsIntrinsicType())
+    {
+        return false;
+    }
+
+    LPCUTF8 nsName;
+    LPCUTF8 className = pMT->GetFullyQualifiedNameInfo(&nsName);
+
+    // GetFullyQualifiedNameInfo returns NULL on failure and can legitimately report a NULL namespace.
+    if ((className == NULL) || (nsName == NULL))
+    {
+        return false;
+    }
+
+    if (strcmp(nsName, "System.Runtime.Intrinsics") == 0)
+    {
+        return (strcmp(className, "Vector128`1") == 0) || (strcmp(className, "Vector64`1") == 0) ||
+               (strcmp(className, "Vector256`1") == 0) || (strcmp(className, "Vector512`1") == 0);
+    }
+
+    if (strcmp(nsName, "System.Numerics") == 0)
+    {
+        return (strcmp(className, "Vector`1") == 0) || (strcmp(className, "Vector2") == 0) ||
+               (strcmp(className, "Vector3") == 0) || (strcmp(className, "Vector4") == 0) ||
+               (strcmp(className, "Quaternion") == 0) || (strcmp(className, "Plane") == 0);
+    }
+
+    return false;
+}
+
 static GetTypeLayoutResult GetTypeLayoutHelper(
     MethodTable* pMT,
     unsigned parentIndex,
@@ -2023,22 +2079,13 @@ static GetTypeLayoutResult GetTypeLayoutHelper(
     parNode.hasSignificantPadding = pClass->HasExplicitFieldOffsetLayout() || pClass->HasExplicitSize();
 
     // The intrinsic SIMD/HW SIMD types have a lot of fields that the JIT does
-    // not care about since they are considered primitives by the JIT. The IEEE 754
-    // decimal floating-point types are the System.Numerics intrinsics that are not
-    // SIMD, so the JIT lays them out like any other struct and needs their fields.
-    if (pMT->IsIntrinsicType() && !pMT->IsDecimalFloatingPointOrHasDecimalFloatingPointFields())
+    // not care about since they are considered primitives by the JIT.
+    if (IsSimdIntrinsicType(pMT))
     {
-        const char* nsName;
-        pMT->GetFullyQualifiedNameInfo(&nsName);
-
-        if ((strcmp(nsName, "System.Runtime.Intrinsics") == 0) ||
-            (strcmp(nsName, "System.Numerics") == 0))
+        parNode.simdTypeHnd = CORINFO_CLASS_HANDLE(pMT);
+        if (parentIndex != UINT32_MAX)
         {
-            parNode.simdTypeHnd = CORINFO_CLASS_HANDLE(pMT);
-            if (parentIndex != UINT32_MAX)
-            {
-                return GetTypeLayoutResult::Success;
-            }
+            return GetTypeLayoutResult::Success;
         }
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/131345#discussion_r3665749190.

The intrinsic check in `getTypeLayout` was a deny form: every `[Intrinsic]` type in `System.Numerics` and `System.Runtime.Intrinsics` was reported to the JIT as an opaque SIMD node, with the decimal floating-point types carved back out via `IsDecimalFloatingPointOrHasDecimalFloatingPointFields`. That only held while every intrinsic type in those namespaces happened to be SIMD, so each new non-SIMD intrinsic type needs another carve-out.

This names the SIMD types explicitly instead, via a new `IsSimdIntrinsicType` helper on both the native VM and the managed (crossgen2 / ILCompiler) side, mirroring the set recognized by `Compiler::getBaseTypeAndSizeOfSIMDType`:

- `System.Runtime.Intrinsics`: `Vector64<T>`, `Vector128<T>`, `Vector256<T>`, `Vector512<T>`
- `System.Numerics`: `Vector<T>`, `Vector2`, `Vector3`, `Vector4`, `Plane`, `Quaternion`

The managed helper reuses the existing `VectorFieldLayoutAlgorithm.IsVectorType` and `VectorOfTFieldLayoutAlgorithm.IsVectorOfTType` rather than duplicating those name checks. `IsDecimalFloatingPointOrHasDecimalFloatingPointFields` is untouched -- it's still used for the by-value marshal restriction in `dllimport.cpp`, `mlinfo.cpp`, `classlayoutinfo.cpp`, and `MarshalHelpers.cs`.

----------

`Matrix3x2`/`Matrix4x4` fall out of the set as well. They're `[Intrinsic]` and live in `System.Numerics`, so the old namespace-only test caught them, but `getBaseTypeAndSizeOfSIMDType` returns `TYP_UNDEF` for them, so their `simdTypeHnd` was never usable. Their fields are now enumerated like any other struct:

- `TryPromoteValueClassAsPrimitive` rejected a `Matrix` field before (SIMD lookup fails, then `numFields == 0 != 1`) and rejects it now (`simdTypeHnd == null`, then `numFields == 6 or 16 != 1`), so no promotion can be lost.
- `TryPromoteStructVar` has a `1 + MAX_NumOfFieldsInPromotableStruct * 2 == 9` node budget; a `Matrix4x4` field overflows it into `Partial` -> `return false`, the same outcome as before.
- `ClassLayout::GetNonPadding` treats a `simdTypeHnd` node as entirely non-padding. Matrices have no padding, and `SegmentList::Add` merges the adjacent per-field segments, so the resulting map is identical.
- For R2R, `Matrix` types no longer hit the `NeedsTypeLayoutCheck` -> `Failure` bail and take the ordinary field-enumeration path. Their fields are primitive `float`s, which `CheckTypeLayout` handles; the `getClassSize` fixup concern applies only to types reported via `simdTypeHnd`.

----------

No JIT-EE GUID bump -- the interface signature and `CORINFO_TYPE_LAYOUT_NODE` are unchanged.

Deliberately out of scope: `MethodTable::ClassifyEightBytes*` and `SystemVStructClassificator` also do intrinsic-type name checks, but against a deliberately smaller set (only `Vector64/128/256/512<T>` and `Vector<T>` -- `Vector2/3/4`, `Plane`, and `Quaternion` *are* passed in registers), so they can't share this helper.

## Validation

SuperPMI can't cover this -- it replays recorded `getTypeLayout` responses, so a VM-side change is invisible to asmdiffs. Validated with a real build instead:

- `build.cmd clr -rc checked` -- 0 warnings, 0 errors. Both `ILCompiler.RyuJit` and `ILCompiler.ReadyToRun` relink, so both `#if READYTORUN` arms compile.
- A/B `JitDump` over wrapper structs for all 15 affected types (10 SIMD + `Matrix3x2`/`Matrix4x4` + `Decimal32/64/128`), before vs. after, address-normalized: **0 differing lines out of 83,382**. This confirms empirically that the `Matrix` delta is inert, including the `Matrix3x2` case that fits within the node budget.
- `JIT/SIMD`: 116/116 passed. `JIT/Directed/StructPromote` + `JIT/Directed/physicalpromotion`: 9/9 passed.

> [!NOTE]
> This PR description and the accompanying code changes were drafted with GitHub Copilot.
