### PR TITLE
Add getter-only configuration binding parity tests

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -1080,6 +1080,23 @@ namespace Microsoft.Extensions
             public AbstractBase AbstractProp { get; set; }
         }
 
+        internal class ClassWithGetterOnlyProperties
+        {
+            public ClassWithGetterOnlyProperties(bool initializeProperties)
+            {
+                if (initializeProperties)
+                {
+                    Nested = new();
+                    Collection = new();
+                    Abstract = new Derived();
+                }
+            }
+
+            public NestedOptions? Nested { get; }
+            public List<string>? Collection { get; }
+            public AbstractBase? Abstract { get; }
+        }
+
         internal class ClassWithAbstractCtorParam
         {
             public AbstractBase AbstractProp { get; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -1087,7 +1087,7 @@ namespace Microsoft.Extensions
                 if (initializeProperties)
                 {
                     Nested = new();
-                    Collection = new();
+                    Collection = ["existing"];
                     Abstract = new Derived();
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2960,7 +2960,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
             Assert.NotNull(instance.Nested);
             Assert.Equal(1, instance.Nested.Integer);
             Assert.NotNull(instance.Collection);
-            Assert.Equal(["item"], instance.Collection);
+            Assert.Equal(["existing", "item"], instance.Collection);
             Assert.NotNull(instance.Abstract);
             Assert.Equal(2, instance.Abstract.Value);
         }
@@ -2972,8 +2972,7 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
                 """
                 {
                     "Nested": { "Integer": 1 },
-                    "Collection": [ "item" ],
-                    "Abstract": { "Value": 2 }
+                    "Collection": [ "item" ]
                 }
                 """);
             ClassWithGetterOnlyProperties instance = new(initializeProperties: false);
@@ -2982,6 +2981,43 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
 
             Assert.Null(instance.Nested);
             Assert.Null(instance.Collection);
+        }
+
+        [Fact]
+        public static void Bind_GetterOnlyProperties_WithMissingConfiguration_LeavesExistingInstancesUnchanged()
+        {
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString("{}");
+            ClassWithGetterOnlyProperties instance = new(initializeProperties: true);
+            Assert.NotNull(instance.Nested);
+            Assert.NotNull(instance.Collection);
+            Assert.NotNull(instance.Abstract);
+            NestedOptions nested = instance.Nested;
+            List<string> collection = instance.Collection;
+            AbstractBase abstractInstance = instance.Abstract;
+
+            configuration.Bind(instance);
+
+            Assert.Same(nested, instance.Nested);
+            Assert.Equal(0, nested.Integer);
+            Assert.Same(collection, instance.Collection);
+            Assert.Equal(["existing"], collection);
+            Assert.Same(abstractInstance, instance.Abstract);
+            Assert.Equal(0, abstractInstance.Value);
+        }
+
+        [Fact]
+        public static void Bind_GetterOnlyAbstractProperty_WithNullValue_IgnoresConfiguration()
+        {
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString(
+                """
+                {
+                    "Abstract": { "Value": 2 }
+                }
+                """);
+            ClassWithGetterOnlyProperties instance = new(initializeProperties: false);
+
+            configuration.Bind(instance);
+
             Assert.Null(instance.Abstract);
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2957,8 +2957,11 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
 
             configuration.Bind(instance);
 
+            Assert.NotNull(instance.Nested);
             Assert.Equal(1, instance.Nested.Integer);
+            Assert.NotNull(instance.Collection);
             Assert.Equal(["item"], instance.Collection);
+            Assert.NotNull(instance.Abstract);
             Assert.Equal(2, instance.Abstract.Value);
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -2943,6 +2943,46 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         [Fact]
+        public static void Bind_GetterOnlyProperties_WithNonNullValues_BindsExistingInstances()
+        {
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString(
+                """
+                {
+                    "Nested": { "Integer": 1 },
+                    "Collection": [ "item" ],
+                    "Abstract": { "Value": 2 }
+                }
+                """);
+            ClassWithGetterOnlyProperties instance = new(initializeProperties: true);
+
+            configuration.Bind(instance);
+
+            Assert.Equal(1, instance.Nested.Integer);
+            Assert.Equal(["item"], instance.Collection);
+            Assert.Equal(2, instance.Abstract.Value);
+        }
+
+        [Fact]
+        public static void Bind_GetterOnlyProperties_WithNullValues_IgnoresConfiguration()
+        {
+            IConfiguration configuration = TestHelpers.GetConfigurationFromJsonString(
+                """
+                {
+                    "Nested": { "Integer": 1 },
+                    "Collection": [ "item" ],
+                    "Abstract": { "Value": 2 }
+                }
+                """);
+            ClassWithGetterOnlyProperties instance = new(initializeProperties: false);
+
+            configuration.Bind(instance);
+
+            Assert.Null(instance.Nested);
+            Assert.Null(instance.Collection);
+            Assert.Null(instance.Abstract);
+        }
+
+        [Fact]
         public void GetIConfigurationSection()
         {
             var configuration = TestHelpers.GetConfigurationFromJsonString("""


### PR DESCRIPTION
Adds the shared reflection/source-generator parity tests requested in this review comment: https://github.com/dotnet/runtime/pull/131045#pullrequestreview-4735783468.

The tests cover get-only nested objects, collections, and abstract-typed properties when their existing values are both non-null and null. They verify that existing instances are bound and null properties are ignored without throwing.

> [!NOTE]
> This pull request was created with GitHub Copilot.