### PR TITLE
Add DI singleton reentrancy regression test

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CircularDependencyTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CircularDependencyTests.cs
@@ -294,8 +294,8 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             public ReentrantSingleton(ReentrantDependency dependency)
             {
                 dependency.SingletonInstanceCount++;
-                // Because of the semaphore, executes synchronously when called for the first time,
-                // but asynchronously when re-entered.
+                // Start an initialization routine that attempts a re-entrant resolution of this singleton
+                // via the root IServiceProvider while the first instance is still being constructed.
                 Initialization = dependency.InitializeAsync();
             }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CircularDependencyTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CircularDependencyTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection.Tests.Fakes;
 using Xunit;
 
@@ -241,6 +243,26 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         }
 
         [Fact]
+        public async Task ReentrantSingletonResolution_DoesNotCreateMultipleInstances()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ReentrantSingleton>();
+            services.AddSingleton<ReentrantDependency>();
+            services.AddSingleton<ReentrantSingletonConsumer>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var consumer = serviceProvider.GetRequiredService<ReentrantSingletonConsumer>();
+            await consumer.Singleton.Initialization;
+            var singleton = serviceProvider.GetRequiredService<ReentrantSingleton>();
+            var dependency = serviceProvider.GetRequiredService<ReentrantDependency>();
+
+            Assert.Same(consumer.Singleton, singleton);
+            Assert.Equal(1, dependency.SingletonInstanceCount);
+            Assert.IsType<InvalidOperationException>(dependency.ResolutionException);
+        }
+
+        [Fact]
         public void FactoryCircularDependency_NotDetectedByValidateOnBuild()
         {
             // This test verifies that ValidateOnBuild does NOT detect factory-based circular
@@ -265,6 +287,62 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             // Verify it's a circular dependency error
             Assert.Contains("circular dependency", exception.Message, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("FactoryCircularDependencyA", exception.Message);
+        }
+
+        private sealed class ReentrantSingleton
+        {
+            public ReentrantSingleton(ReentrantDependency dependency)
+            {
+                dependency.SingletonInstanceCount++;
+                // Because of the semaphore, executes synchronously when called for the first time,
+                // but asynchronously when re-entered.
+                Initialization = dependency.InitializeAsync();
+            }
+
+            public Task Initialization { get; }
+        }
+
+        private sealed class ReentrantDependency
+        {
+            private readonly SemaphoreSlim _connectionLock = new(1, 1);
+            private readonly IServiceProvider _serviceProvider;
+
+            public ReentrantDependency(IServiceProvider serviceProvider)
+            {
+                _serviceProvider = serviceProvider;
+            }
+
+            public int SingletonInstanceCount { get; set; }
+
+            public InvalidOperationException? ResolutionException { get; private set; }
+
+            public async Task InitializeAsync()
+            {
+                await _connectionLock.WaitAsync();
+
+                try
+                {
+                    _ = _serviceProvider.GetRequiredService<ReentrantSingleton>();
+                }
+                catch (InvalidOperationException exception)
+                {
+                    ResolutionException = exception;
+                }
+                finally
+                {
+                    _connectionLock.Release();
+                }
+            }
+        }
+
+        private sealed class ReentrantSingletonConsumer
+        {
+            public ReentrantSingletonConsumer(ReentrantSingleton singleton)
+            {
+                Singleton = singleton;
+            }
+
+            public ReentrantSingleton Singleton { get; }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CircularDependencyTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CircularDependencyTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var serviceProvider = services.BuildServiceProvider();
 
             var consumer = serviceProvider.GetRequiredService<ReentrantSingletonConsumer>();
-            await consumer.Singleton.Initialization;
+            await consumer.Singleton.Initialization.WaitAsync(TimeSpan.FromSeconds(20));
             var singleton = serviceProvider.GetRequiredService<ReentrantSingleton>();
             var dependency = serviceProvider.GetRequiredService<ReentrantDependency>();
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -18,6 +18,8 @@
     <Compile Include="..\DI.Specification.Tests\**\*.cs" />
     <Compile Include="$(CommonPath)..\tests\Extensions\SingleThreadedSynchronizationContext.cs"
              Link="Shared\SingleThreadedSynchronizationContext.cs" />
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
+             Link="Shared\TaskTimeoutExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">


### PR DESCRIPTION
## Summary

- add regression coverage for re-entrant singleton resolution through a constructor-injected consumer
- verify swallowed circular-resolution failures do not create a second singleton instance
- assert the constructor runs exactly once and subsequent direct resolution returns the same instance

This covers the singleton duplication shape identified while investigating dotnet/aspnetcore#67904 and complements the circular-dependency coverage added in #124331.

## Testing

- negative control: the test fails on `Assert.Same` when the re-entry guard from #124331 is removed

> [!NOTE]
> This pull request was created with the assistance of GitHub Copilot.