### PR TITLE
[cDAC] Always assign IStringHolder in DacDbi GetModulePath for pathless modules

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -322,6 +322,8 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             }
             if (string.IsNullOrEmpty(path))
             {
+                // pStrFilename needs to be set for ICorDebugModule::GetName to succeed.
+                hr = StringHolderAssignCopy(pStrFilename, string.Empty);
                 *pResult = Interop.BOOL.FALSE;
             }
             else


### PR DESCRIPTION
cDAC's DacDbiImpl.GetModulePath returned S_OK with pResult=FALSE but left the IStringHolder unassigned when a module has no on-disk path (dynamic / in-memory modules, e.g. LCG DynamicMethod / DLR). The native DBI (CordbModule::GetModulePath) asserts m_strModulePath.IsSet(), so an unassigned holder makes ICorDebugModule::GetName fail with E_FAIL, which the debugger surfaces as "bad OnModuleLoad" on the module-load callback.