### PR TITLE
Remove dead C++ wrappers left over from corehost C conversion

### DIFF
--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -496,8 +496,6 @@ namespace pal
         return ret;
     }
 
-    string_t get_timestamp();
-
     bool getcwd(string_t* recv);
 
     string_t get_current_os_rid_platform();
@@ -515,7 +513,6 @@ namespace pal
     // Fullpath resolves a fully-qualified path to the target. It may resolve through symlinks, depending on platform.
     bool fullpath(string_t* path, bool skip_error_logging = false);
     bool file_exists(const string_t& path);
-    bool is_directory(const pal::string_t& path);
     inline bool directory_exists(const string_t& path) { return file_exists(path); }
     void readdir(const string_t& path, const string_t& pattern, std::vector<string_t>* list);
     void readdir(const string_t& path, std::vector<string_t>* list);

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -49,16 +49,6 @@
 #error "Don't know how to obtain max path on this platform"
 #endif
 
-pal::string_t pal::get_timestamp()
-{
-    std::time_t t = std::time(nullptr);
-    const std::size_t elems = 100;
-    char_t buf[elems];
-    std::strftime(buf, elems, _X("%c %Z"), std::gmtime(&t));
-
-    return pal::string_t(buf);
-}
-
 bool pal::touch_file(const pal::string_t& path)
 {
     int fd = open(path.c_str(), (O_CREAT | O_EXCL), (S_IRUSR | S_IRGRP | S_IROTH));
@@ -954,11 +944,6 @@ bool pal::realpath(pal::string_t* path, bool skip_error_logging)
 bool pal::file_exists(const pal::string_t& path)
 {
     return ::pal_file_exists(path.c_str());
-}
-
-bool pal::is_directory(const pal::string_t& path)
-{
-    return ::pal_directory_exists(path.c_str());
 }
 
 static void readdir(const pal::string_t& path, const pal::string_t& pattern, bool onlydirectories, std::vector<pal::string_t>* list)

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -71,19 +71,6 @@ namespace
     }
 }
 
-pal::string_t pal::get_timestamp()
-{
-    std::time_t t = std::time(nullptr);
-    const std::size_t elems = 100;
-    char_t buf[elems];
-
-    tm tm_l{};
-    ::gmtime_s(&tm_l, &t);
-    std::wcsftime(buf, elems, _X("%c GMT"), &tm_l);
-
-    return pal::string_t(buf);
-}
-
 bool pal::touch_file(const pal::string_t& path)
 {
     HANDLE hnd = ::CreateFileW(path.c_str(), 0, 0, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -855,11 +842,6 @@ bool pal::fullpath(string_t* path, bool skip_error_logging)
 bool pal::file_exists(const string_t& path)
 {
     return ::pal_file_exists(path.c_str());
-}
-
-bool pal::is_directory(const pal::string_t& path)
-{
-    return ::pal_directory_exists(path.c_str());
 }
 
 static void readdir(const pal::string_t& path, const pal::string_t& pattern, bool onlydirectories, std::vector<pal::string_t>* list)

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -331,27 +331,6 @@ bool try_stou(const pal::string_t& str, unsigned* num)
     return true;
 }
 
-pal::string_t get_dotnet_root_env_var_for_arch(pal::architecture arch)
-{
-    return DOTNET_ROOT_ENV_VAR _X("_") + to_upper(get_arch_name(arch));
-}
-
-bool get_dotnet_root_from_env(pal::string_t* dotnet_root_env_var_name, pal::string_t* recv)
-{
-    const pal_char_t* env_var_name = nullptr;
-    pal_char_t* dotnet_root = nullptr;
-    if (!utils_get_dotnet_root_from_env(&env_var_name, &dotnet_root))
-    {
-        recv->clear();
-        return false;
-    }
-
-    dotnet_root_env_var_name->assign(env_var_name);
-    recv->assign(dotnet_root);
-    free(dotnet_root);
-    return true;
-}
-
 /**
 * Given path to app binary, say app.dll or app.exe, retrieve the app.deps.json.
 */
@@ -439,13 +418,6 @@ pal::string_t to_lower(const pal::char_t* in) {
     pal::string_t ret = in;
     std::transform(ret.begin(), ret.end(), ret.begin(),
         [](pal::char_t c) { return static_cast<pal::char_t>(::tolower(c)); });
-    return ret;
-}
-
-pal::string_t to_upper(const pal::char_t* in) {
-    pal::string_t ret = in;
-    std::transform(ret.begin(), ret.end(), ret.begin(),
-        [](pal::char_t c) { return static_cast<pal::char_t>(::toupper(c)); });
     return ret;
 }
 

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -4,6 +4,8 @@
 #include "utils.h"
 #include "trace.h"
 #include "bundle/info.h"
+#include <minipal/strings.h>
+
 #if defined(TARGET_WINDOWS)
 #include <_version.h>
 #else
@@ -417,7 +419,7 @@ pal::string_t get_host_version_description()
 pal::string_t to_lower(const pal::char_t* in) {
     pal::string_t ret = in;
     std::transform(ret.begin(), ret.end(), ret.begin(),
-        [](pal::char_t c) { return static_cast<pal::char_t>(::tolower(c)); });
+        [](pal::char_t c) { return static_cast<pal::char_t>(minipal_tolower_invariant(static_cast<CHAR16_T>(c))); });
     return ret;
 }
 

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -115,9 +115,6 @@ bool get_file_path_from_env(const pal::char_t* env_key, pal::string_t* recv);
 size_t index_of_non_numeric(const pal::string_t& str, size_t i);
 bool try_stou(const pal::string_t& str, unsigned* num);
 
-pal::string_t get_dotnet_root_env_var_for_arch(pal::architecture arch);
-bool get_dotnet_root_from_env(pal::string_t* used_dotnet_root_env_var_name, pal::string_t* recv);
-
 pal::string_t get_deps_from_app_binary(const pal::string_t& app_base, const pal::string_t& app);
 pal::string_t get_runtime_config_path(const pal::string_t& path, const pal::string_t& name);
 pal::string_t get_runtime_config_dev_path(const pal::string_t& path, const pal::string_t& name);
@@ -131,7 +128,6 @@ pal::string_t get_download_url(const pal::char_t* framework_name = nullptr, cons
 pal::string_t get_host_version_description();
 
 pal::string_t to_lower(const pal::char_t* in);
-pal::string_t to_upper(const pal::char_t* in);
 
 // Retrieves environment variable which is only used for testing.
 // This will return the value of the variable only if the product binary is stamped


### PR DESCRIPTION
Following the apphost/nethost conversions to C, a handful of thin C++ wrappers in `hostmisc` (`utils` and `pal`) are no longer referenced by anything. This removes that dead code. 

> [!NOTE]
> This PR description was generated with assistance from GitHub Copilot.