### PR TITLE
Flush after each live enumerable write in SSE & JSON

### DIFF
--- a/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
+++ b/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
@@ -79,6 +79,11 @@ namespace System.Text.Json
             await _stream.WriteAsync(WrittenMemory, cancellationToken).ConfigureAwait(false);
             Clear();
 
+            // Flushing a PipeWriter makes the written data available to the reader, so do the equivalent
+            // for the destination stream. This ensures that consumers of streaming payloads (e.g. values
+            // of an IAsyncEnumerable) aren't held back by any intermediate buffering.
+            await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
             return new FlushResult(isCanceled: false, isCompleted: false);
         }
 

--- a/src/libraries/System.Net.ServerSentEvents/src/System/Net/ServerSentEvents/SseFormatter.cs
+++ b/src/libraries/System.Net.ServerSentEvents/src/System/Net/ServerSentEvents/SseFormatter.cs
@@ -24,6 +24,7 @@ namespace System.Net.ServerSentEvents
         /// <param name="destination">The destination stream to write the events.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the write operation.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
+        /// <remarks>The <paramref name="destination"/> stream is flushed after each event is written.</remarks>
         public static Task WriteAsync(IAsyncEnumerable<SseItem<string>> source, Stream destination, CancellationToken cancellationToken = default)
         {
             if (source is null)
@@ -48,6 +49,7 @@ namespace System.Net.ServerSentEvents
         /// <param name="itemFormatter">The formatter for the data field of given event.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the write operation.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
+        /// <remarks>The <paramref name="destination"/> stream is flushed after each event is written.</remarks>
         public static Task WriteAsync<T>(IAsyncEnumerable<SseItem<T>> source, Stream destination, Action<SseItem<T>, IBufferWriter<byte>> itemFormatter, CancellationToken cancellationToken = default)
         {
             if (source is null)
@@ -85,6 +87,10 @@ namespace System.Net.ServerSentEvents
                     reconnectionInterval: item.ReconnectionInterval);
 
                 await destination.WriteAsync(bufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
+
+                // Each event is a self-contained message that the peer may want to consume in real time,
+                // so flush the destination to ensure it isn't held back by any intermediate buffering.
+                await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
 
                 userDataBufferWriter.Reset();
                 bufferWriter.Reset();

--- a/src/libraries/System.Net.ServerSentEvents/tests/SseFormatterTests.cs
+++ b/src/libraries/System.Net.ServerSentEvents/tests/SseFormatterTests.cs
@@ -97,6 +97,53 @@ namespace System.Net.ServerSentEvents.Tests
             yield return new SseItem<string>("LFCR at end\n\r", null);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static async Task WriteAsync_FlushesAfterEachEvent(bool useItemFormatter)
+        {
+            using FlushTrackingStream stream = new();
+
+            if (useItemFormatter)
+            {
+                await SseFormatter.WriteAsync(GetItemsAsync(), stream, static (item, writer) => writer.Write(Encoding.UTF8.GetBytes(item.Data)));
+            }
+            else
+            {
+                await SseFormatter.WriteAsync(GetItemsAsync(), stream);
+            }
+
+            // The destination must be flushed once after each event, so that consumers
+            // of buffering streams observe events as soon as they are written.
+            Assert.Equal(
+                new[] { "data: data0\n\n", "data: data0\n\ndata: data1\n\n", "data: data0\n\ndata: data1\n\ndata: data2\n\n" },
+                stream.FlushSnapshots);
+
+            static async IAsyncEnumerable<SseItem<string>> GetItemsAsync()
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    await Task.Yield();
+                    yield return new SseItem<string>($"data{i}");
+                }
+            }
+        }
+
+        private sealed class FlushTrackingStream : MemoryStream
+        {
+            /// <summary>Gets the contents of the stream as observed at the time of every flush.</summary>
+            public List<string> FlushSnapshots { get; } = new();
+
+            public override void Flush() => FlushSnapshots.Add(Encoding.UTF8.GetString(ToArray()));
+
+            public override Task FlushAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Flush();
+                return Task.CompletedTask;
+            }
+        }
+
         [Fact]
         public static async Task WriteAsync_HonorsCancellationToken()
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -427,6 +427,9 @@ namespace System.Text.Json
                     Span<byte> dest = bufferWriter.GetSpan(1);
                     dest[0] = (byte)'\n';
                     bufferWriter.Advance(1);
+
+                    // Each line is a self-contained value that consumers may want to observe in real time,
+                    // so flush it out (PooledByteBufferWriter.FlushAsync also flushes the destination stream).
                     await bufferWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }

--- a/src/libraries/System.Text.Json/tests/Common/AsyncEnumerableTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/AsyncEnumerableTests.cs
@@ -736,12 +736,14 @@ namespace System.Text.Json.Serialization.Tests
             using FlushTrackingStream stream = new();
             GatedAsyncEnumerable source = new(count: 3);
             stream.OnFlush = source.ReleaseNext;
+            using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
 
             await JsonSerializer.SerializeAsyncEnumerable(
                 stream,
                 source,
                 ResolveJsonTypeInfo<int>(),
-                topLevelValues);
+                topLevelValues,
+                cts.Token);
 
             Assert.Equal(expectedFlushSnapshots, stream.FlushSnapshots);
             Assert.Equal(expectedOutput, Encoding.UTF8.GetString(stream.ToArray()));
@@ -754,11 +756,13 @@ namespace System.Text.Json.Serialization.Tests
             using FlushTrackingStream stream = new();
             GatedAsyncEnumerable source = new(count: 2);
             stream.OnFlush = source.ReleaseNext;
+            using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
 
             await JsonSerializer.SerializeAsync(
                 stream,
                 new AsyncEnumerableDto { Values = source },
-                ResolveJsonTypeInfo<AsyncEnumerableDto>());
+                ResolveJsonTypeInfo<AsyncEnumerableDto>(),
+                cts.Token);
 
             Assert.Equal(new[] { "{\"Values\":[0", "{\"Values\":[0,1", "{\"Values\":[0,1]}" }, stream.FlushSnapshots);
             Assert.Equal("{\"Values\":[0,1]}", Encoding.UTF8.GetString(stream.ToArray()));
@@ -835,7 +839,10 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     yield return i;
 
-                    await _gates[i].Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+                    // Cancellation ensures the test fails instead of hanging if the value is never flushed.
+                    TaskCompletionSource<bool> gate = _gates[i];
+                    using CancellationTokenRegistration registration = cancellationToken.Register(() => gate.TrySetCanceled(cancellationToken));
+                    await gate.Task;
                 }
             }
         }

--- a/src/libraries/System.Text.Json/tests/Common/AsyncEnumerableTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/AsyncEnumerableTests.cs
@@ -835,9 +835,7 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     yield return i;
 
-                    // The timeout ensures that an implementation that fails to flush
-                    // fails the assertions instead of hanging the test run.
-                    await Task.WhenAny(_gates[i].Task, Task.Delay(TimeSpan.FromSeconds(30)));
+                    await _gates[i].Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
                 }
             }
         }

--- a/src/libraries/System.Text.Json/tests/Common/AsyncEnumerableTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/AsyncEnumerableTests.cs
@@ -719,6 +719,177 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(count, i);
         }
 
+        public static IEnumerable<object[]> FlushPointsData()
+        {
+            // topLevelValues, expected stream contents at each flush, expected final output.
+            yield return new object[] { false, new[] { "[0", "[0,1", "[0,1,2", "[0,1,2]" }, "[0,1,2]" };
+            yield return new object[] { true, new[] { "0\n", "0\n1\n", "0\n1\n2\n" }, "0\n1\n2\n" };
+        }
+
+        [Theory]
+        [MemberData(nameof(FlushPointsData))]
+        public async Task SerializeAsyncEnumerable_FlushesStreamAsValuesAreProduced(bool topLevelValues, string[] expectedFlushSnapshots, string expectedOutput)
+        {
+            // Values produced so far must be flushed to the underlying stream before awaiting
+            // the producer, so that consumers can observe them in real time. The producer is only
+            // released once the flush has been observed, making the expected flush points deterministic.
+            using FlushTrackingStream stream = new();
+            GatedAsyncEnumerable source = new(count: 3);
+            stream.OnFlush = source.ReleaseNext;
+
+            await JsonSerializer.SerializeAsyncEnumerable(
+                stream,
+                source,
+                ResolveJsonTypeInfo<int>(),
+                topLevelValues);
+
+            Assert.Equal(expectedFlushSnapshots, stream.FlushSnapshots);
+            Assert.Equal(expectedOutput, Encoding.UTF8.GetString(stream.ToArray()));
+        }
+
+        [Fact]
+        public async Task SerializeAsync_NestedAsyncEnumerable_FlushesStreamWhenAwaitingProducer()
+        {
+            // The same guarantee applies to IAsyncEnumerable values nested in a larger payload.
+            using FlushTrackingStream stream = new();
+            GatedAsyncEnumerable source = new(count: 2);
+            stream.OnFlush = source.ReleaseNext;
+
+            await JsonSerializer.SerializeAsync(
+                stream,
+                new AsyncEnumerableDto { Values = source },
+                ResolveJsonTypeInfo<AsyncEnumerableDto>());
+
+            Assert.Equal(new[] { "{\"Values\":[0", "{\"Values\":[0,1", "{\"Values\":[0,1]}" }, stream.FlushSnapshots);
+            Assert.Equal("{\"Values\":[0,1]}", Encoding.UTF8.GetString(stream.ToArray()));
+        }
+
+        [Fact]
+        public async Task SerializeAsync_ValueWithoutAsyncEnumerables_FlushesStreamOnCompletion()
+        {
+            // Non-streaming payloads are written in a single flush at the end of serialization.
+            using FlushTrackingStream stream = new();
+
+            await JsonSerializer.SerializeAsync(stream, new int[] { 1, 2, 3 }, ResolveJsonTypeInfo<int[]>());
+
+            Assert.Equal(new[] { "[1,2,3]" }, stream.FlushSnapshots);
+            Assert.Equal("[1,2,3]", Encoding.UTF8.GetString(stream.ToArray()));
+        }
+
+        [Fact]
+        public async Task SerializeAsyncEnumerable_TopLevelValues_DestinationFlushFailure_PropagatesAndDisposesEnumerator()
+        {
+            // A failure to flush the destination must surface to the caller and must not prevent
+            // the enumerator from being disposed.
+            using FlushTrackingStream stream = new();
+            stream.OnFlush = () => throw new IOException("flush failed");
+            SlowAsyncEnumerable source = new(count: 3);
+
+            IOException exception = await Assert.ThrowsAsync<IOException>(() =>
+                JsonSerializer.SerializeAsyncEnumerable(
+                    stream,
+                    source,
+                    ResolveJsonTypeInfo<int>(),
+                    topLevelValues: true));
+
+            Assert.Equal("flush failed", exception.Message);
+            Assert.True(source.Disposed);
+        }
+
+        public class AsyncEnumerableDto
+        {
+            public IAsyncEnumerable<int> Values { get; set; }
+        }
+
+        /// <summary>
+        /// An enumerable of increasing integers whose producer suspends after every element
+        /// until it is explicitly released.
+        /// </summary>
+        private sealed class GatedAsyncEnumerable : IAsyncEnumerable<int>
+        {
+            private readonly TaskCompletionSource<bool>[] _gates;
+            private int _released;
+
+            public GatedAsyncEnumerable(int count)
+            {
+                _gates = new TaskCompletionSource<bool>[count];
+                for (int i = 0; i < count; i++)
+                {
+                    _gates[i] = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+            }
+
+            /// <summary>Lets the producer advance past the element it last yielded.</summary>
+            public void ReleaseNext()
+            {
+                int index = _released++;
+                if (index < _gates.Length)
+                {
+                    _gates[index].TrySetResult(true);
+                }
+            }
+
+            public async IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            {
+                for (int i = 0; i < _gates.Length; i++)
+                {
+                    yield return i;
+
+                    // The timeout ensures that an implementation that fails to flush
+                    // fails the assertions instead of hanging the test run.
+                    await Task.WhenAny(_gates[i].Task, Task.Delay(TimeSpan.FromSeconds(30)));
+                }
+            }
+        }
+
+        /// <summary>An enumerable whose producer always suspends between elements.</summary>
+        private sealed class SlowAsyncEnumerable : IAsyncEnumerable<int>
+        {
+            private readonly int _count;
+
+            public SlowAsyncEnumerable(int count) => _count = count;
+
+            public bool Disposed { get; private set; }
+
+            public async IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            {
+                try
+                {
+                    for (int i = 0; i < _count; i++)
+                    {
+                        yield return i;
+                        await Task.Delay(10, CancellationToken.None);
+                    }
+                }
+                finally
+                {
+                    Disposed = true;
+                }
+            }
+        }
+
+        private sealed class FlushTrackingStream : MemoryStream
+        {
+            /// <summary>Gets the contents of the stream as observed at the time of every flush.</summary>
+            public List<string> FlushSnapshots { get; } = new();
+
+            /// <summary>Gets or sets a callback invoked after every recorded flush.</summary>
+            public Action OnFlush { get; set; }
+
+            public override void Flush()
+            {
+                FlushSnapshots.Add(Encoding.UTF8.GetString(ToArray()));
+                OnFlush?.Invoke();
+            }
+
+            public override Task FlushAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Flush();
+                return Task.CompletedTask;
+            }
+        }
+
         [Fact]
         public async Task SerializeAsyncEnumerable_PipeWriter_TopLevelValues_RoundTripsWithDeserializeAsyncEnumerable()
         {

--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.AsyncEnumerable.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.AsyncEnumerable.cs
@@ -91,7 +91,7 @@ namespace System.Text.Json.Serialization.Tests
         public async Task WriteAsyncEnumerable_CancellationToken_IsPassedToAsyncEnumerator()
         {
             // Regression test for https://github.com/dotnet/runtime/issues/79556
-            using var utf8Stream = new Utf8MemoryStream(ignoreCancellationTokenOnWriteAsync: true);
+            using var utf8Stream = new Utf8MemoryStream(ignoreCancellationTokenOnIO: true);
             using var cts = new CancellationTokenSource();
 
             IAsyncEnumerable<int> value = CreateEnumerable();

--- a/src/libraries/System.Text.Json/tests/Common/Utf8MemoryStream.cs
+++ b/src/libraries/System.Text.Json/tests/Common/Utf8MemoryStream.cs
@@ -9,11 +9,11 @@ namespace System.Text.Json.Serialization.Tests
 {
     public sealed class Utf8MemoryStream : MemoryStream
     {
-        private readonly bool _ignoreCancellationTokenOnWriteAsync;
+        private readonly bool _ignoreCancellationTokenOnIO;
 
-        public Utf8MemoryStream(bool ignoreCancellationTokenOnWriteAsync = false) : base()
+        public Utf8MemoryStream(bool ignoreCancellationTokenOnIO = false) : base()
         {
-            _ignoreCancellationTokenOnWriteAsync = ignoreCancellationTokenOnWriteAsync;
+            _ignoreCancellationTokenOnIO = ignoreCancellationTokenOnIO;
         }
 
         public Utf8MemoryStream(string text) : base(Encoding.UTF8.GetBytes(text))
@@ -22,10 +22,13 @@ namespace System.Text.Json.Serialization.Tests
 
 #if NET
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
-            => base.WriteAsync(buffer, _ignoreCancellationTokenOnWriteAsync ? default : cancellationToken);
+            => base.WriteAsync(buffer, _ignoreCancellationTokenOnIO ? default : cancellationToken);
 #endif
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            => base.WriteAsync(buffer, offset, count, _ignoreCancellationTokenOnWriteAsync ? default : cancellationToken);
+            => base.WriteAsync(buffer, offset, count, _ignoreCancellationTokenOnIO ? default : cancellationToken);
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+            => base.FlushAsync(_ignoreCancellationTokenOnIO ? default : cancellationToken);
 
         public string AsString() => Encoding.UTF8.GetString(ToArray());
     }


### PR DESCRIPTION
Fixes #121003

When writing async enumerables to `Stream`s, proactively flush after writes since there could be buffering at various layers that breaks the "live" nature of this serialization.
This isn't an issue with Kestrel or NetworkStream for example, since those automatically flush all writes. But IIS for example does buffer, so we need to flush explicitly.