### PR TITLE
[NativeAOT] Enable WebAssembly single-method compilation

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -339,6 +339,10 @@
     <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrWasmJitSubset=true</ClrRuntimeBuildSubsets>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(_subset.Contains('+clr.toolstests+')) and '$(DotNetBuildSourceOnly)' != 'true' and ('$(BuildArchitecture)' == 'x64' or '$(BuildArchitecture)' == 'arm64') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')">
+    <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrWasmJitSubset=true</ClrRuntimeBuildSubsets>
+  </PropertyGroup>
+
   <PropertyGroup Condition="$(_subset.Contains('+clr.paltests+'))">
     <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrPalTestsSubset=true</ClrRuntimeBuildSubsets>
   </PropertyGroup>
@@ -393,6 +397,7 @@
   <ItemGroup>
     <!-- crossgen2/ILC have dependencies on the JITs, so build them if the cross component includes crossgen2/ILC. -->
     <_CrossToolSubset Condition="'$(_BuildCrossComponents)' == 'true' and '$(TargetArchitecture)' != 'wasm' and $(_subset.Contains('+clr.toolstests+'))" Include="ClrAllJitsSubset=true" />
+    <_CrossToolSubset Condition="'$(_BuildCrossComponents)' == 'true' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and $(_subset.Contains('+clr.toolstests+')) and ('$(BuildArchitecture)' == 'x64' or '$(BuildArchitecture)' == 'arm64')" Include="ClrWasmJitSubset=true" />
     <_CrossToolSubset Condition="'$(_BuildCrossComponents)' == 'true' and '$(TargetArchitecture)' != 'wasm' and ($(_subset.Contains('+clr.tools+')) or $(_subset.Contains('+clr.nativecorelib+')) or $(_subset.Contains('+clr.crossarchtools+')))" Include="ClrJitSubset=true" />
     <!-- When targeting WebAssembly, only build the wasm JIT for the cross component. -->
     <_CrossToolSubset Condition="'$(_BuildCrossComponents)' == 'true' and '$(TargetArchitecture)' == 'wasm' and ($(_subset.Contains('+clr.tools+')) or $(_subset.Contains('+clr.nativecorelib+')) or $(_subset.Contains('+clr.crossarchtools+')))" Include="ClrWasmJitSubset=true" />

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -872,6 +872,12 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
             break;
 
         case BBJ_SWITCH:
+#if defined(TARGET_WASM)
+            if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+            {
+                genEmitFunctionEnd();
+            }
+#endif
             break;
 
         case BBJ_ALWAYS:
@@ -922,7 +928,6 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
                 genEmitFunctionEnd();
             }
 #endif // defined(TARGET_WASM)
-
             break;
 
         case BBJ_COND:
@@ -933,6 +938,12 @@ void CodeGen::genEmitEndBlock(BasicBlock* block)
             SetLoopAlignBackEdge(block, block->GetFalseTarget());
 #endif // FEATURE_LOOP_ALIGN
 
+#if defined(TARGET_WASM)
+            if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+            {
+                genEmitFunctionEnd();
+            }
+#endif
             break;
 
         default:

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -416,17 +416,17 @@ void CodeGen::genFnEpilog(BasicBlock* block)
     {
         if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
         {
-            instGen(INS_end);
+            genEmitFunctionEnd(/* emitTerminalUnreachable */ false);
         }
         return;
     }
 
     // TODO-WASM: shadow stack maintenance
-    // TODO-WASM: we need to handle the end-of-function case if we reach the end of a codegen for a function
-    // and do NOT have an epilog. In those cases we currently will not emit an end instruction.
+    // Close the root function before the first funclet starts. Other returns
+    // within the root function leave the remaining root blocks reachable.
     if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
     {
-        instGen(INS_end);
+        genEmitFunctionEnd(/* emitTerminalUnreachable */ false);
     }
     else
     {
@@ -3189,7 +3189,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     if (target != nullptr)
     {
         // Codegen should have already evaluated our target node (last) and pushed it onto the stack,
-        //  ready for call_indirect. Consume it.
+        // ready for call_indirect. Consume it.
         genConsumeReg(target);
 
         params.callType = EC_INDIR_R;
@@ -3200,16 +3200,22 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
         // Generate a direct call to a non-virtual user defined or helper method
         assert(call->IsHelperCall() || (call->gtCallType == CT_USER_FUNC));
 
-        assert(call->gtEntryPoint.addr == NULL);
-
         if (call->IsHelperCall())
         {
             assert(!call->IsFastTailCall());
-            CorInfoHelpFunc helperNum = m_compiler->eeGetHelperNum(params.methHnd);
-            noway_assert(helperNum != CORINFO_HELP_UNDEF);
-            CORINFO_CONST_LOOKUP helperLookup = m_compiler->compGetHelperFtn(helperNum);
-            assert(helperLookup.accessType == IAT_VALUE);
-            params.addr = helperLookup.addr;
+
+            if (call->gtDirectCallAddress != nullptr)
+            {
+                params.addr = call->gtDirectCallAddress;
+            }
+            else
+            {
+                CorInfoHelpFunc helperNum = m_compiler->eeGetHelperNum(params.methHnd);
+                noway_assert(helperNum != CORINFO_HELP_UNDEF);
+                CORINFO_CONST_LOOKUP helperLookup = m_compiler->compGetHelperFtn(helperNum);
+                assert(helperLookup.accessType == IAT_VALUE);
+                params.addr = helperLookup.addr;
+            }
         }
         else
         {
@@ -3252,9 +3258,8 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
     }
     else
     {
-        params.addr = nullptr;
         assert(helperFunction.accessType == IAT_PVALUE);
-
+        params.addr     = nullptr;
         params.callType = EC_INDIR_R;
     }
 
@@ -3316,12 +3321,14 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
 
     if (helperIsManaged)
     {
-        // Push PEP onto the stack because we are calling a managed helper that expects it as the last parameter.
-        // The helper function address is the address of an indirection cell, so we load from the cell to get the PEP
-        // address to push.
-        assert(helperFunction.accessType == IAT_PVALUE);
         GetEmitter()->emitAddressConstant(helperFunction.addr);
-        GetEmitter()->emitIns_I(INS_I_load, EA_PTRSIZE, 0);
+        if (helperFunction.accessType != IAT_VALUE)
+        {
+            // Push PEP onto the stack because we are calling a managed helper that expects it as the last parameter.
+            // The helper function address is the address of an indirection cell, so load the PEP from it.
+            assert(helperFunction.accessType == IAT_PVALUE);
+            GetEmitter()->emitIns_I(INS_I_load, EA_PTRSIZE, 0);
+        }
     }
 
     if (params.callType == EC_INDIR_R)

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -321,7 +321,7 @@ void emitter::emitIns_Call(const EmitCallParams& params)
     {
         case EC_FUNC_TOKEN:
             ins = params.isJump ? INS_return_call : INS_call;
-            id  = emitNewInstrSC(EA_HANDLE_CNS_RELOC, 0 /* FIXME-WASM: function index reloc */);
+            id  = emitNewInstrSC(EA_HANDLE_CNS_RELOC, (cnsval_ssize_t)params.addr);
             id->idIns(ins);
             id->idInsFmt(IF_FUNCIDX);
             break;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -866,7 +866,10 @@ GenTreeCall* Compiler::fgGetSharedCCtor(CORINFO_CLASS_HANDLE cls)
 {
 #if defined(TARGET_WASM)
     // Wasm does not support dynamically created helpers
-    return fgGetStaticsCCtorHelper(cls, CORINFO_HELP_INITCLASS);
+    if (!IsNativeAot())
+    {
+        return fgGetStaticsCCtorHelper(cls, CORINFO_HELP_INITCLASS);
+    }
 #endif
 
 #ifdef FEATURE_READYTORUN

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7360,21 +7360,27 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
 {
     noway_assert(call->gtCallType == CT_USER_FUNC);
 
-    GenTree* thisArgNode;
+    CallArg* thisArg;
     if (call->IsTailCallViaJitHelper())
     {
         assert(call->gtArgs.CountArgs() > 0);
-        thisArgNode = call->gtArgs.GetArgByIndex(0)->GetNode();
+        thisArg = call->gtArgs.GetArgByIndex(0);
     }
     else
     {
         assert(call->gtArgs.HasThisPointer());
-        thisArgNode = call->gtArgs.GetThisArg()->GetNode();
+        thisArg = call->gtArgs.GetThisArg();
     }
+    GenTree* thisArgNode = thisArg->GetNode();
 
     // get a reference to the thisPtr being passed
+#if HAS_FIXED_REGISTER_SET
     assert(thisArgNode->OperIs(GT_PUTARG_REG));
     GenTree* thisPtr = thisArgNode->AsUnOp()->gtGetOp1();
+#else
+    // On platforms without fixed registers (e.g., WASM), PUTARG nodes are not inserted.
+    GenTree* thisPtr = thisArgNode;
+#endif
 
     // If what we are passing as the thisptr is not already a local, make a new local to place it in
     // because we will be creating expressions based on it.
@@ -7391,7 +7397,11 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
             vtableCallTemp = m_compiler->lvaGrabTemp(true DEBUGARG("virtual vtable call"));
         }
 
+#if HAS_FIXED_REGISTER_SET
         LIR::Use thisPtrUse(BlockRange(), &thisArgNode->AsUnOp()->gtOp1, thisArgNode);
+#else
+        LIR::Use thisPtrUse(BlockRange(), &thisArg->NodeRef(), call);
+#endif
         ReplaceWithLclVar(thisPtrUse, vtableCallTemp);
 
         lclNum = vtableCallTemp;

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -66,22 +66,28 @@ void Lowering::LowerPEPCall(GenTreeCall* call)
     JITDUMP("Begin lowering PEP call\n");
     DISPTREERANGE(BlockRange(), call);
 
-    // PEP call must always have a control expression
-    assert(call->gtControlExpr != nullptr);
-    LIR::Use callTargetUse(BlockRange(), &call->gtControlExpr, call);
+    GenTree* callTargetForArg;
+    if (call->gtControlExpr != nullptr)
+    {
+        LIR::Use callTargetUse(BlockRange(), &call->gtControlExpr, call);
 
-    JITDUMP("Creating new local variable for PEP");
-    unsigned int   callTargetLclNum    = callTargetUse.ReplaceWithLclVar(m_compiler);
-    GenTreeLclVar* callTargetLclForArg = m_compiler->gtNewLclvNode(callTargetLclNum, TYP_I_IMPL);
+        JITDUMP("Creating new local variable for PEP");
+        unsigned int callTargetLclNum = callTargetUse.ReplaceWithLclVar(m_compiler);
+        callTargetForArg              = m_compiler->gtNewLclvNode(callTargetLclNum, TYP_I_IMPL);
+    }
+    else
+    {
+        assert(call->gtDirectCallAddress != nullptr);
+        callTargetForArg = AddrGen(call->gtDirectCallAddress);
+    }
     DISPTREE(call);
 
     JITDUMP("Add new arg to call arg list corresponding to PEP target");
-    NewCallArg pepTargetArg =
-        NewCallArg::Primitive(callTargetLclForArg).WellKnown(WellKnownArg::WasmPortableEntryPoint);
-    CallArg* pepArg = call->gtArgs.PushBack(m_compiler, pepTargetArg);
+    NewCallArg pepTargetArg = NewCallArg::Primitive(callTargetForArg).WellKnown(WellKnownArg::WasmPortableEntryPoint);
+    CallArg*   pepArg       = call->gtArgs.PushBack(m_compiler, pepTargetArg);
 
     pepArg->SetEarlyNode(nullptr);
-    pepArg->SetLateNode(callTargetLclForArg);
+    pepArg->SetLateNode(callTargetForArg);
     call->gtArgs.PushLateBack(pepArg);
 
     // Set up ABI information for this arg; PEP's should be passed as the last param to a wasm function
@@ -90,11 +96,17 @@ void Lowering::LowerPEPCall(GenTreeCall* call)
     pepArg->AbiInfo =
         ABIPassingInformation::FromSegmentByValue(m_compiler,
                                                   ABIPassingSegment::InRegister(pepReg, 0, TARGET_POINTER_SIZE));
-    BlockRange().InsertBefore(call, callTargetLclForArg);
+    BlockRange().InsertBefore(call, callTargetForArg);
 
     // Lower the new PEP arg now that the call abi info is updated and lcl var is inserted
     LowerArg(call, pepArg);
     DISPTREE(call);
+
+    if (call->gtControlExpr == nullptr)
+    {
+        JITDUMP("Finished lowering direct PEP call\n");
+        return;
+    }
 
     JITDUMP("Rewrite PEP call's control expression to indirect through the new local variable\n");
 

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
@@ -17,8 +17,6 @@ namespace ILCompiler.DependencyAnalysis.Wasm
     {
 #if READYTORUN
         public WasmFunctionBody FunctionBody = null;
-#else
-        internal ObjectDataBuilder Builder;
 #endif
 
         private readonly NodeFactory _factory;
@@ -30,8 +28,6 @@ namespace ILCompiler.DependencyAnalysis.Wasm
             _relocsOnly = relocsOnly;
 #if READYTORUN
             FunctionBody = null;
-#else
-            Builder = new ObjectDataBuilder(factory, relocsOnly);
 #endif
         }
 
@@ -49,9 +45,7 @@ namespace ILCompiler.DependencyAnalysis.Wasm
     
             return new ObjectNode.ObjectData(encodedThunk, relocs, 1, new ISymbolDefinitionNode[] { symbolDefinitionNode });
 #else
-            Builder.RequireInitialAlignment(1);
-            Builder.AddSymbol(symbolDefinitionNode);
-            return Builder.ToObjectData();
+            throw new PlatformNotSupportedException("NativeAOT WebAssembly assembly stubs are not supported.");
 #endif
         }
     }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
@@ -13,14 +13,30 @@ using ILCompiler.ObjectWriter.WasmInstructions;
 
 namespace ILCompiler.DependencyAnalysis.Wasm
 {
-    public struct WasmEmitter(NodeFactory factory, bool relocsOnly)
+    public struct WasmEmitter
     {
 #if READYTORUN
         public WasmFunctionBody FunctionBody = null;
+#else
+        internal ObjectDataBuilder Builder;
 #endif
 
-        public bool Is64Bit => factory.Target.PointerSize == 8;
-        public bool RelocsOnly => relocsOnly;
+        private readonly NodeFactory _factory;
+        private readonly bool _relocsOnly;
+
+        public WasmEmitter(NodeFactory factory, bool relocsOnly)
+        {
+            _factory = factory;
+            _relocsOnly = relocsOnly;
+#if READYTORUN
+            FunctionBody = null;
+#else
+            Builder = new ObjectDataBuilder(factory, relocsOnly);
+#endif
+        }
+
+        public bool Is64Bit => _factory.Target.PointerSize == 8;
+        public bool RelocsOnly => _relocsOnly;
 
         public ObjectNode.ObjectData Encode(ISymbolDefinitionNode symbolDefinitionNode)
         {
@@ -33,7 +49,9 @@ namespace ILCompiler.DependencyAnalysis.Wasm
     
             return new ObjectNode.ObjectData(encodedThunk, relocs, 1, new ISymbolDefinitionNode[] { symbolDefinitionNode });
 #else
-            return default(ObjectNode.ObjectData);
+            Builder.RequireInitialAlignment(1);
+            Builder.AddSymbol(symbolDefinitionNode);
+            return Builder.ToObjectData();
 #endif
         }
     }

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
@@ -399,11 +399,12 @@ namespace ILCompiler.ObjectWriter
                 }
 
                 ObjectNodeSection section = node.GetSection(_nodeFactory);
+                ObjectNodeSection emitSection = GetEmitSection(section);
                 SectionWriter sectionWriter = ShouldShareSymbol(node, section) ?
                     GetOrCreateSection(section, currentSymbolName, currentSymbolName) :
                     GetOrCreateSection(section);
 
-                if (section.NeedsAlignment)
+                if (emitSection.NeedsAlignment)
                 {
                     sectionWriter.EmitAlignment(nodeContents.Alignment);
                 }
@@ -713,6 +714,7 @@ namespace ILCompiler.ObjectWriter
             ObjectWriter objectWriter =
                 factory.Target.IsApplePlatform ? new MachObjectWriter(factory, options) :
                 factory.Target.OperatingSystem == TargetOS.Windows ? new CoffObjectWriter(factory, options) :
+                factory.Target.Architecture == Internal.TypeSystem.TargetArchitecture.Wasm32 ? new WasmObjectWriter(factory, options) :
                 new ElfObjectWriter(factory, options);
 
             using Stream outputFileStream = new FileStream(objectFilePath, FileMode.Create);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmGlobalImports.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmGlobalImports.cs
@@ -4,7 +4,7 @@
 namespace ILCompiler.ObjectWriter
 {
     /// <summary>
-    /// Indices of the Wasm globals imported from the <c>webcil</c> host module into every R2R Wasm module.
+    /// Indices of the Wasm globals imported from the <c>webcil</c> host module into compiler-generated Wasm modules.
     /// </summary>
     /// <remarks>
     /// Must stay in sync with <c>WasmObjectWriter.CreateDefaultGlobalImports()</c>, <c>_globalSymbolNameToGlobalIndex</c>,

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
@@ -199,11 +199,11 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    // Represents a group of Wasm instructions (expressions) which 
+    // Represents a group of Wasm instructions (expressions) which
     // form a complete expression ending with the 'end' opcode.
-    public class WasmInstructionGroup : IWasmEncodable
+    internal sealed class WasmInstructionGroup : IWasmEncodable
     {
-        readonly WasmExpr[] _wasmExprs;
+        private readonly WasmExpr[] _wasmExprs;
         public WasmInstructionGroup(WasmExpr[] wasmExprs)
         {
             _wasmExprs = wasmExprs;
@@ -266,7 +266,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
 
     public abstract class WasmExpr : IWasmEncodable
     {
-        WasmExprKind _kind;
+        private WasmExprKind _kind;
         public WasmExpr(WasmExprKind kind)
         {
             _kind = kind;
@@ -303,7 +303,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    readonly struct WasmEncodableULong : IWasmEncodable
+    internal readonly struct WasmEncodableULong : IWasmEncodable
     {
         private readonly ulong _value;
         public WasmEncodableULong(ulong value)
@@ -322,7 +322,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         public int EncodeRelocations(Span<Relocation> buffer) => 0;
     }
 
-    readonly struct WasmEncodableSymbol : IWasmEncodable
+    internal readonly struct WasmEncodableSymbol : IWasmEncodable
     {
         private readonly ISymbolNode _symbol;
         private readonly RelocType _relocType;
@@ -374,10 +374,10 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    class WasmMemoryArgInstruction<TOffset> : WasmExpr where TOffset : IWasmEncodable
+    internal sealed class WasmMemoryArgInstruction<TOffset> : WasmExpr where TOffset : IWasmEncodable
     {
-        readonly uint _align;
-        readonly TOffset _offset;
+        private readonly uint _align;
+        private readonly TOffset _offset;
 
         public WasmMemoryArgInstruction(WasmExprKind kind, uint align, TOffset offset) : base(kind)
         {
@@ -418,9 +418,9 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
     }
 
     // Represents a constant expression (e.g., (i32.const <value>))
-    class WasmConstExpr : WasmExpr
+    internal sealed class WasmConstExpr : WasmExpr
     {
-        readonly long ConstValue;
+        private readonly long ConstValue;
 
         public WasmConstExpr(WasmExprKind kind, long value) : base(kind)
         {
@@ -448,10 +448,10 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    sealed class WasmIndirectCallInstruction : WasmExpr
+    internal sealed class WasmIndirectCallInstruction : WasmExpr
     {
-        ISymbolNode _type;
-        uint _tableIndex;
+        private readonly ISymbolNode _type;
+        private readonly uint _tableIndex;
 
         public WasmIndirectCallInstruction(WasmExprKind kind, ISymbolNode type, uint tableIndex) : base(kind)
         {
@@ -484,9 +484,9 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    sealed class WasmLEBConstantReloc : WasmExpr
+    internal sealed class WasmLEBConstantReloc : WasmExpr
     {
-        readonly WasmEncodableSymbol _symbol;
+        private readonly WasmEncodableSymbol _symbol;
 
         public WasmLEBConstantReloc(WasmExprKind kind, ISymbolNode symbol, RelocType relocType) : base(kind)
         {
@@ -511,7 +511,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
     }
 
     // Represents a local variable expression (e.g., (local.get <index>))
-    class WasmLocalVarExpr : WasmExpr
+    internal sealed class WasmLocalVarExpr : WasmExpr
     {
         public readonly int LocalIndex;
         public WasmLocalVarExpr(WasmExprKind kind, int localIndex) : base(kind)
@@ -536,7 +536,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
     }
 
     // Represents a global variable expression (e.g., (global.get <index))
-    class WasmGlobalVarExpr : WasmExpr
+    internal sealed class WasmGlobalVarExpr : WasmExpr
     {
         public readonly int GlobalIndex;
         public WasmGlobalVarExpr(WasmExprKind kind, int globalIndex) : base(kind)
@@ -560,7 +560,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
     }
 
     // Represents a binary expression (e.g., i32.add)
-    class WasmBinaryExpr : WasmExpr
+    internal sealed class WasmBinaryExpr : WasmExpr
     {
         public WasmBinaryExpr(WasmExprKind kind) : base(kind)
         {
@@ -570,7 +570,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         // base class defaults are sufficient as the base class encodes just the opcode
     }
 
-    class WasmUnaryExpr : WasmExpr
+    internal sealed class WasmUnaryExpr : WasmExpr
     {
         public WasmUnaryExpr(WasmExprKind kind) : base(kind)
         {
@@ -581,7 +581,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
     // Represents a memory.copy expression.
     // Binary encoding: 0xFC prefix + u32(10) sub-opcode + u32(dstMemoryIndex) + u32(srcMemoryIndex)
     // Stack operands: (dst: i32, src: i32, len: i32) -> ()
-    class WasmMemoryCopyExpr : WasmExpr
+    internal sealed class WasmMemoryCopyExpr : WasmExpr
     {
         public readonly int DstMemoryIndex;
         public readonly int SrcMemoryIndex;
@@ -614,7 +614,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
     // Represents a memory.fill expression.
     // Binary encoding: 0xFC prefix + u32(11) sub-opcode + u32(memoryIndex)
     // Stack operands: (dst: i32, val: i32, len: i32) -> ()
-    class WasmMemoryFillExpr : WasmExpr
+    internal sealed class WasmMemoryFillExpr : WasmExpr
     {
         public readonly int MemoryIndex;
 
@@ -640,7 +640,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
     }
 
     // Represents a memory.init expression.
-    class WasmMemoryInitExpr : WasmExpr
+    internal sealed class WasmMemoryInitExpr : WasmExpr
     {
         public readonly int DataSegmentIndex;
         public readonly int MemoryIndex;
@@ -672,7 +672,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
 
     // Represents a table.init expression.
     // Binary encoding: 0xFC prefix + u32(12) sub-opcode + u32(elemidx) + u32(tableidx)
-    class WasmTableInitExpr : WasmExpr
+    internal sealed class WasmTableInitExpr : WasmExpr
     {
         public readonly int ElemIndex;
         public readonly int TableIndex;
@@ -702,7 +702,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    class WasmTableGrowExpr : WasmExpr
+    internal sealed class WasmTableGrowExpr : WasmExpr
     {
         public readonly uint TableIndex;
 
@@ -723,24 +723,24 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    enum WasmAbsHeapType : byte
+    internal enum WasmAbsHeapType : byte
     {
         Func = 0x70,
     }
 
-    class WasmRefNullExpr : WasmExpr
+    internal sealed class WasmRefNullExpr : WasmExpr
     {
-        WasmAbsHeapType absheaptype;
+        private readonly WasmAbsHeapType _absoluteHeapType;
 
         public WasmRefNullExpr(WasmAbsHeapType heapType) : base(WasmExprKind.RefNull)
         {
-            absheaptype = heapType;
+            _absoluteHeapType = heapType;
         }
 
         public override int Encode(Span<byte> buffer)
         {
             int pos = base.Encode(buffer);
-            buffer[pos++] = (byte)absheaptype;
+            buffer[pos++] = (byte)_absoluteHeapType;
             return pos;
         }
         public override int EncodeSize()
@@ -749,7 +749,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    enum WasmBlockType : byte
+    internal enum WasmBlockType : byte
     {
         Empty = 0x40,
         I32 = 0x7F,
@@ -758,17 +758,19 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         F64 = 0x7C,
         V128 = 0x7B,
     }
-    class WasmBlockStartExpr : WasmExpr
+    internal sealed class WasmBlockStartExpr : WasmExpr
     {
-        WasmBlockType BlockType;
+        private readonly WasmBlockType _blockType;
+
         public WasmBlockStartExpr(WasmExprKind kind, WasmBlockType blockType) : base(kind)
         {
-            BlockType = blockType;
+            _blockType = blockType;
         }
+
         public override int Encode(Span<byte> buffer)
         {
             int pos = base.Encode(buffer);
-            buffer[pos++] = (byte)BlockType;
+            buffer[pos++] = (byte)_blockType;
             return pos;
         }
         public override int EncodeSize()
@@ -780,7 +782,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
     // ************************************************
     // Simple DSL wrapper for creating Wasm expressions
     // ************************************************
-    static class Local
+    internal static class Local
     {
         public static WasmExpr Get(int index)
         {
@@ -796,7 +798,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    static class Global
+    internal static class Global
     {
         public static WasmExpr Get(int index)
         {
@@ -808,7 +810,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    static class I32
+    internal static class I32
     {
         public static WasmExpr Const(long value)
         {
@@ -827,7 +829,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.I32Store, 4, new WasmEncodableULong(offset));
     }
 
-    static class I64
+    internal static class I64
     {
         public static WasmExpr Const(long value)
         {
@@ -837,25 +839,25 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.I64Store, 8, new WasmEncodableULong(offset));
     }
 
-    static class F32
+    internal static class F32
     {
         public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.F32Load, 4, new WasmEncodableULong(offset));
         public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.F32Store, 4, new WasmEncodableULong(offset));
     }
 
-    static class F64
+    internal static class F64
     {
         public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.F64Load, 8, new WasmEncodableULong(offset));
         public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.F64Store, 8, new WasmEncodableULong(offset));
     }
 
-    static class V128
+    internal static class V128
     {
         public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.V128Load, 16, new WasmEncodableULong(offset));
         public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.V128Store, 16, new WasmEncodableULong(offset));
     }
 
-    static class Memory
+    internal static class Memory
     {
         public static WasmExpr Copy(int dstMemoryIndex = 0, int srcMemoryIndex = 0)
         {
@@ -872,20 +874,20 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
             return new WasmMemoryInitExpr(dataSegmentIndex, memoryIndex);
         }
     }
-    static class ControlFlow
+    internal static class ControlFlow
     {
         public static WasmExpr CallIndirect(ISymbolNode funcType, uint tableIndex) => new WasmIndirectCallInstruction(WasmExprKind.CallIndirect, funcType, tableIndex);
     }
-    static class Table
+    internal static class Table
     {
         public static WasmExpr Grow(uint tableIndex) => new WasmTableGrowExpr(tableIndex);
         public static WasmExpr Init(int elemSegmentIndex, int tableIndex = 0) => new WasmTableInitExpr(elemSegmentIndex, tableIndex);
     }
-    static class Ref
+    internal static class Ref
     {
         public static WasmExpr NullFuncRef => new WasmRefNullExpr(WasmAbsHeapType.Func);
     }
-    static class Block
+    internal static class Block
     {
         public static WasmExpr If(WasmBlockType blockType) => new WasmBlockStartExpr(WasmExprKind.If, blockType);
         public static WasmExpr End => new WasmUnaryExpr(WasmExprKind.End);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmNative.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmNative.cs
@@ -74,8 +74,8 @@ namespace ILCompiler.ObjectWriter
 
     public class WasmGlobalImportType : WasmImportType
     {
-        WasmValueType _valueType;
-        WasmMutabilityType _mutability;
+        private WasmValueType _valueType;
+        private WasmMutabilityType _mutability;
 
         public WasmGlobalImportType(WasmValueType valueType, WasmMutabilityType mutability) : base (WasmExternalKind.Global)
         {
@@ -104,7 +104,7 @@ namespace ILCompiler.ObjectWriter
         public override int Encode(Span<byte> buffer)
         {
             int pos = 0;
-            buffer[pos++] = (byte)0x70; // element type: funcref 
+            buffer[pos++] = (byte)0x70; // element type: funcref
             buffer[pos++] = (byte)0; // table limits: flags (0 = min-only, 1 = min+max)
             pos += DwarfHelper.WriteULEB128(buffer.Slice(pos), 1); // Requires 1 table entry
             return pos;
@@ -120,12 +120,12 @@ namespace ILCompiler.ObjectWriter
         HasMin = 0x00,
         HasMinAndMax = 0x01
     }
-  
+
     public class WasmMemoryImportType : WasmImportType
     {
-        WasmLimitType _limitType;
-        uint _min;
-        uint? _max;
+        private WasmLimitType _limitType;
+        private uint _min;
+        private uint? _max;
 
         public WasmMemoryImportType(WasmLimitType limitType, uint min, uint? max = null) : base(WasmExternalKind.Memory)
         {
@@ -211,7 +211,7 @@ namespace ILCompiler.ObjectWriter
         public int EncodeRelocations(Span<Relocation> buffer) => Import.EncodeRelocations(buffer);
     }
 
-    public class WasmGlobal : IWasmEncodable
+    internal sealed class WasmGlobal : IWasmEncodable
     {
         public readonly int Index;
         public readonly string Name;
@@ -219,7 +219,7 @@ namespace ILCompiler.ObjectWriter
         private readonly WasmMutabilityType _mutability;
         private readonly WasmInstructionGroup _initExpr;
 
-        public WasmGlobal(int index, string name, WasmValueType valueType, WasmMutabilityType mutability, WasmInstructionGroup initExpr)
+        internal WasmGlobal(int index, string name, WasmValueType valueType, WasmMutabilityType mutability, WasmInstructionGroup initExpr)
         {
             Index = index;
             Name = name;

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -1043,7 +1043,7 @@ namespace ILCompiler.ObjectWriter
 #if READYTORUN
                             if (symbolWebcilSection is null)
                             {
-                                throw new InvalidDataException($"WebCIL section for symbol '{reloc.SymbolName}' not found");
+                                throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_SLEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
                             }
 
                             Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
@@ -1064,7 +1064,7 @@ namespace ILCompiler.ObjectWriter
 #if READYTORUN
                             if (symbolWebcilSection is null)
                             {
-                                throw new InvalidDataException($"WebCIL section for symbol '{reloc.SymbolName}' not found");
+                                throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_LEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
                             }
 
                             Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -951,6 +951,11 @@ namespace ILCompiler.ObjectWriter
 
                 // The virtual address of the relocation we are resolving
 #if READYTORUN
+                if (definedSymbol is null)
+                {
+                    throw new InvalidDataException($"Symbol definition '{reloc.SymbolName}' not found");
+                }
+
                 uint virtualRelocOffset = 0;
                 if (curSectionAsWebcil is not null)
                 {
@@ -965,7 +970,7 @@ namespace ILCompiler.ObjectWriter
                 // TODO-Wasm: Enforce the below boolean as an assert once we are emitting proper Wasm code
                 // relocs for all code containing nodes
                 // ---> bool betweenWebcilSections = false;
-                if (definedSymbol is not null && _sections[definedSymbol.SectionIndex] is WebcilSection targetSection)
+                if (_sections[definedSymbol.SectionIndex] is WebcilSection targetSection)
                 {
                     symbolWebcilSection = targetSection;
                     virtualSymbolImageOffset = symbolWebcilSection.Header.VirtualAddress + (uint)definedSymbol.Value;
@@ -1036,23 +1041,17 @@ namespace ILCompiler.ObjectWriter
                             // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's
                             // flag mapping
 #if READYTORUN
-                            Debug.Assert(symbolWebcilSection is not null);
+                            if (symbolWebcilSection is null)
+                            {
+                                throw new InvalidDataException($"WebCIL section for symbol '{reloc.SymbolName}' not found");
+                            }
+
                             Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
-#else
-                            if (definedSymbol is null)
-                            {
-                                throw new InvalidDataException($"Symbol definition '{reloc.SymbolName}' not found");
-                            }
-
-                            if (_sections[definedSymbol.SectionIndex].Type == WasmSectionType.Data)
-                            {
-                                throw new PlatformNotSupportedException(
-                                    $"NativeAOT WebAssembly data symbol '{reloc.SymbolName}' is not supported.");
-                            }
-
-                            Relocation.WriteValue(reloc.Type, pData, definedSymbol.Value + addend);
-#endif
                             break;
+#else
+                            throw new PlatformNotSupportedException(
+                                $"NativeAOT WebAssembly memory address relocation for '{reloc.SymbolName}' is not supported.");
+#endif
                         }
                         case RelocType.WASM_MEMORY_ADDR_REL_LEB:
                         {
@@ -1063,23 +1062,17 @@ namespace ILCompiler.ObjectWriter
                             // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's
                             // flag mapping
 #if READYTORUN
-                            Debug.Assert(symbolWebcilSection is not null);
+                            if (symbolWebcilSection is null)
+                            {
+                                throw new InvalidDataException($"WebCIL section for symbol '{reloc.SymbolName}' not found");
+                            }
+
                             Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
-#else
-                            if (definedSymbol is null)
-                            {
-                                throw new InvalidDataException($"Symbol definition '{reloc.SymbolName}' not found");
-                            }
-
-                            if (_sections[definedSymbol.SectionIndex].Type == WasmSectionType.Data)
-                            {
-                                throw new PlatformNotSupportedException(
-                                    $"NativeAOT WebAssembly data symbol '{reloc.SymbolName}' is not supported.");
-                            }
-
-                            Relocation.WriteValue(reloc.Type, pData, definedSymbol.Value + addend);
-#endif
                             break;
+#else
+                            throw new PlatformNotSupportedException(
+                                $"NativeAOT WebAssembly memory address relocation for '{reloc.SymbolName}' is not supported.");
+#endif
                         }
                         case RelocType.WASM_TABLE_INDEX_I32:
                         case RelocType.WASM_TABLE_INDEX_I64:

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Frozen;
 using System.Collections.Generic;
@@ -17,13 +18,15 @@ using ILCompiler.ObjectWriter.WasmInstructions;
 using Internal.JitInterface;
 using Internal.Text;
 using Internal.TypeSystem;
+#if READYTORUN
 using Microsoft.NET.WebAssembly.Webcil;
+#endif
 using CodeDataLayout = CodeDataLayoutMode.CodeDataLayout;
 using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 
 namespace ILCompiler.ObjectWriter
 {
-    internal class PaddingHelper
+    internal sealed class PaddingHelper
     {
         private byte[] _padding;
         public PaddingHelper(int n, byte padByte = 0)
@@ -58,20 +61,21 @@ namespace ILCompiler.ObjectWriter
     /// <summary>
     /// Wasm object file format writer.
     /// </summary>
-    internal sealed class WasmObjectWriter : ObjectWriter
+    internal sealed partial class WasmObjectWriter : ObjectWriter
     {
         protected override CodeDataLayout LayoutMode => CodeDataLayout.Separate;
+        private protected override bool UsesSubsectionsViaSymbols => true;
 
         // We use 2 Wasm data segments for webcil,
         // 1 for the payload size, and the second for the payload itself.
-        const int NumDataSegments = 2;
+        private const int NumDataSegments = 2;
 
-        public WasmObjectWriter(NodeFactory factory, ObjectWritingOptions options, OutputInfoBuilder outputInfoBuilder)
+        public WasmObjectWriter(NodeFactory factory, ObjectWritingOptions options, OutputInfoBuilder outputInfoBuilder = null)
             : base(factory, options, outputInfoBuilder)
         {
         }
 
-        private void EmitWasmHeader(Stream outputFileStream)
+        private static void EmitWasmHeader(Stream outputFileStream)
         {
             outputFileStream.Write("\0asm"u8);
             outputFileStream.Write([0x1, 0x0, 0x0, 0x0]);
@@ -79,7 +83,7 @@ namespace ILCompiler.ObjectWriter
 
         private Dictionary<Utf8String, int> _uniqueSignatures = new();
         private Dictionary<string, int> _uniqueSymbols = new();
-        private int _methodCount = 0;
+        private int _methodCount;
 
         private Dictionary<SortableDependencyNode.ObjectNodeOrder, Utf8String> _wellKnownSymbols = new();
         private protected override void RecordWellKnownSymbol(Utf8String currentSymbolName, SortableDependencyNode.ObjectNodeOrder classCode)
@@ -106,28 +110,19 @@ namespace ILCompiler.ObjectWriter
 
         private protected override void RecordMethodDeclaration(INodeWithTypeSignature node)
         {
-            WasmLowering.LoweringFlags flags = WasmLowering.LoweringFlags.None;
-            if (node.HasGenericContextArg)
-            {
-                flags |= WasmLowering.LoweringFlags.HasGenericContextArg;
-            }
-            if (node.IsAsyncCall)
-            {
-                flags |= WasmLowering.LoweringFlags.IsAsyncCall;
-            }
-            if (node.IsUnmanagedCallersOnly)
-            {
-                flags |= WasmLowering.LoweringFlags.IsUnmanagedCallersOnly;
-            }
+            WasmLowering.LoweringFlags flags = GetLoweringFlags(node);
             WriteSignatureIndexForFunction(node.Signature, flags, node);
             _uniqueSymbols.Add(node.GetMangledName(_nodeFactory.NameMangler), _methodCount);
             _methodCount++;
+#if READYTORUN
             if (node is INodeWithFunclets nodeWithFunclets)
             {
                 RecordFunclets(nodeWithFunclets);
             }
+#endif
         }
 
+#if READYTORUN
         private void RecordFunclets(INodeWithFunclets nodeWithFunclets)
         {
             FuncletKind[] funcletKinds = nodeWithFunclets.GetFuncletKinds();
@@ -141,14 +136,14 @@ namespace ILCompiler.ObjectWriter
 
             for (int i = 0; i < funcletKinds.Length; i++)
             {
-                 WasmFuncType funcletSignature = GetFuncletType(funcletKinds[i], pointerType);
+                WasmFuncType funcletSignature = GetFuncletType(funcletKinds[i], pointerType);
                 _uniqueSymbols.Add($"{mangledNodeName}_funclet_{i}", _methodCount);
                 _methodCount++;
                 RegisterStubIndexAndSignature(funcletSignature);
             }
         }
 
-        private WasmFuncType GetFuncletType(FuncletKind funcletKind, WasmValueType pointerType)
+        private static WasmFuncType GetFuncletType(FuncletKind funcletKind, WasmValueType pointerType)
         {
             return funcletKind switch
             {
@@ -156,6 +151,26 @@ namespace ILCompiler.ObjectWriter
                     new([pointerType, pointerType, pointerType]), new([pointerType])), // (FP, SP, EXN) -> RESULT
                 _ => new WasmFuncType(new([pointerType, pointerType]), new([])), // (FP, SP) -> void
             };
+        }
+#endif
+
+        private static WasmLowering.LoweringFlags GetLoweringFlags(INodeWithTypeSignature node)
+        {
+            WasmLowering.LoweringFlags flags = WasmLowering.LoweringFlags.None;
+            if (node.HasGenericContextArg)
+            {
+                flags |= WasmLowering.LoweringFlags.HasGenericContextArg;
+            }
+            if (node.IsAsyncCall)
+            {
+                flags |= WasmLowering.LoweringFlags.IsAsyncCall;
+            }
+            if (node.IsUnmanagedCallersOnly)
+            {
+                flags |= WasmLowering.LoweringFlags.IsUnmanagedCallersOnly;
+            }
+
+            return flags;
         }
 
         private void WriteSignatureIndexForFunction(MethodSignature managedSignature, WasmLowering.LoweringFlags flags, ISymbolNode node)
@@ -166,7 +181,21 @@ namespace ILCompiler.ObjectWriter
             Utf8String key = signature.GetMangledName(_nodeFactory.NameMangler);
             if (!_uniqueSignatures.TryGetValue(key, out int signatureIndex))
             {
-                throw new InvalidOperationException($"Signature index of {key} not found for function: {node.ToString()}");
+#if READYTORUN
+                throw new InvalidOperationException($"Signature index of {key} not found for function: {node}");
+#else
+                // Auto-register the signature if not already known (e.g., for P/Invoke stubs).
+                signatureIndex = _uniqueSignatures.Count;
+                _uniqueSignatures.Add(key, signatureIndex);
+
+                // Write the type to the type section.
+                SectionWriter typeWriter = GetOrCreateSection(ObjectNodeSection.WasmTypeSection);
+                int encodeSize = signature.EncodeSize();
+                Span<byte> buffer = typeWriter.Buffer.GetSpan(encodeSize);
+                int bytesWritten = signature.Encode(buffer);
+                Debug.Assert(bytesWritten == encodeSize);
+                typeWriter.Buffer.Advance(bytesWritten);
+#endif
             }
 
             writer.WriteULEB128((ulong)signatureIndex);
@@ -265,27 +294,31 @@ namespace ILCompiler.ObjectWriter
 
         private WasmSectionType GetWasmSectionType(ObjectNodeSection section)
         {
-            if (!_sectionToType.ContainsKey(section))
+            if (!_sectionToType.TryGetValue(section, out WasmSectionType type))
             {
                 // All other sections map to generic data segments in Wasm
                 // TODO-WASM: Consider making the mapping explicit for every possible node type.
                 return WasmSectionType.Data;
             }
-            return _sectionToType[section];
+            return type;
         }
 
         protected internal override void UpdateSectionAlignment(int sectionIndex, int alignment)
         {
+#if READYTORUN
             WebcilSection section = _sections[sectionIndex] as WebcilSection;
             // We should only be updating the alignment of Webcil sections; Wasm-native sections should
             // not have alignment constraints.
-            Debug.Assert(section != null || alignment == 1, $"Section: {sectionIndex} is not a WebcilSection but alignment {alignment} requested");
-            if (section == null)
+            Debug.Assert(section is not null || alignment == 1, $"Section: {sectionIndex} is not a WebcilSection but alignment {alignment} requested");
+            if (section is null)
             {
                 return;
             }
 
             section.MinAlignment = Math.Max(section.MinAlignment, alignment);
+#else
+            // SectionWriter pads the data stream to the requested alignment.
+#endif
         }
 
 #if READYTORUN
@@ -493,7 +526,8 @@ namespace ILCompiler.ObjectWriter
 
         private protected override ObjectNodeSection GetEmitSection(ObjectNodeSection section)
         {
-            if (section == ObjectNodeSection.TextSection || section == ObjectNodeSection.ManagedCodeUnixContentSection)
+            if (section == ObjectNodeSection.TextSection ||
+                section == ObjectNodeSection.ManagedCodeUnixContentSection)
             {
                 return ObjectNodeSection.WasmCodeSection;
             }
@@ -531,9 +565,12 @@ namespace ILCompiler.ObjectWriter
             writer.WriteULEB128(NumDataSegments); // number of data segments
         }
 
-        private WebcilSegment _webcilSegment = null;
+#if READYTORUN
+        private WebcilSegment _webcilSegment;
+#endif
         private protected override void EmitSectionsAndLayout()
         {
+#if READYTORUN
             int totalMethodCount = _methodCount + 3;
             InsertWasmStub(new Utf8String("getWebcilSize"), GetWebcilSize);
             InsertWasmStub(new Utf8String("getWebcilPayload"), GetWebcilPayload);
@@ -541,11 +578,12 @@ namespace ILCompiler.ObjectWriter
             Debug.Assert(_methodCount == totalMethodCount);
 
             WriteDataCountSection();
+#endif
 
             PrependCount(SectionByName(ObjectNodeSection.WasmCodeSection.Name), _methodCount);
         }
 
-        private int _numDefinedGlobals = 0;
+        private int _numDefinedGlobals;
         private int NextGlobalIndex()
         {
 
@@ -576,6 +614,7 @@ namespace ILCompiler.ObjectWriter
         }
 
 
+#if READYTORUN
         private void WriteGlobalSection()
         {
             SectionWriter writer = GetOrCreateSection(WasmObjectNodeSection.GlobalSection);
@@ -584,8 +623,9 @@ namespace ILCompiler.ObjectWriter
             WriteGlobal(writer, "webcilVersion", WasmValueType.I32, WasmMutabilityType.Const,
                 new WasmInstructionGroup([new WasmConstExpr(WasmExprKind.I32Const, WebcilConstants.WC_VERSION_MAJOR)]));
         }
+#endif
 
-        private void PrependCount(WasmSection section, int count)
+        private static void PrependCount(WasmSection section, int count)
         {
             section.PrependCount = count;
         }
@@ -597,7 +637,7 @@ namespace ILCompiler.ObjectWriter
         }
 
         // Sections excluding Webcil Data segment
-        readonly string[] SectionOrder =
+        private readonly string[] SectionOrder =
         [
             ObjectNodeSection.WasmTypeSection.Name,
             WasmObjectNodeSection.ImportSection.Name,
@@ -609,23 +649,21 @@ namespace ILCompiler.ObjectWriter
             ObjectNodeSection.WasmCodeSection.Name,
         ];
 
-        private int[] _sectionEmitOrder = null;
+        private int[] _sectionEmitOrder;
         private int[] SectionEmitOrder
         {
             get
             {
-                if (_sectionEmitOrder == null)
-                {
-                    _sectionEmitOrder = SectionOrder
-                        .Where(name => _sectionNameToIndex.ContainsKey(name))
-                        .Select(name => _sectionNameToIndex[name])
-                        .ToArray();
-                }
+                _sectionEmitOrder ??= SectionOrder
+                    .Where(_sectionNameToIndex.ContainsKey)
+                    .Select(name => _sectionNameToIndex[name])
+                    .ToArray();
 
                 return _sectionEmitOrder;
             }
         }
 
+#if READYTORUN
         private static readonly ObjectNodeSection WebcilRelocSection = new ObjectNodeSection("reloc", SectionType.ReadOnly);
         private void EmitRelocSectionData()
         {
@@ -656,12 +694,14 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private PaddingHelper _paddingHelper = new PaddingHelper(WebcilSectionAlignment);
+        private readonly PaddingHelper _paddingHelper = new PaddingHelper(WebcilSectionAlignment);
+#endif
 
         private protected override void EmitObjectFile(Stream outputFileStream)
         {
             Debug.Assert(outputFileStream.CanSeek, $"EmitObjectFile requires seekable output stream");
 
+#if READYTORUN
             if (_pendingBaseRelocs.Count > 0)
             {
                 GetOrCreateSection(WebcilRelocSection);
@@ -689,6 +729,13 @@ namespace ILCompiler.ObjectWriter
             WriteMemoryImport((ulong)_webcilSegment.GetFlatMappedSize());
             // Writing element counts <- imports being finalized.
             EmitSectionElementCounts();
+#else
+            // NativeAOT does not yet emit its data sections, but generated code still
+            // references linear memory. Import a minimum-sized memory and finalize the
+            // section counts so the compiler produces a structurally valid module.
+            WriteMemoryImport(0);
+            EmitSectionElementCounts();
+#endif
 
            /*********************************************************************
            * Write Wasm Sections, Excluding Data
@@ -761,28 +808,29 @@ namespace ILCompiler.ObjectWriter
             BinaryPrimitives.WriteUInt32LittleEndian(lengthBuffer, (uint)_webcilSegment.GetFlatMappedSize());
             BinaryPrimitives.WriteUInt32LittleEndian(lengthBuffer.AsSpan().Slice(4), (uint)_uniqueSymbols.Count);
             MemoryStream webcilSizeSegmentStream = new MemoryStream(lengthBuffer);
-            WasmDataSegment webcilSizeSegment = new WasmDataSegment(webcilSizeSegmentStream, new Utf8String("webcilCount"),
-                WasmDataSectionType.Passive, null);
+            WasmDataSegment webcilSizeSegment = new WasmDataSegment(webcilSizeSegmentStream, WasmDataSectionType.Passive, null);
 
             // Passive data segment for webcil payload contents
-            WasmDataSegment webcilContentsSegment = new WasmDataSegment(webcilStream, new Utf8String("webcilPayload"),
-                WasmDataSectionType.Passive, null);
+            WasmDataSegment webcilContentsSegment = new WasmDataSegment(webcilStream, WasmDataSectionType.Passive, null);
 
             // Create combined data section and emit
             WasmDataSection dataSection = new WasmDataSection([webcilSizeSegment, webcilContentsSegment], new Utf8String("data"), contentAlign: 4);
             dataSection.Emit(outputFileStream);
 #endif
+
         }
 
-        Dictionary<int, List<SymbolicRelocation>> _resolvableRelocations = new();
-        SortedDictionary<uint, List<ushort>> _baseRelocMap = new();
+        private Dictionary<int, List<SymbolicRelocation>> _resolvableRelocations = new();
+#if READYTORUN
+        private readonly SortedDictionary<uint, List<ushort>> _baseRelocMap = new();
         // We group webcil relocs into 4kb blocks, similar to PE
-        const uint WebcilRelocPageSize = 0x1000;
+        private const uint WebcilRelocPageSize = 0x1000;
 
         // File-level relocations whose RVA computation is deferred until webcil section
         // VirtualAddresses have been assigned.
         private readonly record struct PendingBaseReloc(int SectionIndex, long Offset, RelocType FileRelocType);
         private readonly List<PendingBaseReloc> _pendingBaseRelocs = new();
+#endif
 
         private protected override void EmitRelocations(int sectionIndex, List<SymbolicRelocation> relocationList)
         {
@@ -796,6 +844,7 @@ namespace ILCompiler.ObjectWriter
                 // for all relocation types.
                 resolvable.Add(reloc);
 
+#if READYTORUN
                 // A few relocation types (table indices and IMAGE_REL type relocs in Webcil) need
                 // an additional runtime reloc as well to add a base address.
                 // We defer the actual RVA computation to EmitObjectFile, where webcil section
@@ -806,9 +855,11 @@ namespace ILCompiler.ObjectWriter
                     Debug.Assert(_sections[sectionIndex] is WebcilSection);
                     _pendingBaseRelocs.Add(new PendingBaseReloc(sectionIndex, reloc.Offset, fileRelocType));
                 }
+#endif
             }
         }
 
+#if READYTORUN
         /// <summary>
         /// Processes the deferred file-level relocations after webcil section VirtualAddresses
         /// have been assigned. Populates <see cref="_baseRelocMap"/> with page-grouped base reloc
@@ -840,10 +891,11 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private bool IsWithinSection(long rva, WebcilSection section)
+        private static bool IsWithinSection(long rva, WebcilSection section)
         {
             return rva >= section.Header.VirtualAddress && rva < section.Header.VirtualAddress + section.Header.VirtualSize;
         }
+#endif
 
         // TODO-WASM: Currently, all Wasm relocs are resolved to 5 byte values unconditionally (the same size as the original placeholder padding), which is wasteful.
         // We should remove the padding and shrink the resolved values to their minimal size so we don't bloat the binary size.
@@ -852,6 +904,7 @@ namespace ILCompiler.ObjectWriter
         {
             byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
 
+#if READYTORUN
             WebcilSection? curSectionAsWebcil = null;
             uint webcilVirtualStart = 0;
             if (_sections[sectionIndex] is WebcilSection curSection)
@@ -864,6 +917,7 @@ namespace ILCompiler.ObjectWriter
             // we should have written the webcil header and each of the section headers (always non-zero size) before any
             // section contents
             Debug.Assert(curSectionAsWebcil is null || sectionStart != 0);
+#endif
 
             foreach (SymbolicRelocation reloc in relocs)
             {
@@ -893,9 +947,10 @@ namespace ILCompiler.ObjectWriter
                     continue;
                 }
 
-                SymbolDefinition definedSymbol = _definedSymbols[reloc.SymbolName];
+                _definedSymbols.TryGetValue(reloc.SymbolName, out SymbolDefinition? definedSymbol);
 
                 // The virtual address of the relocation we are resolving
+#if READYTORUN
                 uint virtualRelocOffset = 0;
                 if (curSectionAsWebcil is not null)
                 {
@@ -910,12 +965,13 @@ namespace ILCompiler.ObjectWriter
                 // TODO-Wasm: Enforce the below boolean as an assert once we are emitting proper Wasm code
                 // relocs for all code containing nodes
                 // ---> bool betweenWebcilSections = false;
-                if (_sections[definedSymbol.SectionIndex] is WebcilSection targetSection)
+                if (definedSymbol is not null && _sections[definedSymbol.SectionIndex] is WebcilSection targetSection)
                 {
                     symbolWebcilSection = targetSection;
                     virtualSymbolImageOffset = symbolWebcilSection.Header.VirtualAddress + (uint)definedSymbol.Value;
                     Debug.Assert(IsWithinSection(virtualSymbolImageOffset, symbolWebcilSection));
                 }
+#endif
 
                 // We need a pinned raw pointer here for manipulation with Relocation.WriteValue
                 fixed (byte* pData = ReadRelocToDataSpan(reloc, relocScratchBuffer, sectionStart))
@@ -938,11 +994,11 @@ namespace ILCompiler.ObjectWriter
 
                             break;
                         }
-
                         case RelocType.IMAGE_REL_BASED_ABSOLUTE:
                             // No action required
                             break;
 
+#if READYTORUN
                         case RelocType.IMAGE_REL_BASED_DIR64:
                         case RelocType.IMAGE_REL_BASED_HIGHLOW:
                             // This is an ImageBase-relative value in PE, but our image base
@@ -960,10 +1016,15 @@ namespace ILCompiler.ObjectWriter
                             Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset - (virtualRelocOffset + relocLength) + addend);
                             break;
                         case RelocType.IMAGE_REL_FILE_ABSOLUTE:
-                            Debug.Assert(symbolWebcilSection != null);
+                            if (symbolWebcilSection is null || definedSymbol is null)
+                            {
+                                throw new InvalidDataException($"Symbol definition '{reloc.SymbolName}' not found");
+                            }
+
                             long fileOffset = symbolWebcilSection.Header.PointerToRawData + definedSymbol.Value;
                             Relocation.WriteValue(reloc.Type, pData, fileOffset + addend);
                             break;
+#endif
                         case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
                         {
                             // These relocs should be for cases of the form:
@@ -974,12 +1035,23 @@ namespace ILCompiler.ObjectWriter
                             // So, the relocated address value should always represent an offset relative to image base.
                             // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's
                             // flag mapping
-                            if (symbolWebcilSection is null)
+#if READYTORUN
+                            Debug.Assert(symbolWebcilSection is not null);
+                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+#else
+                            if (definedSymbol is null)
                             {
-                                throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_SLEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
+                                throw new InvalidDataException($"Symbol definition '{reloc.SymbolName}' not found");
                             }
 
-                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                            if (_sections[definedSymbol.SectionIndex].Type == WasmSectionType.Data)
+                            {
+                                throw new PlatformNotSupportedException(
+                                    $"NativeAOT WebAssembly data symbol '{reloc.SymbolName}' is not supported.");
+                            }
+
+                            Relocation.WriteValue(reloc.Type, pData, definedSymbol.Value + addend);
+#endif
                             break;
                         }
                         case RelocType.WASM_MEMORY_ADDR_REL_LEB:
@@ -990,12 +1062,23 @@ namespace ILCompiler.ObjectWriter
                             // So, the relocated address value should always represent an offset relative to image base.
                             // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's
                             // flag mapping
-                            if (symbolWebcilSection is null)
+#if READYTORUN
+                            Debug.Assert(symbolWebcilSection is not null);
+                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+#else
+                            if (definedSymbol is null)
                             {
-                                throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_LEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
+                                throw new InvalidDataException($"Symbol definition '{reloc.SymbolName}' not found");
                             }
 
-                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                            if (_sections[definedSymbol.SectionIndex].Type == WasmSectionType.Data)
+                            {
+                                throw new PlatformNotSupportedException(
+                                    $"NativeAOT WebAssembly data symbol '{reloc.SymbolName}' is not supported.");
+                            }
+
+                            Relocation.WriteValue(reloc.Type, pData, definedSymbol.Value + addend);
+#endif
                             break;
                         }
                         case RelocType.WASM_TABLE_INDEX_I32:
@@ -1004,7 +1087,11 @@ namespace ILCompiler.ObjectWriter
                         case RelocType.WASM_TABLE_INDEX_REL_I32:
                         {
                             string symbolName = reloc.SymbolName.ToString();
-                            int index = _uniqueSymbols[symbolName];
+                            if (!_uniqueSymbols.TryGetValue(symbolName, out int index))
+                            {
+                                throw new InvalidDataException($"Function table symbol definition '{reloc.SymbolName}' not found");
+                            }
+
                             // Here, we are effectively writing a table offset relative to the table_base.
                             // These will need to be fixed up by the runtime after load by adding tableBase
                             // except for WASM_TABLE_INDEX_REL_I32 and WASM_TABLE_INDEX_SLEB which are relative
@@ -1015,10 +1102,11 @@ namespace ILCompiler.ObjectWriter
                         case RelocType.WASM_FUNCTION_INDEX_LEB:
                         {
                             string symbolName = reloc.SymbolName.ToString();
-                            int index = _uniqueSymbols[symbolName];
+                            if (!_uniqueSymbols.TryGetValue(symbolName, out int index))
+                            {
+                                throw new InvalidDataException($"Function symbol definition '{reloc.SymbolName}' not found");
+                            }
 
-                            // These are module-local function pointer indices, so we can simply write out the assigned function index
-                            // for this particular symbol
                             Relocation.WriteValue(reloc.Type, pData, index + addend);
                             break;
                         }
@@ -1134,8 +1222,10 @@ namespace ILCompiler.ObjectWriter
         {
             WriteTableExport("table", 0);
 
+#if READYTORUN
             Debug.Assert(_definedGlobals.ContainsKey("webcilVersion"));
             WriteGlobalExport("webcilVersion", _definedGlobals["webcilVersion"].Index);
+#endif
 
             string[] functionExports = _uniqueSymbols.Keys.ToArray();
             // TODO-WASM: Handle exports better (e.g., only export public methods, etc.)
@@ -1167,7 +1257,9 @@ namespace ILCompiler.ObjectWriter
         private protected override void EmitSymbolTable(IDictionary<Utf8String, SymbolDefinition> definedSymbols, SortedSet<Utf8String> undefinedSymbols)
         {
             WriteImports();
+#if READYTORUN
             WriteGlobalSection();
+#endif
             WriteExports();
             WriteElements();
 
@@ -1179,6 +1271,9 @@ namespace ILCompiler.ObjectWriter
         {
             int funcIdx = _sectionNameToIndex[WasmObjectNodeSection.FunctionSection.Name];
             PrependCount(_sections[funcIdx], _methodCount);
+
+            int codeIdx = _sectionNameToIndex[ObjectNodeSection.WasmCodeSection.Name];
+            PrependCount(_sections[codeIdx], _methodCount);
 
             int typeIdx = _sectionNameToIndex[ObjectNodeSection.WasmTypeSection.Name];
             PrependCount(_sections[typeIdx], _uniqueSignatures.Count);
@@ -1193,7 +1288,9 @@ namespace ILCompiler.ObjectWriter
 
             PrependCount(SectionByName(WasmObjectNodeSection.ImportSection.Name), _numImports);
 
+#if READYTORUN
             PrependCount(SectionByName(WasmObjectNodeSection.GlobalSection.Name), _numDefinedGlobals);
+#endif
         }
     }
 
@@ -1203,7 +1300,7 @@ namespace ILCompiler.ObjectWriter
         public WasmSectionType Type { get; }
         public Utf8String Name { get; }
 
-        public int? PrependCount = null;
+        public int? PrependCount;
         public int PrependCountSize => PrependCount.HasValue ? (int)DwarfHelper.SizeOfULEB128((ulong)PrependCount.Value) : 0;
 
         private int EncodePrependCount(Span<byte> dest)
@@ -1231,7 +1328,7 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        Stream _dataStream;
+        private Stream _dataStream;
 
         public virtual int HeaderSize
         {
@@ -1292,7 +1389,7 @@ namespace ILCompiler.ObjectWriter
         }
     }
 
-    internal class WasmDataSection : WasmSection
+    internal sealed class WasmDataSection : WasmSection
     {
         private List<WasmDataSegment> _segments;
         public List<WasmDataSegment> Segments => _segments;
@@ -1387,15 +1484,15 @@ namespace ILCompiler.ObjectWriter
         ActiveMemorySpecified = 2 // (data list(byte) (active memidx offset-expr))
     }
 
-    internal class WasmDataSegment
+    internal sealed class WasmDataSegment
     {
         // The segments are not sections per se, but they represent data segments within the data section.
-        Stream _stream;
-        WasmDataSectionType _type;
-        WasmInstructionGroup _initExpr;
+        private Stream _stream;
+        private WasmDataSectionType _type;
+        private WasmInstructionGroup _initExpr;
         private PaddingHelper _paddingHelper;
 
-        public WasmDataSegment(Stream contents, Utf8String name, WasmDataSectionType type, WasmInstructionGroup initExpr)
+        public WasmDataSegment(Stream contents, WasmDataSectionType type, WasmInstructionGroup initExpr)
         {
             _stream = contents;
             _type = type;
@@ -1427,19 +1524,20 @@ namespace ILCompiler.ObjectWriter
             return HeaderSize + ContentSize;
         }
 
-        private bool _paddingSet = false;
-        int _padding = 0;
+        private bool _paddingSet;
+        private int _padding;
+
         public int Padding
         {
-            set
-            {
-                _paddingSet = true;
-                _padding = value;
-            }
             get
             {
                 Debug.Assert(_paddingSet);
                 return _padding;
+            }
+            set
+            {
+                _paddingSet = true;
+                _padding = value;
             }
         }
 
@@ -1452,8 +1550,7 @@ namespace ILCompiler.ObjectWriter
             {
                 case WasmDataSectionType.Active:
                 {
-                    int len = 0;
-                    len = DwarfHelper.WriteULEB128(headerBuffer, (ulong)_type);
+                    int len = DwarfHelper.WriteULEB128(headerBuffer, (ulong)_type);
                     len += _initExpr.Encode(headerBuffer.Slice(len));
                     Debug.Assert(headerBuffer.Slice(len).Length == Relocation.WASM_PADDED_RELOC_SIZE_32);
                     DwarfHelper.WritePaddedULEB128(headerBuffer.Slice(len), (ulong)ContentSize);
@@ -1462,8 +1559,7 @@ namespace ILCompiler.ObjectWriter
                 }
                 case WasmDataSectionType.Passive:
                 {
-                    int len = 0;
-                    len = DwarfHelper.WriteULEB128(headerBuffer, (ulong)_type);
+                    int len = DwarfHelper.WriteULEB128(headerBuffer, (ulong)_type);
                     Debug.Assert(headerBuffer.Slice(len).Length == Relocation.WASM_PADDED_RELOC_SIZE_32, $"{headerBuffer.Slice(len).Length} != {Relocation.WASM_PADDED_RELOC_SIZE_32}");
                     DwarfHelper.WritePaddedULEB128(headerBuffer.Slice(len), (ulong)ContentSize);
                     len += headerBuffer.Slice(len).Length;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -4796,12 +4796,10 @@ namespace Internal.JitInterface
                 flags.Clear(CorJitFlag.CORJIT_FLAG_PROCSPLIT);
             }
 
-#if READYTORUN
             if (this.MethodBeingCompiled.Context.Target.Architecture == TargetArchitecture.Wasm32)
             {
                 flags.Set(CorJitFlag.CORJIT_FLAG_PORTABLE_ENTRY_POINTS);
             }
-#endif
 
             return (uint)sizeof(CORJIT_FLAGS);
         }

--- a/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
+++ b/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
@@ -394,7 +394,7 @@ namespace Internal.JitInterface
         {
             if (!flags.HasFlag(LoweringFlags.IsUnmanagedCallersOnly) && signature.Flags.HasFlag(MethodSignatureFlags.UnmanagedCallingConvention))
             {
-                flags = flags | LoweringFlags.IsUnmanagedCallersOnly;
+                flags |= LoweringFlags.IsUnmanagedCallersOnly;
             }
 
             TypeDesc returnType = signature.ReturnType;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.Assets/ILCompiler.Compiler.Tests.Assets.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.Assets/ILCompiler.Compiler.Tests.Assets.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\..\..\..\nativeaot\Test.CoreLib\src\Test.CoreLib.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\..\..\..\tests\JIT\CodeGenBringUpTests\Switch.cs" Link="Switch.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.Assets/XunitStubs.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.Assets/XunitStubs.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Xunit
+{
+    internal sealed class FactAttribute : System.Attribute
+    {
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
@@ -26,6 +26,9 @@
     <ProjectReference Include="..\ILCompiler.MetadataTransform\ILCompiler.MetadataTransform.csproj" />
     <ProjectReference Include="..\ILCompiler.RyuJit\ILCompiler.RyuJit.csproj" />
     <ProjectReference Include="..\ILCompiler.TypeSystem\ILCompiler.TypeSystem.csproj" />
+    <ProjectReference Include="..\ILCompiler\ILCompiler_inbuild.csproj" ReferenceOutputAssembly="false">
+      <SetConfiguration Condition="'$(Configuration)' != '$(CoreCLRConfiguration)'">Configuration=$(CoreCLRConfiguration)</SetConfiguration>
+    </ProjectReference>
 
     <ProjectReference Include="..\..\..\nativeaot\Test.CoreLib\src\Test.CoreLib.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
@@ -43,5 +46,31 @@
     <Compile Include="DependencyGraphTests.cs" />
     <Compile Include="DevirtualizationTests.cs" />
     <Compile Include="SwiftLoweringTests.cs" />
+    <Compile Include="WasmSingleMethodTests.cs" />
+  </ItemGroup>
+
+  <!-- The end-to-end WASM tests invoke ILC with a WASM cross-JIT, so build that JIT as part of the test project. -->
+  <PropertyGroup>
+    <_BuildWasmJitCrossArch Condition="'$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(HostOS)' != '$(TargetOS)' or '$(EnableNativeSanitizers)' != ''">true</_BuildWasmJitCrossArch>
+    <_BuildWasmJitProperties>ClrWasmJitSubset=true;Configuration=$(CoreCLRConfiguration)</_BuildWasmJitProperties>
+    <_BuildWasmJitProperties Condition="!$([MSBuild]::IsOsPlatform(Windows))">$(_BuildWasmJitProperties);Ninja=true</_BuildWasmJitProperties>
+    <_BuildWasmJitProperties Condition="'$(_BuildWasmJitCrossArch)' == 'true'">$(_BuildWasmJitProperties);HostArchitecture=$(BuildArchitecture);HostCrossOS=$(HostOS);CrossBuild=false;BuildSubdirectory=$(BuildArchitecture);CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1;PgoInstrument=false;NoPgoOptimize=true</_BuildWasmJitProperties>
+  </PropertyGroup>
+
+  <Target Name="BuildWasmJitForCompilerTests"
+          BeforeTargets="ResolveProjectReferences"
+          Condition="'$(DesignTimeBuild)' != 'true'">
+    <MSBuild Projects="$(CoreClrProjectRoot)runtime.proj"
+             Targets="Build"
+             Properties="$(_BuildWasmJitProperties)" />
+  </Target>
+
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="NativeAotWasmTest.BuildArchitecture">
+      <Value>$(BuildArchitecture)</Value>
+    </RuntimeHostConfigurationOption>
+    <RuntimeHostConfigurationOption Include="NativeAotWasmTest.CoreCLRArtifactsDir">
+      <Value>$(CoreCLRArtifactsPath)</Value>
+    </RuntimeHostConfigurationOption>
   </ItemGroup>
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
@@ -49,23 +49,14 @@
     <Compile Include="WasmSingleMethodTests.cs" />
   </ItemGroup>
 
-  <!-- The end-to-end WASM tests invoke ILC with a WASM cross-JIT, so build that JIT as part of the test project. -->
   <PropertyGroup>
-    <_BuildWasmJitCrossArch Condition="'$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(HostOS)' != '$(TargetOS)' or '$(EnableNativeSanitizers)' != ''">true</_BuildWasmJitCrossArch>
-    <_BuildWasmJitProperties>ClrWasmJitSubset=true;Configuration=$(CoreCLRConfiguration)</_BuildWasmJitProperties>
-    <_BuildWasmJitProperties Condition="!$([MSBuild]::IsOsPlatform(Windows))">$(_BuildWasmJitProperties);Ninja=true</_BuildWasmJitProperties>
-    <_BuildWasmJitProperties Condition="'$(_BuildWasmJitCrossArch)' == 'true'">$(_BuildWasmJitProperties);HostArchitecture=$(BuildArchitecture);HostCrossOS=$(HostOS);CrossBuild=false;BuildSubdirectory=$(BuildArchitecture);CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1;PgoInstrument=false;NoPgoOptimize=true</_BuildWasmJitProperties>
+    <_NativeAotWasmTestSupported Condition="('$(BuildArchitecture)' == 'x64' or '$(BuildArchitecture)' == 'arm64') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')">true</_NativeAotWasmTestSupported>
   </PropertyGroup>
 
-  <Target Name="BuildWasmJitForCompilerTests"
-          BeforeTargets="ResolveProjectReferences"
-          Condition="'$(DesignTimeBuild)' != 'true'">
-    <MSBuild Projects="$(CoreClrProjectRoot)runtime.proj"
-             Targets="Build"
-             Properties="$(_BuildWasmJitProperties)" />
-  </Target>
-
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="NativeAotWasmTest.IsSupported">
+      <Value>$(_NativeAotWasmTestSupported)</Value>
+    </RuntimeHostConfigurationOption>
     <RuntimeHostConfigurationOption Include="NativeAotWasmTest.BuildArchitecture">
       <Value>$(BuildArchitecture)</Value>
     </RuntimeHostConfigurationOption>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/WasmSingleMethodTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/WasmSingleMethodTests.cs
@@ -66,6 +66,7 @@ namespace ILCompiler.Compiler.Tests
                         stackPointer: new WebAssembly.Global({ value: "i32", mutable: true }, 65000),
                         imageBase: new WebAssembly.Global({ value: "i32", mutable: false }, 0),
                         tableBase: new WebAssembly.Global({ value: "i32", mutable: false }, 0),
+                        asyncContinuation: new WebAssembly.Global({ value: "i32", mutable: true }, 0),
                         table: new WebAssembly.Table({ initial: 4096, element: "anyfunc" }),
                         rtlRestoreContextTag: new WebAssembly.Tag({ parameters: [] }),
                         memory: new WebAssembly.Memory({ initial: 16 }),

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/WasmSingleMethodTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/WasmSingleMethodTests.cs
@@ -1,0 +1,187 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+using Microsoft.DotNet.XUnitExtensions;
+
+using Xunit;
+
+namespace ILCompiler.Compiler.Tests
+{
+    public class WasmSingleMethodTests
+    {
+        private const string ExportName = "ILCompiler_Compiler_Tests_Assets_SwitchTest__TestEntryPoint";
+        private static readonly byte[] WasmHeader = [0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00];
+
+        public static bool IsNodeWithWasmExceptionHandlingAvailable =>
+            RunProcess(
+                "node",
+                ["-e", "process.exit(typeof WebAssembly.Tag === 'function' ? 0 : 1)"],
+                throwOnError: false).ExitCode == 0;
+
+        [Fact]
+        public void NativeAotWasmSingleMethodCompiles()
+        {
+            string outputPath = CompileSwitchTest();
+            try
+            {
+                byte[] output = File.ReadAllBytes(outputPath);
+                Assert.True(output.Length >= WasmHeader.Length);
+                Assert.Equal(WasmHeader, output.AsSpan(0, WasmHeader.Length).ToArray());
+            }
+            finally
+            {
+                File.Delete(outputPath);
+            }
+        }
+
+        [ConditionalFact(nameof(IsNodeWithWasmExceptionHandlingAvailable))]
+        public void NativeAotWasmSingleMethodExecutes()
+        {
+            string outputPath = CompileSwitchTest();
+            string scriptPath = Path.ChangeExtension(outputPath, ".js");
+            try
+            {
+                File.WriteAllText(scriptPath,
+                    $$"""
+                    const fs = require("fs");
+                    const bytes = fs.readFileSync({{ToJavaScriptString(outputPath)}});
+                    if (!WebAssembly.validate(bytes)) {
+                        throw new Error("NativeAOT produced an invalid WebAssembly module.");
+                    }
+                    const webcil = {
+                        stackPointer: new WebAssembly.Global({ value: "i32", mutable: true }, 65000),
+                        imageBase: new WebAssembly.Global({ value: "i32", mutable: false }, 0),
+                        tableBase: new WebAssembly.Global({ value: "i32", mutable: false }, 0),
+                        table: new WebAssembly.Table({ initial: 4096, element: "anyfunc" }),
+                        rtlRestoreContextTag: new WebAssembly.Tag({ parameters: [] }),
+                        memory: new WebAssembly.Memory({ initial: 16 }),
+                    };
+                    WebAssembly.instantiate(bytes, { webcil }).then(({ instance }) => {
+                        const result = instance.exports.{{ExportName}}(65000, 0);
+                        if (result !== 100) {
+                            throw new Error(`Expected 100, got ${result}.`);
+                        }
+                    });
+                    """);
+
+                ProcessResult result = RunProcess("node", [scriptPath], throwOnError: false);
+                Assert.True(result.ExitCode == 0, result.Output);
+            }
+            finally
+            {
+                File.Delete(scriptPath);
+                File.Delete(outputPath);
+            }
+        }
+
+        private static string CompileSwitchTest()
+        {
+            string coreClrArtifactsDir = Assert.IsType<string>(AppContext.GetData("NativeAotWasmTest.CoreCLRArtifactsDir"));
+            string buildArchitecture = Assert.IsType<string>(AppContext.GetData("NativeAotWasmTest.BuildArchitecture"));
+            string ilcPath = Path.Combine(
+                coreClrArtifactsDir,
+                buildArchitecture,
+                "ilc",
+                OperatingSystem.IsWindows() ? "ilc.exe" : "ilc");
+            string jitFileName = OperatingSystem.IsWindows()
+                ? $"clrjit_universal_wasm_{buildArchitecture}.dll"
+                : OperatingSystem.IsMacOS()
+                    ? $"libclrjit_universal_wasm_{buildArchitecture}.dylib"
+                    : $"libclrjit_universal_wasm_{buildArchitecture}.so";
+            string jitPath = Path.Combine(coreClrArtifactsDir, jitFileName);
+            if (!File.Exists(jitPath))
+            {
+                jitPath = Path.Combine(coreClrArtifactsDir, buildArchitecture, jitFileName);
+            }
+
+            Assert.True(File.Exists(jitPath), $"WASM JIT not found at '{jitPath}'.");
+
+            string outputPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.wasm");
+            try
+            {
+                RunProcess(
+                    ilcPath,
+                    [
+                        "--singlemethodtypename", "SwitchTest, ILCompiler.Compiler.Tests.Assets",
+                        "--singlemethodname", "TestEntryPoint",
+                        Path.Combine(AppContext.BaseDirectory, "ILCompiler.Compiler.Tests.Assets.dll"),
+                        $"-r:{Path.Combine(AppContext.BaseDirectory, "Test.CoreLib.dll")}",
+                        "--systemmodule:Test.CoreLib",
+                        $"-o:{outputPath}",
+                        "--targetarch:wasm",
+                        "--targetos:browser",
+                        $"--jitpath:{jitPath}",
+                        "--stacktracedata:none",
+                        "--reflectiondata:none",
+                    ],
+                    throwOnError: true);
+
+                return outputPath;
+            }
+            catch
+            {
+                File.Delete(outputPath);
+                throw;
+            }
+        }
+
+        private static ProcessResult RunProcess(string fileName, IEnumerable<string> arguments, bool throwOnError)
+        {
+            var startInfo = new ProcessStartInfo(fileName)
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+            foreach (string argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            try
+            {
+                using Process process = Process.Start(startInfo) ??
+                    throw new InvalidOperationException($"Failed to start '{fileName}'.");
+                Task<string> standardOutput = process.StandardOutput.ReadToEndAsync();
+                Task<string> standardError = process.StandardError.ReadToEndAsync();
+                process.WaitForExit();
+
+                var result = new ProcessResult(
+                    process.ExitCode,
+                    standardOutput.GetAwaiter().GetResult() + standardError.GetAwaiter().GetResult());
+                if (throwOnError && result.ExitCode != 0)
+                {
+                    throw new InvalidOperationException(result.Output);
+                }
+
+                return result;
+            }
+            catch (Exception ex) when (!throwOnError && ex is Win32Exception or InvalidOperationException)
+            {
+                return new ProcessResult(-1, ex.ToString());
+            }
+        }
+
+        private static string ToJavaScriptString(string value) =>
+            '"' + value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal) + '"';
+
+        private readonly struct ProcessResult
+        {
+            public ProcessResult(int exitCode, string output)
+            {
+                ExitCode = exitCode;
+                Output = output;
+            }
+
+            public int ExitCode { get; }
+            public string Output { get; }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/WasmSingleMethodTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/WasmSingleMethodTests.cs
@@ -19,13 +19,20 @@ namespace ILCompiler.Compiler.Tests
         private const string ExportName = "ILCompiler_Compiler_Tests_Assets_SwitchTest__TestEntryPoint";
         private static readonly byte[] WasmHeader = [0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00];
 
-        public static bool IsNodeWithWasmExceptionHandlingAvailable =>
+        public static bool IsWasmCompilationSupported =>
+            string.Equals(
+                AppContext.GetData("NativeAotWasmTest.IsSupported") as string,
+                "true",
+                StringComparison.OrdinalIgnoreCase);
+
+        public static bool IsWasmExecutionSupported =>
+            IsWasmCompilationSupported &&
             RunProcess(
                 "node",
                 ["-e", "process.exit(typeof WebAssembly.Tag === 'function' ? 0 : 1)"],
                 throwOnError: false).ExitCode == 0;
 
-        [Fact]
+        [ConditionalFact(nameof(IsWasmCompilationSupported))]
         public void NativeAotWasmSingleMethodCompiles()
         {
             string outputPath = CompileSwitchTest();
@@ -41,7 +48,7 @@ namespace ILCompiler.Compiler.Tests
             }
         }
 
-        [ConditionalFact(nameof(IsNodeWithWasmExceptionHandlingAvailable))]
+        [ConditionalFact(nameof(IsWasmExecutionSupported))]
         public void NativeAotWasmSingleMethodExecutes()
         {
             string outputPath = CompileSwitchTest();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -11,6 +11,7 @@ using ILCompiler.DependencyAnalysis.Wasm;
 using ILCompiler.DependencyAnalysisFramework;
 
 using Internal.IL;
+using Internal.JitInterface;
 using Internal.NativeFormat;
 using Internal.Runtime;
 using Internal.Text;
@@ -1618,9 +1619,14 @@ namespace ILCompiler.DependencyAnalysis
         // memory efficiency on lookup
         public WasmTypeNode WasmTypeNode(MethodDesc desc)
         {
-            // TODO-Wasm: Construct proper function type based on the passed in MethodDesc
-            // once we have defined lowering rules for signatures in NativeAOT.
-            throw new NotImplementedException("NAOT wasm type signature lowering not yet implemented");
+            WasmFuncType funcType = WasmLowering.GetSignature(desc).FuncType;
+            return _wasmTypeNodes.GetOrAdd(funcType);
+        }
+
+        public WasmTypeNode WasmTypeNode(CorInfoWasmType[] types)
+        {
+            WasmFuncType funcType = WasmFuncType.FromCorInfoSignature(types);
+            return _wasmTypeNodes.GetOrAdd(funcType);
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -13,6 +13,10 @@ using ILCompiler.DependencyAnalysisFramework;
 
 namespace ILCompiler.DependencyAnalysis
 {
+    /// <summary>
+    /// Represents a NativeAOT runtime generic dictionary lookup helper.
+    /// "ReadyToRun" refers to the JIT helper ABI used to request the lookup, not to the ReadyToRun compiler.
+    /// </summary>
     public abstract partial class ReadyToRunGenericHelperNode : AssemblyStubNode, INodeWithRuntimeDeterminedDependencies
     {
         private readonly ReadyToRunHelperId _id;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmJumpStubNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmJumpStubNode.cs
@@ -4,19 +4,11 @@
 using System;
 
 using ILCompiler.DependencyAnalysis.Wasm;
-using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class JumpStubNode : INodeWithTypeSignature
+    public partial class JumpStubNode
     {
-        private INodeWithTypeSignature TargetWithSignature => (INodeWithTypeSignature)Target;
-
-        MethodSignature INodeWithTypeSignature.Signature => TargetWithSignature.Signature;
-        bool INodeWithTypeSignature.IsUnmanagedCallersOnly => TargetWithSignature.IsUnmanagedCallersOnly;
-        bool INodeWithTypeSignature.IsAsyncCall => TargetWithSignature.IsAsyncCall;
-        bool INodeWithTypeSignature.HasGenericContextArg => TargetWithSignature.HasGenericContextArg;
-
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
             throw new PlatformNotSupportedException("NativeAOT WebAssembly jump stubs are not supported.");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmJumpStubNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmJumpStubNode.cs
@@ -4,14 +4,22 @@
 using System;
 
 using ILCompiler.DependencyAnalysis.Wasm;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class JumpStubNode
+    public partial class JumpStubNode : INodeWithTypeSignature
     {
+        private INodeWithTypeSignature TargetWithSignature => (INodeWithTypeSignature)Target;
+
+        MethodSignature INodeWithTypeSignature.Signature => TargetWithSignature.Signature;
+        bool INodeWithTypeSignature.IsUnmanagedCallersOnly => TargetWithSignature.IsUnmanagedCallersOnly;
+        bool INodeWithTypeSignature.IsAsyncCall => TargetWithSignature.IsAsyncCall;
+        bool INodeWithTypeSignature.HasGenericContextArg => TargetWithSignature.HasGenericContextArg;
+
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException("NativeAOT WebAssembly jump stubs are not supported.");
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
@@ -4,19 +4,44 @@
 using System;
 
 using ILCompiler.DependencyAnalysis.Wasm;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class ReadyToRunGenericHelperNode
+    public partial class ReadyToRunGenericHelperNode : INodeWithTypeSignature
     {
+        MethodSignature INodeWithTypeSignature.Signature
+        {
+            get
+            {
+                TypeSystemContext context = DictionaryOwner switch
+                {
+                    TypeDesc type => type.Context,
+                    MethodDesc method => method.Context,
+                    _ => throw new NotSupportedException()
+                };
+                TypeDesc intPtrType = context.GetWellKnownType(WellKnownType.IntPtr);
+                bool isDelegateCtor = Id == ReadyToRunHelperId.DelegateCtor;
+                return new MethodSignature(
+                    MethodSignatureFlags.Static,
+                    genericParameterCount: 0,
+                    isDelegateCtor ? context.GetWellKnownType(WellKnownType.Void) : intPtrType,
+                    isDelegateCtor ? [intPtrType, intPtrType, intPtrType] : [intPtrType]);
+            }
+        }
+
+        bool INodeWithTypeSignature.IsUnmanagedCallersOnly => false;
+        bool INodeWithTypeSignature.IsAsyncCall => false;
+        bool INodeWithTypeSignature.HasGenericContextArg => false;
+
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException("NativeAOT WebAssembly generic lookup helpers are not supported.");
         }
 
         protected virtual void EmitLoadGenericContext(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException("NativeAOT WebAssembly generic context loading is not supported.");
         }
     }
 
@@ -24,7 +49,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         protected override void EmitLoadGenericContext(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException(
+                "NativeAOT WebAssembly generic context loading from a type is not supported.");
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
@@ -11,12 +11,14 @@ namespace ILCompiler.DependencyAnalysis
     {
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
-            throw new PlatformNotSupportedException("NativeAOT WebAssembly generic lookup helpers are not supported.");
+            throw new PlatformNotSupportedException(
+                "NativeAOT WebAssembly does not support runtime generic dictionary lookup helpers.");
         }
 
         protected virtual void EmitLoadGenericContext(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
-            throw new PlatformNotSupportedException("NativeAOT WebAssembly generic context loading is not supported.");
+            throw new PlatformNotSupportedException(
+                "NativeAOT WebAssembly runtime generic dictionary context loading is not supported.");
         }
     }
 
@@ -25,7 +27,7 @@ namespace ILCompiler.DependencyAnalysis
         protected override void EmitLoadGenericContext(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
             throw new PlatformNotSupportedException(
-                "NativeAOT WebAssembly generic context loading from a type is not supported.");
+                "NativeAOT WebAssembly runtime generic dictionary context loading from a type is not supported.");
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
@@ -4,36 +4,11 @@
 using System;
 
 using ILCompiler.DependencyAnalysis.Wasm;
-using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class ReadyToRunGenericHelperNode : INodeWithTypeSignature
+    public partial class ReadyToRunGenericHelperNode
     {
-        MethodSignature INodeWithTypeSignature.Signature
-        {
-            get
-            {
-                TypeSystemContext context = DictionaryOwner switch
-                {
-                    TypeDesc type => type.Context,
-                    MethodDesc method => method.Context,
-                    _ => throw new NotSupportedException()
-                };
-                TypeDesc intPtrType = context.GetWellKnownType(WellKnownType.IntPtr);
-                bool isDelegateCtor = Id == ReadyToRunHelperId.DelegateCtor;
-                return new MethodSignature(
-                    MethodSignatureFlags.Static,
-                    genericParameterCount: 0,
-                    isDelegateCtor ? context.GetWellKnownType(WellKnownType.Void) : intPtrType,
-                    isDelegateCtor ? [intPtrType, intPtrType, intPtrType] : [intPtrType]);
-            }
-        }
-
-        bool INodeWithTypeSignature.IsUnmanagedCallersOnly => false;
-        bool INodeWithTypeSignature.IsAsyncCall => false;
-        bool INodeWithTypeSignature.HasGenericContextArg => false;
-
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
             throw new PlatformNotSupportedException("NativeAOT WebAssembly generic lookup helpers are not supported.");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunHelperNode.cs
@@ -4,14 +4,62 @@
 using System;
 
 using ILCompiler.DependencyAnalysis.Wasm;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class ReadyToRunHelperNode
+    public partial class ReadyToRunHelperNode : INodeWithTypeSignature
     {
+        MethodSignature INodeWithTypeSignature.Signature
+        {
+            get
+            {
+                TypeSystemContext context = Target switch
+                {
+                    DelegateCreationInfo info => info.Constructor.Method.Context,
+                    TypeDesc type => type.Context,
+                    MethodDesc method => method.Context,
+                    _ => throw new NotSupportedException()
+                };
+
+                TypeDesc intPtrType = context.GetWellKnownType(WellKnownType.IntPtr);
+                TypeDesc returnType;
+                TypeDesc[] parameters;
+                switch (Id)
+                {
+                    case ReadyToRunHelperId.DelegateCtor:
+                        // The helper receives the two arguments populated by the JIT and supplies
+                        // the target method and optional thunk before tailcalling the constructor.
+                        returnType = context.GetWellKnownType(WellKnownType.Void);
+                        parameters = [intPtrType, intPtrType];
+                        break;
+
+                    case ReadyToRunHelperId.ResolveVirtualFunction:
+                        returnType = intPtrType;
+                        parameters = [intPtrType];
+                        break;
+
+                    default:
+                        returnType = intPtrType;
+                        parameters = [];
+                        break;
+                }
+
+                return new MethodSignature(
+                    MethodSignatureFlags.Static,
+                    genericParameterCount: 0,
+                    returnType,
+                    parameters);
+            }
+        }
+
+        bool INodeWithTypeSignature.IsUnmanagedCallersOnly => false;
+        bool INodeWithTypeSignature.IsAsyncCall => false;
+        bool INodeWithTypeSignature.HasGenericContextArg => false;
+
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException("NativeAOT WebAssembly ReadyToRun helpers are not supported.");
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunHelperNode.cs
@@ -4,59 +4,11 @@
 using System;
 
 using ILCompiler.DependencyAnalysis.Wasm;
-using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class ReadyToRunHelperNode : INodeWithTypeSignature
+    public partial class ReadyToRunHelperNode
     {
-        MethodSignature INodeWithTypeSignature.Signature
-        {
-            get
-            {
-                TypeSystemContext context = Target switch
-                {
-                    DelegateCreationInfo info => info.Constructor.Method.Context,
-                    TypeDesc type => type.Context,
-                    MethodDesc method => method.Context,
-                    _ => throw new NotSupportedException()
-                };
-
-                TypeDesc intPtrType = context.GetWellKnownType(WellKnownType.IntPtr);
-                TypeDesc returnType;
-                TypeDesc[] parameters;
-                switch (Id)
-                {
-                    case ReadyToRunHelperId.DelegateCtor:
-                        // The helper receives the two arguments populated by the JIT and supplies
-                        // the target method and optional thunk before tailcalling the constructor.
-                        returnType = context.GetWellKnownType(WellKnownType.Void);
-                        parameters = [intPtrType, intPtrType];
-                        break;
-
-                    case ReadyToRunHelperId.ResolveVirtualFunction:
-                        returnType = intPtrType;
-                        parameters = [intPtrType];
-                        break;
-
-                    default:
-                        returnType = intPtrType;
-                        parameters = [];
-                        break;
-                }
-
-                return new MethodSignature(
-                    MethodSignatureFlags.Static,
-                    genericParameterCount: 0,
-                    returnType,
-                    parameters);
-            }
-        }
-
-        bool INodeWithTypeSignature.IsUnmanagedCallersOnly => false;
-        bool INodeWithTypeSignature.IsAsyncCall => false;
-        bool INodeWithTypeSignature.HasGenericContextArg => false;
-
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
             throw new PlatformNotSupportedException("NativeAOT WebAssembly ReadyToRun helpers are not supported.");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmTentativeMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmTentativeMethodNode.cs
@@ -7,11 +7,11 @@ using ILCompiler.DependencyAnalysis.Wasm;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class TentativeMethodNode
+    public partial class TentativeMethodNode : IMethodCodeNodeWithTypeSignature
     {
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException("NativeAOT WebAssembly tentative method stubs are not supported.");
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmTentativeMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmTentativeMethodNode.cs
@@ -7,7 +7,7 @@ using ILCompiler.DependencyAnalysis.Wasm;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class TentativeMethodNode : IMethodCodeNodeWithTypeSignature
+    public partial class TentativeMethodNode
     {
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmUnboxingStubNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmUnboxingStubNode.cs
@@ -7,11 +7,11 @@ using ILCompiler.DependencyAnalysis.Wasm;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class UnboxingStubNode
+    public partial class UnboxingStubNode : IMethodCodeNodeWithTypeSignature
     {
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {
-            throw new NotImplementedException();
+            throw new PlatformNotSupportedException("NativeAOT WebAssembly unboxing stubs are not supported.");
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmUnboxingStubNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmUnboxingStubNode.cs
@@ -7,7 +7,7 @@ using ILCompiler.DependencyAnalysis.Wasm;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public partial class UnboxingStubNode : IMethodCodeNodeWithTypeSignature
+    public partial class UnboxingStubNode
     {
         protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/WasmObjectWriter.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/WasmObjectWriter.Aot.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using ILCompiler.DependencyAnalysis;
+using Internal.Text;
+using Internal.TypeSystem.TypesDebugInfo;
+
+namespace ILCompiler.ObjectWriter
+{
+    internal sealed partial class WasmObjectWriter
+    {
+        private protected override ITypesDebugInfoWriter CreateDebugInfoBuilder()
+        {
+            throw new PlatformNotSupportedException("NativeAOT WASM debug information is not supported.");
+        }
+
+        private protected override void EmitDebugFunctionInfo(
+            uint methodTypeIndex,
+            Utf8String methodName,
+            SymbolDefinition methodSymbol,
+            INodeWithDebugInfo debugNode,
+            bool hasSequencePoints)
+        {
+            // No debug info emission for WASM.
+        }
+
+        private protected override void EmitDebugSections(IDictionary<Utf8String, SymbolDefinition> definedSymbols)
+        {
+            // No debug sections for WASM.
+        }
+
+        private protected override void CreateEhSections()
+        {
+            // No EH sections for WASM (exception handling uses WASM-specific mechanisms).
+        }
+
+        private protected override void EmitUnwindInfo(
+            SectionWriter sectionWriter,
+            INodeWithCodeInfo nodeWithCodeInfo,
+            Utf8String currentSymbolName)
+        {
+            if (nodeWithCodeInfo.EHInfo is not null ||
+                nodeWithCodeInfo.FrameInfos is FrameInfo[] frameInfos &&
+                Array.Exists(frameInfos, static frameInfo => (frameInfo.Flags & (FrameInfoFlags.Handler | FrameInfoFlags.Filter | FrameInfoFlags.HasEHInfo)) != 0))
+            {
+                throw new PlatformNotSupportedException("NativeAOT WASM exception handling is not supported.");
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -369,6 +369,7 @@
     <Compile Include="..\..\Common\Compiler\ObjectWriter\ElfObjectWriter.cs" Link="Compiler\ObjectWriter\ElfObjectWriter.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\UnixObjectWriter.cs" Link="Compiler\ObjectWriter\UnixObjectWriter.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmObjectWriter.cs" Link="Compiler\ObjectWriter\WasmObjectWriter.cs" />
+    <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmGlobalImports.cs" Link="Compiler\ObjectWriter\WasmGlobalImports.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmInstructions.cs" Link="Compiler\ObjectWriter\WasmInstructions.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmNative.cs" Link="Compiler\ObjectWriter\WasmNative.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\CoffObjectWriter.cs" Link="Compiler\ObjectWriter\CoffObjectWriter.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -368,6 +368,9 @@
     <Compile Include="..\..\Common\Compiler\ObjectWriter\ElfNative.cs" Link="Compiler\ObjectWriter\ElfNative.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\ElfObjectWriter.cs" Link="Compiler\ObjectWriter\ElfObjectWriter.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\UnixObjectWriter.cs" Link="Compiler\ObjectWriter\UnixObjectWriter.cs" />
+    <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmObjectWriter.cs" Link="Compiler\ObjectWriter\WasmObjectWriter.cs" />
+    <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmInstructions.cs" Link="Compiler\ObjectWriter\WasmInstructions.cs" />
+    <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmNative.cs" Link="Compiler\ObjectWriter\WasmNative.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\CoffObjectWriter.cs" Link="Compiler\ObjectWriter\CoffObjectWriter.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\OutputInfoBuilder.cs" Link="Compiler\ObjectWriter\OutputInfoBuilder.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\PEObjectWriter.cs" Link="Compiler\ObjectWriter\PEObjectWriter.cs" />
@@ -686,6 +689,7 @@
     <Compile Include="Compiler\ObjectWriter\Eabi\EabiUnwindConverter.cs" />
     <Compile Include="Compiler\ObjectWriter\ElfObjectWriter.Aot.cs" />
     <Compile Include="Compiler\ObjectWriter\CoffObjectWriter.Aot.cs" />
+    <Compile Include="Compiler\ObjectWriter\WasmObjectWriter.Aot.cs" />
     <Compile Include="Compiler\ObjectWriter\ObjectWriter.Aot.cs" />
     <Compile Include="Compiler\ObjectWriter\UnixObjectWriter.Aot.cs" />
     <Compile Include="Compiler\ObjectWriter\MachObjectWriter.Aot.cs" />
@@ -787,6 +791,9 @@
     </Compile>
     <Compile Include="..\..\Common\JitInterface\CorInfoTypes.VarInfo.cs">
       <Link>JitInterface\CorInfoTypes.VarInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\JitInterface\WasmLowering.cs">
+      <Link>JitInterface\WasmLowering.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\TypesDebugInfoWriter\TypesDebugInfoWriter.cs">
       <Link>TypeSystem\TypesDebugInfoWriter\TypesDebugInfoWriter.cs</Link>

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -110,8 +110,11 @@ namespace ILCompiler
             if ((_compilationOptions & RyuJitCompilationOptions.UseDwarf5) != 0)
                 options |= ObjectWritingOptions.UseDwarf5;
 
-            if (_debugInformationProvider is not NullDebugInformationProvider)
+            if (_debugInformationProvider is not NullDebugInformationProvider &&
+                NodeFactory.Target.Architecture != TargetArchitecture.Wasm32)
+            {
                 options |= ObjectWritingOptions.GenerateDebugInfo;
+            }
 
             if ((_compilationOptions & RyuJitCompilationOptions.ControlFlowGuardAnnotations) != 0)
                 options |= ObjectWritingOptions.ControlFlowGuard;

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/ILCompiler.RyuJit.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/ILCompiler.RyuJit.csproj
@@ -50,12 +50,6 @@
     <Compile Include="..\ILCompiler.Compiler\Compiler\JitHelper.cs">
       <Link>Compiler\JitHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmNative.cs">
-      <Link>ObjectWriter\WasmNative.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmInstructions.cs">
-      <Link>ObjectWriter\WasmInstructions.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\HelperExtensions.cs">
       <Link>IL\HelperExtensions.cs</Link>
     </Compile>
@@ -95,9 +89,7 @@
     <Compile Include="..\..\Common\JitInterface\SwiftPhysicalLowering.cs">
       <Link>JitInterface\SwiftPhysicalLowering.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\JitInterface\WasmLowering.cs">
-      <Link>JitInterface\WasmLowering.cs</Link>
-    </Compile>
+    <!-- WasmLowering.cs is now included via ILCompiler.Compiler -->
     <Compile Include="..\..\Common\Pgo\TypeSystemEntityOrUnknown.cs">
       <Link>Pgo\TypeSystemEntityOrUnknown.cs</Link>
     </Compile>

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -15,6 +15,7 @@ using Internal.TypeSystem.Ecma;
 
 using ILCompiler;
 using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysis.Wasm;
 using System.Runtime.CompilerServices;
 
 #if SUPPORT_JIT
@@ -2518,7 +2519,10 @@ namespace Internal.JitInterface
 
         private CORINFO_WASM_TYPE_SYMBOL_STRUCT_* getWasmTypeSymbol(CorInfoWasmType* types, nuint typesSize)
         {
-            throw new NotImplementedException();
+            CorInfoWasmType[] typeArray = new ReadOnlySpan<CorInfoWasmType>(types, (int)typesSize).ToArray();
+
+            WasmTypeNode typeNode = _compilation.NodeFactory.WasmTypeNode(typeArray);
+            return (CORINFO_WASM_TYPE_SYMBOL_STRUCT_*)ObjectToHandle(typeNode);
         }
 
 #pragma warning disable CA1822 // Mark members as static


### PR DESCRIPTION
## Summary

- Add the minimal NativeAOT and RyuJIT integration needed to compile an explicitly selected method to WebAssembly with `--singlemethod`.
- Extend the shared WebAssembly object writer for NativeAOT while preserving ReadyToRun/WebCIL behavior.
- Fail explicitly for unsupported runtime closure, data, helpers, stubs, debugging, generic lookups, and exception handling.
- Add end-to-end compiler coverage using the existing `JIT/CodeGenBringUpTests/Switch.cs` test, including WebAssembly validation and execution.

## Scope

This is intentionally a narrow vertical slice rather than complete NativeAOT WebAssembly support. It establishes a working, tested path from ILC through the WebAssembly RyuJIT and object writer for a self-contained single method. Full dependency closure, runtime helpers, data sections, allocation, generics, unboxing, exception handling, and browser hosting remain future work.

## Testing

- `./build.sh clr.wasmjit -c debug`
- `dotnet build src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj --no-restore`
- `dotnet build src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj --no-restore`
- `dotnet test src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj --no-build --no-restore --filter FullyQualifiedName~WasmSingleMethodTests`

> [!NOTE]
> This pull request description was generated with GitHub Copilot.