### PR TITLE
Remove NYI_WASM_SIMD and JitNyiWasmSimdToR2RUnsupported

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -156,7 +156,7 @@
       <CrossGenDllCmd>$(CrossGenDllCmd) -r:$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '*.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>
       <CrossGenDllCmd Condition="'$(PublishReadyToRunContainerFormat)' != ''">$(CrossGenDllCmd) --obj-format:$(PublishReadyToRunContainerFormat)</CrossGenDllCmd>
-      <CrossGenDllCmd Condition="'$(PublishReadyToRunContainerFormat)' == 'wasm'">$(CrossGenDllCmd) --codegenopt:JitWasmNyiToR2RUnsupported=1 --codegenopt:JitWasmSimdNyiToR2RUnsupported=1 </CrossGenDllCmd>
+      <CrossGenDllCmd Condition="'$(PublishReadyToRunContainerFormat)' == 'wasm'">$(CrossGenDllCmd) --codegenopt:JitWasmNyiToR2RUnsupported=1</CrossGenDllCmd>
       <CrossGenDllCmd Condition="'$(UseComposite)' == 'true'">$(CrossGenDllCmd) --composite</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetos:$(TargetOS)</CrossGenDllCmd>
       <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(EnableNgenOptimization)' == 'true'">$(CrossGenDllCmd) -m:$(MergedMibcPath) --embed-pgo-data</CrossGenDllCmd>

--- a/src/coreclr/jit/error.h
+++ b/src/coreclr/jit/error.h
@@ -169,7 +169,6 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 #define NYI_LOONGARCH64(msg) do { } while (0)
 #define NYI_RISCV64(msg) do { } while (0)
 #define NYI_WASM(msg) do { } while (0)
-#define NYI_WASM_SIMD(msg) do { } while (0)
 
 #elif defined(TARGET_X86)
 
@@ -180,7 +179,6 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 #define NYI_LOONGARCH64(msg) do { } while (0)
 #define NYI_RISCV64(msg) do { } while (0)
 #define NYI_WASM(msg) do { } while (0)
-#define NYI_WASM_SIMD(msg) do { } while (0)
 
 #elif defined(TARGET_ARM)
 
@@ -191,7 +189,6 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 #define NYI_LOONGARCH64(msg) do { } while (0)
 #define NYI_RISCV64(msg) do { } while (0)
 #define NYI_WASM(msg) do { } while (0)
-#define NYI_WASM_SIMD(msg) do { } while (0)
 
 #elif defined(TARGET_ARM64)
 
@@ -202,7 +199,6 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 #define NYI_LOONGARCH64(msg) do { } while (0)
 #define NYI_RISCV64(msg) do { } while (0)
 #define NYI_WASM(msg) do { } while (0)
-#define NYI_WASM_SIMD(msg) do { } while (0)
 
 #elif defined(TARGET_LOONGARCH64)
 #define NYI_AMD64(msg)  do { } while (0)
@@ -212,7 +208,6 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 #define NYI_LOONGARCH64(msg) NYIRAW("NYI_LOONGARCH64: " msg)
 #define NYI_RISCV64(msg) do { } while (0)
 #define NYI_WASM(msg) do { } while (0)
-#define NYI_WASM_SIMD(msg) do { } while (0)
 
 #elif defined(TARGET_RISCV64)
 #define NYI_AMD64(msg)  do { } while (0)
@@ -222,7 +217,6 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 #define NYI_LOONGARCH64(msg) do { } while (0)
 #define NYI_RISCV64(msg) NYIRAW("NYI_RISCV64: " msg)
 #define NYI_WASM(msg) do { } while (0)
-#define NYI_WASM_SIMD(msg) do { } while (0)
 
 #elif defined(TARGET_WASM)
 #define NYI_AMD64(msg)  do { } while (0)
@@ -235,10 +229,6 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 #define NYI_WASM(msg) do { if (JitConfig.JitWasmNyiToR2RUnsupported() > 0) \
    { JITDUMP("NYI_WASM: " msg); implReadyToRunUnsupported(); } \
    else { NYIRAW("NYI_WASM: " msg); } } while (0)
-
-#define NYI_WASM_SIMD(msg) do { if (JitConfig.JitWasmSimdNyiToR2RUnsupported() > 0) \
-   { JITDUMP("NYI_WASM_SIMD: " msg); implReadyToRunUnsupported(); } \
-   else { NYIRAW("NYI_WASM_SIMD: " msg); } } while (0)
 
 #else
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -24068,16 +24068,10 @@ GenTree* Compiler::gtNewSimdCvtNativeNode(
             intrinsic = NI_PackedSimd_ConvertToUInt32Saturate;
             break;
         }
-
-        case TYP_LONG:
-        case TYP_ULONG:
-        {
-            NYI_WASM_SIMD("gtNewSimdCvtNativeNode");
-            return nullptr;
-        }
-
         default:
         {
+            // Note: float/double -> TYP_LONG and TYP_ULONG
+            // conversions are not natively supported on Wasm, so the unreached() here is appropriate.
             unreached();
         }
     }
@@ -25106,10 +25100,10 @@ GenTree* Compiler::gtNewSimdFmaNode(
 
     std::swap(op1, op3);
 #elif defined(TARGET_WASM)
-    NYI_WASM_SIMD("gtNewSimdFmaNode");
+    IMPL_LIMITATION("Wasm has no single-rounding FMA");
 #else
 #error Unsupported platform
-#endif // !TARGET_XARCH && !TARGET_ARM64
+#endif // !TARGET_XARCH && !TARGET_ARM64 && !TARGET_WASM
 
     assert(intrinsic != NI_Illegal);
     return gtNewSimdHWIntrinsicNode(type, op1, op2, op3, intrinsic, simdBaseType, simdSize);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -25100,7 +25100,8 @@ GenTree* Compiler::gtNewSimdFmaNode(
 
     std::swap(op1, op3);
 #elif defined(TARGET_WASM)
-    IMPL_LIMITATION("Wasm has no single-rounding FMA");
+    // Wasm has no single rounding FMA, and this should be guarded against already in import.
+    unreached();
 #else
 #error Unsupported platform
 #endif // !TARGET_XARCH && !TARGET_ARM64 && !TARGET_WASM

--- a/src/coreclr/jit/hwintrinsiccodegenwasm.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenwasm.cpp
@@ -100,7 +100,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             }
             default:
             {
-                NYI_WASM_SIMD("CodeGen::genHWIntrinsic: Unsupported category for table-driven intrinsic");
+                unreached();
             }
         }
     }
@@ -120,7 +120,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
             default:
             {
-                NYI_WASM_SIMD("!codeGenIsTableDriven");
+                unreached();
             }
         }
     }
@@ -249,8 +249,7 @@ void CodeGen::genHWIntrinsicJumpTableFallback(GenTreeHWIntrinsic* node, HWIntrin
                 }
                 default:
                 {
-                    NYI_WASM_SIMD(
-                        "CodeGen::genHWIntrinsicJumpTableFallback: Unsupported category for jump table intrinsic");
+                    unreached();
                 }
             }
             // proper branch depth is immUpperBound + 1 - i; The $inner block accounts for the + 1.

--- a/src/coreclr/jit/hwintrinsicwasm.cpp
+++ b/src/coreclr/jit/hwintrinsicwasm.cpp
@@ -78,7 +78,7 @@ GenTree* Compiler::impNonConstFallback(NamedIntrinsic intrinsic, var_types simdT
 {
     // On Wasm, for non-const immediate only instructions, we either emit a jump table
     // or re-write to a fallback sequence, so impNonConstFallback should never be used.
-    NO_WAY("Wasm has no non-const intrinsic fallbacks");
+    unreached();
     return nullptr;
 }
 

--- a/src/coreclr/jit/hwintrinsicwasm.cpp
+++ b/src/coreclr/jit/hwintrinsicwasm.cpp
@@ -76,7 +76,9 @@ CORINFO_InstructionSet Compiler::lookupIsa(const char* className,
 
 GenTree* Compiler::impNonConstFallback(NamedIntrinsic intrinsic, var_types simdType, var_types simdBaseType)
 {
-    NYI_WASM_SIMD("impNonConstFallback");
+    // On Wasm, for non-const immediate only instructions, we either emit a jump table
+    // or re-write to a fallback sequence, so impNonConstFallback should never be used.
+    NO_WAY("Wasm has no non-const intrinsic fallbacks");
     return nullptr;
 }
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -901,7 +901,6 @@ CONFIG_INTEGER(JitDispIns, "JitDispIns", 0)
 #if defined(TARGET_WASM)
 // Set this to 1 to turn NYI_WASM into R2R unsupported failures instead of asserts.
 RELEASE_CONFIG_INTEGER(JitWasmNyiToR2RUnsupported, "JitWasmNyiToR2RUnsupported", 0)
-RELEASE_CONFIG_INTEGER(JitWasmSimdNyiToR2RUnsupported, "JitWasmSimdNyiToR2RUnsupported", 0)
 
 // Specify methods that will fail with R2R unsupported after codegen.
 // Useful for bypassing methods that compile cleanly but have invalid Wasm codegen.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11764,7 +11764,7 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
 #endif // TARGET_XARCH
                     }
                     else
-#endif // !FEATURE_MASKED_HW_INTRINSICS
+#endif // FEATURE_MASKED_HW_INTRINSICS
                     {
                         newNode = gtNewSimdUnOpNode(GT_NOT, op1Type, op1, simdBaseType, simdSize);
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11738,6 +11738,7 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
                     GenTree*  newNode = nullptr;
                     var_types op1Type = op1->TypeGet();
 
+#ifdef FEATURE_MASKED_HW_INTRINSICS
                     if (op1->OperIsConvertVectorToMask())
                     {
                         GenTreeHWIntrinsic* op1Intrinsic = op1->AsHWIntrinsic();
@@ -11747,17 +11748,15 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
 #elif defined(TARGET_ARM64)
                         op1 = op1Intrinsic->Op(2);
                         DEBUG_DESTROY_NODE(op1Intrinsic->Op(1));
-#elif defined(TARGET_WASM)
-                        NYI_WASM_SIMD("fgMorphHWIntrinsicRequired");
 #else
+// Wasm not handled here as it doesn't support masked intrinsics.
 #error Unsupported platform
-#endif // !TARGET_XARCH && !TARGET_ARM64 && !TARGET_WASM
+#endif // !TARGET_XARCH && !TARGET_ARM64
 
                         op1Type = op1->TypeGet();
                         DEBUG_DESTROY_NODE(op1Intrinsic);
                     }
 
-#ifdef FEATURE_MASKED_HW_INTRINSICS
                     if (op1Type == TYP_MASK)
                     {
 #if defined(TARGET_XARCH)
@@ -11765,7 +11764,7 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
 #endif // TARGET_XARCH
                     }
                     else
-#endif
+#endif // !FEATURE_MASKED_HW_INTRINSICS
                     {
                         newNode = gtNewSimdUnOpNode(GT_NOT, op1Type, op1, simdBaseType, simdSize);
 
@@ -11778,6 +11777,7 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
                     {
                         DEBUG_DESTROY_NODE(op2);
                         DEBUG_DESTROY_NODE(tree);
+
 #ifdef FEATURE_MASKED_HW_INTRINSICS
                         if (op1Type != retType)
                         {
@@ -11788,7 +11788,6 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
                                 newNode = fgMorphHWIntrinsicOptional(newNode->AsHWIntrinsic());
                             }
                             newNode->SetMorphed(this);
-
                             if (retType == TYP_MASK)
                             {
                                 newNode = gtNewSimdCvtVectorToMaskNode(retType, newNode, simdBaseType, simdSize);
@@ -11798,10 +11797,7 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
                                 newNode = gtNewSimdCvtMaskToVectorNode(retType, newNode, simdBaseType, simdSize);
                             }
                         }
-#else
-                        assert(op1Type == retType);
-#endif
-
+#endif // !FEATURE_MASKED_HW_INTRINSICS
                         return fgMorphHWIntrinsicRequired(newNode->AsHWIntrinsic());
                     }
                 }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11777,7 +11777,6 @@ GenTree* Compiler::fgMorphHWIntrinsicRequired(GenTreeHWIntrinsic* tree)
                     {
                         DEBUG_DESTROY_NODE(op2);
                         DEBUG_DESTROY_NODE(tree);
-
 #ifdef FEATURE_MASKED_HW_INTRINSICS
                         if (op1Type != retType)
                         {

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1106,8 +1106,6 @@ class SuperPMICollect:
                             rsp_write_handle.write("--obj-format:wasm" + "\n")
                             # FIXME: Remove JitWasmNyiToR2RUnsupported once wasm codegen covers all cases
                             rsp_write_handle.write("--codegenopt:JitWasmNyiToR2RUnsupported=1" + "\n")
-                            # FIXME: Remove JitWasmSimdNyiToR2RUnsupported once wasm codegen covers all SIMD cases
-                            rsp_write_handle.write("--codegenopt:JitWasmSimdNyiToR2RUnsupported=1" + "\n")
                         for var, value in dotnet_env.items():
                             rsp_write_handle.write("--codegenopt:" + var + "=" + value + "\n")
 
@@ -1740,13 +1738,6 @@ class SuperPMIReplay:
             if self.coreclr_args.arch != self.coreclr_args.target_arch:
                 repro_flags += [ "-target", self.coreclr_args.target_arch ]
 
-            if self.coreclr_args.target_arch == "wasm":
-                # FIXME: Remove JitWasmSimdNyiToR2RUnsupported as soon as we have collections which include the option
-                repro_flags += [
-                    "-jitoption", "force", "JitWasmSimdNyiToR2RUnsupported=1",
-                    "-jit2option", "force", "JitWasmSimdNyiToR2RUnsupported=1"
-                ]
-
             if not self.coreclr_args.sequential and not self.coreclr_args.compile:
                 if not self.coreclr_args.parallelism:
                     common_flags += [ "-p" ]
@@ -2230,12 +2221,6 @@ class SuperPMIReplayAsmDiffs:
                 "-jitoption", "force", "AltJitNgen=*"
             ]
 
-        if self.coreclr_args.target_arch == "wasm":
-            # FIXME: Remove JitWasmSimdNyiToR2RUnsupported as soon as we have collections which include the option
-            altjit_replay_flags += [
-                "-jitoption", "force", "JitWasmSimdNyiToR2RUnsupported=1"
-            ]
-
         # Keep track if any MCH file replay had asm diffs
         files_with_asm_diffs = []
         files_with_replay_failures = []
@@ -2316,14 +2301,6 @@ class SuperPMIReplayAsmDiffs:
                             "-jitoption", "force", "JitWasmNyiToR2RUnsupported=1",
                             "-jit2option", "force", "JitWasmNyiToR2RUnsupported=1"
                         ]
-
-                # TODO: Remove this (and add under the above ignoreStoredConfig option)
-                # once we have collections which include JitWasmSimdNyiToR2RUnsupported
-                if self.coreclr_args.target_arch == "wasm":
-                    flags += [
-                            "-jitoption", "force", "JitWasmSimdNyiToR2RUnsupported=1",
-                            "-jit2option", "force", "JitWasmSimdNyiToR2RUnsupported=1"
-                    ]
 
                 # Change the working directory to the Core_Root we will call SuperPMI from.
                 # This is done to allow libcoredistools to be loaded correctly on unix
@@ -2415,21 +2392,6 @@ class SuperPMIReplayAsmDiffs:
                                 if proc.returncode != 0:
                                     # No miss/replay failure is expected in contexts that were reported as having diffs since then they succeeded during the diffs run.
                                     raise create_exception()
-
-                                # A Wasm JIT may exit successfully without writing any disassembly to DOTNET_JitStdOutFile. For example, the wasm JIT
-                                # with JitWasmSimdNyiToR2RUnsupported=1 exits via
-                                # implReadyToRunUnsupported() (CORJIT_R2R_UNSUPPORTED) for NYI_WASM_SIMD during import, so no code is produced. This is an expected behavior.
-                                # TODO-WASM: This check can potentially be removed once we no longer have any NYI's in the import stage.
-                                if not os.path.exists(item_path) and self.coreclr_args.target_arch == "wasm":
-                                    # Log a warning so that unexpected misses (vs the expected JitWasmSimdNyiToR2RUnsupported path) remain diagnosable
-                                    # rather than being silently masked as empty diffs.
-                                    stderr_snippet = stderr.decode(errors='replace').strip().splitlines()
-                                    stderr_first_line = stderr_snippet[0] if stderr_snippet else ""
-                                    logging.warning(
-                                        "%sNo JitStdOutFile produced for wasm context %s at %s (exit=%d, stderr first line: %r). "
-                                        "Treating as empty diff; verify this is the expected JitWasmSimdNyiToR2RUnsupported path.",
-                                        print_prefix, context_index, item_path, proc.returncode, stderr_first_line)
-                                    return ""
 
                                 try:
                                     with open(item_path, 'r') as file_handle:

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -132,7 +132,6 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         echo --method-layout:random >> "$__ResponseFile"
         if [ "$(CrossGen2OutputFormat)" == "wasm" ]; then
             echo --codegenopt:JitWasmNyiToR2RUnsupported=1 >> "$__ResponseFile"
-            echo --codegenopt:JitWasmSimdNyiToR2RUnsupported=1 >> "$__ResponseFile"
         fi
         if [ ! -z ${CrossGen2SynthesizePgo+x} ]%3B then
             echo --synthesize-random-mibc >> "$__ResponseFile"
@@ -345,7 +344,6 @@ if defined RunCrossGen2 (
     echo --method-layout:random>>!__ResponseFile!
     if "$(CrossGen2OutputFormat)"=="wasm" (
         echo "--codegenopt:JitWasmNyiToR2RUnsupported=1">>!__ResponseFile!
-        echo "--codegenopt:JitWasmSimdNyiToR2RUnsupported=1">>!__ResponseFile!
     )
     if not "$(CrossGen2OutputFormat)"=="" (
         echo -f:$(CrossGen2OutputFormat)>>!__ResponseFile!


### PR DESCRIPTION
Remove NYI_WASM_SIMD and replace with either:
1. altered preprocessor ifdefs around unreachable Wasm code(for `fgMorphHWIntrinsic`) 
2. `unreached()`