### PR TITLE
[Diagnostics] Avoid resolving IL offsets for framed crash frames

### DIFF
--- a/src/coreclr/vm/crashreportstackwalker.cpp
+++ b/src/coreclr/vm/crashreportstackwalker.cpp
@@ -260,8 +260,8 @@ FrameCallbackAdapter(
 
     Module* pModule = pMD->GetModule();
 
-    bool hasManagedNativeCode = !pCF->HasFaulted() && pCF->IsFrameless();
-    uint32_t nativeOffset = hasManagedNativeCode ? pCF->GetRelOffset() : 0;
+    bool canResolveOffsets = !pCF->HasFaulted() && pCF->IsFrameless();
+    uint32_t nativeOffset = canResolveOffsets ? pCF->GetRelOffset() : 0;
     uint32_t ilOffset = 0;
     PCODE ip = (PCODE)0;
     TADDR stackPointer = (TADDR)0;
@@ -277,7 +277,7 @@ FrameCallbackAdapter(
         return SWA_CONTINUE;
     }
 
-    if (g_pDebugInterface != nullptr && hasManagedNativeCode)
+    if (g_pDebugInterface != nullptr && canResolveOffsets)
     {
         DWORD resolvedILOffset = 0;
         BOOL haveILOffset = FALSE;

--- a/src/coreclr/vm/crashreportstackwalker.cpp
+++ b/src/coreclr/vm/crashreportstackwalker.cpp
@@ -260,7 +260,7 @@ FrameCallbackAdapter(
 
     Module* pModule = pMD->GetModule();
 
-    bool canResolveOffsets = !pCF->HasFaulted() && pCF->IsFrameless();
+    bool canResolveOffsets = pCF->IsFrameless();
     uint32_t nativeOffset = canResolveOffsets ? pCF->GetRelOffset() : 0;
     uint32_t ilOffset = 0;
     PCODE ip = (PCODE)0;

--- a/src/coreclr/vm/crashreportstackwalker.cpp
+++ b/src/coreclr/vm/crashreportstackwalker.cpp
@@ -260,7 +260,8 @@ FrameCallbackAdapter(
 
     Module* pModule = pMD->GetModule();
 
-    uint32_t nativeOffset = (pCF->HasFaulted() || !pCF->IsFrameless()) ? 0 : pCF->GetRelOffset();
+    bool hasManagedNativeCode = !pCF->HasFaulted() && pCF->IsFrameless();
+    uint32_t nativeOffset = hasManagedNativeCode ? pCF->GetRelOffset() : 0;
     uint32_t ilOffset = 0;
     PCODE ip = (PCODE)0;
     TADDR stackPointer = (TADDR)0;
@@ -276,7 +277,7 @@ FrameCallbackAdapter(
         return SWA_CONTINUE;
     }
 
-    if (g_pDebugInterface != nullptr && pMD != nullptr)
+    if (g_pDebugInterface != nullptr && hasManagedNativeCode)
     {
         DWORD resolvedILOffset = 0;
         BOOL haveILOffset = FALSE;


### PR DESCRIPTION
FIxes #131517

#131273 avoided calling CrawlFrame::GetRelOffset() for framed crash-report stack frames. However, the reporter still attempted to resolve an IL offset for those frames.

A native SIGSEGV during a managed P/Invoke transition produced a framed CrawlFrame where:

• the MethodDesc represented the managed P/Invoke method;
• the instruction pointer was inside the native function that faulted.

Passing that pair to GetILOffsetFromNative triggered this Checked-build assertion:

`g_pEEInterface->GetNativeCodeMethodDesc(startAddr) == fd`

This change only resolves native and IL offsets for frameless frames, where the stack walker has valid managed  EECodeInfo . This includes faulted frameless frames. Framed transition frames still retain their method, module, and token information, but report native and IL offsets of zero.

Testing

Validated real macOS arm64 in-proc crash reports in both Checked and Release builds, including a native SIGSEGV triggered through P/Invoke.