### PR TITLE
[browser][mono][MT] Uncaught TypeError: He._emscripten_force_exit is not a function

### DIFF
--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -143,6 +143,7 @@
       <EmccExportedRuntimeMethod Include="HEAP64" />
       <EmccExportedRuntimeMethod Include="HEAPU64" />
       <EmccExportedRuntimeMethod Include="PThread" Condition="'$(WasmEnableThreads)' == 'true'" />
+      <EmccExportedRuntimeMethod Include="emscripten_force_exit" Condition="'$(WasmEnableThreads)' == 'true'" />
 
       <EmccExportedFunction Include="_free" />
       <EmccExportedFunction Include="_htons" />

--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -143,8 +143,8 @@
       <EmccExportedRuntimeMethod Include="HEAP64" />
       <EmccExportedRuntimeMethod Include="HEAPU64" />
       <EmccExportedRuntimeMethod Include="PThread" Condition="'$(WasmEnableThreads)' == 'true'" />
-      <EmccExportedRuntimeMethod Include="emscripten_force_exit" Condition="'$(WasmEnableThreads)' == 'true'" />
 
+      <EmccExportedFunction Include="_emscripten_force_exit" Condition="'$(WasmEnableThreads)' == 'true'" />
       <EmccExportedFunction Include="_free" />
       <EmccExportedFunction Include="_htons" />
       <EmccExportedFunction Include="_malloc" />


### PR DESCRIPTION
[Log](https://helix.dot.net/api/2019-06-17/jobs/8781260a-5691-4284-9a74-fb08eb673eb7/workitems/WasmTestOnChrome-MONO-MT-System.Threading.Thread.Tests/console)
```
[10:48:35] info: MONO_WASM: Uncaught TypeError: He._emscripten_force_exit is not a function
                 Error
                     at Object.eo [as mono_exit] (http://127.0.0.1:37617/_framework/dotnet.js:4:24400)
                     at tt.config.exitOnUnhandledError.e.onerror (http://127.0.0.1:37617/_framework/dotnet.runtime.1f097nq1pv.js:3:207546)
```
