### PR TITLE
Fix Uri perf regression from stackallocs

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3501,6 +3501,15 @@ namespace System
             _string = vsb.ToString();
         }
 
+        private static string EscapeUnescapeIri(scoped ReadOnlySpan<char> prefix, scoped ReadOnlySpan<char> span, bool isQuery)
+        {
+            var vsb = new ValueStringBuilder(stackalloc char[StackallocThreshold]);
+            IriHelper.EscapeUnescapeIri(ref vsb, span, isQuery);
+            string result = string.Concat(prefix, vsb.AsSpan());
+            vsb.Dispose();
+            return result;
+        }
+
         // verifies the syntax of the scheme part
         // Checks on implicit File: scheme due to simple Dos/Unc path passed
         // returns the start of the next component  position
@@ -3724,10 +3733,7 @@ namespace System
                     // Iri'ze userinfo
                     if (hasUnicode)
                     {
-                        var vsb = new ValueStringBuilder(stackalloc char[StackallocThreshold]);
-                        IriHelper.EscapeUnescapeIri(ref vsb, slice.Slice(0, userInfoLength), isQuery: false);
-                        newHost = string.Concat(newHost, vsb.AsSpan());
-                        vsb.Dispose();
+                        newHost = EscapeUnescapeIri(newHost, slice.Slice(0, userInfoLength), isQuery: false);
                     }
                 }
             }

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -161,9 +161,7 @@ namespace System
 
             if (hasUnicode)
             {
-                var vsb = new ValueStringBuilder(stackalloc char[StackallocThreshold]);
-                IriHelper.EscapeUnescapeIri(ref vsb, _originalUnicodeString, isQuery: false);
-                _string = vsb.ToString();
+                _string = EscapeUnescapeIri(default, _originalUnicodeString, isQuery: false);
             }
 
             DebugSetLeftCtor();


### PR DESCRIPTION
Moves the stackalloc into a separate method to avoid codegen impact on the rest of those larger methods

Closes #123394

| Method | Toolchain  | input                                | Mean      | Error    | Ratio |
|------- |----------- |------------------------------------- |----------:|---------:|------:|
| Ctor   | main       | http://dot.net                       |  66.44 ns | 0.298 ns |  1.00 |
| Ctor   | pr         | http://dot.net                       |  62.28 ns | 0.331 ns |  0.94 |
|        |            |                                      |           |          |       |
| Ctor   | main       | http://höst.with.ünicode             | 315.73 ns | 0.606 ns |  1.00 |
| Ctor   | pr         | http://höst.with.ünicode             | 301.96 ns | 0.664 ns |  0.96 |
|        |            |                                      |           |          |       |
| Ctor   | main       | http://xn--hs(...)n--nicode-2ya [38] |  69.56 ns | 0.053 ns |  1.00 |
| Ctor   | pr         | http://xn--hs(...)n--nicode-2ya [38] |  62.85 ns | 0.080 ns |  0.90 |
|        |            |                                      |           |          |       |
| Ctor   | main       | https://a.much.longer.domain.name    |  86.41 ns | 0.125 ns |  1.00 |
| Ctor   | pr         | https://a.much.longer.domain.name    |  81.02 ns | 0.080 ns |  0.94 |
|        |            |                                      |           |          |       |
| Ctor   | main       | https://contoso.com                  |  57.11 ns | 0.059 ns |  1.00 |
| Ctor   | pr         | https://contoso.com                  |  52.30 ns | 0.115 ns |  0.92 |
|        |            |                                      |           |          |       |
| Ctor   | main       | https://CONTOSO.com                  |  59.13 ns | 0.189 ns |  1.00 |
| Ctor   | pr         | https://CONTOSO.com                  |  52.31 ns | 0.166 ns |  0.88 |