### PR TITLE
Fix deadlock between EventListenersLock and ArrayPoolEventSource static ctor

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3893,6 +3893,12 @@ namespace System.Diagnostics.Tracing
             // the FrameworkEventSource is being used, creating it on-demand will acquire the EventListener lock which can deadlock.
             // See https://github.com/dotnet/runtime/issues/126591. We avoid that by pre-creating the FrameworkEventSource here.
             _ = FrameworkEventSource.Log;
+            // MetricsEventSource.ParseSpecs uses string interpolation which calls SharedArrayPool<char>.Rent(), which accesses
+            // ArrayPoolEventSource.Log and triggers its static constructor. This is called while holding the EventListenerLock
+            // (inside DoCommand), so if another thread is concurrently running the ArrayPoolEventSource static constructor
+            // (which also acquires the EventListenerLock), a deadlock occurs.
+            // See https://github.com/dotnet/runtime/issues/119014. We avoid that by pre-creating ArrayPoolEventSource here.
+            _ = System.Buffers.ArrayPoolEventSource.Log;
 #if !TARGET_BROWSER
             _ = RuntimeEventSource.Log;
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3894,9 +3894,9 @@ namespace System.Diagnostics.Tracing
             // See https://github.com/dotnet/runtime/issues/126591. We avoid that by pre-creating the FrameworkEventSource here.
             _ = FrameworkEventSource.Log;
             // MetricsEventSource.ParseSpecs uses string interpolation which calls SharedArrayPool<char>.Rent(), which accesses
-            // ArrayPoolEventSource.Log and triggers its static constructor. This is called while holding the EventListenerLock
-            // (inside DoCommand), so if another thread is concurrently running the ArrayPoolEventSource static constructor
-            // (which also acquires the EventListenerLock), a deadlock occurs.
+            // ArrayPoolEventSource.Log and can require ArrayPoolEventSource type initialization. ParseSpecs runs while holding
+            // EventListener.EventListenersLock (inside DoCommand), so if another thread is currently running ArrayPoolEventSource's
+            // type initializer (holding the type-init lock) and then tries to take EventListenersLock, a deadlock can occur.
             // See https://github.com/dotnet/runtime/issues/119014. We avoid that by pre-creating ArrayPoolEventSource here.
             _ = System.Buffers.ArrayPoolEventSource.Log;
 #if !TARGET_BROWSER


### PR DESCRIPTION
Fixes #119014

Starting  dotnet-counters  during .NET app initialization can deadlock two threads with a lock-order cycle:

• Thread A holds  EventListenersLock  (inside  EventSource.DoCommand  for  MetricsEventSource ) and triggers the first-ever use of  ArrayPool<char>  via string interpolation in  ParseSpecs . This causes  SharedArrayPool<char>.Rent()  to access  ArrayPoolEventSource.Log , which needs  ArrayPoolEventSource 's type-init lock — held by Thread B.
• Thread B is running  ArrayPoolEventSource 's static constructor (holds the type-init lock) and is blocked waiting for  EventListenersLock .

The fix pre-initializes  ArrayPoolEventSource  in  InitializeDefaultEventSources() , following the identical pattern already used to fix the analogous  FrameworkEventSource  deadlock in  #126591  (PR  #126737 ). After pre-initialization,  ArrayPoolEventSource.Log  is never uninitialized when  Rent()  accesses it, so no type-init lock is ever needed — the cycle cannot form.