### PR TITLE
Mark InteropServices.ObjectiveC APIs as available on all Apple platforms.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCMarshal.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCMarshal.PlatformNotSupported.cs
@@ -11,6 +11,9 @@ namespace System.Runtime.InteropServices.ObjectiveC
     /// API to enable Objective-C marshalling.
     /// </summary>
     [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("ios")]
+    [SupportedOSPlatform("tvos")]
+    [SupportedOSPlatform("maccatalyst")]
     [CLSCompliant(false)]
     public static class ObjectiveCMarshal
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCMarshal.cs
@@ -12,6 +12,9 @@ namespace System.Runtime.InteropServices.ObjectiveC
     /// API to enable Objective-C marshalling.
     /// </summary>
     [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("ios")]
+    [SupportedOSPlatform("tvos")]
+    [SupportedOSPlatform("maccatalyst")]
     [CLSCompliant(false)]
     public static partial class ObjectiveCMarshal
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCTrackedTypeAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCTrackedTypeAttribute.cs
@@ -9,6 +9,9 @@ namespace System.Runtime.InteropServices.ObjectiveC
     /// Attribute used to indicate a class represents a tracked Objective-C type.
     /// </summary>
     [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("ios")]
+    [SupportedOSPlatform("tvos")]
+    [SupportedOSPlatform("maccatalyst")]
     [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
     public sealed class ObjectiveCTrackedTypeAttribute : Attribute
     {

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -2430,6 +2430,9 @@ namespace System.Runtime.InteropServices.Java
 namespace System.Runtime.InteropServices.ObjectiveC
 {
     [System.Runtime.Versioning.SupportedOSPlatformAttribute("macos")]
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("ios")]
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("tvos")]
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("maccatalyst")]
     [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
     public sealed class ObjectiveCTrackedTypeAttribute : System.Attribute
     {
@@ -2437,6 +2440,9 @@ namespace System.Runtime.InteropServices.ObjectiveC
     }
 
     [System.Runtime.Versioning.SupportedOSPlatformAttribute("macos")]
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("ios")]
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("tvos")]
+    [System.Runtime.Versioning.SupportedOSPlatformAttribute("maccatalyst")]
     [System.CLSCompliantAttribute(false)]
     public static class ObjectiveCMarshal
     {


### PR DESCRIPTION
Mark InteropServices.ObjectiveC APIs as available on all Apple platforms, because in .NET 11+ they are.