### PR TITLE
Add System.Text.Json converters for BFloat16 and the IEEE 754 decimal types

### DIFF
--- a/src/libraries/System.Text.Json/gen/Helpers/KnownTypeSymbols.cs
+++ b/src/libraries/System.Text.Json/gen/Helpers/KnownTypeSymbols.cs
@@ -151,6 +151,18 @@ namespace System.Text.Json.SourceGeneration
         public INamedTypeSymbol? HalfType => GetOrResolveType("System.Half", ref _HalfType);
         private Option<INamedTypeSymbol?> _HalfType;
 
+        public INamedTypeSymbol? BFloat16Type => GetOrResolveType("System.Numerics.BFloat16", ref _BFloat16Type);
+        private Option<INamedTypeSymbol?> _BFloat16Type;
+
+        public INamedTypeSymbol? Decimal32Type => GetOrResolveType("System.Numerics.Decimal32", ref _Decimal32Type);
+        private Option<INamedTypeSymbol?> _Decimal32Type;
+
+        public INamedTypeSymbol? Decimal64Type => GetOrResolveType("System.Numerics.Decimal64", ref _Decimal64Type);
+        private Option<INamedTypeSymbol?> _Decimal64Type;
+
+        public INamedTypeSymbol? Decimal128Type => GetOrResolveType("System.Numerics.Decimal128", ref _Decimal128Type);
+        private Option<INamedTypeSymbol?> _Decimal128Type;
+
         public IArrayTypeSymbol? ByteArrayType => _ByteArrayType.HasValue
             ? _ByteArrayType.Value
             : (_ByteArrayType = new(Compilation.CreateArrayTypeSymbol(Compilation.GetSpecialType(SpecialType.System_Byte), rank: 1))).Value;

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -1812,11 +1812,15 @@ namespace System.Text.Json.SourceGeneration
                     return JsonValueType.Boolean;
                 }
 
-                // Numeric primitives + Half / Int128 / UInt128
+                // Numeric primitives + Half / Int128 / UInt128 / BFloat16 / Decimal32 / Decimal64 / Decimal128
                 if (IsBuiltInNumericType(type) ||
                     SymbolEqualityComparer.Default.Equals(type, _knownSymbols.HalfType) ||
                     SymbolEqualityComparer.Default.Equals(type, _knownSymbols.Int128Type) ||
-                    SymbolEqualityComparer.Default.Equals(type, _knownSymbols.UInt128Type))
+                    SymbolEqualityComparer.Default.Equals(type, _knownSymbols.UInt128Type) ||
+                    SymbolEqualityComparer.Default.Equals(type, _knownSymbols.BFloat16Type) ||
+                    SymbolEqualityComparer.Default.Equals(type, _knownSymbols.Decimal32Type) ||
+                    SymbolEqualityComparer.Default.Equals(type, _knownSymbols.Decimal64Type) ||
+                    SymbolEqualityComparer.Default.Equals(type, _knownSymbols.Decimal128Type))
                 {
                     return HasAllowReadingFromString(type)
                         ? JsonValueType.Number | JsonValueType.String
@@ -3315,6 +3319,10 @@ namespace System.Text.Json.SourceGeneration
                 AddTypeIfNotNull(knownSymbols.Int128Type);
                 AddTypeIfNotNull(knownSymbols.UInt128Type);
                 AddTypeIfNotNull(knownSymbols.HalfType);
+                AddTypeIfNotNull(knownSymbols.BFloat16Type);
+                AddTypeIfNotNull(knownSymbols.Decimal32Type);
+                AddTypeIfNotNull(knownSymbols.Decimal64Type);
+                AddTypeIfNotNull(knownSymbols.Decimal128Type);
                 AddTypeIfNotNull(knownSymbols.GuidType);
                 AddTypeIfNotNull(knownSymbols.UriType);
                 AddTypeIfNotNull(knownSymbols.VersionType);

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.csproj
@@ -14,6 +14,10 @@
     <Compile Include="System.Text.Json.netcoreapp.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <Compile Include="System.Text.Json.net11.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.net11.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.net11.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the https://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    public static partial class JsonMetadataServices
+    {
+        public static System.Text.Json.Serialization.JsonConverter<System.Numerics.BFloat16> BFloat16Converter { get { throw null; } }
+        public static System.Text.Json.Serialization.JsonConverter<System.Numerics.Decimal128> Decimal128Converter { get { throw null; } }
+        public static System.Text.Json.Serialization.JsonConverter<System.Numerics.Decimal32> Decimal32Converter { get { throw null; } }
+        public static System.Text.Json.Serialization.JsonConverter<System.Numerics.Decimal64> Decimal64Converter { get { throw null; } }
+    }
+}

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -279,27 +279,6 @@
   <data name="PropertyNameTooLarge" xml:space="preserve">
     <value>The JSON property name of length {0} is too large and not supported.</value>
   </data>
-  <data name="FormatDecimal" xml:space="preserve">
-    <value>The JSON value is either too large or too small for a Decimal.</value>
-  </data>
-  <data name="FormatDouble" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for a Double.</value>
-  </data>
-  <data name="FormatInt32" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for an Int32.</value>
-  </data>
-  <data name="FormatInt64" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for an Int64.</value>
-  </data>
-  <data name="FormatSingle" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for a Single.</value>
-  </data>
-  <data name="FormatUInt32" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for a UInt32.</value>
-  </data>
-  <data name="FormatUInt64" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for a UInt64.</value>
-  </data>
   <data name="RequiredDigitNotFoundAfterDecimal" xml:space="preserve">
     <value>'{0}' is invalid within a number, immediately after a decimal point ('.'). Expected a digit ('0'-'9').</value>
   </data>
@@ -440,18 +419,6 @@
   </data>
   <data name="SerializeUnableToSerialize" xml:space="preserve">
     <value>The object or value could not be serialized.</value>
-  </data>
-  <data name="FormatByte" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for an unsigned byte.</value>
-  </data>
-  <data name="FormatInt16" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for an Int16.</value>
-  </data>
-  <data name="FormatSByte" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for a signed byte.</value>
-  </data>
-  <data name="FormatUInt16" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for a UInt16.</value>
   </data>
   <data name="SerializerCycleDetected" xml:space="preserve">
     <value>A possible object cycle was detected. This can either be due to a cycle or if the object depth is larger than the maximum allowed depth of {0}. Consider using ReferenceHandler.Preserve on JsonSerializerOptions to support cycles.</value>
@@ -761,14 +728,8 @@
   <data name="ObjectCreationHandlingPropertyDoesNotSupportParameterizedConstructors" xml:space="preserve">
     <value>JsonObjectCreationHandling.Populate is currently not supported in types with parameterized constructors.</value>
   </data>
-  <data name="FormatInt128" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for an Int128.</value>
-  </data>
-  <data name="FormatUInt128" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for an UInt128.</value>
-  </data>
-  <data name="FormatHalf" xml:space="preserve">
-    <value>Either the JSON value is not in a supported format, or is out of bounds for a Half.</value>
+  <data name="FormatNumericType" xml:space="preserve">
+    <value>Either the JSON value is not in a supported format, or is out of bounds for the {0} type.</value>
   </data>
   <data name="InvalidIndentCharacter" xml:space="preserve">
     <value>Supported indentation characters are space and horizontal tab.</value>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -419,6 +419,10 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IReadOnlySetOfTConverter.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <Compile Include="System\Text\Json\Serialization\Converters\Value\Ieee754FloatingPointConverter.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <Compile Include="$(CommonPath)Polyfills\StreamMemoryPolyfills.cs" Link="Common\Polyfills\StreamMemoryPolyfills.cs" />
     <Compile Include="$(CommonPath)Polyfills\StringBuilderPolyfills.cs" Link="Common\Polyfills\StringBuilderPolyfills.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -43,6 +43,7 @@ namespace System.Text.Json
         public static ReadOnlySpan<byte> NaNValue => "NaN"u8;
         public static ReadOnlySpan<byte> PositiveInfinityValue => "Infinity"u8;
         public static ReadOnlySpan<byte> NegativeInfinityValue => "-Infinity"u8;
+        // The length of the longest of the three named literals above, i.e. "-Infinity".
         public const int MaximumFloatingPointConstantLength = 9;
 
         // Used to search for the end of a number

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
@@ -104,6 +104,13 @@ namespace System.Text.Json.Nodes
                 return JsonValueKind.Number;
             }
 #endif
+#if NET11_0_OR_GREATER
+            if (type == typeof(System.Numerics.BFloat16) || type == typeof(System.Numerics.Decimal32) ||
+                type == typeof(System.Numerics.Decimal64) || type == typeof(System.Numerics.Decimal128))
+            {
+                return JsonValueKind.Number;
+            }
+#endif
             return Type.GetTypeCode(type) switch
             {
                 TypeCode.Boolean => JsonValueKind.Undefined, // Can vary dependending on value.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Ieee754FloatingPointConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Ieee754FloatingPointConverter.cs
@@ -1,0 +1,279 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Globalization;
+using System.Numerics;
+using System.Text.Json.Schema;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    /// <summary>
+    /// Converter for IEEE 754 floating-point types that share the same JSON number representation,
+    /// such as <see cref="BFloat16"/> and the IEEE 754 decimal types.
+    /// </summary>
+    internal sealed class Ieee754FloatingPointConverter<T> : JsonPrimitiveConverter<T>
+        where T : struct, IFloatingPointIeee754<T>
+    {
+        // Values that need more room than this are formatted into a pooled buffer.
+        // The IEEE 754 decimal types are formatted without scientific notation, so
+        // their worst-case length is in the thousands of digits.
+        private const int StackBufferLength = 64;
+        private const int MaxUnescapedFormatLength = JsonConstants.MaximumFloatingPointConstantLength * JsonConstants.MaxExpansionFactorWhileEscaping;
+
+        private readonly NumericType _numericType;
+
+        public Ieee754FloatingPointConverter(NumericType numericType)
+        {
+            _numericType = numericType;
+            IsInternalConverterForNumberType = true;
+        }
+
+        internal override bool IsIeeeFloatingPointConverter => true;
+
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (options?.NumberHandling is not null and not JsonNumberHandling.Strict)
+            {
+                return ReadNumberWithCustomHandling(ref reader, options.NumberHandling, options);
+            }
+
+            if (reader.TokenType != JsonTokenType.Number)
+            {
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(reader.TokenType);
+            }
+
+            return ReadCore(ref reader);
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            if (options?.NumberHandling is not null and not JsonNumberHandling.Strict)
+            {
+                WriteNumberWithCustomHandling(writer, value, options.NumberHandling);
+                return;
+            }
+
+            WriteCore(writer, value);
+        }
+
+        internal override T ReadAsPropertyNameCore(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
+            return ReadCore(ref reader);
+        }
+
+        internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, T value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
+        {
+            Span<byte> stackBuffer = stackalloc byte[StackBufferLength];
+            byte[]? rented = Format(value, stackBuffer, out ReadOnlySpan<byte> formatted);
+            writer.WritePropertyName(formatted);
+            Return(rented);
+        }
+
+        internal override T ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                if ((JsonNumberHandling.AllowReadingFromString & handling) != 0)
+                {
+                    if (TryGetFloatingPointConstant(ref reader, out T value))
+                    {
+                        return value;
+                    }
+
+                    return ReadCore(ref reader);
+                }
+                else if ((JsonNumberHandling.AllowNamedFloatingPointLiterals & handling) != 0)
+                {
+                    if (!TryGetFloatingPointConstant(ref reader, out T value))
+                    {
+                        ThrowHelper.ThrowFormatException(_numericType);
+                    }
+
+                    return value;
+                }
+            }
+
+            if (reader.TokenType != JsonTokenType.Number)
+            {
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(reader.TokenType);
+            }
+
+            return ReadCore(ref reader);
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, T value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                Span<byte> stackBuffer = stackalloc byte[StackBufferLength];
+                byte[]? rented = Format(value, stackBuffer, out ReadOnlySpan<byte> formatted);
+                writer.WriteNumberValueAsStringUnescaped(formatted);
+                Return(rented);
+            }
+            else if ((JsonNumberHandling.AllowNamedFloatingPointLiterals & handling) != 0)
+            {
+                WriteFloatingPointConstant(writer, value);
+            }
+            else
+            {
+                WriteCore(writer, value);
+            }
+        }
+
+        internal override JsonSchema? GetSchema(JsonNumberHandling numberHandling) =>
+            GetSchemaForNumericType(JsonSchemaType.Number, numberHandling, isIeeeFloatingPoint: true);
+
+        internal override JsonValueType GetSupportedJsonValueTypes(JsonNumberHandling numberHandling) =>
+            GetSupportedJsonValueTypesForNumericType(numberHandling);
+
+        private T ReadCore(ref Utf8JsonReader reader)
+        {
+            byte[]? rentedByteBuffer = null;
+            int bufferLength = reader.ValueLength;
+
+            Span<byte> byteBuffer = bufferLength <= JsonConstants.StackallocByteThreshold
+                ? stackalloc byte[JsonConstants.StackallocByteThreshold]
+                : (rentedByteBuffer = ArrayPool<byte>.Shared.Rent(bufferLength));
+
+            int written = reader.CopyValue(byteBuffer);
+            byteBuffer = byteBuffer.Slice(0, written);
+
+            bool success = TryParse(byteBuffer, out T result);
+            Return(rentedByteBuffer);
+
+            if (!success)
+            {
+                ThrowHelper.ThrowFormatException(_numericType);
+            }
+
+            Debug.Assert(!T.IsNaN(result) && !T.IsInfinity(result));
+            return result;
+        }
+
+        private static void WriteCore(Utf8JsonWriter writer, T value)
+        {
+            Span<byte> stackBuffer = stackalloc byte[StackBufferLength];
+            byte[]? rented = Format(value, stackBuffer, out ReadOnlySpan<byte> formatted);
+            writer.WriteRawValue(formatted);
+            Return(rented);
+        }
+
+        private static void WriteFloatingPointConstant(Utf8JsonWriter writer, T value)
+        {
+            if (T.IsNaN(value))
+            {
+                writer.WriteNumberValueAsStringUnescaped(JsonConstants.NaNValue);
+            }
+            else if (T.IsPositiveInfinity(value))
+            {
+                writer.WriteNumberValueAsStringUnescaped(JsonConstants.PositiveInfinityValue);
+            }
+            else if (T.IsNegativeInfinity(value))
+            {
+                writer.WriteNumberValueAsStringUnescaped(JsonConstants.NegativeInfinityValue);
+            }
+            else
+            {
+                WriteCore(writer, value);
+            }
+        }
+
+        private static bool TryGetFloatingPointConstant(ref Utf8JsonReader reader, out T value)
+        {
+            scoped Span<byte> buffer;
+
+            if (reader.ValueIsEscaped)
+            {
+                if (reader.ValueLength > MaxUnescapedFormatLength)
+                {
+                    value = default;
+                    return false;
+                }
+
+                buffer = stackalloc byte[MaxUnescapedFormatLength];
+            }
+            else
+            {
+                if (reader.ValueLength > JsonConstants.MaximumFloatingPointConstantLength)
+                {
+                    value = default;
+                    return false;
+                }
+
+                buffer = stackalloc byte[JsonConstants.MaximumFloatingPointConstantLength];
+            }
+
+            int written = reader.CopyValue(buffer);
+            return TryGetFloatingPointConstant(buffer.Slice(0, written), out value);
+        }
+
+        private static bool TryGetFloatingPointConstant(ReadOnlySpan<byte> span, out T value)
+        {
+            if (span.SequenceEqual(JsonConstants.NaNValue))
+            {
+                value = T.NaN;
+                return true;
+            }
+
+            if (span.SequenceEqual(JsonConstants.PositiveInfinityValue))
+            {
+                value = T.PositiveInfinity;
+                return true;
+            }
+
+            if (span.SequenceEqual(JsonConstants.NegativeInfinityValue))
+            {
+                value = T.NegativeInfinity;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        private static bool TryParse(ReadOnlySpan<byte> buffer, out T result)
+        {
+            bool success = T.TryParse(buffer, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out result);
+
+            // The underlying parsers are more lax with floating-point literals than S.T.Json
+            // e.g: they parse "naN" successfully. Only succeed with the exact match.
+            return success &&
+                (!T.IsNaN(result) || buffer.SequenceEqual(JsonConstants.NaNValue)) &&
+                (!T.IsPositiveInfinity(result) || buffer.SequenceEqual(JsonConstants.PositiveInfinityValue)) &&
+                (!T.IsNegativeInfinity(result) || buffer.SequenceEqual(JsonConstants.NegativeInfinityValue));
+        }
+
+        /// <summary>
+        /// Formats <paramref name="value"/> into <paramref name="initialBuffer"/>, growing into a
+        /// pooled buffer if necessary. Returns the rented array, if any, which the caller must return.
+        /// </summary>
+        private static byte[]? Format(T value, Span<byte> initialBuffer, out ReadOnlySpan<byte> formatted)
+        {
+            byte[]? rented = null;
+            Span<byte> destination = initialBuffer;
+            int written;
+
+            while (!value.TryFormat(destination, out written, format: default, provider: CultureInfo.InvariantCulture))
+            {
+                byte[]? toReturn = rented;
+                rented = ArrayPool<byte>.Shared.Rent(destination.Length * 2);
+                destination = rented;
+                Return(toReturn);
+            }
+
+            formatted = destination.Slice(0, written);
+            return rented;
+        }
+
+        private static void Return(byte[]? rented)
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Ieee754FloatingPointConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Ieee754FloatingPointConverter.cs
@@ -20,7 +20,9 @@ namespace System.Text.Json.Serialization.Converters
         // Formatting of the IEEE 754 decimal types only uses scientific notation when it is
         // required or more compact, so large-magnitude values expand to many digits.
         private const int StackBufferLength = 64;
-        private const int MaxUnescapedFormatLength = JsonConstants.MaximumFloatingPointConstantLength * JsonConstants.MaxExpansionFactorWhileEscaping;
+        // This buffer only ever holds one of the named literals "NaN", "Infinity" or "-Infinity",
+        // so it is sized from their maximum length rather than from any numeric format length.
+        private const int MaxEscapedNamedLiteralLength = JsonConstants.MaximumFloatingPointConstantLength * JsonConstants.MaxExpansionFactorWhileEscaping;
 
         private readonly NumericType _numericType;
 
@@ -206,13 +208,13 @@ namespace System.Text.Json.Serialization.Converters
 
             if (reader.ValueIsEscaped)
             {
-                if (reader.ValueLength > MaxUnescapedFormatLength)
+                if (reader.ValueLength > MaxEscapedNamedLiteralLength)
                 {
                     value = default;
                     return false;
                 }
 
-                buffer = stackalloc byte[MaxUnescapedFormatLength];
+                buffer = stackalloc byte[MaxEscapedNamedLiteralLength];
             }
             else
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Ieee754FloatingPointConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Ieee754FloatingPointConverter.cs
@@ -17,8 +17,8 @@ namespace System.Text.Json.Serialization.Converters
         where T : struct, IFloatingPointIeee754<T>
     {
         // Values that need more room than this are formatted into a pooled buffer.
-        // The IEEE 754 decimal types are formatted without scientific notation, so
-        // their worst-case length is in the thousands of digits.
+        // Formatting of the IEEE 754 decimal types only uses scientific notation when it is
+        // required or more compact, so large-magnitude values expand to many digits.
         private const int StackBufferLength = 64;
         private const int MaxUnescapedFormatLength = JsonConstants.MaximumFloatingPointConstantLength * JsonConstants.MaxExpansionFactorWhileEscaping;
 
@@ -44,7 +44,7 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(reader.TokenType);
             }
 
-            return ReadCore(ref reader);
+            return ReadCore(ref reader, isStringValue: false);
         }
 
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
@@ -61,11 +61,13 @@ namespace System.Text.Json.Serialization.Converters
         internal override T ReadAsPropertyNameCore(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
-            return ReadCore(ref reader);
+            return ReadCore(ref reader, isStringValue: true);
         }
 
         internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, T value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
         {
+            ValidateFinite(value);
+
             Span<byte> stackBuffer = stackalloc byte[StackBufferLength];
             byte[]? rented = Format(value, stackBuffer, out ReadOnlySpan<byte> formatted);
             writer.WritePropertyName(formatted);
@@ -83,7 +85,7 @@ namespace System.Text.Json.Serialization.Converters
                         return value;
                     }
 
-                    return ReadCore(ref reader);
+                    return ReadCore(ref reader, isStringValue: true);
                 }
                 else if ((JsonNumberHandling.AllowNamedFloatingPointLiterals & handling) != 0)
                 {
@@ -101,7 +103,7 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(reader.TokenType);
             }
 
-            return ReadCore(ref reader);
+            return ReadCore(ref reader, isStringValue: false);
         }
 
         internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, T value, JsonNumberHandling handling)
@@ -129,7 +131,12 @@ namespace System.Text.Json.Serialization.Converters
         internal override JsonValueType GetSupportedJsonValueTypes(JsonNumberHandling numberHandling) =>
             GetSupportedJsonValueTypesForNumericType(numberHandling);
 
-        private T ReadCore(ref Utf8JsonReader reader)
+        // Reads the current token as a number. When the token is a string or property name,
+        // non-finite results are rejected: the underlying parsers accept named literals such as "naN"
+        // that are not valid JSON, and a string that overflows to infinity is rejected for consistency
+        // with float and double. Number tokens are already constrained to the JSON number grammar by
+        // the reader, so they are permitted to overflow to infinity per IEEE 754.
+        private T ReadCore(ref Utf8JsonReader reader, bool isStringValue)
         {
             byte[]? rentedByteBuffer = null;
             int bufferLength = reader.ValueLength;
@@ -141,7 +148,7 @@ namespace System.Text.Json.Serialization.Converters
             int written = reader.CopyValue(byteBuffer);
             byteBuffer = byteBuffer.Slice(0, written);
 
-            bool success = TryParse(byteBuffer, out T result);
+            bool success = TryParse(byteBuffer, out T result) && (!isStringValue || T.IsFinite(result));
             Return(rentedByteBuffer);
 
             if (!success)
@@ -149,16 +156,28 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowFormatException(_numericType);
             }
 
-            Debug.Assert(!T.IsNaN(result) && !T.IsInfinity(result));
             return result;
         }
 
         private static void WriteCore(Utf8JsonWriter writer, T value)
         {
+            ValidateFinite(value);
+
             Span<byte> stackBuffer = stackalloc byte[StackBufferLength];
             byte[]? rented = Format(value, stackBuffer, out ReadOnlySpan<byte> formatted);
             writer.WriteRawValue(formatted);
             Return(rented);
+        }
+
+        // NaN and infinity have no representation in the JSON number grammar. Reject them with the
+        // same error Utf8JsonWriter reports for float and double, which points callers at
+        // JsonNumberHandling.AllowNamedFloatingPointLiterals.
+        private static void ValidateFinite(T value)
+        {
+            if (!T.IsFinite(value))
+            {
+                ThrowHelper.ThrowArgumentException_ValueNotSupported();
+            }
         }
 
         private static void WriteFloatingPointConstant(Utf8JsonWriter writer, T value)
@@ -234,22 +253,11 @@ namespace System.Text.Json.Serialization.Converters
             return false;
         }
 
-        private static bool TryParse(ReadOnlySpan<byte> buffer, out T result)
-        {
-            bool success = T.TryParse(buffer, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out result);
+        private static bool TryParse(ReadOnlySpan<byte> buffer, out T result) =>
+            T.TryParse(buffer, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out result);
 
-            // The underlying parsers are more lax with floating-point literals than S.T.Json
-            // e.g: they parse "naN" successfully. Only succeed with the exact match.
-            return success &&
-                (!T.IsNaN(result) || buffer.SequenceEqual(JsonConstants.NaNValue)) &&
-                (!T.IsPositiveInfinity(result) || buffer.SequenceEqual(JsonConstants.PositiveInfinityValue)) &&
-                (!T.IsNegativeInfinity(result) || buffer.SequenceEqual(JsonConstants.NegativeInfinityValue));
-        }
-
-        /// <summary>
-        /// Formats <paramref name="value"/> into <paramref name="initialBuffer"/>, growing into a
-        /// pooled buffer if necessary. Returns the rented array, if any, which the caller must return.
-        /// </summary>
+        // Formats value into initialBuffer, growing into a pooled buffer if necessary.
+        // Returns the rented array, if any, which the caller must return.
         private static byte[]? Format(T value, Span<byte> initialBuffer, out ReadOnlySpan<byte> formatted)
         {
             byte[]? rented = null;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonPrimitiveConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/JsonPrimitiveConverter.cs
@@ -34,7 +34,11 @@ namespace System.Text.Json.Serialization.Converters
         {
             Debug.Assert(schemaType is JsonSchemaType.Integer or JsonSchemaType.Number);
             Debug.Assert(!isIeeeFloatingPoint || schemaType is JsonSchemaType.Number);
-#if NET
+#if NET11_0_OR_GREATER
+            Debug.Assert(isIeeeFloatingPoint == (typeof(T) == typeof(double) || typeof(T) == typeof(float) || typeof(T) == typeof(Half) ||
+                typeof(T) == typeof(System.Numerics.BFloat16) || typeof(T) == typeof(System.Numerics.Decimal32) ||
+                typeof(T) == typeof(System.Numerics.Decimal64) || typeof(T) == typeof(System.Numerics.Decimal128)));
+#elif NET
             Debug.Assert(isIeeeFloatingPoint == (typeof(T) == typeof(double) || typeof(T) == typeof(float) || typeof(T) == typeof(Half)));
 #endif
             string? pattern = null;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
@@ -42,7 +42,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         private static Dictionary<Type, JsonConverter> GetDefaultSimpleConverters()
         {
-            const int NumberOfSimpleConverters = 31;
+            const int NumberOfSimpleConverters = 35;
             var converters = new Dictionary<Type, JsonConverter>(NumberOfSimpleConverters);
 
             // Use a dictionary for simple converters.
@@ -83,6 +83,12 @@ namespace System.Text.Json.Serialization.Metadata
 #if NET
             Add(JsonMetadataServices.Int128Converter);
             Add(JsonMetadataServices.UInt128Converter);
+#endif
+#if NET11_0_OR_GREATER
+            Add(JsonMetadataServices.BFloat16Converter);
+            Add(JsonMetadataServices.Decimal32Converter);
+            Add(JsonMetadataServices.Decimal64Converter);
+            Add(JsonMetadataServices.Decimal128Converter);
 #endif
             Add(JsonMetadataServices.UriConverter);
             Add(JsonMetadataServices.VersionConverter);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
@@ -16,257 +16,252 @@ namespace System.Text.Json.Serialization.Metadata
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="bool"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<bool> BooleanConverter => s_booleanConverter ??= new BooleanConverter();
-        private static JsonConverter<bool>? s_booleanConverter;
+        public static JsonConverter<bool> BooleanConverter => field ??= new BooleanConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts byte array values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<byte[]?> ByteArrayConverter => s_byteArrayConverter ??= new ByteArrayConverter();
-        private static JsonConverter<byte[]?>? s_byteArrayConverter;
+        public static JsonConverter<byte[]?> ByteArrayConverter => field ??= new ByteArrayConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="byte"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<byte> ByteConverter => s_byteConverter ??= new ByteConverter();
-        private static JsonConverter<byte>? s_byteConverter;
+        public static JsonConverter<byte> ByteConverter => field ??= new ByteConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="char"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<char> CharConverter => s_charConverter ??= new CharConverter();
-        private static JsonConverter<char>? s_charConverter;
+        public static JsonConverter<char> CharConverter => field ??= new CharConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="DateTime"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<DateTime> DateTimeConverter => s_dateTimeConverter ??= new DateTimeConverter();
-        private static JsonConverter<DateTime>? s_dateTimeConverter;
+        public static JsonConverter<DateTime> DateTimeConverter => field ??= new DateTimeConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="DateTimeOffset"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<DateTimeOffset> DateTimeOffsetConverter => s_dateTimeOffsetConverter ??= new DateTimeOffsetConverter();
-        private static JsonConverter<DateTimeOffset>? s_dateTimeOffsetConverter;
+        public static JsonConverter<DateTimeOffset> DateTimeOffsetConverter => field ??= new DateTimeOffsetConverter();
 
 #if NET
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="DateOnly"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<DateOnly> DateOnlyConverter => s_dateOnlyConverter ??= new DateOnlyConverter();
-        private static JsonConverter<DateOnly>? s_dateOnlyConverter;
+        public static JsonConverter<DateOnly> DateOnlyConverter => field ??= new DateOnlyConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="TimeOnly"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<TimeOnly> TimeOnlyConverter => s_timeOnlyConverter ??= new TimeOnlyConverter();
-        private static JsonConverter<TimeOnly>? s_timeOnlyConverter;
+        public static JsonConverter<TimeOnly> TimeOnlyConverter => field ??= new TimeOnlyConverter();
 #endif
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="decimal"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<decimal> DecimalConverter => s_decimalConverter ??= new DecimalConverter();
-        private static JsonConverter<decimal>? s_decimalConverter;
+        public static JsonConverter<decimal> DecimalConverter => field ??= new DecimalConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="double"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<double> DoubleConverter => s_doubleConverter ??= new DoubleConverter();
-        private static JsonConverter<double>? s_doubleConverter;
+        public static JsonConverter<double> DoubleConverter => field ??= new DoubleConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Guid"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<Guid> GuidConverter => s_guidConverter ??= new GuidConverter();
-        private static JsonConverter<Guid>? s_guidConverter;
+        public static JsonConverter<Guid> GuidConverter => field ??= new GuidConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="short"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<short> Int16Converter => s_int16Converter ??= new Int16Converter();
-        private static JsonConverter<short>? s_int16Converter;
+        public static JsonConverter<short> Int16Converter => field ??= new Int16Converter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="int"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<int> Int32Converter => s_int32Converter ??= new Int32Converter();
-        private static JsonConverter<int>? s_int32Converter;
+        public static JsonConverter<int> Int32Converter => field ??= new Int32Converter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="long"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<long> Int64Converter => s_int64Converter ??= new Int64Converter();
-        private static JsonConverter<long>? s_int64Converter;
+        public static JsonConverter<long> Int64Converter => field ??= new Int64Converter();
 
 #if NET
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Int128"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<Int128> Int128Converter => s_int128Converter ??= new Int128Converter();
-        private static JsonConverter<Int128>? s_int128Converter;
+        public static JsonConverter<Int128> Int128Converter => field ??= new Int128Converter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="UInt128"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         [CLSCompliant(false)]
-        public static JsonConverter<UInt128> UInt128Converter => s_uint128Converter ??= new UInt128Converter();
-        private static JsonConverter<UInt128>? s_uint128Converter;
+        public static JsonConverter<UInt128> UInt128Converter => field ??= new UInt128Converter();
 #endif
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonArray"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<JsonArray?> JsonArrayConverter => s_jsonArrayConverter ??= new JsonArrayConverter();
-        private static JsonConverter<JsonArray?>? s_jsonArrayConverter;
+        public static JsonConverter<JsonArray?> JsonArrayConverter => field ??= new JsonArrayConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonElement"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<JsonElement> JsonElementConverter => s_jsonElementConverter ??= new JsonElementConverter();
-        private static JsonConverter<JsonElement>? s_jsonElementConverter;
+        public static JsonConverter<JsonElement> JsonElementConverter => field ??= new JsonElementConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonNode"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<JsonNode?> JsonNodeConverter => s_jsonNodeConverter ??= new JsonNodeConverter();
-        private static JsonConverter<JsonNode?>? s_jsonNodeConverter;
+        public static JsonConverter<JsonNode?> JsonNodeConverter => field ??= new JsonNodeConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonObject"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<JsonObject?> JsonObjectConverter => s_jsonObjectConverter ??= new JsonObjectConverter();
-        private static JsonConverter<JsonObject?>? s_jsonObjectConverter;
+        public static JsonConverter<JsonObject?> JsonObjectConverter => field ??= new JsonObjectConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonArray"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<JsonValue?> JsonValueConverter => s_jsonValueConverter ??= new JsonValueConverter();
-        private static JsonConverter<JsonValue?>? s_jsonValueConverter;
+        public static JsonConverter<JsonValue?> JsonValueConverter => field ??= new JsonValueConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonDocument"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<JsonDocument?> JsonDocumentConverter => s_jsonDocumentConverter ??= new JsonDocumentConverter();
-        private static JsonConverter<JsonDocument?>? s_jsonDocumentConverter;
+        public static JsonConverter<JsonDocument?> JsonDocumentConverter => field ??= new JsonDocumentConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Memory{Byte}"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<Memory<byte>> MemoryByteConverter => s_memoryByteConverter ??= new MemoryByteConverter();
-        private static JsonConverter<Memory<byte>>? s_memoryByteConverter;
+        public static JsonConverter<Memory<byte>> MemoryByteConverter => field ??= new MemoryByteConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="ReadOnlyMemory{Byte}"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<ReadOnlyMemory<byte>> ReadOnlyMemoryByteConverter => s_readOnlyMemoryByteConverter ??= new ReadOnlyMemoryByteConverter();
-        private static JsonConverter<ReadOnlyMemory<byte>>? s_readOnlyMemoryByteConverter;
+        public static JsonConverter<ReadOnlyMemory<byte>> ReadOnlyMemoryByteConverter => field ??= new ReadOnlyMemoryByteConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="object"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<object?> ObjectConverter => s_objectConverter ??= new DefaultObjectConverter();
-        private static JsonConverter<object?>? s_objectConverter;
+        public static JsonConverter<object?> ObjectConverter => field ??= new DefaultObjectConverter();
 
 #if NET
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Half"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<Half> HalfConverter => s_halfConverter ??= new HalfConverter();
-        private static JsonConverter<Half>? s_halfConverter;
+        public static JsonConverter<Half> HalfConverter => field ??= new HalfConverter();
+#endif
+
+#if NET11_0_OR_GREATER
+        /// <summary>
+        /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="System.Numerics.BFloat16"/> values.
+        /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
+        public static JsonConverter<System.Numerics.BFloat16> BFloat16Converter =>
+            field ??= new Ieee754FloatingPointConverter<System.Numerics.BFloat16>(NumericType.BFloat16);
+
+        /// <summary>
+        /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="System.Numerics.Decimal32"/> values.
+        /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
+        public static JsonConverter<System.Numerics.Decimal32> Decimal32Converter =>
+            field ??= new Ieee754FloatingPointConverter<System.Numerics.Decimal32>(NumericType.Decimal32);
+
+        /// <summary>
+        /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="System.Numerics.Decimal64"/> values.
+        /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
+        public static JsonConverter<System.Numerics.Decimal64> Decimal64Converter =>
+            field ??= new Ieee754FloatingPointConverter<System.Numerics.Decimal64>(NumericType.Decimal64);
+
+        /// <summary>
+        /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="System.Numerics.Decimal128"/> values.
+        /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
+        public static JsonConverter<System.Numerics.Decimal128> Decimal128Converter =>
+            field ??= new Ieee754FloatingPointConverter<System.Numerics.Decimal128>(NumericType.Decimal128);
 #endif
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="float"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<float> SingleConverter => s_singleConverter ??= new SingleConverter();
-        private static JsonConverter<float>? s_singleConverter;
+        public static JsonConverter<float> SingleConverter => field ??= new SingleConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="sbyte"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         [CLSCompliant(false)]
-        public static JsonConverter<sbyte> SByteConverter => s_sbyteConverter ??= new SByteConverter();
-        private static JsonConverter<sbyte>? s_sbyteConverter;
+        public static JsonConverter<sbyte> SByteConverter => field ??= new SByteConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="string"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<string?> StringConverter => s_stringConverter ??= new StringConverter();
-        private static JsonConverter<string?>? s_stringConverter;
+        public static JsonConverter<string?> StringConverter => field ??= new StringConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="TimeSpan"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<TimeSpan> TimeSpanConverter => s_timeSpanConverter ??= new TimeSpanConverter();
-        private static JsonConverter<TimeSpan>? s_timeSpanConverter;
+        public static JsonConverter<TimeSpan> TimeSpanConverter => field ??= new TimeSpanConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="ushort"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         [CLSCompliant(false)]
-        public static JsonConverter<ushort> UInt16Converter => s_uint16Converter ??= new UInt16Converter();
-        private static JsonConverter<ushort>? s_uint16Converter;
+        public static JsonConverter<ushort> UInt16Converter => field ??= new UInt16Converter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="uint"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         [CLSCompliant(false)]
-        public static JsonConverter<uint> UInt32Converter => s_uint32Converter ??= new UInt32Converter();
-        private static JsonConverter<uint>? s_uint32Converter;
+        public static JsonConverter<uint> UInt32Converter => field ??= new UInt32Converter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="ulong"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         [CLSCompliant(false)]
-        public static JsonConverter<ulong> UInt64Converter => s_uint64Converter ??= new UInt64Converter();
-        private static JsonConverter<ulong>? s_uint64Converter;
+        public static JsonConverter<ulong> UInt64Converter => field ??= new UInt64Converter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Uri"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<Uri?> UriConverter => s_uriConverter ??= new UriConverter();
-        private static JsonConverter<Uri?>? s_uriConverter;
+        public static JsonConverter<Uri?> UriConverter => field ??= new UriConverter();
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Version"/> values.
         /// </summary>
         /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
-        public static JsonConverter<Version?> VersionConverter => s_versionConverter ??= new VersionConverter();
-        private static JsonConverter<Version?>? s_versionConverter;
+        public static JsonConverter<Version?> VersionConverter => field ??= new VersionConverter();
 
         /// <summary>
         /// Creates a <see cref="JsonConverter{T}"/> instance that throws <see cref="NotSupportedException"/>.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -725,6 +725,12 @@ namespace System.Text.Json.Serialization.Metadata
                 potentialNumberType == typeof(Int128) ||
                 potentialNumberType == typeof(UInt128) ||
 #endif
+#if NET11_0_OR_GREATER
+                potentialNumberType == typeof(System.Numerics.BFloat16) ||
+                potentialNumberType == typeof(System.Numerics.Decimal32) ||
+                potentialNumberType == typeof(System.Numerics.Decimal64) ||
+                potentialNumberType == typeof(System.Numerics.Decimal128) ||
+#endif
                 potentialNumberType == JsonTypeInfo.ObjectType;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -654,60 +654,10 @@ namespace System.Text.Json
             throw new FormatException { Source = ExceptionSourceValueToRethrowAsJsonException };
         }
 
+        [DoesNotReturn]
         public static void ThrowFormatException(NumericType numericType)
         {
-            string message = "";
-
-            switch (numericType)
-            {
-                case NumericType.Byte:
-                    message = SR.FormatByte;
-                    break;
-                case NumericType.SByte:
-                    message = SR.FormatSByte;
-                    break;
-                case NumericType.Int16:
-                    message = SR.FormatInt16;
-                    break;
-                case NumericType.Int32:
-                    message = SR.FormatInt32;
-                    break;
-                case NumericType.Int64:
-                    message = SR.FormatInt64;
-                    break;
-                case NumericType.Int128:
-                    message = SR.FormatInt128;
-                    break;
-                case NumericType.UInt16:
-                    message = SR.FormatUInt16;
-                    break;
-                case NumericType.UInt32:
-                    message = SR.FormatUInt32;
-                    break;
-                case NumericType.UInt64:
-                    message = SR.FormatUInt64;
-                    break;
-                case NumericType.UInt128:
-                    message = SR.FormatUInt128;
-                    break;
-                case NumericType.Half:
-                    message = SR.FormatHalf;
-                    break;
-                case NumericType.Single:
-                    message = SR.FormatSingle;
-                    break;
-                case NumericType.Double:
-                    message = SR.FormatDouble;
-                    break;
-                case NumericType.Decimal:
-                    message = SR.FormatDecimal;
-                    break;
-                default:
-                    Debug.Fail($"The NumericType enum value: {numericType} is not part of the switch. Add the appropriate case and exception message.");
-                    break;
-            }
-
-            throw new FormatException(message) { Source = ExceptionSourceValueToRethrowAsJsonException };
+            throw new FormatException(SR.Format(SR.FormatNumericType, numericType)) { Source = ExceptionSourceValueToRethrowAsJsonException };
         }
 
         [DoesNotReturn]
@@ -824,7 +774,11 @@ namespace System.Text.Json
         Half,
         Single,
         Double,
-        Decimal
+        Decimal,
+        BFloat16,
+        Decimal32,
+        Decimal64,
+        Decimal128
     }
 
     internal enum DataType

--- a/src/libraries/System.Text.Json/tests/Common/Ieee754NumericConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/Ieee754NumericConverterTests.cs
@@ -133,6 +133,27 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public async Task FullPrecisionValues_RoundtripAsKeysAndStrings()
+        {
+            // Reading a string or property name buffers the token, so exercise the widest significand
+            // each type can represent: 7, 16 and 34 significant digits for the decimal types.
+            await AssertFullPrecision(Parse<Decimal32>("-1.234567E-95"));
+            await AssertFullPrecision(Parse<Decimal64>("-1.234567890123456E-383"));
+            await AssertFullPrecision(Parse<Decimal128>("-1.234567890123456789012345678901234E-6143"));
+            await AssertFullPrecision(BFloat16.Epsilon);
+
+            async Task AssertFullPrecision<T>(T value) where T : struct, IFloatingPointIeee754<T>
+            {
+                string text = value.ToString(null, CultureInfo.InvariantCulture);
+
+                await AssertDictionaryKeyRoundtrip(value, text);
+
+                var options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.AllowReadingFromString };
+                Assert.Equal(value, await Serializer.DeserializeWrapper<T>($"\"{text}\"", options));
+            }
+        }
+
+        [Fact]
         public async Task NumberOverflowingToInfinity_IsReadAsInfinity()
         {
             // IEEE 754 rounds a magnitude beyond the largest finite value to infinity, and the JSON

--- a/src/libraries/System.Text.Json/tests/Common/Ieee754NumericConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/Ieee754NumericConverterTests.cs
@@ -60,17 +60,16 @@ namespace System.Text.Json.Serialization.Tests
         public Task Decimal128_Roundtrip(string json) => AssertRoundtrip<Decimal128>(json);
 
         [Fact]
-        public async Task Decimal128_LargeMagnitudeValue_Roundtrips()
+        public async Task Decimal128_ExtremeValues_Roundtrip()
         {
-            // Exercises the pooled-buffer growth path of the converter: the general format of the
-            // IEEE 754 decimal types is fully positional, so extreme values expand to thousands of digits.
-            Decimal128 value = Decimal128.MaxValue;
-            string expected = value.ToString(null, CultureInfo.InvariantCulture);
-            Assert.True(expected.Length > 64, $"Expected an expanded representation, got '{expected}'.");
-
-            string json = await Serializer.SerializeWrapper(value);
-            Assert.Equal(expected, json);
-            Assert.Equal(value, await Serializer.DeserializeWrapper<Decimal128>(json));
+            // MaxValue and Epsilon are the values most likely to exercise the converter's pooled-buffer
+            // growth path, since their general format is the longest the type can produce.
+            foreach (Decimal128 value in new[] { Decimal128.MaxValue, Decimal128.MinValue, Decimal128.Epsilon })
+            {
+                string json = await Serializer.SerializeWrapper(value);
+                Assert.Equal(value.ToString(null, CultureInfo.InvariantCulture), json);
+                Assert.Equal(value, await Serializer.DeserializeWrapper<Decimal128>(json));
+            }
         }
 
         [Theory]
@@ -131,6 +130,57 @@ namespace System.Text.Json.Serialization.Tests
             await AssertDictionaryKeyRoundtrip(Parse<Decimal32>("1.5"), "1.5");
             await AssertDictionaryKeyRoundtrip(Parse<Decimal64>("1.5"), "1.5");
             await AssertDictionaryKeyRoundtrip(Parse<Decimal128>("1.5"), "1.5");
+        }
+
+        [Fact]
+        public async Task NumberOverflowingToInfinity_IsReadAsInfinity()
+        {
+            // IEEE 754 rounds a magnitude beyond the largest finite value to infinity, and the JSON
+            // number grammar cannot express infinity, so overflow is only detectable by inspecting the
+            // parsed result. Matches the behavior of float and double.
+            const string Json = "1e999999";
+
+            Assert.Equal(BFloat16.PositiveInfinity, await Serializer.DeserializeWrapper<BFloat16>(Json));
+            Assert.Equal(Decimal32.PositiveInfinity, await Serializer.DeserializeWrapper<Decimal32>(Json));
+            Assert.Equal(Decimal64.PositiveInfinity, await Serializer.DeserializeWrapper<Decimal64>(Json));
+            Assert.Equal(Decimal128.PositiveInfinity, await Serializer.DeserializeWrapper<Decimal128>(Json));
+
+            Assert.Equal(BFloat16.NegativeInfinity, await Serializer.DeserializeWrapper<BFloat16>("-" + Json));
+            Assert.Equal(Decimal128.NegativeInfinity, await Serializer.DeserializeWrapper<Decimal128>("-" + Json));
+        }
+
+        [Fact]
+        public async Task StringOverflowingToInfinity_Throws()
+        {
+            // Unlike number tokens, strings are rejected when they do not parse to a finite value.
+            // Matches the behavior of float and double.
+            var options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.AllowReadingFromString };
+            const string Json = "\"1e999999\"";
+
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<BFloat16>(Json, options));
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<Decimal32>(Json, options));
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<Decimal64>(Json, options));
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<Decimal128>(Json, options));
+        }
+
+        [Fact]
+        public async Task NonFiniteValues_WithoutNamedLiterals_Throw()
+        {
+            // NaN and infinity have no JSON number representation, so serializing them without
+            // AllowNamedFloatingPointLiterals reports the same error float and double do.
+            await AssertNotSupported(BFloat16.NaN, BFloat16.PositiveInfinity);
+            await AssertNotSupported(Decimal32.NaN, Decimal32.PositiveInfinity);
+            await AssertNotSupported(Decimal64.NaN, Decimal64.PositiveInfinity);
+            await AssertNotSupported(Decimal128.NaN, Decimal128.NegativeInfinity);
+
+            async Task AssertNotSupported<T>(T nan, T infinity) where T : struct, IFloatingPointIeee754<T>
+            {
+                await Assert.ThrowsAsync<ArgumentException>(() => Serializer.SerializeWrapper(nan));
+                await Assert.ThrowsAsync<ArgumentException>(() => Serializer.SerializeWrapper(infinity));
+
+                var dictionary = new Dictionary<T, int> { [infinity] = 42 };
+                await Assert.ThrowsAsync<ArgumentException>(() => Serializer.SerializeWrapper(dictionary));
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/Common/Ieee754NumericConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/Ieee754NumericConverterTests.cs
@@ -1,0 +1,236 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    /// <summary>
+    /// Tests for the built-in converters of the IEEE 754 types that were added in .NET 11:
+    /// <see cref="BFloat16"/>, <see cref="Decimal32"/>, <see cref="Decimal64"/> and <see cref="Decimal128"/>.
+    /// </summary>
+    public abstract class Ieee754NumericConverterTests : SerializerTests
+    {
+        protected Ieee754NumericConverterTests(JsonSerializerWrapper serializer) : base(serializer)
+        {
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("-1")]
+        [InlineData("0.5")]
+        [InlineData("-0.75")]
+        [InlineData("1.5")]
+        [InlineData("256")]
+        [InlineData("-1024")]
+        public Task BFloat16_Roundtrip(string json) => AssertRoundtrip<BFloat16>(json);
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("-1")]
+        [InlineData("1.5")]
+        [InlineData("-2.25")]
+        [InlineData("1000000")]
+        public Task Decimal32_Roundtrip(string json) => AssertRoundtrip<Decimal32>(json);
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("-1")]
+        [InlineData("1.5")]
+        [InlineData("-2.25")]
+        [InlineData("1234567890123456")]
+        public Task Decimal64_Roundtrip(string json) => AssertRoundtrip<Decimal64>(json);
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("-1")]
+        [InlineData("1.5")]
+        [InlineData("-2.25")]
+        [InlineData("1234567890123456789012345678901234")]
+        public Task Decimal128_Roundtrip(string json) => AssertRoundtrip<Decimal128>(json);
+
+        [Fact]
+        public async Task Decimal128_LargeMagnitudeValue_Roundtrips()
+        {
+            // Exercises the pooled-buffer growth path of the converter: the general format of the
+            // IEEE 754 decimal types is fully positional, so extreme values expand to thousands of digits.
+            Decimal128 value = Decimal128.MaxValue;
+            string expected = value.ToString(null, CultureInfo.InvariantCulture);
+            Assert.True(expected.Length > 64, $"Expected an expanded representation, got '{expected}'.");
+
+            string json = await Serializer.SerializeWrapper(value);
+            Assert.Equal(expected, json);
+            Assert.Equal(value, await Serializer.DeserializeWrapper<Decimal128>(json));
+        }
+
+        [Theory]
+        [MemberData(nameof(SupportedTypes))]
+        public void MetadataServicesExposesConverterForType(Type type, JsonConverter converter)
+        {
+            Assert.Equal(type, converter.Type);
+
+            // Both the reflection-based resolver and the source generator must map these types to a
+            // value converter rather than treating them as object or unsupported types.
+            JsonTypeInfo typeInfo = Serializer.GetTypeInfo(type);
+            Assert.Equal(JsonTypeInfoKind.None, typeInfo.Kind);
+        }
+
+        public static IEnumerable<object[]> SupportedTypes()
+        {
+            yield return new object[] { typeof(BFloat16), JsonMetadataServices.BFloat16Converter };
+            yield return new object[] { typeof(Decimal32), JsonMetadataServices.Decimal32Converter };
+            yield return new object[] { typeof(Decimal64), JsonMetadataServices.Decimal64Converter };
+            yield return new object[] { typeof(Decimal128), JsonMetadataServices.Decimal128Converter };
+        }
+
+        [Fact]
+        public async Task NamedFloatingPointLiterals_Roundtrip()
+        {
+            await AssertNamedLiterals(BFloat16.NaN, BFloat16.PositiveInfinity, BFloat16.NegativeInfinity);
+            await AssertNamedLiterals(Decimal32.NaN, Decimal32.PositiveInfinity, Decimal32.NegativeInfinity);
+            await AssertNamedLiterals(Decimal64.NaN, Decimal64.PositiveInfinity, Decimal64.NegativeInfinity);
+            await AssertNamedLiterals(Decimal128.NaN, Decimal128.PositiveInfinity, Decimal128.NegativeInfinity);
+        }
+
+        [Fact]
+        public async Task AllowReadingFromString()
+        {
+            var options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.AllowReadingFromString };
+
+            Assert.Equal((BFloat16)1.5f, await Serializer.DeserializeWrapper<BFloat16>("\"1.5\"", options));
+            Assert.Equal(Parse<Decimal32>("1.5"), await Serializer.DeserializeWrapper<Decimal32>("\"1.5\"", options));
+            Assert.Equal(Parse<Decimal64>("1.5"), await Serializer.DeserializeWrapper<Decimal64>("\"1.5\"", options));
+            Assert.Equal(Parse<Decimal128>("1.5"), await Serializer.DeserializeWrapper<Decimal128>("\"1.5\"", options));
+        }
+
+        [Fact]
+        public async Task WriteAsString()
+        {
+            var options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.WriteAsString };
+
+            Assert.Equal("\"1.5\"", await Serializer.SerializeWrapper((BFloat16)1.5f, options));
+            Assert.Equal("\"1.5\"", await Serializer.SerializeWrapper(Parse<Decimal32>("1.5"), options));
+            Assert.Equal("\"1.5\"", await Serializer.SerializeWrapper(Parse<Decimal64>("1.5"), options));
+            Assert.Equal("\"1.5\"", await Serializer.SerializeWrapper(Parse<Decimal128>("1.5"), options));
+        }
+
+        [Fact]
+        public async Task DictionaryKeys_Roundtrip()
+        {
+            await AssertDictionaryKeyRoundtrip((BFloat16)1.5f, "1.5");
+            await AssertDictionaryKeyRoundtrip(Parse<Decimal32>("1.5"), "1.5");
+            await AssertDictionaryKeyRoundtrip(Parse<Decimal64>("1.5"), "1.5");
+            await AssertDictionaryKeyRoundtrip(Parse<Decimal128>("1.5"), "1.5");
+        }
+
+        [Fact]
+        public async Task PocoWithIeee754Properties_Roundtrips()
+        {
+            var poco = new Ieee754Poco
+            {
+                BFloat16Value = (BFloat16)1.5f,
+                Decimal32Value = Parse<Decimal32>("2.5"),
+                Decimal64Value = Parse<Decimal64>("3.5"),
+                Decimal128Value = Parse<Decimal128>("4.5"),
+            };
+
+            string json = await Serializer.SerializeWrapper(poco);
+            JsonTestHelper.AssertJsonEqual(
+                """{"BFloat16Value":1.5,"Decimal32Value":2.5,"Decimal64Value":3.5,"Decimal128Value":4.5}""",
+                json);
+
+            Ieee754Poco deserialized = await Serializer.DeserializeWrapper<Ieee754Poco>(json);
+            Assert.Equal(poco.BFloat16Value, deserialized.BFloat16Value);
+            Assert.Equal(poco.Decimal32Value, deserialized.Decimal32Value);
+            Assert.Equal(poco.Decimal64Value, deserialized.Decimal64Value);
+            Assert.Equal(poco.Decimal128Value, deserialized.Decimal128Value);
+        }
+
+        [Theory]
+        [InlineData("\"abc\"")]
+        [InlineData("\"naN\"")]
+        [InlineData("\"1.5abc\"")]
+        public async Task InvalidValues_ThrowJsonException(string json)
+        {
+            var options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.AllowReadingFromString };
+
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<BFloat16>(json, options));
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<Decimal32>(json, options));
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<Decimal64>(json, options));
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<Decimal128>(json, options));
+        }
+
+        [Fact]
+        public void JsonValue_ReportsNumberValueKind()
+        {
+            AssertNumberValueKind((BFloat16)1.5f);
+            AssertNumberValueKind(Parse<Decimal32>("1.5"));
+            AssertNumberValueKind(Parse<Decimal64>("1.5"));
+            AssertNumberValueKind(Parse<Decimal128>("1.5"));
+
+            void AssertNumberValueKind<T>(T value) where T : struct, IFloatingPointIeee754<T>
+                => Assert.Equal(JsonValueKind.Number, JsonValue.Create(value, Serializer.GetTypeInfo<T>()).GetValueKind());
+        }
+
+        private static T Parse<T>(string value) where T : struct, IFloatingPointIeee754<T>
+            => T.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+
+        private async Task AssertRoundtrip<T>(string json) where T : struct, IFloatingPointIeee754<T>
+        {
+            T value = Parse<T>(json);
+            Assert.Equal(json, value.ToString(null, CultureInfo.InvariantCulture));
+
+            // Exercises root values, object properties, collection elements, dictionary values,
+            // JsonNode values and boxed values.
+            await TestMultiContextSerialization(value, json);
+            await TestMultiContextDeserialization(json, value);
+        }
+
+        private async Task AssertNamedLiterals<T>(T nan, T positiveInfinity, T negativeInfinity)
+            where T : struct, IFloatingPointIeee754<T>
+        {
+            var options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals };
+
+            Assert.Equal("\"NaN\"", await Serializer.SerializeWrapper(nan, options));
+            Assert.Equal("\"Infinity\"", await Serializer.SerializeWrapper(positiveInfinity, options));
+            Assert.Equal("\"-Infinity\"", await Serializer.SerializeWrapper(negativeInfinity, options));
+
+            Assert.True(T.IsNaN(await Serializer.DeserializeWrapper<T>("\"NaN\"", options)));
+            Assert.Equal(positiveInfinity, await Serializer.DeserializeWrapper<T>("\"Infinity\"", options));
+            Assert.Equal(negativeInfinity, await Serializer.DeserializeWrapper<T>("\"-Infinity\"", options));
+
+            // Named literals are rejected unless the corresponding flag is enabled.
+            await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<T>("\"NaN\""));
+        }
+
+        private async Task AssertDictionaryKeyRoundtrip<T>(T value, string expectedKey)
+            where T : struct, IFloatingPointIeee754<T>
+        {
+            var dictionary = new Dictionary<T, int> { [value] = 42 };
+
+            string json = await Serializer.SerializeWrapper(dictionary);
+            Assert.Equal($"{{\"{expectedKey}\":42}}", json);
+
+            Dictionary<T, int> deserialized = await Serializer.DeserializeWrapper<Dictionary<T, int>>(json);
+            Assert.Equal(42, deserialized[value]);
+        }
+
+        public class Ieee754Poco
+        {
+            public BFloat16 BFloat16Value { get; set; }
+            public Decimal32 Decimal32Value { get; set; }
+            public Decimal64 Decimal64Value { get; set; }
+            public Decimal128 Decimal128Value { get; set; }
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Nodes;
@@ -51,6 +52,12 @@ namespace System.Text.Json.Schema.Tests
             yield return new TestData<UInt128>(42, ExpectedJsonSchema: """{"type":"integer"}""");
             yield return new TestData<Int128>(42, ExpectedJsonSchema: """{"type":"integer"}""");
             yield return new TestData<Half>((Half)3.141, ExpectedJsonSchema: """{"type":"number"}""");
+#endif
+#if NET11_0_OR_GREATER
+            yield return new TestData<System.Numerics.BFloat16>((System.Numerics.BFloat16)3.141f, ExpectedJsonSchema: """{"type":"number"}""");
+            yield return new TestData<System.Numerics.Decimal32>(System.Numerics.Decimal32.Parse("3.14159", CultureInfo.InvariantCulture), ExpectedJsonSchema: """{"type":"number"}""");
+            yield return new TestData<System.Numerics.Decimal64>(System.Numerics.Decimal64.Parse("3.14159", CultureInfo.InvariantCulture), ExpectedJsonSchema: """{"type":"number"}""");
+            yield return new TestData<System.Numerics.Decimal128>(System.Numerics.Decimal128.Parse("3.14159", CultureInfo.InvariantCulture), ExpectedJsonSchema: """{"type":"number"}""");
 #endif
             yield return new TestData<string>("I am a string", ExpectedJsonSchema: """{"type":["string","null"]}""");
             yield return new TestData<char>('c', ExpectedJsonSchema: """{"type":"string", "minLength":1, "maxLength":1 }""");
@@ -317,6 +324,33 @@ namespace System.Text.Json.Schema.Tests
             yield return new TestData<Half?>(
                 Value: (Half)1.5,
                 AdditionalValues: [null, Half.NaN, Half.PositiveInfinity, Half.NegativeInfinity],
+                ExpectedJsonSchema: """
+                    {
+                        "anyOf": [
+                            { "type": ["number", "null"] },
+                            { "enum": ["NaN", "Infinity", "-Infinity"] }
+                        ]
+                    }
+                    """,
+                SerializerOptions: new() { NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals });
+#endif
+#if NET11_0_OR_GREATER
+            yield return new TestData<System.Numerics.BFloat16?>(
+                Value: (System.Numerics.BFloat16)1.5f,
+                AdditionalValues: [null, System.Numerics.BFloat16.NaN, System.Numerics.BFloat16.PositiveInfinity, System.Numerics.BFloat16.NegativeInfinity],
+                ExpectedJsonSchema: """
+                    {
+                        "anyOf": [
+                            { "type": ["number", "null"] },
+                            { "enum": ["NaN", "Infinity", "-Infinity"] }
+                        ]
+                    }
+                    """,
+                SerializerOptions: new() { NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals });
+
+            yield return new TestData<System.Numerics.Decimal64?>(
+                Value: System.Numerics.Decimal64.Parse("1.5", CultureInfo.InvariantCulture),
+                AdditionalValues: [null, System.Numerics.Decimal64.NaN, System.Numerics.Decimal64.PositiveInfinity, System.Numerics.Decimal64.NegativeInfinity],
                 ExpectedJsonSchema: """
                     {
                         "anyOf": [

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/Ieee754NumericConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/Ieee754NumericConverterTests.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Tests;
+
+namespace System.Text.Json.SourceGeneration.Tests
+{
+    public sealed partial class Ieee754NumericConverterTests_Metadata : Ieee754NumericConverterTests
+    {
+        public Ieee754NumericConverterTests_Metadata()
+            : base(new StringSerializerWrapper(Ieee754NumericConverterTestsContext_Metadata.Default))
+        {
+        }
+
+        [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+        [JsonSerializable(typeof(object))]
+        [JsonSerializable(typeof(JsonNode))]
+        [JsonSerializable(typeof(JsonObject))]
+        [JsonSerializable(typeof(List<object>))]
+        [JsonSerializable(typeof(Dictionary<string, object>))]
+        [JsonSerializable(typeof(GenericPoco<object>))]
+        [JsonSerializable(typeof(BFloat16))]
+        [JsonSerializable(typeof(List<BFloat16>))]
+        [JsonSerializable(typeof(Dictionary<string, BFloat16>))]
+        [JsonSerializable(typeof(Dictionary<BFloat16, int>))]
+        [JsonSerializable(typeof(GenericPoco<BFloat16>))]
+        [JsonSerializable(typeof(Decimal32))]
+        [JsonSerializable(typeof(List<Decimal32>))]
+        [JsonSerializable(typeof(Dictionary<string, Decimal32>))]
+        [JsonSerializable(typeof(Dictionary<Decimal32, int>))]
+        [JsonSerializable(typeof(GenericPoco<Decimal32>))]
+        [JsonSerializable(typeof(Decimal64))]
+        [JsonSerializable(typeof(List<Decimal64>))]
+        [JsonSerializable(typeof(Dictionary<string, Decimal64>))]
+        [JsonSerializable(typeof(Dictionary<Decimal64, int>))]
+        [JsonSerializable(typeof(GenericPoco<Decimal64>))]
+        [JsonSerializable(typeof(Decimal128))]
+        [JsonSerializable(typeof(List<Decimal128>))]
+        [JsonSerializable(typeof(Dictionary<string, Decimal128>))]
+        [JsonSerializable(typeof(Dictionary<Decimal128, int>))]
+        [JsonSerializable(typeof(GenericPoco<Decimal128>))]
+        [JsonSerializable(typeof(Ieee754Poco))]
+        internal sealed partial class Ieee754NumericConverterTestsContext_Metadata : JsonSerializerContext
+        {
+        }
+    }
+
+    public sealed partial class Ieee754NumericConverterTests_Default : Ieee754NumericConverterTests
+    {
+        public Ieee754NumericConverterTests_Default()
+            : base(new StringSerializerWrapper(Ieee754NumericConverterTestsContext_Default.Default))
+        {
+        }
+
+        [JsonSerializable(typeof(object))]
+        [JsonSerializable(typeof(JsonNode))]
+        [JsonSerializable(typeof(JsonObject))]
+        [JsonSerializable(typeof(List<object>))]
+        [JsonSerializable(typeof(Dictionary<string, object>))]
+        [JsonSerializable(typeof(GenericPoco<object>))]
+        [JsonSerializable(typeof(BFloat16))]
+        [JsonSerializable(typeof(List<BFloat16>))]
+        [JsonSerializable(typeof(Dictionary<string, BFloat16>))]
+        [JsonSerializable(typeof(Dictionary<BFloat16, int>))]
+        [JsonSerializable(typeof(GenericPoco<BFloat16>))]
+        [JsonSerializable(typeof(Decimal32))]
+        [JsonSerializable(typeof(List<Decimal32>))]
+        [JsonSerializable(typeof(Dictionary<string, Decimal32>))]
+        [JsonSerializable(typeof(Dictionary<Decimal32, int>))]
+        [JsonSerializable(typeof(GenericPoco<Decimal32>))]
+        [JsonSerializable(typeof(Decimal64))]
+        [JsonSerializable(typeof(List<Decimal64>))]
+        [JsonSerializable(typeof(Dictionary<string, Decimal64>))]
+        [JsonSerializable(typeof(Dictionary<Decimal64, int>))]
+        [JsonSerializable(typeof(GenericPoco<Decimal64>))]
+        [JsonSerializable(typeof(Decimal128))]
+        [JsonSerializable(typeof(List<Decimal128>))]
+        [JsonSerializable(typeof(Dictionary<string, Decimal128>))]
+        [JsonSerializable(typeof(Dictionary<Decimal128, int>))]
+        [JsonSerializable(typeof(GenericPoco<Decimal128>))]
+        [JsonSerializable(typeof(Ieee754Poco))]
+        internal sealed partial class Ieee754NumericConverterTestsContext_Default : JsonSerializerContext
+        {
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
@@ -34,6 +34,12 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(Int128))]
         [JsonSerializable(typeof(Half))]
 #endif
+#if NET11_0_OR_GREATER
+        [JsonSerializable(typeof(System.Numerics.BFloat16))]
+        [JsonSerializable(typeof(System.Numerics.Decimal32))]
+        [JsonSerializable(typeof(System.Numerics.Decimal64))]
+        [JsonSerializable(typeof(System.Numerics.Decimal128))]
+#endif
         [JsonSerializable(typeof(string))]
         [JsonSerializable(typeof(char))]
         [JsonSerializable(typeof(byte[]))]
@@ -75,6 +81,10 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(float?))]
 #if NET
         [JsonSerializable(typeof(Half?))]
+#endif
+#if NET11_0_OR_GREATER
+        [JsonSerializable(typeof(System.Numerics.BFloat16?))]
+        [JsonSerializable(typeof(System.Numerics.Decimal64?))]
 #endif
         [JsonSerializable(typeof(Guid?))]
         [JsonSerializable(typeof(JsonElement?))]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.targets
@@ -183,6 +183,11 @@
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TestedRoslynVersion)' >= '4.0' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <Compile Include="..\Common\Ieee754NumericConverterTests.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\Ieee754NumericConverterTests.cs" />
+    <Compile Include="Serialization\Ieee754NumericConverterTests.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <DefaultReferenceExclusion Include="System.Text.Json.SourceGeneration" />
   </ItemGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Ieee754NumericConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Ieee754NumericConverterTests.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public sealed class Ieee754NumericConverterTestsDynamic : Ieee754NumericConverterTests
+    {
+        public Ieee754NumericConverterTestsDynamic() : base(JsonSerializerWrapper.StringSerializer) { }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -275,6 +275,11 @@
     <Compile Include="Serialization\ConvertersForUnsupportedTypesFunctionalTests.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <Compile Include="..\Common\Ieee754NumericConverterTests.cs" Link="CommonTest\System\Text\Json\Tests\Serialization\Ieee754NumericConverterTests.cs" />
+    <Compile Include="Serialization\Ieee754NumericConverterTests.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Compile Include="$(CommonPath)System\Buffers\ArrayBufferWriter.cs" Link="CommonTest\System\Buffers\ArrayBufferWriter.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />


### PR DESCRIPTION
Implements the API approved in #131097: built-in `System.Text.Json` serialization support for `System.Numerics.BFloat16`, `Decimal32`, `Decimal64`, and `Decimal128`.

Fixes #131097.

## Public API

```csharp
namespace System.Text.Json.Serialization.Metadata
{
    public static partial class JsonMetadataServices
    {
        public static JsonConverter<System.Numerics.BFloat16> BFloat16Converter { get; }
        public static JsonConverter<System.Numerics.Decimal32> Decimal32Converter { get; }
        public static JsonConverter<System.Numerics.Decimal64> Decimal64Converter { get; }
        public static JsonConverter<System.Numerics.Decimal128> Decimal128Converter { get; }
    }
}
```

## Implementation

All four types are backed by a single `Ieee754FloatingPointConverter<T>` constrained to `struct, IFloatingPointIeee754<T>`, which supplies the `TryFormat`, static `TryParse`, and `NaN`/`PositiveInfinity`/`NegativeInfinity` members the converter needs. The constructor takes a `NumericType` so the shared format-exception path reports the right type name.

The one place it deviates from `HalfConverter` is buffer sizing. `HalfConverter` can use a `const MaxFormatLength = 20` because `Half` formats in scientific notation, but the IEEE 754 decimal types format positionally under `"G"` (`suppressScientific: true`), so `Decimal128.MaxValue` expands to thousands of digits. The converter therefore starts on a 64-byte stack buffer and grows through `ArrayPool<byte>` on `TryFormat` failure.

Wire-up follows the existing pattern for a built-in simple converter:

- `DefaultJsonTypeInfoResolver.Converters` (`NumberOfSimpleConverters` 31 → 35)
- `JsonPropertyInfo` number-handling applicability
- `JsonValueOfT.DetermineValueKindForType`
- `JsonPrimitiveConverter`'s `isIeeeFloatingPoint` assert
- The source generator's `KnownTypeSymbols` and `CreateBuiltInSupportTypeSet`, so `[JsonSerializable]` on these types resolves to `JsonMetadataServices.{Type}Converter` with no emitter change

Everything new is gated on `#if NET11_0_OR_GREATER` in source and on `IsTargetFrameworkCompatible(..., 'net11.0')` in the project files; `#if NET` isn't sufficient since the library still targets netstandard2.0 and net462.

## Drive-by cleanup

`ThrowHelper.ThrowFormatException(NumericType)` was a 14-arm switch over near-identical resource strings. Rather than add four more, it collapses to a single parameterized `FormatNumericType` string and the 14 per-type `Format*` resources are removed. The message wording changed slightly, from `"…out of bounds for a Half."` to `"…out of bounds for the Half type."`, because the originals alternated `a`/`an` per type name. No test asserts on these strings.

`JsonMetadataServices.Converters.cs` now uses the C# `field` keyword for its lazily-initialized converter properties, which drops 39 `s_xxx` backing fields.

## Testing

New shared suite at `tests/Common/Ieee754NumericConverterTests.cs`, derived by both the reflection and source-gen test projects (the latter twice, for metadata and default modes). Round-trip theories route through `SerializerTests.TestMultiContextSerialization`/`TestMultiContextDeserialization`, so every literal is exercised as a root value, a boxed `object`, a POCO property, a `List<T>`/`List<object>` element, a `Dictionary<string, T>`/`Dictionary<string, object>` value, and through `JsonNode`/`JsonObject`. Dictionary *keys* are covered separately.

Also covers named literals (`NaN`/`Infinity`) under `JsonNumberHandling.AllowNamedFloatingPointLiterals`, `AllowReadingFromString`, `WriteAsString`, invalid input, `JsonValue` value-kind reporting, and a large-magnitude `Decimal128` value that forces the pooled-buffer growth path.

`JsonSchemaExporter` coverage was added for all four types plus nullable named-literal `anyOf` cases.

Results on net11.0 (Windows x64):

| Suite | Result |
| --- | --- |
| `System.Text.Json.Tests` | 53471 passed, 0 failed |
| `System.Text.Json.SourceGeneration.Roslyn4.4.Tests` | 10868 passed, 9 skipped, 0 failed |

net10.0 and netstandard2.0 build clean. net462 was not built locally — no .NET Framework 4.6.2 targeting pack in this environment — so CI is the first check for that leg.

> [!NOTE]
> This pull request was authored by GitHub Copilot.