### PR TITLE
Interop.Process: Avoid unhandled exception on FreeBSD

### DIFF
--- a/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.cs
+++ b/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.cs
@@ -108,9 +108,11 @@ internal static partial class Interop
 
             ProcessInfo info;
 
-            kinfo_proc* kinfo = GetProcInfo(pid, true, out int count);
+            kinfo_proc* kinfo = null;
             try
             {
+                kinfo = GetProcInfo(pid, true, out int count);
+
                 ArgumentOutOfRangeException.ThrowIfLessThan(count, 1, nameof(pid));
 
                 var process = new ReadOnlySpan<kinfo_proc>(kinfo, count);


### PR DESCRIPTION
The GetProcInfo() helper method may throw an exception when passed a non-existing PID. It might be quite often for short-lived processes that spawn and die quickly enough for their PID to become invalid.

Put the call under try {} block to fix the issue.

@Thefrank @wfurt @sec 