### PR TITLE
Disable ReentrantWaitFromSyncContextTest test on Mono

### DIFF
--- a/src/libraries/System.Threading/tests/MonitorTests.cs
+++ b/src/libraries/System.Threading/tests/MonitorTests.cs
@@ -513,8 +513,9 @@ namespace System.Threading.Tests
 
         // Validates that reentrant Monitor.Wait calls from a SynchronizationContext
         // message pump do not steal each other's pulse signals.
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/126138", TestRuntimes.Mono)]
+        // The test is not applicable to Mono. Monitor.Wait is implemented natively and doesn't end up
+        // forwarding to SynchronizationContext.Wait, the reentrancy this test covers cannot occur.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported), nameof(PlatformDetection.IsNotMonoRuntime))]
         public static void ReentrantWaitFromSyncContextTest()
         {
             // Since we set the SynchronizationContext for the current thread, we run


### PR DESCRIPTION
Closes #126138. This was not an unexpected behavior on Mono, since Monitor.Wait is still implemented natively (CoreCLR moved to managed in .NET 11), it doesn't end up forwarding to `SynchronizationContext.Wait` which is a necessary condition for this test.