### PR TITLE
Add safety documentation analyzers

### DIFF
--- a/src/tools/illink/src/ILLink.CodeFix/AddSafetyCommentCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/AddSafetyCommentCodeFixProvider.cs
@@ -1,0 +1,122 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ILLink.CodeFixProvider;
+using ILLink.RoslynAnalyzer;
+using ILLink.Shared;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace ILLink.CodeFix
+{
+    /// <summary>
+    /// Fixes analyzer diagnostic <c>IL5009</c> by inserting a <c>// SAFETY: TODO</c> stub above an undocumented
+    /// <c>unsafe</c> region.
+    /// </summary>
+    /// <remarks>
+    /// The stub only marks the region for review. It deliberately does not attempt to describe the reasoning,
+    /// which is what the developer has to supply.
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddSafetyCommentCodeFixProvider)), Shared]
+    public sealed class AddSafetyCommentCodeFixProvider : Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider
+    {
+        private const string SafetyComment = "// SAFETY: TODO";
+
+        private static LocalizableString CodeFixTitle =>
+            new LocalizableResourceString(
+                nameof(Resources.AddSafetyCommentCodeFixTitle),
+                Resources.ResourceManager,
+                typeof(Resources));
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            [DiagnosticId.UnsafeBlockMissingSafetyComment.AsString()];
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            Diagnostic diagnostic = context.Diagnostics[0];
+            if (await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false) is not { } root)
+                return;
+
+            SyntaxToken unsafeKeyword = root.FindToken(diagnostic.Location.SourceSpan.Start);
+            if (!unsafeKeyword.IsKind(SyntaxKind.UnsafeKeyword)
+                || GetCommentTarget(unsafeKeyword) is not { } target)
+            {
+                return;
+            }
+
+            string title = CodeFixTitle.ToString();
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title,
+                    cancellationToken => AddSafetyCommentAsync(context.Document, target, cancellationToken),
+                    title),
+                diagnostic);
+        }
+
+        private static async Task<Document> AddSafetyCommentAsync(
+            Document document,
+            SyntaxNode target,
+            CancellationToken cancellationToken)
+        {
+            var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+            // The comment goes on its own line directly above the target, keeping any existing leading trivia
+            // such as XML documentation or other comments in place.
+            SyntaxTriviaList leadingTrivia = target.GetLeadingTrivia();
+            int insertionIndex = GetInsertionIndex(leadingTrivia);
+            SyntaxTriviaList updated = leadingTrivia.InsertRange(
+                insertionIndex,
+                new[] { SyntaxFactory.Comment(SafetyComment), SyntaxFactory.ElasticCarriageReturnLineFeed });
+
+            editor.ReplaceNode(target, target.WithLeadingTrivia(updated));
+            return editor.GetChangedDocument();
+        }
+
+        /// <summary>
+        /// Inserts after any trivia that must stay attached to the line above, such as directives.
+        /// </summary>
+        private static int GetInsertionIndex(SyntaxTriviaList leadingTrivia)
+        {
+            int index = 0;
+            for (int i = 0; i < leadingTrivia.Count; i++)
+            {
+                if (leadingTrivia[i].IsDirective || leadingTrivia[i].IsKind(SyntaxKind.DisabledTextTrivia))
+                    index = i + 1;
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// Finds the node the comment should be attached to.
+        /// </summary>
+        /// <remarks>
+        /// An <c>unsafe</c> block is its own statement, but an <c>unsafe</c> expression sits inside a larger
+        /// statement, and a comment reads better above that statement than inline before the keyword.
+        /// </remarks>
+        private static SyntaxNode? GetCommentTarget(SyntaxToken unsafeKeyword)
+        {
+            if (unsafeKeyword.Parent is null)
+                return null;
+
+            if (unsafeKeyword.Parent.IsKind(SyntaxKind.UnsafeStatement))
+                return unsafeKeyword.Parent;
+
+            return unsafeKeyword.Parent.AncestorsAndSelf()
+                .FirstOrDefault(static ancestor => ancestor is StatementSyntax or MemberDeclarationSyntax);
+        }
+    }
+}
+#endif

--- a/src/tools/illink/src/ILLink.CodeFix/AddSafetyCommentCodeFixProvider.cs
+++ b/src/tools/illink/src/ILLink.CodeFix/AddSafetyCommentCodeFixProvider.cs
@@ -72,31 +72,29 @@ namespace ILLink.CodeFix
         {
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
-            // The comment goes on its own line directly above the target, keeping any existing leading trivia
-            // such as XML documentation or other comments in place.
+            // The comment goes on its own line immediately above the target, below any existing leading trivia,
+            // so that it stays adjacent to the code it describes and XML documentation keeps its place on top.
             SyntaxTriviaList leadingTrivia = target.GetLeadingTrivia();
-            int insertionIndex = GetInsertionIndex(leadingTrivia);
-            SyntaxTriviaList updated = leadingTrivia.InsertRange(
-                insertionIndex,
-                new[] { SyntaxFactory.Comment(SafetyComment), SyntaxFactory.ElasticCarriageReturnLineFeed });
+            SyntaxTriviaList indentation = GetIndentation(leadingTrivia);
+            SyntaxTriviaList updated = leadingTrivia
+                .Add(SyntaxFactory.Comment(SafetyComment))
+                .Add(SyntaxFactory.ElasticCarriageReturnLineFeed)
+                .AddRange(indentation);
 
             editor.ReplaceNode(target, target.WithLeadingTrivia(updated));
             return editor.GetChangedDocument();
         }
 
         /// <summary>
-        /// Inserts after any trivia that must stay attached to the line above, such as directives.
+        /// Returns the whitespace that indents the target, so the inserted comment and the target line up.
         /// </summary>
-        private static int GetInsertionIndex(SyntaxTriviaList leadingTrivia)
+        private static SyntaxTriviaList GetIndentation(SyntaxTriviaList leadingTrivia)
         {
-            int index = 0;
-            for (int i = 0; i < leadingTrivia.Count; i++)
-            {
-                if (leadingTrivia[i].IsDirective || leadingTrivia[i].IsKind(SyntaxKind.DisabledTextTrivia))
-                    index = i + 1;
-            }
+            int start = leadingTrivia.Count;
+            while (start > 0 && leadingTrivia[start - 1].IsKind(SyntaxKind.WhitespaceTrivia))
+                start--;
 
-            return index;
+            return SyntaxFactory.TriviaList(leadingTrivia.Skip(start));
         }
 
         /// <summary>

--- a/src/tools/illink/src/ILLink.CodeFix/Resources.resx
+++ b/src/tools/illink/src/ILLink.CodeFix/Resources.resx
@@ -144,6 +144,9 @@
   <data name="AddUnsafeToFieldCodeFixTitle" xml:space="preserve">
     <value>Mark field-like member 'unsafe'</value>
   </data>
+  <data name="AddSafetyCommentCodeFixTitle" xml:space="preserve">
+    <value>Add '// SAFETY:' comment</value>
+  </data>
   <data name="UconditionalSuppressMessageCodeFixTitle" xml:space="preserve">
     <value>Add UnconditionalSuppressMessage attribute to parent method</value>
   </data>

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/SafeModifierMissingJustificationAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/SafeModifierMissingJustificationAnalyzer.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Collections.Immutable;
+using ILLink.Shared;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace ILLink.RoslynAnalyzer
+{
+    /// <summary>
+    /// Reports <c>IL5010</c> for an explicit <c>safe</c> modifier that has no <c>&lt;safety&gt;</c> XML
+    /// documentation.
+    /// </summary>
+    /// <remarks>
+    /// This is the symmetric hole to <c>IL5005</c>. <c>safe</c> is a hand-written assertion the compiler cannot
+    /// verify: on an <c>extern</c> member or a <c>LibraryImport</c> it claims the native boundary upholds its
+    /// contract, and on a field in an explicit or extended layout it claims the overlap cannot be used to
+    /// type-pun. Both deserve a recorded audit. No code fix is offered because only a developer can write the
+    /// justification. The diagnostic is disabled by default while this migration tooling remains experimental.
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class SafeModifierMissingJustificationAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor s_rule =
+            DiagnosticDescriptors.GetDiagnosticDescriptor(
+                DiagnosticId.SafeModifierMissingJustification,
+                isEnabledByDefault: false);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            if (!System.Diagnostics.Debugger.IsAttached)
+                context.EnableConcurrentExecution();
+
+            context.RegisterSymbolAction(
+                AnalyzeSymbol,
+                SymbolKind.Method,
+                SymbolKind.Property,
+                SymbolKind.Field,
+                SymbolKind.Event);
+            context.RegisterOperationAction(AnalyzeLocalFunction, OperationKind.LocalFunction);
+        }
+
+        private static void AnalyzeSymbol(SymbolAnalysisContext context) =>
+            AnalyzeSymbol(context.Symbol, context.CancellationToken, context.ReportDiagnostic);
+
+        private static void AnalyzeLocalFunction(OperationAnalysisContext context) =>
+            AnalyzeSymbol(
+                ((ILocalFunctionOperation)context.Operation).Symbol,
+                context.CancellationToken,
+                context.ReportDiagnostic);
+
+        private static void AnalyzeSymbol(
+            ISymbol symbol,
+            System.Threading.CancellationToken cancellationToken,
+            System.Action<Diagnostic> reportDiagnostic)
+        {
+            // Accessors take their contract from the containing property or event, which is analyzed separately.
+            if (symbol is IMethodSymbol { AssociatedSymbol: not null })
+                return;
+
+            foreach (SyntaxNode declaration in UnsafeMigrationAnalyzerHelpers.GetDeclarations(symbol, cancellationToken))
+            {
+                if (!UnsafeMigrationSyntaxHelpers.HasSafeModifier(declaration)
+                    || UnsafeMigrationAnalyzerHelpers.HasSafetyDocumentation(declaration, symbol, cancellationToken))
+                {
+                    continue;
+                }
+
+                SyntaxToken safeModifier = UnsafeMigrationSyntaxHelpers.GetModifier(
+                    declaration,
+                    UnsafeMigrationSyntaxHelpers.SafeKeywordKind);
+                if (safeModifier == default)
+                    continue;
+
+                reportDiagnostic(Diagnostic.Create(s_rule, safeModifier.GetLocation()));
+            }
+        }
+    }
+}
+#endif

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeBlockMissingSafetyCommentAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeBlockMissingSafetyCommentAnalyzer.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using ILLink.Shared;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ILLink.RoslynAnalyzer
+{
+    /// <summary>
+    /// Reports <c>IL5009</c> for an <c>unsafe</c> region that has no <c>// SAFETY:</c> comment explaining how its
+    /// obligations are discharged.
+    /// </summary>
+    /// <remarks>
+    /// <c>IL5005</c> covers the signature side of the contract, where an <c>unsafe</c> member documents what it
+    /// asks of its callers. This covers the other side: an <c>unsafe</c> region is where those obligations are
+    /// actually discharged, and the reasoning is invisible unless it is written down. The convention follows
+    /// <see href="https://std-dev-guide.rust-lang.org/policy/safety-comments.html">Rust's safety comments</see>,
+    /// which the speclet recommends. The diagnostic is disabled by default while this migration tooling remains
+    /// experimental.
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UnsafeBlockMissingSafetyCommentAnalyzer : DiagnosticAnalyzer
+    {
+        internal const string SafetyCommentPrefix = "SAFETY";
+
+        private static readonly DiagnosticDescriptor s_rule =
+            DiagnosticDescriptors.GetDiagnosticDescriptor(
+                DiagnosticId.UnsafeBlockMissingSafetyComment,
+                isEnabledByDefault: false);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            if (!System.Diagnostics.Debugger.IsAttached)
+                context.EnableConcurrentExecution();
+
+            // 'unsafe' expressions are newer than the Roslyn this analyzer compiles against, so both forms are
+            // matched on the keyword token rather than on a node type.
+            context.RegisterSyntaxNodeAction(AnalyzeUnsafeStatement, SyntaxKind.UnsafeStatement);
+            context.RegisterSyntaxTreeAction(AnalyzeUnsafeExpressions);
+        }
+
+        private static void AnalyzeUnsafeStatement(SyntaxNodeAnalysisContext context)
+        {
+            SyntaxNode unsafeStatement = context.Node;
+
+            // A nested region inherits the reasoning of the one that already documents it.
+            if (IsNestedInUnsafeRegion(unsafeStatement)
+                || HasSafetyComment(unsafeStatement.GetFirstToken()))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(s_rule, unsafeStatement.GetFirstToken().GetLocation()));
+        }
+
+        private static void AnalyzeUnsafeExpressions(SyntaxTreeAnalysisContext context)
+        {
+            SyntaxNode root = context.Tree.GetRoot(context.CancellationToken);
+            foreach (SyntaxToken token in root.DescendantTokens())
+            {
+                if (!UnsafeMigrationSyntaxHelpers.IsUnsafeExpressionKeyword(token)
+                    || token.Parent is null
+                    || IsNestedInUnsafeRegion(token.Parent)
+                    || HasSafetyComment(token))
+                {
+                    continue;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(s_rule, token.GetLocation()));
+            }
+        }
+
+        /// <summary>
+        /// Determines whether a region sits inside another <c>unsafe</c> region, whose comment already covers it.
+        /// </summary>
+        private static bool IsNestedInUnsafeRegion(SyntaxNode region) =>
+            region.Ancestors().Any(static ancestor =>
+                ancestor.IsKind(SyntaxKind.UnsafeStatement)
+                || UnsafeMigrationSyntaxHelpers.IsUnsafeExpressionKeyword(ancestor.GetFirstToken()));
+
+        /// <summary>
+        /// Looks for a <c>// SAFETY:</c> comment attached to the region or to the statement that contains it.
+        /// </summary>
+        /// <remarks>
+        /// An <c>unsafe</c> expression sits inside a larger statement, so its comment is normally written above
+        /// that statement rather than immediately before the keyword.
+        /// </remarks>
+        private static bool HasSafetyComment(SyntaxToken unsafeKeyword)
+        {
+            if (ContainsSafetyComment(unsafeKeyword.LeadingTrivia))
+                return true;
+
+            for (SyntaxNode? node = unsafeKeyword.Parent; node is not null; node = node.Parent)
+            {
+                if (ContainsSafetyComment(node.GetLeadingTrivia()))
+                    return true;
+
+                // Stop at the statement or member that owns the region; trivia further out documents something else.
+                if (node is StatementSyntax or MemberDeclarationSyntax)
+                    break;
+            }
+
+            return false;
+        }
+
+        private static bool ContainsSafetyComment(SyntaxTriviaList trivia) =>
+            trivia.Any(static t =>
+                (t.IsKind(SyntaxKind.SingleLineCommentTrivia) || t.IsKind(SyntaxKind.MultiLineCommentTrivia))
+                && t.ToString().IndexOf(SafetyCommentPrefix, StringComparison.Ordinal) >= 0);
+    }
+}
+#endif

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeBlockMissingSafetyCommentAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeBlockMissingSafetyCommentAnalyzer.cs
@@ -95,7 +95,7 @@ namespace ILLink.RoslynAnalyzer
         private static bool IsNestedInUnsafeRegion(SyntaxNode region) =>
             region.Ancestors().Any(static ancestor =>
                 ancestor.IsKind(SyntaxKind.UnsafeStatement)
-                || UnsafeMigrationSyntaxHelpers.IsUnsafeExpressionKeyword(ancestor.GetFirstToken()));
+                || UnsafeMigrationSyntaxHelpers.IsUnsafeExpression(ancestor));
 
         /// <summary>
         /// Looks for a <c>// SAFETY:</c> comment attached to the region or to the statement that contains it.

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeBlockMissingSafetyCommentAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeBlockMissingSafetyCommentAnalyzer.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if DEBUG
-using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text.RegularExpressions;
 using ILLink.Shared;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -28,7 +28,15 @@ namespace ILLink.RoslynAnalyzer
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class UnsafeBlockMissingSafetyCommentAnalyzer : DiagnosticAnalyzer
     {
-        internal const string SafetyCommentPrefix = "SAFETY";
+        /// <summary>
+        /// Matches the <c>SAFETY:</c> marker anywhere inside a comment.
+        /// </summary>
+        /// <remarks>
+        /// The marker is matched as a whole word so that <c>// UNSAFETY:</c> or <c>// SAFETYNET</c> do not count,
+        /// and it is case-sensitive to keep the convention greppable across a code base. Matching anywhere in the
+        /// comment allows the marker to sit on an inner line of a block comment.
+        /// </remarks>
+        private static readonly Regex s_safetyComment = new(@"\bSAFETY\s*:", RegexOptions.CultureInvariant);
 
         private static readonly DiagnosticDescriptor s_rule =
             DiagnosticDescriptors.GetDiagnosticDescriptor(
@@ -117,7 +125,7 @@ namespace ILLink.RoslynAnalyzer
         private static bool ContainsSafetyComment(SyntaxTriviaList trivia) =>
             trivia.Any(static t =>
                 (t.IsKind(SyntaxKind.SingleLineCommentTrivia) || t.IsKind(SyntaxKind.MultiLineCommentTrivia))
-                && t.ToString().IndexOf(SafetyCommentPrefix, StringComparison.Ordinal) >= 0);
+                && s_safetyComment.IsMatch(t.ToString()));
     }
 }
 #endif

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeMigrationSyntaxHelpers.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeMigrationSyntaxHelpers.cs
@@ -61,6 +61,20 @@ namespace ILLink.RoslynAnalyzer
         /// </remarks>
         internal static bool IsUnsafeExpressionKeyword(SyntaxToken token) =>
             token.IsKind(SyntaxKind.UnsafeKeyword) && token.Parent is ExpressionSyntax;
+
+        /// <summary>
+        /// Determines whether a node is itself an <c>unsafe(...)</c> expression.
+        /// </summary>
+        /// <remarks>
+        /// Testing only the first token is not enough: a node's first token can belong to a descendant, so the
+        /// enclosing binary expression in <c>unsafe(a) + b</c> also starts with an <c>unsafe</c> keyword. The
+        /// token must therefore be owned by the node being tested.
+        /// </remarks>
+        internal static bool IsUnsafeExpression(SyntaxNode node)
+        {
+            SyntaxToken first = node.GetFirstToken();
+            return IsUnsafeExpressionKeyword(first) && ReferenceEquals(first.Parent, node);
+        }
     }
 }
 #endif

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeMigrationSyntaxHelpers.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeMigrationSyntaxHelpers.cs
@@ -17,6 +17,12 @@ namespace ILLink.RoslynAnalyzer
         // The analyzer builds against a Roslyn version that predates SyntaxKind.SafeKeyword.
         private static readonly SyntaxKind s_safeKeyword = SyntaxFacts.GetContextualKeywordKind("safe");
 
+        /// <summary>
+        /// The kind of the <c>safe</c> contextual keyword, or <see cref="SyntaxKind.None"/> when the hosting
+        /// compiler does not know it.
+        /// </summary>
+        internal static SyntaxKind SafeKeywordKind => s_safeKeyword;
+
         internal static SyntaxTokenList GetModifiers(SyntaxNode declaration) =>
             declaration switch
             {
@@ -42,6 +48,19 @@ namespace ILLink.RoslynAnalyzer
 
             return default;
         }
+
+        /// <summary>
+        /// Determines whether an <c>unsafe</c> keyword token introduces an <c>unsafe(...)</c> expression rather
+        /// than a modifier or a block.
+        /// </summary>
+        /// <remarks>
+        /// <c>UnsafeExpressionSyntax</c> is newer than the Roslyn these analyzers compile against, but it derives
+        /// from <see cref="ExpressionSyntax"/>, which is not, so the expression form is recognized by its parent's
+        /// base type. Matching on a following open parenthesis instead would misclassify the modifier on any
+        /// member whose type is a tuple, such as <c>static unsafe (int, int) M()</c>.
+        /// </remarks>
+        internal static bool IsUnsafeExpressionKeyword(SyntaxToken token) =>
+            token.IsKind(SyntaxKind.UnsafeKeyword) && token.Parent is ExpressionSyntax;
     }
 }
 #endif

--- a/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
@@ -223,6 +223,8 @@ namespace ILLink.Shared
         // Memory safety migration diagnostic ids.
         UnsafeMemberMissingSafetyDocumentation = 5005,
         PointerSignatureRequiresUnsafe = 5006,
+        UnsafeBlockMissingSafetyComment = 5009,
+        SafeModifierMissingJustification = 5010,
     }
 
     public static class DiagnosticIdExtensions
@@ -255,7 +257,7 @@ namespace ILLink.Shared
             {
                 > 2000 and < 3000 => DiagnosticCategory.Trimming,
                 >= 3000 and < 3050 => DiagnosticCategory.SingleFile,
-                5005 or 5006 => DiagnosticCategory.Safety,
+                >= 5000 and < 5100 => DiagnosticCategory.Safety,
                 >= 3050 and <= 6000 => DiagnosticCategory.AOT,
                 _ => throw new ArgumentException($"The provided diagnostic id '{diagnosticId}' does not fall into the range of supported warning codes 2001 to 6000 (inclusive).")
             };

--- a/src/tools/illink/src/ILLink.Shared/SharedStrings.resx
+++ b/src/tools/illink/src/ILLink.Shared/SharedStrings.resx
@@ -699,6 +699,18 @@
   <data name="PointerSignatureRequiresUnsafeMessage" xml:space="preserve">
     <value>A member with a pointer or function-pointer signature must be marked 'unsafe' or include a '&lt;safety&gt;' XML documentation comment explaining why it is safe.</value>
   </data>
+  <data name="UnsafeBlockMissingSafetyCommentTitle" xml:space="preserve">
+    <value>Unsafe regions should document why they are safe</value>
+  </data>
+  <data name="UnsafeBlockMissingSafetyCommentMessage" xml:space="preserve">
+    <value>An 'unsafe' region should be preceded by a '// SAFETY:' comment explaining how its obligations are discharged.</value>
+  </data>
+  <data name="SafeModifierMissingJustificationTitle" xml:space="preserve">
+    <value>Explicit 'safe' members should document why they are safe</value>
+  </data>
+  <data name="SafeModifierMissingJustificationMessage" xml:space="preserve">
+    <value>A member marked 'safe' asserts a contract the compiler cannot verify and must include a '&lt;safety&gt;' XML documentation comment explaining why it holds.</value>
+  </data>
   <data name="XmlPropertyDoesNotContainAttributeNameTitle" xml:space="preserve">
     <value>An attribute element has property but this could not be found.</value>
   </data>

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/AddSafetyCommentCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/AddSafetyCommentCodeFixTests.cs
@@ -87,6 +87,44 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public async Task AddsOneCommentForMultipleUnsafeExpressionsInOneStatement()
+        {
+            // Both diagnostics resolve to the same statement, so the fix converges on a single comment covering it.
+            string source = """
+                class C
+                {
+                    static unsafe int Foo() => 0;
+                    static unsafe int Baz() => 0;
+
+                    void M()
+                    {
+                        var x = {|IL5009:unsafe|}(Foo()) + {|IL5009:unsafe|}(Baz());
+                    }
+                }
+                """;
+
+            string fixedSource = """
+                class C
+                {
+                    static unsafe int Foo() => 0;
+                    static unsafe int Baz() => 0;
+
+                    void M()
+                    {
+                        // SAFETY: TODO
+                        var x = unsafe(Foo()) + unsafe(Baz());
+                    }
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<UnsafeBlockMissingSafetyCommentAnalyzer, AddSafetyCommentCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
         public async Task PlacesCommentBelowExistingLeadingComment()
         {
             // The safety comment belongs next to the region it describes, so it goes below an existing comment.

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/AddSafetyCommentCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/AddSafetyCommentCodeFixTests.cs
@@ -87,8 +87,9 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
-        public async Task PreservesExistingLeadingComment()
+        public async Task PlacesCommentBelowExistingLeadingComment()
         {
+            // The safety comment belongs next to the region it describes, so it goes below an existing comment.
             string source = """
                 class C
                 {
@@ -108,13 +109,45 @@ namespace ILLink.RoslynAnalyzer.Tests
                 {
                     unsafe void M(int* p)
                     {
-                        // SAFETY: TODO
                         // Read the first element.
+                        // SAFETY: TODO
                         unsafe
                         {
                             int x = *p;
                         }
                     }
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<UnsafeBlockMissingSafetyCommentAnalyzer, AddSafetyCommentCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PlacesCommentBelowXmlDocumentation()
+        {
+            // XML documentation keeps its place directly above the declaration it documents.
+            string source = """
+                class C
+                {
+                    static unsafe int Read() => 0;
+
+                    /// <summary>The initial value.</summary>
+                    static int Value = {|IL5009:unsafe|}(Read());
+                }
+                """;
+
+            string fixedSource = """
+                class C
+                {
+                    static unsafe int Read() => 0;
+
+                    /// <summary>The initial value.</summary>
+                    // SAFETY: TODO
+                    static int Value = unsafe(Read());
                 }
                 """;
 

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/AddSafetyCommentCodeFixTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/AddSafetyCommentCodeFixTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Threading.Tasks;
+using ILLink.CodeFix;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+    /// <summary>
+    /// Verifies the <c>IL5009</c> code fix, which inserts a <c>// SAFETY: TODO</c> stub above an undocumented
+    /// <c>unsafe</c> region.
+    /// </summary>
+    public class AddSafetyCommentCodeFixTests
+    {
+        [Fact]
+        public async Task AddsCommentAboveUnsafeBlock()
+        {
+            string source = """
+                class C
+                {
+                    unsafe void M(int* p)
+                    {
+                        {|IL5009:unsafe|}
+                        {
+                            int x = *p;
+                        }
+                    }
+                }
+                """;
+
+            string fixedSource = """
+                class C
+                {
+                    unsafe void M(int* p)
+                    {
+                        // SAFETY: TODO
+                        unsafe
+                        {
+                            int x = *p;
+                        }
+                    }
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<UnsafeBlockMissingSafetyCommentAnalyzer, AddSafetyCommentCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task AddsCommentAboveStatementContainingUnsafeExpression()
+        {
+            string source = """
+                class C
+                {
+                    static unsafe int Read() => 0;
+
+                    void M()
+                    {
+                        int x = {|IL5009:unsafe|}(Read());
+                    }
+                }
+                """;
+
+            string fixedSource = """
+                class C
+                {
+                    static unsafe int Read() => 0;
+
+                    void M()
+                    {
+                        // SAFETY: TODO
+                        int x = unsafe(Read());
+                    }
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<UnsafeBlockMissingSafetyCommentAnalyzer, AddSafetyCommentCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task PreservesExistingLeadingComment()
+        {
+            string source = """
+                class C
+                {
+                    unsafe void M(int* p)
+                    {
+                        // Read the first element.
+                        {|IL5009:unsafe|}
+                        {
+                            int x = *p;
+                        }
+                    }
+                }
+                """;
+
+            string fixedSource = """
+                class C
+                {
+                    unsafe void M(int* p)
+                    {
+                        // SAFETY: TODO
+                        // Read the first element.
+                        unsafe
+                        {
+                            int x = *p;
+                        }
+                    }
+                }
+                """;
+
+            var test = UnsafeMigrationTestHelpers
+                .CreateCodeFixTest<UnsafeBlockMissingSafetyCommentAnalyzer, AddSafetyCommentCodeFixProvider>(
+                    source,
+                    fixedSource);
+            await test.RunAsync();
+        }
+    }
+}
+#endif

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/SafeModifierMissingJustificationAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/SafeModifierMissingJustificationAnalyzerTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+    /// <summary>
+    /// Verifies that <c>IL5010</c> reports an explicit <c>safe</c> modifier that records no justification.
+    /// </summary>
+    public class SafeModifierMissingJustificationAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsUndocumentedSafeExternMethod()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+
+                class C
+                {
+                    [DllImport("nativelib")]
+                    public static {|IL5010:safe|} extern int M(int x);
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<SafeModifierMissingJustificationAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportDocumentedSafeExternMethod()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+
+                class C
+                {
+                    /// <safety>The native entry point only reads the value it is given.</safety>
+                    [DllImport("nativelib")]
+                    public static safe extern int M(int x);
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<SafeModifierMissingJustificationAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task ReportsUndocumentedSafeFieldInExplicitLayout()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+
+                [StructLayout(LayoutKind.Explicit)]
+                struct S
+                {
+                    [FieldOffset(0)]
+                    public {|IL5010:safe|} int Value;
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<SafeModifierMissingJustificationAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportDocumentedSafeFieldInExplicitLayout()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+
+                [StructLayout(LayoutKind.Explicit)]
+                struct S
+                {
+                    /// <safety>Both overlapping fields are unmanaged and the same size.</safety>
+                    [FieldOffset(0)]
+                    public safe int Value;
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<SafeModifierMissingJustificationAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportMembersWithoutSafeModifier()
+        {
+            string source = """
+                using System.Runtime.InteropServices;
+
+                class C
+                {
+                    [DllImport("nativelib")]
+                    public static unsafe extern int M(int x);
+
+                    public void Other() { }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<SafeModifierMissingJustificationAnalyzer>(source)
+                .RunAsync();
+        }
+    }
+}
+#endif

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnsafeBlockMissingSafetyCommentAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnsafeBlockMissingSafetyCommentAnalyzerTests.cs
@@ -249,6 +249,74 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public async Task ReportsUnsafeExpressionInsideComplexExpression()
+        {
+            string source = """
+                class C
+                {
+                    static int Foo() => 0;
+                    static unsafe int Baz() => 0;
+                    static int z = 0;
+
+                    void M()
+                    {
+                        var x = Foo() + Foo() * {|IL5009:unsafe|}(Baz()) + z;
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task ReportsEveryUnsafeExpressionInOneStatement()
+        {
+            // A leading unsafe expression must not suppress its siblings: the enclosing binary expression starts
+            // with the same keyword token, which is not the same thing as containing an unsafe region.
+            string source = """
+                class C
+                {
+                    static unsafe int Foo() => 0;
+                    static int Bar() => 0;
+                    static unsafe int Baz() => 0;
+                    static int z = 0;
+
+                    void M()
+                    {
+                        var x = {|IL5009:unsafe|}(Foo()) + Bar() * {|IL5009:unsafe|}(Baz()) + z;
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportUnsafeExpressionNestedInUnsafeExpression()
+        {
+            string source = """
+                class C
+                {
+                    static unsafe int Foo() => 0;
+                    static unsafe int Baz() => 0;
+
+                    void M()
+                    {
+                        var x = {|IL5009:unsafe|}(Foo() + unsafe(Baz()));
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
         public async Task DoesNotReportUnsafeModifier()
         {
             // The modifier is a contract, not a region. IL5005 covers its documentation.

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnsafeBlockMissingSafetyCommentAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnsafeBlockMissingSafetyCommentAnalyzerTests.cs
@@ -37,6 +37,8 @@ namespace ILLink.RoslynAnalyzer.Tests
         [Theory]
         [InlineData("// SAFETY: p is validated by the caller")]
         [InlineData("// SAFETY:")]
+        [InlineData("//SAFETY: no space after the comment marker")]
+        [InlineData("// Reads one element. SAFETY: p is validated by the caller")]
         [InlineData("/* SAFETY: p is validated by the caller */")]
         public async Task DoesNotReportDocumentedUnsafeBlock(string comment)
         {
@@ -46,6 +48,60 @@ namespace ILLink.RoslynAnalyzer.Tests
                     unsafe void M(int* p)
                     {
                         {{comment}}
+                        unsafe
+                        {
+                            int x = *p;
+                        }
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Theory]
+        // The marker is matched as a whole word, so these are not safety comments.
+        [InlineData("// UNSAFETY: this is a different word")]
+        [InlineData("// SAFETYNET: this is a different word")]
+        // It is case-sensitive so the convention stays greppable.
+        [InlineData("// safety: lowercase does not count")]
+        [InlineData("// Safety: mixed case does not count")]
+        // The marker has to be followed by a colon.
+        [InlineData("// SAFETY concerns are handled elsewhere")]
+        public async Task ReportsUnsafeBlockWithoutTheSafetyMarker(string comment)
+        {
+            string source = $$"""
+                class C
+                {
+                    unsafe void M(int* p)
+                    {
+                        {{comment}}
+                        {|IL5009:unsafe|}
+                        {
+                            int x = *p;
+                        }
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportMarkerOnInnerLineOfBlockComment()
+        {
+            string source = """
+                class C
+                {
+                    unsafe void M(int* p)
+                    {
+                        /*
+                         * SAFETY: p is validated by the caller
+                         */
                         unsafe
                         {
                             int x = *p;

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnsafeBlockMissingSafetyCommentAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnsafeBlockMissingSafetyCommentAnalyzerTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+    /// <summary>
+    /// Verifies that <c>IL5009</c> reports undocumented <c>unsafe</c> regions and respects an existing
+    /// <c>// SAFETY:</c> comment.
+    /// </summary>
+    public class UnsafeBlockMissingSafetyCommentAnalyzerTests
+    {
+        [Fact]
+        public async Task ReportsUndocumentedUnsafeBlock()
+        {
+            string source = """
+                class C
+                {
+                    unsafe void M(int* p)
+                    {
+                        {|IL5009:unsafe|}
+                        {
+                            int x = *p;
+                        }
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Theory]
+        [InlineData("// SAFETY: p is validated by the caller")]
+        [InlineData("// SAFETY:")]
+        [InlineData("/* SAFETY: p is validated by the caller */")]
+        public async Task DoesNotReportDocumentedUnsafeBlock(string comment)
+        {
+            string source = $$"""
+                class C
+                {
+                    unsafe void M(int* p)
+                    {
+                        {{comment}}
+                        unsafe
+                        {
+                            int x = *p;
+                        }
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportNestedUnsafeBlock()
+        {
+            // The nested region is covered by the reasoning recorded for the one that contains it.
+            string source = """
+                class C
+                {
+                    unsafe void M(int* p)
+                    {
+                        // SAFETY: p is validated by the caller
+                        unsafe
+                        {
+                            unsafe
+                            {
+                                int x = *p;
+                            }
+                        }
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task ReportsUndocumentedUnsafeExpression()
+        {
+            string source = """
+                class C
+                {
+                    static unsafe int Read() => 0;
+
+                    void M()
+                    {
+                        int x = {|IL5009:unsafe|}(Read());
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportDocumentedUnsafeExpression()
+        {
+            // An unsafe expression sits inside a larger statement, so its comment is written above that statement.
+            string source = """
+                class C
+                {
+                    static unsafe int Read() => 0;
+
+                    void M()
+                    {
+                        // SAFETY: Read only touches memory it owns
+                        int x = unsafe(Read());
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task ReportsUndocumentedUnsafeExpressionInFieldInitializer()
+        {
+            // A field initializer cannot contain an unsafe block, so the expression form is the only option.
+            string source = """
+                class C
+                {
+                    static unsafe int Read() => 0;
+
+                    static int Value = {|IL5009:unsafe|}(Read());
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportUnsafeModifierOnTupleReturningMember()
+        {
+            // The 'unsafe' modifier is followed by '(' here, but it introduces no region. This shape is common,
+            // for example across the hardware intrinsics APIs.
+            string source = """
+                class C
+                {
+                    public static unsafe (int, int) GetPair() => default;
+
+                    unsafe (int, int) Prop { get; set; }
+
+                    unsafe (int, int) Field;
+
+                    unsafe (int, int) this[int i] => default;
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportUnsafeExpressionNestedInDocumentedBlock()
+        {
+            string source = """
+                class C
+                {
+                    static unsafe int Read() => 0;
+
+                    void M()
+                    {
+                        // SAFETY: Read only touches memory it owns
+                        unsafe
+                        {
+                            int y = unsafe(Read());
+                        }
+                    }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportUnsafeModifier()
+        {
+            // The modifier is a contract, not a region. IL5005 covers its documentation.
+            string source = """
+                class C
+                {
+                    unsafe void M() { }
+                }
+                """;
+
+            await UnsafeMigrationTestHelpers
+                .CreateAnalyzerTest<UnsafeBlockMissingSafetyCommentAnalyzer>(source)
+                .RunAsync();
+        }
+    }
+}
+#endif

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnsafeMigrationTestHelpers.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/UnsafeMigrationTestHelpers.cs
@@ -70,7 +70,9 @@ namespace ILLink.RoslynAnalyzer.Tests
             var diagnosticOptions = compilationOptions.SpecificDiagnosticOptions
                 .SetItems(CSharpVerifierHelper.NullableWarnings)
                 .SetItem(DiagnosticId.UnsafeMemberMissingSafetyDocumentation.AsString(), ReportDiagnostic.Warn)
-                .SetItem(DiagnosticId.PointerSignatureRequiresUnsafe.AsString(), ReportDiagnostic.Warn);
+                .SetItem(DiagnosticId.PointerSignatureRequiresUnsafe.AsString(), ReportDiagnostic.Warn)
+                .SetItem(DiagnosticId.UnsafeBlockMissingSafetyComment.AsString(), ReportDiagnostic.Warn)
+                .SetItem(DiagnosticId.SafeModifierMissingJustification.AsString(), ReportDiagnostic.Warn);
             compilationOptions = compilationOptions
                 .WithAllowUnsafe(true)
                 .WithWarningLevel(999)


### PR DESCRIPTION
This PR prototypes the **safety documentation** part of the unsafe-v2 migration tooling ([tracking issue](https://github.com/dotnet/runtime/issues/131451) §5), continuing #131002, #131245 and #131454. Everything here is non-shipping (`#if DEBUG`) and disabled by default.

### Background

Passing an obligation to a caller comes with a responsibility to say what that obligation is, and discharging one comes with a responsibility to say how. `IL5005` from #131002 covers the first half: an `unsafe` member must carry a `<safety>` XML comment. Two gaps remain.

The first is the other side of the same contract. An `unsafe` region is *where* the obligations are actually met, and that reasoning is invisible unless it is written down. The speclet recommends Rust-style [`// SAFETY` comments](https://std-dev-guide.rust-lang.org/policy/safety-comments.html) and [LDM 2026-05-27](https://github.com/dotnet/csharplang/blob/main/meetings/2026/LDM-2026-05-27.md#safety-comments) left "compiler or analyzer?" open, so an analyzer is the natural home.

The second is `safe` itself. It is a hand-written assertion the compiler cannot verify, and it is arguably the annotation that most needs a recorded audit, yet nothing checks it.

### Changes in this PR

1. 🔍 **`UnsafeBlockMissingSafetyCommentAnalyzer` (`IL5009`)** reports an `unsafe` block or `unsafe(...)` expression with no `// SAFETY:` comment. A region nested inside an already-documented one is not reported, since the outer comment covers it.

2. 🔧 **`AddSafetyCommentCodeFixProvider`** fixes `IL5009` by inserting a `// SAFETY: TODO` stub, matching the `/* SAFETY: Audit */` convention #131002 already uses. The stub only marks the region for review; describing the reasoning is the developer's job.

3. 🔍 **`SafeModifierMissingJustificationAnalyzer` (`IL5010`)** reports an explicit `safe` modifier with no `<safety>` documentation, wherever `safe` can appear: `extern` members and `[LibraryImport]` methods, where it claims the native boundary upholds its contract, and fields in explicit or extended layouts, where it claims the overlap cannot be used to type-pun. No code fix, since only a developer can write the justification.

### The `SAFETY:` marker

Recognized by `\bSAFETY\s*:`, case-sensitive, matched anywhere inside a comment.

Accepted: `// SAFETY:`, `//SAFETY:`, `// Reads one element. SAFETY: ...`, `/* SAFETY: ... */`, and a marker on an inner line of a block comment. Rejected: `// UNSAFETY:` and `// SAFETYNET:` (whole word), `// SAFETY concerns are handled elsewhere` (no colon), and `// safety:` or `// Safety:`.

Case sensitivity is deliberate: it keeps `git grep 'SAFETY:'` authoritative as an audit tool, at the cost of a mildly confusing report for someone who writes `// Safety:`. Both that and the leniency about spacing before the colon are pinned by tests, so they are easy to revisit.

### Notable case handled

`unsafe(...)` expressions are newer than the Roslyn these analyzers compile against, so `UnsafeExpressionSyntax` and `SyntaxKind.UnsafeExpression` are unavailable at build time even though they exist at run time. Detecting the expression form as "an `unsafe` keyword followed by `(`" is wrong: the *modifier* is also followed by `(` on any member whose type is a tuple.

```cs
public static unsafe (int, int) GetPair() => default;   // modifier, not a region
int x = unsafe(Read());                                 // the actual expression
```

That shape is pervasive in the hardware intrinsics (`AdvSimd.cs` alone has around 15), and every one of them would have been reported as an undocumented unsafe region, with the fixer offering to stamp a `// SAFETY: TODO` on it. The analyzer instead tests `token.Parent is ExpressionSyntax`, which is version-safe because `ExpressionSyntax` predates the feature.

### Diagnostics IDs

Just for reference

- `IL5005` [**#131002**] - An unsafe member has no `<safety>` XML documentation.
- `IL5009` [**This PR**] - An `unsafe` region has no `// SAFETY:` comment.
- `IL5010` [**This PR**] - An explicit `safe` modifier has no justification.

### Known limitations / follow ups

- `IL5009` treats any `// SAFETY:` comment as sufficient. It cannot judge whether the reasoning is correct, or whether it still applies after the region is edited.
- The nesting exemption is deliberately coarse: a documented outer region silences every region inside it, even a much later one that may warrant its own note.
- This branch adds `UnsafeMigrationSyntaxHelpers.SafeKeywordKind`, which #131454 also adds. Whichever merges second will need a trivial conflict resolution.

### Testing

`ILLink.RoslynAnalyzer.Tests`: 1238 passed. New coverage for both region forms, the accepted and rejected marker spellings, nesting in both directions, `unsafe` expressions in field initializers where a block is not valid syntax, the tuple-returning modifier shapes above, and `safe` on both `extern` members and explicit-layout fields.

> [!NOTE]
> This description and the changes in this PR were generated with GitHub Copilot.
