### PR TITLE
Fix EventPipe dispose-in-callback deadlock

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
@@ -302,13 +302,33 @@ namespace BasicEventSourceTests
             }
         }
 
-        [Fact]
-        public void Test_EventSource_DisposeInOnEventSourceCreated_Throws()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Test_EventSource_DisposeInOnEventSourceCreated_Throws(bool sourceBeforeListener)
         {
-            using var listener = new DisposeOnCreatedListener();
-            using var source = new DisposeOnCreatedEventSource();
+            DisposeOnCreatedEventSource? source = null;
+            DisposeOnCreatedListener? listener = null;
+            try
+            {
+                if (sourceBeforeListener)
+                {
+                    source = new DisposeOnCreatedEventSource();
+                    listener = new DisposeOnCreatedListener();
+                }
+                else
+                {
+                    listener = new DisposeOnCreatedListener();
+                    source = new DisposeOnCreatedEventSource();
+                }
 
-            Assert.IsType<InvalidOperationException>(listener._disposeException);
+                Assert.IsType<InvalidOperationException>(listener._disposeException);
+            }
+            finally
+            {
+                source?.Dispose();
+                listener?.Dispose();
+            }
         }
 
         private sealed class DisposeOnCreatedListener : EventListener

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
@@ -254,5 +254,39 @@ namespace BasicEventSourceTests
                 }
             }
         }
+
+        [Fact]
+        public void Test_EventSource_DisposeInOnEventSourceCreated_Throws()
+        {
+            using var listener = new DisposeOnCreatedListener();
+            using var source = new DisposeOnCreatedEventSource();
+
+            Assert.IsType<InvalidOperationException>(listener._disposeException);
+        }
+
+        private sealed class DisposeOnCreatedListener : EventListener
+        {
+            internal InvalidOperationException? _disposeException;
+
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                if (eventSource.Name == "TestsEventSourceCallbacks.DisposeOnCreatedEventSource")
+                {
+                    try
+                    {
+                        eventSource.Dispose();
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        _disposeException = ex;
+                    }
+                }
+            }
+        }
+
+        [EventSource(Name = "TestsEventSourceCallbacks.DisposeOnCreatedEventSource")]
+        private sealed class DisposeOnCreatedEventSource : EventSource
+        {
+        }
     }
 }

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
@@ -211,5 +211,48 @@ namespace BasicEventSourceTests
                 }
             }
         }
+
+        [Fact]
+        public void Test_EventSource_DisposeInDeferredOnEventCommand_Throws()
+        {
+            DeferredCommandEventSource.s_disposeException = null;
+
+            using var listener = new DeferredCommandListener();
+            using var source = new DeferredCommandEventSource();
+
+            Assert.IsType<InvalidOperationException>(DeferredCommandEventSource.s_disposeException);
+        }
+
+        private sealed class DeferredCommandListener : EventListener
+        {
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                if (eventSource.Name == "TestsEventSourceCallbacks.DeferredCommandEventSource")
+                {
+                    EnableEvents(eventSource, EventLevel.Verbose);
+                }
+            }
+        }
+
+        [EventSource(Name = "TestsEventSourceCallbacks.DeferredCommandEventSource")]
+        private sealed class DeferredCommandEventSource : EventSource
+        {
+            internal static InvalidOperationException? s_disposeException;
+
+            protected override void OnEventCommand(EventCommandEventArgs command)
+            {
+                if (command.Command == EventCommand.Enable)
+                {
+                    try
+                    {
+                        Dispose();
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        s_disposeException = ex;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Diagnostics.NETCore.Client;
@@ -84,7 +86,7 @@ namespace BasicEventSourceTests
         }
 
         /// <summary>
-        /// Validates that calling Dispose() on an EventSource from within OnEventCommand is rejected.
+        /// Validates that disposing an EventSource from its own OnEventCommand callback is rejected.
         /// </summary>
         [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "DiagnosticsClient IPC is not available on browser")]
@@ -146,6 +148,66 @@ namespace BasicEventSourceTests
                     {
                         _callbackCompleted.Set();
                     }
+                }
+            }
+        }
+
+        [Fact]
+        public void Test_EventSource_ConcurrentDisposeWaitsForCallback()
+        {
+            using var callbackEntered = new ManualResetEventSlim(false);
+            using var callbackRelease = new ManualResetEventSlim(false);
+            using var disposeStarted = new ManualResetEventSlim(false);
+            using var source = new BlockingCallbackEventSource(callbackEntered, callbackRelease);
+            using var listener = new PassiveListener();
+
+            Task enableTask = Task.Run(() => listener.EnableEvents(source, EventLevel.Verbose));
+            Task? disposeTask = null;
+            try
+            {
+                Assert.True(callbackEntered.Wait(TimeSpan.FromSeconds(30)));
+
+                disposeTask = Task.Run(() =>
+                {
+                    disposeStarted.Set();
+                    source.Dispose();
+                });
+                Assert.True(disposeStarted.Wait(TimeSpan.FromSeconds(30)));
+                Assert.False(disposeTask.Wait(TimeSpan.FromMilliseconds(100)));
+            }
+            finally
+            {
+                callbackRelease.Set();
+                Assert.True(disposeTask is null
+                    ? enableTask.Wait(TimeSpan.FromSeconds(30))
+                    : Task.WaitAll(new[] { enableTask, disposeTask }, TimeSpan.FromSeconds(30)));
+            }
+        }
+
+        private sealed class PassiveListener : EventListener
+        {
+        }
+
+        [EventSource(Name = "TestsEventSourceCallbacks.BlockingCallbackEventSource")]
+        private sealed class BlockingCallbackEventSource : EventSource
+        {
+            private readonly ManualResetEventSlim _callbackEntered;
+            private readonly ManualResetEventSlim _callbackRelease;
+
+            internal BlockingCallbackEventSource(
+                ManualResetEventSlim callbackEntered,
+                ManualResetEventSlim callbackRelease)
+            {
+                _callbackEntered = callbackEntered;
+                _callbackRelease = callbackRelease;
+            }
+
+            protected override void OnEventCommand(EventCommandEventArgs command)
+            {
+                if (command.Command == EventCommand.Enable)
+                {
+                    _callbackEntered.Set();
+                    _callbackRelease.Wait();
                 }
             }
         }

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace BasicEventSourceTests
@@ -86,16 +87,35 @@ namespace BasicEventSourceTests
         }
 
         /// <summary>
-        /// Validates that disposing an EventSource from its own OnEventCommand callback is rejected.
+        /// Validates disposing the current or another EventSource from within OnEventCommand.
         /// </summary>
-        [Fact]
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [InlineData(false)]
+        [InlineData(true)]
         [SkipOnPlatform(TestPlatforms.Browser, "DiagnosticsClient IPC is not available on browser")]
-        public void Test_EventSource_DisposeInOnEventCommand_Throws()
+        public void Test_EventSource_DisposeInOnEventCommand(bool disposeOtherSource)
         {
+            RemoteExecutor.Invoke(
+                RunDisposeInOnEventCommand,
+                disposeOtherSource.ToString(),
+                new RemoteInvokeOptions { TimeOut = 45_000 }).Dispose();
+        }
+
+        private static void RunDisposeInOnEventCommand(string disposeOtherSourceString)
+        {
+            bool disposeOtherSource = bool.Parse(disposeOtherSourceString);
             using var callbackCompleted = new ManualResetEventSlim(false);
             using var source = new DisposeInCallbackEventSource(callbackCompleted);
+            using var otherSource = disposeOtherSource ? new PassiveEventSource() : null;
+            source._sourceToDispose = otherSource;
 
-            var providers = new[] { new EventPipeProvider(source.Name, System.Diagnostics.Tracing.EventLevel.Verbose, long.MaxValue) };
+            var providers = disposeOtherSource
+                ? new[]
+                {
+                    new EventPipeProvider(source.Name, System.Diagnostics.Tracing.EventLevel.Verbose, long.MaxValue),
+                    new EventPipeProvider(otherSource!.Name, System.Diagnostics.Tracing.EventLevel.Verbose, long.MaxValue)
+                }
+                : new[] { new EventPipeProvider(source.Name, System.Diagnostics.Tracing.EventLevel.Verbose, long.MaxValue) };
             var client = new DiagnosticsClient(Environment.ProcessId);
             using var session = client.StartEventPipeSession(providers, requestRundown: false);
 
@@ -118,14 +138,27 @@ namespace BasicEventSourceTests
             readerTask.Wait(TimeSpan.FromSeconds(5));
 
             Assert.True(completed, "The EventSource callback did not complete.");
-            Assert.IsType<InvalidOperationException>(source._disposeException);
+            if (disposeOtherSource)
+            {
+                Assert.Null(source._disposeException);
+                Assert.True(source._disposeCompleted);
+                Assert.False(source._targetCallbackObservedBeforeDispose);
+            }
+            else
+            {
+                Assert.IsType<InvalidOperationException>(source._disposeException);
+                Assert.False(source._disposeCompleted);
+            }
         }
 
         [EventSource(Name = "TestsEventSourceCallbacks.DisposeInCallbackEventSource")]
         private class DisposeInCallbackEventSource : EventSource
         {
             private readonly ManualResetEventSlim _callbackCompleted;
+            internal EventSource? _sourceToDispose;
+            internal bool _disposeCompleted;
             internal InvalidOperationException? _disposeException;
+            internal bool _targetCallbackObservedBeforeDispose;
 
             internal DisposeInCallbackEventSource(ManualResetEventSlim callbackCompleted)
             {
@@ -138,7 +171,10 @@ namespace BasicEventSourceTests
                 {
                     try
                     {
-                        Dispose();
+                        _targetCallbackObservedBeforeDispose =
+                            _sourceToDispose is PassiveEventSource passiveSource && passiveSource._callbackObserved;
+                        (_sourceToDispose ?? this).Dispose();
+                        _disposeCompleted = true;
                     }
                     catch (InvalidOperationException ex)
                     {
@@ -149,6 +185,17 @@ namespace BasicEventSourceTests
                         _callbackCompleted.Set();
                     }
                 }
+            }
+        }
+
+        [EventSource(Name = "TestsEventSourceCallbacks.PassiveEventSource")]
+        private sealed class PassiveEventSource : EventSource
+        {
+            internal bool _callbackObserved;
+
+            protected override void OnEventCommand(EventCommandEventArgs command)
+            {
+                _callbackObserved = true;
             }
         }
 

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Diagnostics.NETCore.Client;
@@ -86,16 +84,14 @@ namespace BasicEventSourceTests
         }
 
         /// <summary>
-        /// Validates that calling Dispose() on an EventSource from within OnEventCommand
-        /// (triggered by an EventPipe session enabling the provider) does not deadlock.
-        /// See https://github.com/dotnet/runtime/issues/106087
+        /// Validates that calling Dispose() on an EventSource from within OnEventCommand is rejected.
         /// </summary>
         [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "DiagnosticsClient IPC is not available on browser")]
-        public void Test_EventSource_DisposeInOnEventCommand_DoesNotDeadlock()
+        public void Test_EventSource_DisposeInOnEventCommand_Throws()
         {
-            using var disposeCompleted = new ManualResetEventSlim(false);
-            using var source = new DisposeInCallbackEventSource(disposeCompleted);
+            using var callbackCompleted = new ManualResetEventSlim(false);
+            using var source = new DisposeInCallbackEventSource(callbackCompleted);
 
             var providers = new[] { new EventPipeProvider(source.Name, System.Diagnostics.Tracing.EventLevel.Verbose, long.MaxValue) };
             var client = new DiagnosticsClient(Environment.ProcessId);
@@ -114,31 +110,42 @@ namespace BasicEventSourceTests
                                        // varies by TraceEvent version/platform, so catch broadly here.
             });
 
-            // Wait for Dispose() to complete; if it deadlocks, this will timeout.
-            bool disposed = disposeCompleted.Wait(TimeSpan.FromSeconds(30));
+            bool completed = callbackCompleted.Wait(TimeSpan.FromSeconds(30));
 
             session.Stop();
             readerTask.Wait(TimeSpan.FromSeconds(5));
 
-            Assert.True(disposed, "EventSource.Dispose() called from within OnEventCommand did not complete. Possible deadlock.");
+            Assert.True(completed, "The EventSource callback did not complete.");
+            Assert.IsType<InvalidOperationException>(source._disposeException);
         }
 
         [EventSource(Name = "TestsEventSourceCallbacks.DisposeInCallbackEventSource")]
         private class DisposeInCallbackEventSource : EventSource
         {
-            private readonly ManualResetEventSlim _disposeCompleted;
+            private readonly ManualResetEventSlim _callbackCompleted;
+            internal InvalidOperationException? _disposeException;
 
-            internal DisposeInCallbackEventSource(ManualResetEventSlim disposeCompleted)
+            internal DisposeInCallbackEventSource(ManualResetEventSlim callbackCompleted)
             {
-                _disposeCompleted = disposeCompleted;
+                _callbackCompleted = callbackCompleted;
             }
 
             protected override void OnEventCommand(EventCommandEventArgs command)
             {
                 if (command.Command == EventCommand.Enable)
                 {
-                    Dispose();
-                    _disposeCompleted.Set();
+                    try
+                    {
+                        Dispose();
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        _disposeException = ex;
+                    }
+                    finally
+                    {
+                        _callbackCompleted.Set();
+                    }
                 }
             }
         }

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
@@ -107,8 +107,8 @@ namespace BasicEventSourceTests
             {
                 try
                 {
-                    using var source = new Microsoft.Diagnostics.Tracing.EventPipeEventSource(session.EventStream);
-                    source.Process();
+                    using var eventPipeSource = new Microsoft.Diagnostics.Tracing.EventPipeEventSource(session.EventStream);
+                    eventPipeSource.Process();
                 }
                 catch (Exception) { }  // Stream is closed when session stops. The exact exception type
                                        // varies by TraceEvent version/platform, so catch broadly here.

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestCallbacks.cs
@@ -7,7 +7,9 @@ using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Diagnostics.NETCore.Client;
 using Xunit;
 
 namespace BasicEventSourceTests
@@ -80,6 +82,64 @@ namespace BasicEventSourceTests
                 base.OnEventCommand(command);
 
                 _isDisabledInCallback = !IsEnabled();
+            }
+        }
+
+        /// <summary>
+        /// Validates that calling Dispose() on an EventSource from within OnEventCommand
+        /// (triggered by an EventPipe session enabling the provider) does not deadlock.
+        /// See https://github.com/dotnet/runtime/issues/106087
+        /// </summary>
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "DiagnosticsClient IPC is not available on browser")]
+        public void Test_EventSource_DisposeInOnEventCommand_DoesNotDeadlock()
+        {
+            using var disposeCompleted = new ManualResetEventSlim(false);
+            using var source = new DisposeInCallbackEventSource(disposeCompleted);
+
+            var providers = new[] { new EventPipeProvider(source.Name, System.Diagnostics.Tracing.EventLevel.Verbose, long.MaxValue) };
+            var client = new DiagnosticsClient(Environment.ProcessId);
+            using var session = client.StartEventPipeSession(providers, requestRundown: false);
+
+            // Drain the event stream in a background thread so the runtime's buffer doesn't fill up
+            // and so session.Stop() can complete.
+            Task readerTask = Task.Run(() =>
+            {
+                try
+                {
+                    using var source = new Microsoft.Diagnostics.Tracing.EventPipeEventSource(session.EventStream);
+                    source.Process();
+                }
+                catch (Exception) { }  // Stream is closed when session stops. The exact exception type
+                                       // varies by TraceEvent version/platform, so catch broadly here.
+            });
+
+            // Wait for Dispose() to complete; if it deadlocks, this will timeout.
+            bool disposed = disposeCompleted.Wait(TimeSpan.FromSeconds(30));
+
+            session.Stop();
+            readerTask.Wait(TimeSpan.FromSeconds(5));
+
+            Assert.True(disposed, "EventSource.Dispose() called from within OnEventCommand did not complete. Possible deadlock.");
+        }
+
+        [EventSource(Name = "TestsEventSourceCallbacks.DisposeInCallbackEventSource")]
+        private class DisposeInCallbackEventSource : EventSource
+        {
+            private readonly ManualResetEventSlim _disposeCompleted;
+
+            internal DisposeInCallbackEventSource(ManualResetEventSlim disposeCompleted)
+            {
+                _disposeCompleted = disposeCompleted;
+            }
+
+            protected override void OnEventCommand(EventCommandEventArgs command)
+            {
+                if (command.Command == EventCommand.Enable)
+                {
+                    Dispose();
+                    _disposeCompleted.Set();
+                }
             }
         }
     }

--- a/src/libraries/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="BasicEventSourceTest\Harness\Listeners.cs" />
     <Compile Include="BasicEventSourceTest\TestEventCounter.cs" />
     <Compile Include="BasicEventSourceTest\TestFilter.cs" />
+    <Compile Include="BasicEventSourceTest\TestCallbacks.cs" />
     <Compile Include="BasicEventSourceTest\TestNotSupported.cs" />
     <Compile Include="BasicEventSourceTest\TestsEventSourceLifetime.cs" />
     <Compile Include="BasicEventSourceTest\TestsManifestGeneration.cs" />

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2142,7 +2142,7 @@
     <value>Data descriptors are out of range.</value>
   </data>
   <data name="EventSource_DisposeInsideCallback" xml:space="preserve">
-    <value>EventSource cannot be disposed while an EventSource callback is executing.</value>
+    <value>EventSource cannot be disposed from an EventSource callback while one of its callbacks is in progress.</value>
   </data>
   <data name="EventSource_DuplicateStringKey" xml:space="preserve">
     <value>Multiple definitions for string "{0}".</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2141,6 +2141,9 @@
   <data name="EventSource_DataDescriptorsOutOfRange" xml:space="preserve">
     <value>Data descriptors are out of range.</value>
   </data>
+  <data name="EventSource_DisposeInsideCallback" xml:space="preserve">
+    <value>EventSource cannot be disposed while an EventSource callback is executing.</value>
+  </data>
   <data name="EventSource_DuplicateStringKey" xml:space="preserve">
     <value>Multiple definitions for string "{0}".</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventListener.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventListener.cs
@@ -578,9 +578,29 @@ public abstract class EventListener : IDisposable
                             WeakReference<EventSource> eventSourceRef = eventSourcesSnapshot[i];
                             if (eventSourceRef.TryGetTarget(out EventSource? eventSource))
                             {
-                                EventSourceCreatedEventArgs args = new EventSourceCreatedEventArgs();
-                                args.EventSource = eventSource;
-                                callback(this, args);
+                                bool callbackEntered = eventSource.TryEnterCallback();
+                                if (!callbackEntered)
+                                {
+                                    EventSource.EnterCallbackScope();
+                                }
+
+                                try
+                                {
+                                    EventSourceCreatedEventArgs args = new EventSourceCreatedEventArgs();
+                                    args.EventSource = eventSource;
+                                    callback(this, args);
+                                }
+                                finally
+                                {
+                                    if (callbackEntered)
+                                    {
+                                        eventSource.ExitCallback();
+                                    }
+                                    else
+                                    {
+                                        EventSource.ExitCallbackScope();
+                                    }
+                                }
                             }
                         }
 #if DEBUG

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace System.Diagnostics.Tracing
 {
@@ -13,11 +12,6 @@ namespace System.Diagnostics.Tracing
         private readonly WeakReference<EventProvider> _eventProvider;
         private IntPtr _provHandle;
         private GCHandle<EventPipeEventProvider> _gcHandle;
-
-        // Tracks the EventPipeEventProvider whose callback is currently executing on the current thread.
-        // Used to detect re-entrant Unregister() calls that would otherwise deadlock.
-        [ThreadStatic]
-        private static EventPipeEventProvider? t_callbackProvider;
 
         internal EventPipeEventProvider(EventProvider eventProvider)
         {
@@ -72,16 +66,7 @@ namespace System.Diagnostics.Tracing
             EventPipeEventProvider _this = GCHandle<EventPipeEventProvider>.FromIntPtr((IntPtr)callbackContext).Target;
             if (_this._eventProvider.TryGetTarget(out EventProvider? target))
             {
-                EventPipeEventProvider? previousProvider = t_callbackProvider;
-                t_callbackProvider = _this;
-                try
-                {
-                    _this.ProviderCallback(target, sourceId, isEnabled, level, matchAnyKeywords, matchAllKeywords, filterData);
-                }
-                finally
-                {
-                    t_callbackProvider = previousProvider;
-                }
+                _this.ProviderCallback(target, sourceId, isEnabled, level, matchAnyKeywords, matchAllKeywords, filterData);
             }
         }
 
@@ -101,48 +86,17 @@ namespace System.Diagnostics.Tracing
         }
 
         // Unregister an event provider.
+        // Calling Unregister within a Callback will result in a deadlock
+        // as deleting the provider with an active tracing session will block
+        // until all of the provider's callbacks are completed.
         internal override void Unregister()
         {
-            if (t_callbackProvider == this)
+            if (_provHandle != 0)
             {
-                // Calling EventPipeInternal.DeleteProvider from within a callback for this provider
-                // would deadlock: ep_delete_provider blocks until all in-flight callbacks complete,
-                // but we are currently executing from within a callback. Defer the unregistration
-                // to a background thread so it runs after the callback returns and the pending
-                // callback count is decremented.
-                IntPtr handleToDelete = _provHandle;
+                EventPipeInternal.DeleteProvider(_provHandle);
                 _provHandle = 0;
-                GCHandle<EventPipeEventProvider> gcHandleToDispose = _gcHandle;
-                _gcHandle = default;
-
-                if (handleToDelete != 0)
-                {
-                    ThreadPool.UnsafeQueueUserWorkItem(_ =>
-                    {
-                        try
-                        {
-                            EventPipeInternal.DeleteProvider(handleToDelete);
-                        }
-                        finally
-                        {
-                            gcHandleToDispose.Dispose();
-                        }
-                    }, null);
-                }
-                else
-                {
-                    gcHandleToDispose.Dispose();
-                }
             }
-            else
-            {
-                if (_provHandle != 0)
-                {
-                    EventPipeInternal.DeleteProvider(_provHandle);
-                    _provHandle = 0;
-                }
-                _gcHandle.Dispose();
-            }
+            _gcHandle.Dispose();
         }
 
         // Write an event.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Diagnostics.Tracing
 {
@@ -12,6 +13,11 @@ namespace System.Diagnostics.Tracing
         private readonly WeakReference<EventProvider> _eventProvider;
         private IntPtr _provHandle;
         private GCHandle<EventPipeEventProvider> _gcHandle;
+
+        // Tracks the EventPipeEventProvider whose callback is currently executing on the current thread.
+        // Used to detect re-entrant Unregister() calls that would otherwise deadlock.
+        [ThreadStatic]
+        private static EventPipeEventProvider? t_callbackProvider;
 
         internal EventPipeEventProvider(EventProvider eventProvider)
         {
@@ -66,7 +72,16 @@ namespace System.Diagnostics.Tracing
             EventPipeEventProvider _this = GCHandle<EventPipeEventProvider>.FromIntPtr((IntPtr)callbackContext).Target;
             if (_this._eventProvider.TryGetTarget(out EventProvider? target))
             {
-                _this.ProviderCallback(target, sourceId, isEnabled, level, matchAnyKeywords, matchAllKeywords, filterData);
+                EventPipeEventProvider? previousProvider = t_callbackProvider;
+                t_callbackProvider = _this;
+                try
+                {
+                    _this.ProviderCallback(target, sourceId, isEnabled, level, matchAnyKeywords, matchAllKeywords, filterData);
+                }
+                finally
+                {
+                    t_callbackProvider = previousProvider;
+                }
             }
         }
 
@@ -86,17 +101,42 @@ namespace System.Diagnostics.Tracing
         }
 
         // Unregister an event provider.
-        // Calling Unregister within a Callback will result in a deadlock
-        // as deleting the provider with an active tracing session will block
-        // until all of the provider's callbacks are completed.
         internal override void Unregister()
         {
-            if (_provHandle != 0)
+            if (t_callbackProvider == this)
             {
-                EventPipeInternal.DeleteProvider(_provHandle);
+                // Calling EventPipeInternal.DeleteProvider from within a callback for this provider
+                // would deadlock: ep_delete_provider blocks until all in-flight callbacks complete,
+                // but we are currently executing from within a callback. Defer the unregistration
+                // to a background thread so it runs after the callback returns and the pending
+                // callback count is decremented.
+                IntPtr handleToDelete = _provHandle;
                 _provHandle = 0;
+                GCHandle<EventPipeEventProvider> gcHandleToDispose = _gcHandle;
+                _gcHandle = default;
+
+                if (handleToDelete != 0)
+                {
+                    ThreadPool.UnsafeQueueUserWorkItem(_ =>
+                    {
+                        EventPipeInternal.DeleteProvider(handleToDelete);
+                        gcHandleToDispose.Dispose();
+                    }, null);
+                }
+                else
+                {
+                    gcHandleToDispose.Dispose();
+                }
             }
-            _gcHandle.Dispose();
+            else
+            {
+                if (_provHandle != 0)
+                {
+                    EventPipeInternal.DeleteProvider(_provHandle);
+                    _provHandle = 0;
+                }
+                _gcHandle.Dispose();
+            }
         }
 
         // Write an event.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -119,8 +119,14 @@ namespace System.Diagnostics.Tracing
                 {
                     ThreadPool.UnsafeQueueUserWorkItem(_ =>
                     {
-                        EventPipeInternal.DeleteProvider(handleToDelete);
-                        gcHandleToDispose.Dispose();
+                        try
+                        {
+                            EventPipeInternal.DeleteProvider(handleToDelete);
+                        }
+                        finally
+                        {
+                            gcHandleToDispose.Dispose();
+                        }
                     }, null);
                 }
                 else

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -50,6 +50,10 @@ namespace System.Diagnostics.Tracing
     /// </summary>
     internal class EventProvider : IDisposable
     {
+        private const int UnregisterPending = 0;
+        private const int UnregisterInProgress = 1;
+        private const int UnregisterComplete = 2;
+
         // This is the windows EVENT_DATA_DESCRIPTOR structure.  We expose it because this is what
         // subclasses of EventProvider use when creating efficient (but unsafe) version of
         // EventWrite.   We do make it a nested type because we really don't expect anyone to use
@@ -65,7 +69,8 @@ namespace System.Diagnostics.Tracing
         internal EventProviderImpl _eventProvider;      // The implementation of the specific logging mechanism functions.
         private string? _providerName;                  // Control name
         private Guid _providerId;                       // Control Guid
-        internal bool _disposed;                        // when true provider has unregistered
+        internal bool _disposed;                        // when true provider disposal has started
+        private int _unregisterState;
 
         [ThreadStatic]
         private static WriteEventErrorCode s_returnCode; // The last return code
@@ -124,7 +129,10 @@ namespace System.Diagnostics.Tracing
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
+            if (Volatile.Read(ref _unregisterState) == UnregisterComplete)
+            {
+                GC.SuppressFinalize(this);
+            }
         }
 
         protected virtual void Dispose(bool disposing)
@@ -140,7 +148,14 @@ namespace System.Diagnostics.Tracing
             // check if the object has been already disposed
             //
             if (_disposed)
+            {
+                if (!disposing)
+                {
+                    _ = TryCompleteUnregister(throwOnFailure: false);
+                }
+
                 return;
+            }
 
             // Disable the provider.
             _eventProvider.Disable();
@@ -156,16 +171,51 @@ namespace System.Diagnostics.Tracing
                 _disposed = true;
             }
 
-            // We do the Unregistration outside the EventListenerLock because there is a lock
-            // inside the ETW routines.   This lock is taken before ETW issues commands
-            // Thus the ETW lock gets taken first and then our EventListenersLock gets taken
-            // in SendCommand(), and also here.  If we called EventUnregister after taking
-            // the EventListenersLock then the take-lock order is reversed and we can have
-            // deadlocks in race conditions (dispose racing with an ETW command).
-            //
-            // We solve by Unregistering after releasing the EventListenerLock.
-            Debug.Assert(!Monitor.IsEntered(EventListener.EventListenersLock));
-            _eventProvider.Unregister();
+            if (EventSource.IsExecutingCallback)
+            {
+                // Native unregistration may wait for callbacks queued behind the current callback.
+                ThreadPool.UnsafeQueueUserWorkItem(
+                    static eventProvider =>
+                    {
+                        if (eventProvider.TryCompleteUnregister(throwOnFailure: false))
+                        {
+                            GC.SuppressFinalize(eventProvider);
+                        }
+                    },
+                    this,
+                    preferLocal: false);
+            }
+            else
+            {
+                Debug.Assert(!Monitor.IsEntered(EventListener.EventListenersLock));
+                _ = TryCompleteUnregister(throwOnFailure: disposing);
+            }
+        }
+
+        private bool TryCompleteUnregister(bool throwOnFailure)
+        {
+            if (Interlocked.CompareExchange(ref _unregisterState, UnregisterInProgress, UnregisterPending) == UnregisterPending)
+            {
+                try
+                {
+                    _eventProvider.Unregister();
+                }
+                catch
+                {
+                    Volatile.Write(ref _unregisterState, UnregisterPending);
+                    if (throwOnFailure)
+                    {
+                        throw;
+                    }
+
+                    return false;
+                }
+
+                Volatile.Write(ref _unregisterState, UnregisterComplete);
+                return true;
+            }
+
+            return Volatile.Read(ref _unregisterState) == UnregisterComplete;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1501,6 +1501,9 @@ namespace System.Diagnostics.Tracing
         /// <summary>
         /// Disposes of an EventSource.
         /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The method was called while an <see cref="EventSource"/> callback was executing.
+        /// </exception>
         public void Dispose()
         {
             this.Dispose(true);
@@ -1527,7 +1530,10 @@ namespace System.Diagnostics.Tracing
 
             // Do not invoke Dispose under the lock as this can lead to a deadlock.
             // See https://github.com/dotnet/runtime/issues/48342 for details.
-            Debug.Assert(!Monitor.IsEntered(EventListener.EventListenersLock));
+            if (Monitor.IsEntered(EventListener.EventListenersLock))
+            {
+                throw new InvalidOperationException(SR.EventSource_DisposeInsideCallback);
+            }
 
             if (disposing)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1825,10 +1825,20 @@ namespace System.Diagnostics.Tracing
                 // Note that we are NOT resetting m_deferredCommands to NULL here,
                 // We are giving for EventHandler<EventCommandEventArgs> that will be attached later
                 EventCommandEventArgs? deferredCommands = m_deferredCommands;
-                while (deferredCommands != null)
+                if (deferredCommands != null && TryEnterCallback())
                 {
-                    DoCommand(deferredCommands);      // This can never throw, it catches them and reports the errors.
-                    deferredCommands = deferredCommands.nextCommand;
+                    try
+                    {
+                        while (deferredCommands != null)
+                        {
+                            DoCommand(deferredCommands);      // This can never throw, it catches them and reports the errors.
+                            deferredCommands = deferredCommands.nextCommand;
+                        }
+                    }
+                    finally
+                    {
+                        ExitCallback();
+                    }
                 }
 
                 if (m_constructionException == null)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1798,17 +1798,25 @@ namespace System.Diagnostics.Tracing
 
                 }
 #endif
-                // Add the eventSource to the global (weak) list.
-                // This also sets m_id, which is the index in the list.
-                EventListener.AddEventSource(this);
+                ObjectDisposedException.ThrowIf(!TryEnterCallback(), this);
+                try
+                {
+                    // Add the eventSource to the global (weak) list.
+                    // This also sets m_id, which is the index in the list.
+                    EventListener.AddEventSource(this);
 
-                // OK if we get this far without an exception, then we can at least write out error messages.
-                // Set m_provider, which allows this.
-                m_etwProvider = etwProvider;
+                    // OK if we get this far without an exception, then we can at least write out error messages.
+                    // Set m_provider, which allows this.
+                    m_etwProvider = etwProvider;
 
 #if FEATURE_PERFTRACING
-                m_eventPipeProvider = eventPipeProvider;
+                    m_eventPipeProvider = eventPipeProvider;
 #endif
+                }
+                finally
+                {
+                    ExitCallback();
+                }
                 Debug.Assert(!m_eventSourceEnabled);     // We can't be enabled until we are completely initted.
             }
             catch (Exception e)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -228,7 +228,16 @@ namespace System.Diagnostics.Tracing
 
         private readonly EventSourceSettings m_config;      // configuration information
 
+        // Callback state encoding:
+        //   [0, int.MaxValue]   - number of admitted callbacks
+        //   (int.MinValue, 0)   - disposal claimed, with the remaining callback count added to int.MinValue
+        //   int.MinValue        - disposal claimed and all admitted callbacks have exited
+        // Once disposal makes the state negative, no new callbacks are admitted. Existing callbacks decrement
+        // the state until it reaches CallbackDisposing, allowing the disposing thread to continue.
+        private const int CallbackDisposing = int.MinValue;
+
         private bool m_eventSourceDisposed;              // has Dispose been called.
+        private int m_eventSourceCallbackState;          // callback count, or a negative disposing state
 
         // Enabling bits
         private bool m_eventSourceEnabled;              // am I enabled (any of my events are enabled for any dispatcher)
@@ -252,6 +261,22 @@ namespace System.Diagnostics.Tracing
 
         [ThreadStatic]
         private static byte m_EventSourceExceptionRecurenceCount; // current recursion count inside ThrowEventSourceException
+
+        [ThreadStatic]
+        private static int t_callbackDepth;
+
+        internal static bool IsExecutingCallback => t_callbackDepth > 0;
+
+        internal static void EnterCallbackScope()
+        {
+            t_callbackDepth++;
+        }
+
+        internal static void ExitCallbackScope()
+        {
+            Debug.Assert(t_callbackDepth > 0);
+            t_callbackDepth--;
+        }
 
         internal volatile ulong[]? m_channelData;
 
@@ -1502,7 +1527,8 @@ namespace System.Diagnostics.Tracing
         /// Disposes of an EventSource.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// The method was called while an <see cref="EventSource"/> callback was executing.
+        /// The method was called from an <see cref="EventSource"/> callback while a callback for this
+        /// <see cref="EventSource"/> was already in progress.
         /// </exception>
         public void Dispose()
         {
@@ -1528,11 +1554,63 @@ namespace System.Diagnostics.Tracing
                 return;
             }
 
-            // Do not invoke Dispose under the lock as this can lead to a deadlock.
-            // See https://github.com/dotnet/runtime/issues/48342 for details.
-            if (Monitor.IsEntered(EventListener.EventListenersLock))
+            int callbackState = Volatile.Read(ref m_eventSourceCallbackState);
+            while (callbackState >= 0)
             {
-                throw new InvalidOperationException(SR.EventSource_DisposeInsideCallback);
+                if (callbackState == 0)
+                {
+                    // Claim disposal only if no callback entered after the state was read.
+                    int zeroObservedState = Interlocked.CompareExchange(
+                        ref m_eventSourceCallbackState,
+                        CallbackDisposing,
+                        0);
+                    if (zeroObservedState == 0)
+                    {
+                        break;
+                    }
+
+                    callbackState = zeroObservedState;
+                    continue;
+                }
+
+                if (!disposing)
+                {
+                    // A callback keeps the source alive, so this should not occur during finalization.
+                    Debug.Fail("An EventSource command callback should keep the EventSource alive.");
+                    return;
+                }
+
+                if (IsExecutingCallback)
+                {
+                    // Waiting here would deadlock if this thread is responsible for completing a callback.
+                    throw new InvalidOperationException(SR.EventSource_DisposeInsideCallback);
+                }
+
+                // Make the state negative to close callback admission while preserving the number to drain.
+                int observedState = Interlocked.CompareExchange(
+                    ref m_eventSourceCallbackState,
+                    CallbackDisposing + callbackState,
+                    callbackState);
+                if (observedState == callbackState)
+                {
+                    // Each admitted callback decrements the state as it exits.
+                    SpinWait spinWait = default;
+                    while (Volatile.Read(ref m_eventSourceCallbackState) != CallbackDisposing)
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    break;
+                }
+
+                // The callback count changed, or another thread claimed disposal. Retry with its value.
+                callbackState = observedState;
+            }
+
+            if (callbackState < 0)
+            {
+                // Another thread claimed disposal and owns the remaining cleanup.
+                return;
             }
 
             if (disposing)
@@ -2626,38 +2704,85 @@ namespace System.Diagnostics.Tracing
                                   EventLevel level, EventKeywords matchAnyKeyword,
                                   IDictionary<string, string?>? commandArguments)
         {
-            if (!IsSupported)
+            if (!IsSupported || !TryEnterCallback())
             {
                 return;
             }
 
-            var commandArgs = new EventCommandEventArgs(command, commandArguments, this, listener, eventProviderType, perEventSourceSessionId, enable, level, matchAnyKeyword);
-            lock (EventListener.EventListenersLock)
+            try
             {
-                if (m_completelyInited)
+                var commandArgs = new EventCommandEventArgs(command, commandArguments, this, listener, eventProviderType, perEventSourceSessionId, enable, level, matchAnyKeyword);
+                lock (EventListener.EventListenersLock)
                 {
-                    // After the first command arrive after construction, we are ready to get rid of the deferred commands
-                    this.m_deferredCommands = null;
-                    // We are fully initialized, do the command
-                    DoCommand(commandArgs);
-                }
-                else
-                {
-                    // We can't do the command, simply remember it and we do it when we are fully constructed.
-                    if (m_deferredCommands == null)
+                    if (m_completelyInited)
                     {
-                        m_deferredCommands = commandArgs;       // create the first entry
+                        // After the first command arrive after construction, we are ready to get rid of the deferred commands
+                        this.m_deferredCommands = null;
+                        // We are fully initialized, do the command
+                        DoCommand(commandArgs);
                     }
                     else
                     {
-                        // We have one or more entries, find the last one and add it to that.
-                        EventCommandEventArgs lastCommand = m_deferredCommands;
-                        while (lastCommand.nextCommand != null)
-                            lastCommand = lastCommand.nextCommand;
-                        lastCommand.nextCommand = commandArgs;
+                        // We can't do the command, simply remember it and we do it when we are fully constructed.
+                        if (m_deferredCommands == null)
+                        {
+                            m_deferredCommands = commandArgs;       // create the first entry
+                        }
+                        else
+                        {
+                            // We have one or more entries, find the last one and add it to that.
+                            EventCommandEventArgs lastCommand = m_deferredCommands;
+                            while (lastCommand.nextCommand != null)
+                                lastCommand = lastCommand.nextCommand;
+                            lastCommand.nextCommand = commandArgs;
+                        }
                     }
                 }
             }
+            finally
+            {
+                ExitCallback();
+            }
+        }
+
+        // Atomically admits a callback unless disposal has started and marks the current thread
+        // as executing callback code. SendCommand admits before taking EventListenersLock so
+        // disposal can observe callbacks waiting for that lock.
+        internal bool TryEnterCallback()
+        {
+            int callbackState = Volatile.Read(ref m_eventSourceCallbackState);
+            while (callbackState >= 0)
+            {
+                if (callbackState == int.MaxValue)
+                {
+                    Debug.Fail("Too many concurrent EventSource command callbacks.");
+                    return false;
+                }
+
+                int observedState = Interlocked.CompareExchange(
+                    ref m_eventSourceCallbackState,
+                    callbackState + 1,
+                    callbackState);
+                if (observedState == callbackState)
+                {
+                    EnterCallbackScope();
+                    return true;
+                }
+
+                callbackState = observedState;
+            }
+
+            // A negative state means disposal has started and no new callbacks may enter.
+            return false;
+        }
+
+        // Releases the per-source admission and thread callback scope acquired by TryEnterCallback.
+        // This must run on the admitting thread in a finally block.
+        internal void ExitCallback()
+        {
+            int callbackState = Interlocked.Decrement(ref m_eventSourceCallbackState);
+            Debug.Assert(callbackState != int.MaxValue, "Callback state underflowed.");
+            ExitCallbackScope();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #106087

## Summary

This PR prevents deadlocks when an `EventSource` is disposed from an `EventSource` callback, without broadly prohibiting all callback-time disposal.

The original failure occurs when disposal reaches native provider unregistration while a tracing callback is active. Native unregistration can wait for callbacks to complete, but the current callback cannot complete until `Dispose()` returns.

The resulting behavior is:

- Disposing an `EventSource` that has an active callback from within an `EventSource` callback throws `InvalidOperationException` instead of deadlocking.
- A callback for source A may still dispose inactive source B.
- Disposal from an ordinary thread closes callback admission and waits for callbacks already admitted for that source to finish.
- Once disposal has claimed a source, no additional callbacks are admitted.

## Implementation

### Per-EventSource callback gate

Each `EventSource` has an atomic callback state:

- `0..int.MaxValue`: the number of admitted callbacks.
- `int.MinValue + n`: disposal has claimed the source, callback admission is closed, and `n` admitted callbacks remain.
- `int.MinValue`: disposal has claimed the source and all admitted callbacks have drained.

`Dispose()` atomically claims the source before teardown. If an ordinary thread observes active callbacks, it waits for them to drain. If a thread already executing an `EventSource` callback attempts to dispose a source with active callbacks, it throws rather than performing a wait that could deadlock.

A thread-static callback depth tracks whether the current thread is anywhere within a possibly nested `EventSource` callback chain. The per-source state identifies whether the target source is active; the thread-static depth identifies whether the disposing thread may participate in the callback dependency.

### Managed callback lifetime

The managed drain is needed in addition to native provider unregistration. Native unregistration covers native ETW/EventPipe callbacks, but it does not cover every managed callback path. Without the managed drain, callbacks already admitted, or blocked waiting for `EventListenersLock`, could execute while `Dispose()` disables and clears providers or after disposal returns.

The gate is applied to:

- Normal command dispatch.
- Deferred command replay during source initialization.
- Provider publication and `OnEventSourceCreated`.
- Existing-source listener catch-up.

### Native unregister deferral

Native callbacks may already have been queued before reaching the managed callback gate. Therefore, when provider disposal occurs from an `EventSource` callback, native unregister is deferred to the thread pool.

This logic lives in the shared `EventProvider` implementation, so it applies to both EventPipe and ETW. Its state machine ensures only one thread performs unregister, permits finalization to retry after a failed deferred attempt, and prevents exceptions from escaping thread-pool or finalizer paths.

## Tests

Added coverage for:

- Same-source disposal from `OnEventCommand`.
- Disposal of inactive source B from source A's callback.
- Ordinary concurrent disposal waiting for an active callback.
- Deferred command callbacks.
- Provider publication callbacks.
- Listener catch-up callbacks.
- Nested callback chains.

Validation completed:

- Checked `System.Private.CoreLib` build.
- Full `System.Diagnostics.Tracing.Tests`: 61 total, 0 failed, 7 skipped.
- Standalone EventPipe scenario where A's callback disposes inactive B: completed.
- Standalone nested scenario where A's callback enters B's callback and B disposes active A: rejected without deadlock.
