### PR TITLE
Remove length check on debug log content

### DIFF
--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -4926,8 +4926,7 @@ void CordbProcess::RawDispatchEvent(
             ULONG cchCategory = pEvent->FirstLogMessage.cchCategory;
             ULONG cchContent = pEvent->FirstLogMessage.cchContent;
 
-            const ULONG cchMax = 0x10000;
-            if (cchCategory > cchMax || cchContent > cchMax)
+            if (cchCategory > MAX_LOG_SWITCH_NAME_LEN)
             {
                 IfFailThrow(E_UNEXPECTED);
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/131073