### PR TITLE
[RyuJIT Wasm] Remove some unreachable uses of `NYI_WASM`

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2390,8 +2390,10 @@ void CodeGen::genGenerateMachineCode()
     // check to see if any jumps can be removed
     GetEmitter()->emitRemoveJumpToNextInst();
 
+#if !defined(TARGET_WASM)
     /* Bind jump distances */
     GetEmitter()->emitJumpDistBind();
+#endif
 
 #if FEATURE_LOOP_ALIGN
     /* Perform alignment adjustments */

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1253,8 +1253,7 @@ void CodeGen::genReturnSuspend(GenTreeUnOp* treeNode)
                 emit->emitIns_I(INS_f64_const, EA_8BYTE, 0);
                 break;
             default:
-                NYI_WASM("genReturnSuspend: unhandled return type");
-                break;
+                unreached();
         }
     }
 }
@@ -1714,9 +1713,7 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
             break;
 
         default:
-            ins = INS_none;
-            NYI_WASM("genCodeForBinary");
-            break;
+            unreached();
     }
 
     GetEmitter()->emitIns(ins);
@@ -2144,9 +2141,7 @@ void CodeGen::genCodeForShift(GenTree* tree)
             break;
 
         default:
-            ins = INS_none;
-            NYI_WASM("genCodeForShift");
-            break;
+            unreached();
     }
 
     GetEmitter()->emitIns(ins);
@@ -3303,10 +3298,8 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
         // RhBulkMoveWithWriteBarrier
         HELPER_SIG(CORINFO_HELP_BULK_WRITEBARRIER, UNMANAGED, CORINFO_WASM_TYPE_VOID /* retval */, CORINFO_WASM_TYPE_I,
                    CORINFO_WASM_TYPE_I, CORINFO_WASM_TYPE_I);
-
         default:
             JITDUMP("Helper '%s' has no hard-coded signature\n", m_compiler->eeGetMethodFullName(params.methHnd));
-            NYI_WASM("Missing signature for helper in genEmitHelperCall");
             unreached();
     }
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -5543,8 +5543,8 @@ AGAIN:
 #elif defined(TARGET_RISCV64)
         assert((sizeDif == 0) || (sizeDif == 4) || (sizeDif == 8));
 #elif defined(TARGET_WASM)
-        // TODO-WASM: likely the whole thing needs to be made unreachable.
-        NYI_WASM("emitJumpDistBind");
+        // We should never call emitJumpDistBind() for wasm, as wasm has no variable-length jumps.
+        unreached();
 #else
 #error Unsupported or unset target architecture
 #endif
@@ -7690,7 +7690,7 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
                     // For LoongArch64 and RiscV64 `emitFwdJumps` is always false.
                     unreached();
 #elif defined(TARGET_WASM)
-                    NYI_WASM("Short jump distance adjustment");
+                    unreached();
 #else
 #error Unsupported or unset target architecture
 #endif
@@ -7706,7 +7706,7 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
                     // For LoongArch64 and RiscV64 `emitFwdJumps` is always false.
                     unreached();
 #elif defined(TARGET_WASM)
-                    NYI_WASM("Jump distance adjustment");
+                    unreached();
 #else
 #error Unsupported or unset target architecture
 #endif

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -164,33 +164,32 @@ void emitter::emitIns_S(instruction ins, emitAttr attr, int varx, int offs)
 
 void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
 {
-    NYI_WASM("emitIns_R");
+    unreached();
 }
 
 void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, cnsval_ssize_t imm)
 {
-    NYI_WASM("emitIns_R_I");
+    unreached();
 }
 
 void emitter::emitIns_Mov(instruction ins, emitAttr attr, regNumber dstReg, regNumber srcReg, bool canSkip)
 {
-    NYI_WASM("emitIns_Mov");
+    unreached();
 }
 
 void emitter::emitIns_R_R(instruction ins, emitAttr attr, regNumber reg1, regNumber reg2)
 {
-    NYI_WASM("emitIns_R_R");
+    unreached();
 }
 
 void emitter::emitIns_S_R(instruction ins, emitAttr attr, regNumber ireg, int varx, int offs)
 {
-    NYI_WASM("emitIns_S_R");
+    unreached();
 }
 
 bool emitter::emitInsIsStore(instruction ins)
 {
-    NYI_WASM("emitInsIsStore");
-    return false;
+    unreached();
 }
 
 //------------------------------------------------------------------------
@@ -838,7 +837,7 @@ unsigned emitter::instrDesc::idCodeSize() const
 
 void emitter::emitSetShortJump(instrDescJmp* id)
 {
-    NYI_WASM("emitSetShortJump");
+    unreached();
 }
 
 size_t emitter::emitOutputULEB128(uint8_t* destination, uint64_t value)
@@ -1203,8 +1202,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             break;
         }
         default:
-            NYI_WASM("emitOutputInstr");
-            break;
+            unreached();
     }
 
 #ifdef DEBUG


### PR DESCRIPTION
Removes some NYI_WASM instances in emit/codegen which are never expected to be reached. Additionally, places `emitJumpDistBind` under ifdef since this should likely stay unreached and unneeded for Wasm.