### PR TITLE
Fix CLR_Tools_Tests build break in WasmArgumentLayoutTests

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/WasmArgumentLayoutTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/WasmArgumentLayoutTests.cs
@@ -163,7 +163,8 @@ public class WasmArgumentLayoutTests
         InstructionSetSupport instructionSetSupport = new(default, default, TargetArchitecture.Wasm32);
         TargetDetails target = new(TargetArchitecture.Wasm32, TargetOS.Browser, TargetAbi.NativeAot, instructionSetSupport.GetVectorTSimdVector());
 
-        ReadyToRunCompilerContext context = new(target, SharedGenericsMode.CanonicalReferenceTypes, bubbleIncludesCoreModule: true, instructionSetSupport, oldTypeSystemContext: null)
+        // Wasm cannot generate code at runtime, matching what crossgen2's Program computes for this target.
+        ReadyToRunCompilerContext context = new(target, SharedGenericsMode.CanonicalReferenceTypes, bubbleIncludesCoreModule: true, targetAllowsRuntimeCodeGeneration: false, instructionSetSupport, oldTypeSystemContext: null)
         {
             InputFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "System.Private.CoreLib", coreLibPath } },
             ReferenceFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),


### PR DESCRIPTION
`main` does not currently build. The `linux-x64 checked CLR_Tools_Tests` leg fails in `Build product`:

```
src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/WasmArgumentLayoutTests.cs(166,45): error CS7036: There is no argument given that corresponds to the required parameter 'instructionSetSupport' of 'ReadyToRunCompilerContext.ReadyToRunCompilerContext(TargetDetails, SharedGenericsMode, bool, bool, InstructionSetSupport, CompilerTypeSystemContext)'
```

## Cause

A semantic merge conflict between two PRs that landed ~18 hours apart, so neither one's CI saw the other:

- #131429 (merged 2026-07-27T20:14Z) added `WasmArgumentLayoutTests.cs`, whose `CreateWasmContext` constructs `ReadyToRunCompilerContext` with 5 arguments.
- #130622 (merged 2026-07-28T14:04Z) added a `bool targetAllowsRuntimeCodeGeneration` parameter to that constructor, making it 6.

## Fix

Pass the missing argument. `false` is the value crossgen2 itself computes for this target: `Program.GetTargetAllowsRuntimeCodeGeneration` returns `false` when the OS is `Browser`/`Wasi`/Apple-mobile or the architecture is `Wasm32`, and this test context mirrors `--targetarch wasm --targetos browser` (as its own doc comment states). The flag governs whether `Vector<T>` stays optimistic and whether explicitly-unsupported ISA markers are emitted — on wasm there is no runtime codegen to fall back to.

## Validation

- `./build.sh clr+libs -rc Checked` succeeds, and `ILCompiler.ReadyToRun.Tests.csproj` then compiles clean — the exact compile that fails in CI.
- All 20 `WasmArgumentLayoutTests` cases pass, so the regression coverage #131429 added still tests what it was written to test.

Other tests in that assembly fail on my macOS-arm64 box for an unrelated local reason (`DllNotFoundException` for `clrjit_universal_arm64_arm64` / `clrjit_unix_x64_arm64` — `build.sh clr+libs` publishes only the wasm cross-jit into the crossgen2 output directory on this host). Those suites invoke crossgen2 as a subprocess and do not touch the changed file.

Fixes #131504

> [!NOTE]
> This change was developed with GitHub Copilot and reviewed by me before submitting.