### PR TITLE
Fix Avx.Compare miscompile with non-constant FloatComparisonMode

### DIFF
--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -2766,7 +2766,23 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
 
     if (setMethodHandle && (retNode != nullptr))
     {
-        retNode->AsHWIntrinsic()->SetMethodHandle(this, method R2RARG(*entryPoint));
+        GenTree* userCall = retNode;
+
+#if defined(TARGET_XARCH)
+        if (userCall->OperIsConvertMaskToVector())
+        {
+            // A mask-producing intrinsic was wrapped in a mask-to-vector conversion, but the user call
+            // replaces the inner node, so attach the handle there to keep its operands. ConvertMaskToVector
+            // is always unary, so its sole operand is the mask node being tagged.
+            GenTreeHWIntrinsic* cvtMaskToVector = userCall->AsHWIntrinsic();
+            assert(cvtMaskToVector->GetOperandCount() == 1);
+
+            userCall = cvtMaskToVector->Op(1);
+            assert(userCall->TypeIs(TYP_MASK));
+        }
+#endif // TARGET_XARCH
+
+        userCall->AsHWIntrinsic()->SetMethodHandle(this, method R2RARG(*entryPoint));
     }
 
 #if defined(FEATURE_MASKED_HW_INTRINSICS) && defined(TARGET_ARM64)

--- a/src/tests/JIT/Regression/JitBlue/GitHub_131472/GitHub_131472.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_131472/GitHub_131472.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+public class GitHub_131472
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static FloatComparisonMode Opaque(FloatComparisonMode value) => value;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector256<float> Compare(Vector256<float> l, Vector256<float> r, FloatComparisonMode m) => Avx.Compare(l, r, m);
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    private static Vector256<float> Reference(Vector256<float> l, Vector256<float> r, FloatComparisonMode m) => Avx.Compare(l, r, m);
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector512<float> Compare(Vector512<float> l, Vector512<float> r, FloatComparisonMode m) => Avx512F.Compare(l, r, m);
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    private static Vector512<float> Reference(Vector512<float> l, Vector512<float> r, FloatComparisonMode m) => Avx512F.Compare(l, r, m);
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        // A non-constant mode must expand without leaving right/mode uninitialized when Compare is
+        // promoted to its mask-returning form. Vector256 exercises the optional EVEX promotion;
+        // Vector512 exercises the mandatory-mask path.
+        for (int i = 0; i <= (int)FloatComparisonMode.UnorderedTrueSignaling; i++)
+        {
+            FloatComparisonMode mode = Opaque((FloatComparisonMode)i);
+
+            if (Avx.IsSupported)
+            {
+                Vector256<float> l = Vector256.Create(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f);
+                Vector256<float> r = Vector256.Create(8f, 2f, 6f, 4f, 4f, 6f, 2f, 8f);
+                Assert.Equal(Reference(l, r, mode), Compare(l, r, mode));
+            }
+
+            if (Avx512F.IsSupported)
+            {
+                Vector512<float> l = Vector512.Create(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f, 10f, 11f, 12f, 13f, 14f, 15f, 16f);
+                Vector512<float> r = Vector512.Create(8f, 2f, 6f, 4f, 4f, 6f, 2f, 8f, 16f, 10f, 12f, 12f, 12f, 14f, 10f, 16f);
+                Assert.Equal(Reference(l, r, mode), Compare(l, r, mode));
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -122,6 +122,7 @@
     <Compile Include="JitBlue\Runtime_131137\Runtime_131137.cs" />
     <Compile Include="JitBlue\Runtime_10337\Runtime_10337.cs" />
     <Compile Include="JitBlue\Runtime_125160\Runtime_125160.cs" />
+    <Compile Include="JitBlue\GitHub_131472\GitHub_131472.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Fixes #131472.

`Avx.Compare` / `Avx512F.Compare` produced garbage or AV'd under FullOpts when the `FloatComparisonMode` argument was not a compile-time constant (e.g. a loop induction variable). It reproduces on shipped `11.0.0-preview.6` with `DOTNET_TieredCompilation=0`; tiering masked it.

## Root cause

A non-constant mode has no register-variable encoding, so `Compare` defers to its managed fallback via a user call (`setMethodHandle` in `impHWIntrinsic`). On EVEX-capable hardware the intrinsic is promoted to the mask-returning form and wrapped in a `ConvertMaskToVector` node. The shared attach block tagged that unary **wrapper** rather than the inner 3-operand compare, so the rationalizer built a call carrying only `left` — `right`/`mode` were never set up, and the call fell through to the self-recursive managed body on uninitialized registers.

512-bit is affected for the same reason and cannot avoid the mask: `NI_AVX512_Compare` carries `HW_Flag_InvalidNodeId`, so the mask form is mandatory.

## Fix

In the rare `setMethodHandle` path, when the return node is a `ConvertMaskToVector`, attach the fallback handle to its inner mask operand instead of the wrapper. This runs only for the non-constant-imm-under-optimization case (no common-path cost) and covers 128/256-bit EVEX and mandatory-mask 512-bit uniformly. `ConvertMaskToVector` is unary on both xarch and arm64, so `Op(1)` is unambiguous; asserts guard against future wrong-node tagging.

## Testing

- New JitBlue regression test (`GitHub_131472`) covering `Vector256<float>` (optional EVEX promotion) and `Vector512<float>` (mandatory mask), comparing FullOpts against a MinOpts reference over all 32 modes. Fails without the fix, passes with it.
- Constant-mode `Compare` codegen is provably unchanged (the new code only executes when `setMethodHandle` is set, which never happens for a constant mode); verified correct results.
- Checked and Release JIT build clean; `jitformat` clean.

> [!NOTE]
> This change was authored with the assistance of GitHub Copilot.
