### PR TITLE
Add reply size limits to SmtpReplyReaderFactory

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReaderFactory.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReaderFactory.cs
@@ -32,6 +32,10 @@ namespace System.Net.Mail
         private byte[]? _byteBuffer;
         private SmtpReplyReader? _currentReader;
         private const int DefaultBufferSize = 256;
+        // RFC 4954 section 4 recommends accepting authentication replies up to 12,288 octets.
+        private const int MaxReplyLineLength = 16 * 1024;
+        // SMTP does not define a maximum size for a multiline reply.
+        private const int MaxReplyLength = 256 * 1024;
         private ReadState _readState = ReadState.Status0;
         private SmtpStatusCode _statusCode;
 
@@ -260,6 +264,8 @@ namespace System.Net.Mail
 
             var builder = new StringBuilder();
             var lines = new List<LineInfo>();
+            int lineLength = 0;
+            int replyLength = 0;
             int statusRead = 0;
 
             int start = 0;
@@ -279,6 +285,14 @@ namespace System.Net.Mail
 
                 int actual = ProcessRead(_byteBuffer!.AsSpan(start, read - start), true);
 
+                if (actual > MaxReplyLineLength - lineLength ||
+                    actual > MaxReplyLength - replyLength)
+                {
+                    throw new FormatException(SR.SmtpInvalidResponse);
+                }
+                lineLength += actual;
+                replyLength += actual;
+
                 if (statusRead < 4)
                 {
                     int left = Math.Min(4 - statusRead, actual);
@@ -296,6 +310,7 @@ namespace System.Net.Mail
 
                 if (_readState == ReadState.Status0)
                 {
+                    lineLength = 0;
                     statusRead = 0;
                     lines.Add(new LineInfo(_statusCode, builder.ToString(0, builder.Length - 2))); // Exclude CRLF
 

--- a/src/libraries/System.Net.Mail/tests/Functional/LoopbackSmtpServer.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/LoopbackSmtpServer.cs
@@ -124,7 +124,9 @@ namespace System.Net.Mail.Tests
 
             async ValueTask SendMessageAsync(string text)
             {
-                var bytes = buffer.Slice(0, Encoding.UTF8.GetBytes(text, buffer.Span) + 2);
+                int byteCount = Encoding.UTF8.GetByteCount(text);
+                Memory<byte> bytes = byteCount + 2 <= buffer.Length ? buffer.Slice(0, byteCount + 2) : new byte[byteCount + 2];
+                Encoding.UTF8.GetBytes(text, bytes.Span);
                 bytes.Span[^2] = (byte)'\r';
                 bytes.Span[^1] = (byte)'\n';
 

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Mail.Tests;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,6 +12,9 @@ namespace System.Net.Mail.Tests
     public abstract class SmtpClientConnectionTest<TSendMethod> : LoopbackServerTestBase<TSendMethod>
         where TSendMethod : ISendMethodProvider
     {
+        private const int MaxReplyLineLength = 16 * 1024;
+        private const int MaxReplyLength = 256 * 1024;
+
         public SmtpClientConnectionTest(ITestOutputHelper output) : base(output)
         {
         }
@@ -29,6 +33,35 @@ namespace System.Net.Mail.Tests
             {
                 return "Go away";
             };
+
+            await SendMail<SmtpException>(new MailMessage("mono@novell.com", "everyone@novell.com", "introduction", "hello"));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task OversizedReply_Throws(bool multiline)
+        {
+            string reply;
+            if (multiline)
+            {
+                const int ContinuationLineLength = 8 * 1024;
+                string continuationLine = $"250-{new string('a', ContinuationLineLength - 6)}\r\n";
+                StringBuilder builder = new StringBuilder(MaxReplyLength + ContinuationLineLength);
+                while (builder.Length <= MaxReplyLength)
+                {
+                    builder.Append(continuationLine);
+                }
+                builder.Append("250 OK");
+                reply = builder.ToString();
+            }
+            else
+            {
+                reply = $"250 {new string('a', MaxReplyLineLength)}";
+            }
+
+            Server.OnCommandReceived = (command, _) =>
+                command.Equals("EHLO", StringComparison.OrdinalIgnoreCase) ? reply : null;
 
             await SendMail<SmtpException>(new MailMessage("mono@novell.com", "everyone@novell.com", "introduction", "hello"));
         }


### PR DESCRIPTION
Adds a size limit when reading SMTP server replies: 16 KiB for a single line and 256 KiB for a full multiline reply.