### PR TITLE
Fix NetworkInterface list on Windows

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -83,14 +83,21 @@ namespace System.Net.NetworkInformation
 
             List<SystemNetworkInterface> interfaceList = new List<SystemNetworkInterface>();
 
-            // Pass 1 (cheap): collect adapter GUIDs returned without GAA_FLAG_INCLUDE_ALL_INTERFACES
-            // — the same set that .NET 8 returned. Any adapter absent from this set is a newly-visible
-            // NDIS filter module or interface with no IP stack. Those get OperationalStatus.Unknown
-            // so callers can trivially filter to restore the pre-.NET 9 behavior:
+            // GetAdaptersAddresses without GAA_FLAG_INCLUDE_ALL_INTERFACES returns only real
+            // network adapters — roughly the same set shown by ipconfig and ncpa.cpl, and the
+            // same set .NET 8 returned. Starting with .NET 9, GAA_FLAG_INCLUDE_ALL_INTERFACES
+            // was added, which also surfaces NDIS filter modules (WFP, QoS, Hyper-V extension
+            // filters) that have no IP stack and are not shown by any standard Windows tool.
+            // Those extra entries all report OperationalStatus.Up, which causes
+            // GetIsNetworkAvailable() to return true even when no real network is present.
+            //
+            // Collect the adapter GUIDs from the non-IncludeAllInterfaces call (the
+            // "ipconfig-equivalent" set). Any adapter absent from that set but reporting Up
+            // is a filter module; mark it Unknown so callers can restore the original behavior:
             //   ni.OperationalStatus != OperationalStatus.Unknown
             HashSet<string> legacyGuids = GetLegacyAdapterGuids();
 
-            // Pass 2: full list including all NDIS interfaces.
+            // Full list including all NDIS interfaces.
             Interop.IpHlpApi.GetAdaptersAddressesFlags flags =
                 Interop.IpHlpApi.GetAdaptersAddressesFlags.IncludeGateways |
                 Interop.IpHlpApi.GetAdaptersAddressesFlags.IncludeWins |
@@ -143,8 +150,9 @@ namespace System.Net.NetworkInformation
             return interfaceList.ToArray();
         }
 
-        // Calls GetAdaptersAddresses with the legacy flags (no GAA_FLAG_INCLUDE_ALL_INTERFACES)
-        // and returns the set of adapter GUIDs (AdapterName) it reports.
+        // Calls GetAdaptersAddresses without GAA_FLAG_INCLUDE_ALL_INTERFACES and returns
+        // the set of adapter GUIDs (AdapterName) it reports — the same adapters visible
+        // in ipconfig and ncpa.cpl.  NDIS filter modules are absent from this set.
         private static unsafe HashSet<string> GetLegacyAdapterGuids()
         {
             Interop.IpHlpApi.GetAdaptersAddressesFlags legacyFlags =
@@ -193,10 +201,15 @@ namespace System.Net.NetworkInformation
             _physicalAddress = ipAdapterAddresses.Address;
 
             _type = ipAdapterAddresses.type;
-            // Interfaces not present in the legacy (pre-GAA_FLAG_INCLUDE_ALL_INTERFACES) call are
-            // NDIS filter modules or adapters with no IP stack. Mark them Unknown so callers can
-            // restore the original behavior by filtering on ni.OperationalStatus != Unknown.
-            _operStatus = legacyGuids.Contains(_id) ? ipAdapterAddresses.operStatus : OperationalStatus.Unknown;
+            // Interfaces absent from the ipconfig-equivalent set (see GetLegacyAdapterGuids) that
+            // report Up are NDIS filter modules with no IP stack — mark them Unknown so callers can
+            // easily restore ipconfig-equivalent behavior: ni.OperationalStatus != Unknown.
+            // Interfaces absent from that set but not reporting Up are genuinely disabled adapters
+            // (Down, Dormant, etc.) that GAA_FLAG_INCLUDE_ALL_INTERFACES was added to expose;
+            // preserve their real status.
+            _operStatus = (!legacyGuids.Contains(_id) && ipAdapterAddresses.operStatus == OperationalStatus.Up)
+                ? OperationalStatus.Unknown
+                : ipAdapterAddresses.operStatus;
             _speed = unchecked((long)ipAdapterAddresses.receiveLinkSpeed);
 
             // API specific info.

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -201,15 +201,10 @@ namespace System.Net.NetworkInformation
             _physicalAddress = ipAdapterAddresses.Address;
 
             _type = ipAdapterAddresses.type;
-            // Interfaces absent from the ipconfig-equivalent set (see GetLegacyAdapterGuids) that
-            // report Up are NDIS filter modules with no IP stack — mark them Unknown so callers can
-            // easily restore ipconfig-equivalent behavior: ni.OperationalStatus != Unknown.
-            // Interfaces absent from that set but not reporting Up are genuinely disabled adapters
-            // (Down, Dormant, etc.) that GAA_FLAG_INCLUDE_ALL_INTERFACES was added to expose;
-            // preserve their real status.
-            _operStatus = (!legacyGuids.Contains(_id) && ipAdapterAddresses.operStatus == OperationalStatus.Up)
-                ? OperationalStatus.Unknown
-                : ipAdapterAddresses.operStatus;
+            // Interfaces absent from the ipconfig-equivalent set (see GetLegacyAdapterGuids) are
+            // NDIS filter modules or adapters with no IP stack — mark them Unknown so callers can
+            // restore ipconfig-equivalent behavior: ni.OperationalStatus != OperationalStatus.Unknown.
+            _operStatus = legacyGuids.Contains(_id) ? ipAdapterAddresses.operStatus : OperationalStatus.Unknown;
             _speed = unchecked((long)ipAdapterAddresses.receiveLinkSpeed);
 
             // API specific info.

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -79,11 +79,18 @@ namespace System.Net.NetworkInformation
 
         internal static unsafe NetworkInterface[] GetNetworkInterfaces()
         {
-            AddressFamily family = AddressFamily.Unspecified;
             uint bufferSize = 0;
 
             List<SystemNetworkInterface> interfaceList = new List<SystemNetworkInterface>();
 
+            // Pass 1 (cheap): collect adapter GUIDs returned without GAA_FLAG_INCLUDE_ALL_INTERFACES
+            // — the same set that .NET 8 returned. Any adapter absent from this set is a newly-visible
+            // NDIS filter module or interface with no IP stack. Those get OperationalStatus.Unknown
+            // so callers can trivially filter to restore the pre-.NET 9 behavior:
+            //   ni.OperationalStatus != OperationalStatus.Unknown
+            HashSet<string> legacyGuids = GetLegacyAdapterGuids();
+
+            // Pass 2: full list including all NDIS interfaces.
             Interop.IpHlpApi.GetAdaptersAddressesFlags flags =
                 Interop.IpHlpApi.GetAdaptersAddressesFlags.IncludeGateways |
                 Interop.IpHlpApi.GetAdaptersAddressesFlags.IncludeWins |
@@ -91,17 +98,16 @@ namespace System.Net.NetworkInformation
 
             // Figure out the right buffer size for the adapter information.
             uint result = Interop.IpHlpApi.GetAdaptersAddresses(
-                family, (uint)flags, IntPtr.Zero, IntPtr.Zero, &bufferSize);
+                AddressFamily.Unspecified, (uint)flags, IntPtr.Zero, IntPtr.Zero, &bufferSize);
 
             while (result == Interop.IpHlpApi.ERROR_BUFFER_OVERFLOW)
             {
-
                 // Allocate the buffer and get the adapter info.
                 IntPtr buffer = Marshal.AllocHGlobal((int)bufferSize);
                 try
                 {
                     result = Interop.IpHlpApi.GetAdaptersAddresses(
-                        family, (uint)flags, IntPtr.Zero, buffer, &bufferSize);
+                        AddressFamily.Unspecified, (uint)flags, IntPtr.Zero, buffer, &bufferSize);
 
                     // If succeeded, we're going to add each new interface.
                     if (result == Interop.IpHlpApi.ERROR_SUCCESS)
@@ -111,7 +117,7 @@ namespace System.Net.NetworkInformation
                         while (adapterAddresses != null)
                         {
                             // Traverse the list, marshal in the native structures, and create new NetworkInterfaces.
-                            interfaceList.Add(new SystemNetworkInterface(in *adapterAddresses));
+                            interfaceList.Add(new SystemNetworkInterface(in *adapterAddresses, legacyGuids));
                             adapterAddresses = adapterAddresses->next;
                         }
                     }
@@ -137,7 +143,46 @@ namespace System.Net.NetworkInformation
             return interfaceList.ToArray();
         }
 
-        internal SystemNetworkInterface(in Interop.IpHlpApi.IpAdapterAddresses ipAdapterAddresses)
+        // Calls GetAdaptersAddresses with the legacy flags (no GAA_FLAG_INCLUDE_ALL_INTERFACES)
+        // and returns the set of adapter GUIDs (AdapterName) it reports.
+        private static unsafe HashSet<string> GetLegacyAdapterGuids()
+        {
+            Interop.IpHlpApi.GetAdaptersAddressesFlags legacyFlags =
+                Interop.IpHlpApi.GetAdaptersAddressesFlags.IncludeGateways |
+                Interop.IpHlpApi.GetAdaptersAddressesFlags.IncludeWins;
+
+            uint bufferSize = 0;
+            uint result = Interop.IpHlpApi.GetAdaptersAddresses(
+                AddressFamily.Unspecified, (uint)legacyFlags, IntPtr.Zero, IntPtr.Zero, &bufferSize);
+
+            HashSet<string> guids = new HashSet<string>();
+            while (result == Interop.IpHlpApi.ERROR_BUFFER_OVERFLOW)
+            {
+                IntPtr buffer = Marshal.AllocHGlobal((int)bufferSize);
+                try
+                {
+                    result = Interop.IpHlpApi.GetAdaptersAddresses(
+                        AddressFamily.Unspecified, (uint)legacyFlags, IntPtr.Zero, buffer, &bufferSize);
+
+                    if (result == Interop.IpHlpApi.ERROR_SUCCESS)
+                    {
+                        Interop.IpHlpApi.IpAdapterAddresses* addr = (Interop.IpHlpApi.IpAdapterAddresses*)buffer;
+                        while (addr != null)
+                        {
+                            guids.Add(addr->AdapterName);
+                            addr = addr->next;
+                        }
+                    }
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(buffer);
+                }
+            }
+            return guids;
+        }
+
+        internal SystemNetworkInterface(in Interop.IpHlpApi.IpAdapterAddresses ipAdapterAddresses, HashSet<string> legacyGuids)
         {
             // Store the common API information.
             _id = ipAdapterAddresses.AdapterName;
@@ -148,7 +193,10 @@ namespace System.Net.NetworkInformation
             _physicalAddress = ipAdapterAddresses.Address;
 
             _type = ipAdapterAddresses.type;
-            _operStatus = ipAdapterAddresses.operStatus;
+            // Interfaces not present in the legacy (pre-GAA_FLAG_INCLUDE_ALL_INTERFACES) call are
+            // NDIS filter modules or adapters with no IP stack. Mark them Unknown so callers can
+            // restore the original behavior by filtering on ni.OperationalStatus != Unknown.
+            _operStatus = legacyGuids.Contains(_id) ? ipAdapterAddresses.operStatus : OperationalStatus.Unknown;
             _speed = unchecked((long)ipAdapterAddresses.receiveLinkSpeed);
 
             // API specific info.


### PR DESCRIPTION
We changed `GetAllNetworkInterfaces`  to pass in GAA_FLAG_INCLUDE_ALL_INTERFACES flag in .NET 9 to also list disabled interfaces. That make sense that the method to get `*All*` interfaces returns  `*All*` interfaces. However, on Windows there are many hidden interfaces for tunneling, VPN etc. And that confuses some applications as the list can be now very long and it broke GetIsNetworkAvailable (https://github.com/dotnet/runtime/issues/125167) 

While I feel the current behavior is correct there is no good way how to get the legacy "useful" list that basically matches output of `ipconfig`.

While I count not find any good solution that would meet all the expectations I did come up with this workaround. This PR changes the behavior so it first gets the "normal" interface list as it did in .NET 8. And then it adds all extra interfaces just like in .NET 9+ but with status set to `OperationalStatus.Unknown`. 

That has few consequences:
1) fixes the `GetIsNetworkAvailable` instantly. We look for interfaces that are 'Up' so if you disconnect all cables the network availability will be false.
2) give user path to get the legacy set. Filtering out the "Unknown" interfaces is trivial without need to make any name patterns or any other special tricks. 
3) Since the motivation for the change was to show disabled interfaces, the capability is preserved. The status may not be 100% correct but the "Unknown" seems like reasonable sentinel. 

any more thoughts on this @dotnet/ncl ? 

fixes https://github.com/dotnet/runtime/issues/122751
fixes https://github.com/dotnet/runtime/issues/125167


