### PR TITLE
Fix interpreter TraceCall GC mode

### DIFF
--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2054,8 +2054,14 @@ extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBl
             ProfilerUnmanagedToManagedTransitionMD(methodDescToReportAsTransition, COR_PRF_TRANSITION_CALL);
         }
 #endif
+    }
+
+    void* retVal;
+    {
+        GCX_MAYBE_COOP(pInterpreterCode->Method->unmanagedCallersOnly);
+
 #ifdef DEBUGGING_SUPPORTED
-        if (g_TrapReturningThreads && CORDebuggerTraceCall())
+        if (pInterpreterCode->Method->unmanagedCallersOnly && g_TrapReturningThreads && CORDebuggerTraceCall())
         {
             void* thunkDataMaybe = nullptr;
 #ifndef FEATURE_PORTABLE_ENTRYPOINTS
@@ -2065,11 +2071,6 @@ extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBl
             DebuggerTraceCall((void*)pInterpreterCode->GetByteCodes(), thunkDataMaybe);
         }
 #endif // DEBUGGING_SUPPORTED
-    }
-
-    void* retVal;
-    {
-        GCX_MAYBE_COOP(pInterpreterCode->Method->unmanagedCallersOnly);
 
         // This construct ensures that the InterpreterFrame is always stored at a higher address than the
         // InterpMethodContextFrame. This is important for the stack walking code.


### PR DESCRIPTION
## Summary

- Move the interpreter debugger `TraceCall` into the existing cooperative GC scope for interpreted `UnmanagedCallersOnly` entries.
- Keep profiler unmanaged-to-managed and managed-to-unmanaged transition callbacks in preemptive mode.
- Match the ordering used by `JIT_ReversePInvokeEnterRare*`.

## Root cause

`ExecuteInterpretedMethod` called `DebuggerTraceCall` before `GCX_MAYBE_COOP` when entering an interpreted `UnmanagedCallersOnly` method. The caller is still in preemptive mode at that point, but `Debugger::TraceCall` declares a `MODE_COOPERATIVE` contract. This caused Checked runtime contract failures whenever a managed debugger had armed TraceCall. The ordering originated in #122421.

The fix moves only the debugger block immediately after `GCX_MAYBE_COOP` and adds an explicit `unmanagedCallersOnly` guard because the block is no longer lexically nested in the UCO-only section. Profiler callbacks remain where their `MODE_PREEMPTIVE` contracts require them.


> [!NOTE]
> This pull request description was generated with GitHub Copilot.