### PR TITLE
[arm64] Use the scalar shift when scaling Vector64 shuffle indices

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -29041,8 +29041,12 @@ GenTree* Compiler::gtNewSimdShuffleVariableNode(
         }
 
         // shift all indices to the left by tzcnt(size)
+        // a 64-bit element in a Vector64 is a 1D arrangement, which the vector form of the shift
+        // has no encoding for; that case has to use the scalar form instead.
+        NamedIntrinsic shiftIntrinsic =
+            ((simdSize == 8) && (elementSize == 8)) ? NI_AdvSimd_ShiftLeftLogicalScalar : NI_AdvSimd_ShiftLeftLogical;
         cnsNode = gtNewIconNode(BitOperations::TrailingZeroCount(static_cast<uint64_t>(elementSize)), TYP_INT);
-        op2     = gtNewSimdHWIntrinsicNode(type, op2, cnsNode, NI_AdvSimd_ShiftLeftLogical, simdBaseType, simdSize);
+        op2     = gtNewSimdHWIntrinsicNode(type, op2, cnsNode, shiftIntrinsic, simdBaseType, simdSize);
 
         // VectorTableLookup is only valid on byte/sbyte
         simdBaseType = varTypeIsUnsigned(simdBaseType) ? TYP_UBYTE : TYP_BYTE;

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
@@ -2436,6 +2436,102 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
             }
         }
 
+        // nint/nuint are the only Vector64 shuffle overloads with a 64-bit element type, and only on
+        // a 64-bit platform. The indices are passed through a non-inlined call so they stay variable,
+        // which is what selects the index fix-up path in the JIT.
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Vector64<nint> ShuffleNativeNoInline(Vector64<nint> vector, Vector64<nint> indices) => Vector64.ShuffleNative(vector, indices);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Vector64<nuint> ShuffleNativeNoInline(Vector64<nuint> vector, Vector64<nuint> indices) => Vector64.ShuffleNative(vector, indices);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Vector64<nint> ShuffleNoInline(Vector64<nint> vector, Vector64<nint> indices) => Vector64.Shuffle(vector, indices);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Vector64<nuint> ShuffleNoInline(Vector64<nuint> vector, Vector64<nuint> indices) => Vector64.Shuffle(vector, indices);
+
+        [Fact]
+        public void Vector64NIntShuffleWithVariableIndicesTest()
+        {
+            Vector64<nint> vector = Vector64<nint>.Zero;
+            Vector64<nint> indices = Vector64<nint>.Zero;
+
+            for (int index = 0; index < Vector64<nint>.Count; index++)
+            {
+                vector = vector.WithElement(index, (nint)(index + 1));
+                indices = indices.WithElement(index, (nint)(Vector64<nint>.Count - index - 1));
+            }
+
+            Vector64<nint> result = ShuffleNoInline(vector, indices);
+
+            for (int index = 0; index < Vector64<nint>.Count; index++)
+            {
+                Assert.Equal((nint)(Vector64<nint>.Count - index), result.GetElement(index));
+            }
+        }
+
+        [Fact]
+        public void Vector64NUIntShuffleWithVariableIndicesTest()
+        {
+            Vector64<nuint> vector = Vector64<nuint>.Zero;
+            Vector64<nuint> indices = Vector64<nuint>.Zero;
+
+            for (int index = 0; index < Vector64<nuint>.Count; index++)
+            {
+                vector = vector.WithElement(index, (nuint)(index + 1));
+                indices = indices.WithElement(index, (nuint)(Vector64<nuint>.Count - index - 1));
+            }
+
+            Vector64<nuint> result = ShuffleNoInline(vector, indices);
+
+            for (int index = 0; index < Vector64<nuint>.Count; index++)
+            {
+                Assert.Equal((nuint)(Vector64<nuint>.Count - index), result.GetElement(index));
+            }
+        }
+
+        [Fact]
+        public void Vector64NIntShuffleNativeWithVariableIndicesTest()
+        {
+            Vector64<nint> vector = Vector64<nint>.Zero;
+            Vector64<nint> indices = Vector64<nint>.Zero;
+
+            for (int index = 0; index < Vector64<nint>.Count; index++)
+            {
+                vector = vector.WithElement(index, (nint)(index + 1));
+                indices = indices.WithElement(index, (nint)(Vector64<nint>.Count - index - 1));
+            }
+
+            Vector64<nint> result = ShuffleNativeNoInline(vector, indices);
+
+            for (int index = 0; index < Vector64<nint>.Count; index++)
+            {
+                Assert.Equal((nint)(Vector64<nint>.Count - index), result.GetElement(index));
+            }
+        }
+
+        [Fact]
+        public void Vector64NUIntShuffleNativeWithVariableIndicesTest()
+        {
+            Vector64<nuint> vector = Vector64<nuint>.Zero;
+            Vector64<nuint> indices = Vector64<nuint>.Zero;
+
+            for (int index = 0; index < Vector64<nuint>.Count; index++)
+            {
+                vector = vector.WithElement(index, (nuint)(index + 1));
+                indices = indices.WithElement(index, (nuint)(Vector64<nuint>.Count - index - 1));
+            }
+
+            Vector64<nuint> result = ShuffleNativeNoInline(vector, indices);
+
+            for (int index = 0; index < Vector64<nuint>.Count; index++)
+            {
+                Assert.Equal((nuint)(Vector64<nuint>.Count - index), result.GetElement(index));
+            }
+        }
+
         [Fact]
         public void Vector64SByteShuffleNativeOneInputTest()
         {

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
@@ -2436,9 +2436,10 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
             }
         }
 
-        // nint/nuint are the only Vector64 shuffle overloads with a 64-bit element type, and only on
-        // a 64-bit platform. The indices are passed through a non-inlined call so they stay variable,
-        // which is what selects the index fix-up path in the JIT.
+        // nint/nuint are the only Vector64 shuffle overloads with a pointer-sized element, so on a
+        // 64-bit platform they are the only way to reach a 64-bit element type (a 1D arrangement).
+        // The indices are passed through a non-inlined call so they stay variable, which is what
+        // selects the index fix-up path in the JIT.
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Vector64<nint> ShuffleNativeNoInline(Vector64<nint> vector, Vector64<nint> indices) => Vector64.ShuffleNative(vector, indices);


### PR DESCRIPTION
Fixes #131487

`gtNewSimdShuffleVariableNode` scales variable shuffle indices into byte offsets with `AdvSimd.ShiftLeftLogical`. For a `Vector64` with a 64-bit element type that is a `1D` arrangement, which the vector form of the arm64 shift-by-immediate has no encoding for, so a checked JIT trips `assert(opt != INS_OPTS_1D)` in `emitarm64.cpp`.

`gtNewSimdBinOpNode` already selects the scalar form for exactly this case; the shuffle path builds the HWINTRINSIC node directly and so never got the guard. This applies the same condition.

```diff
-        cnsNode = gtNewIconNode(BitOperations::TrailingZeroCount(static_cast<uint64_t>(elementSize)), TYP_INT);
-        op2     = gtNewSimdHWIntrinsicNode(type, op2, cnsNode, NI_AdvSimd_ShiftLeftLogical, simdBaseType, simdSize);
+        NamedIntrinsic shiftIntrinsic =
+            ((simdSize == 8) && (elementSize == 8)) ? NI_AdvSimd_ShiftLeftLogicalScalar : NI_AdvSimd_ShiftLeftLogical;
+        cnsNode = gtNewIconNode(BitOperations::TrailingZeroCount(static_cast<uint64_t>(elementSize)), TYP_INT);
+        op2     = gtNewSimdHWIntrinsicNode(type, op2, cnsNode, shiftIntrinsic, simdBaseType, simdSize);
```

## Impact

ILC instantiates `ShuffleNative<nuint>` when compiling CoreLib whole-program, so this fails **any** NativeAOT build using a checked arm64 JIT (`ilc … exited with code 133`), which blocks `src/tests/build.sh nativeaot checked` on an arm64 host. It escapes CI because `windows-x64 Checked NativeAOT` is the only checked NativeAOT leg and the arm64 NativeAOT legs are Release, where the assert is compiled out.

## Tests

Four tests added to `Vector64Tests.cs` covering `nint`/`nuint` × `Shuffle`/`ShuffleNative`. Two details drove their shape:

- `nint`/`nuint` are the only `Vector64` shuffle overloads with a 64-bit element type — there are no `long`/`ulong`/`double` ones — and only on a 64-bit platform. The tests are written pointer-size agnostic.
- Only the **variable** indices path emits the shift, so the indices are routed through a `[MethodImpl(NoInlining)]` wrapper. The existing constant/local-indices style folds and would not cover this.

Verified on osx-arm64, checked runtime:

| | result |
|---|---|
| new tests without the fix | SIGABRT — `Assertion failed 'opt != INS_OPTS_1D'` |
| new tests with the fix | 4/4 pass |
| full `System.Runtime.Intrinsics.Tests` | 13008 total, 0 failed |
| ILC compiling CoreLib | previously exit 133; now completes |

> [!NOTE]
> This change was prepared with GitHub Copilot assistance and reviewed by the submitting developer.
