### PR TITLE
Fix an out-of-bounds read when matching UTF-8 number separators

### DIFF
--- a/src/libraries/Common/src/System/Number.Parsing.Common.cs
+++ b/src/libraries/Common/src/System/Number.Parsing.Common.cs
@@ -368,35 +368,29 @@ namespace System
             fixed (TChar* stringPointer = &MemoryMarshal.GetReference(value))
             {
                 TChar* str = stringPointer;
-
-                // When TChar is byte, value is one of NumberFormatInfo's UTF-8 caches, which are plain
-                // byte[] rather than NUL terminated strings, so the end has to be tracked explicitly.
                 TChar* strEnd = stringPointer + value.Length;
 
-                if (TChar.CastToUInt32(*str) != '\0')
+                while (true)
                 {
+                    uint cp = (p < pEnd) ? TChar.CastToUInt32(*p) : '\0';
+                    uint val = TChar.CastToUInt32(*str);
+
                     // We only hurt the failure case
                     // This fix is for cultures that use NBSP (U+00A0) or narrow NBSP (U+202F) as group/decimal separators
                     // (e.g., French, Kazakh, Ukrainian). Since a user cannot easily type these characters,
                     // we accept regular space (U+0020) as equivalent.
                     // We also need to handle the reverse case where the input has NBSP and the format string has space.
-                    while (true)
+                    if (cp != val && NormalizeSpaceReplacingChar(cp) != NormalizeSpaceReplacingChar(val))
                     {
-                        uint cp = (p < pEnd) ? TChar.CastToUInt32(*p) : '\0';
-                        uint val = TChar.CastToUInt32(*str);
+                        break;
+                    }
 
-                        if (cp != val && NormalizeSpaceReplacingChar(cp) != NormalizeSpaceReplacingChar(val))
-                        {
-                            break;
-                        }
+                    p++;
+                    str++;
 
-                        p++;
-                        str++;
-
-                        if ((str == strEnd) || (TChar.CastToUInt32(*str) == '\0'))
-                        {
-                            return p;
-                        }
+                    if (str == strEnd)
+                    {
+                        return p;
                     }
                 }
             }

--- a/src/libraries/Common/src/System/Number.Parsing.Common.cs
+++ b/src/libraries/Common/src/System/Number.Parsing.Common.cs
@@ -355,12 +355,15 @@ namespace System
             where TChar : unmanaged, IUtfChar<TChar>
         {
             // p/pEnd may be null when the input being parsed is an empty span (e.g. from a null string),
-            // in which case they are both null and the range is empty; the loop below never dereferences p then.
+            // in which case they are both null and the range is empty; the length check below then rejects
+            // any non-empty pattern before the loop can dereference p.
             Debug.Assert((p != null) || (p == pEnd));
             Debug.Assert((pEnd != null) || (p == pEnd));
             Debug.Assert(p <= pEnd);
 
-            if (value.IsEmpty)
+            // An empty pattern never matches, and one longer than the remaining input cannot match, so
+            // the loop only has to bound itself by the pattern.
+            if (value.IsEmpty || (value.Length > (pEnd - p)))
             {
                 return null;
             }
@@ -370,9 +373,9 @@ namespace System
                 TChar* str = stringPointer;
                 TChar* strEnd = stringPointer + value.Length;
 
-                while (true)
+                do
                 {
-                    uint cp = (p < pEnd) ? TChar.CastToUInt32(*p) : '\0';
+                    uint cp = TChar.CastToUInt32(*p);
                     uint val = TChar.CastToUInt32(*str);
 
                     // We only hurt the failure case
@@ -382,20 +385,16 @@ namespace System
                     // We also need to handle the reverse case where the input has NBSP and the format string has space.
                     if (cp != val && NormalizeSpaceReplacingChar(cp) != NormalizeSpaceReplacingChar(val))
                     {
-                        break;
+                        return null;
                     }
 
                     p++;
                     str++;
-
-                    if (str == strEnd)
-                    {
-                        return p;
-                    }
                 }
+                while (str != strEnd);
             }
 
-            return null;
+            return p;
         }
     }
 }

--- a/src/libraries/Common/src/System/Number.Parsing.Common.cs
+++ b/src/libraries/Common/src/System/Number.Parsing.Common.cs
@@ -360,9 +360,18 @@ namespace System
             Debug.Assert((pEnd != null) || (p == pEnd));
             Debug.Assert(p <= pEnd);
 
+            if (value.IsEmpty)
+            {
+                return null;
+            }
+
             fixed (TChar* stringPointer = &MemoryMarshal.GetReference(value))
             {
                 TChar* str = stringPointer;
+
+                // When TChar is byte, value is one of NumberFormatInfo's UTF-8 caches, which are plain
+                // byte[] rather than NUL terminated strings, so the end has to be tracked explicitly.
+                TChar* strEnd = stringPointer + value.Length;
 
                 if (TChar.CastToUInt32(*str) != '\0')
                 {
@@ -384,7 +393,7 @@ namespace System
                         p++;
                         str++;
 
-                        if (TChar.CastToUInt32(*str) == '\0')
+                        if ((str == strEnd) || (TChar.CastToUInt32(*str) == '\0'))
                         {
                             return p;
                         }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -96,6 +96,24 @@ namespace System.Globalization
         // negative sign is not the hyphen. For example, the Swedish culture (e.g. "sv-SE") has U+2212 as the negative sign.
         private bool _allowHyphenDuringParsing;
 
+        // Each UTF-8 cache is allocated one byte longer than the text it holds and the returned span
+        // excludes that trailing NUL. Consumers should still bound themselves by the span length; the
+        // terminator only exists so that a helper which scans for one cannot run off the end.
+        private static ReadOnlySpan<byte> GetUtf8Span(ref byte[]? utf8Cache, string value)
+        {
+            byte[] utf8 = utf8Cache ?? CreateUtf8Cache(ref utf8Cache, value);
+            Debug.Assert(utf8.Length > 0);
+            return MemoryMarshal.CreateReadOnlySpan(ref MemoryMarshal.GetArrayDataReference(utf8), utf8.Length - 1);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static byte[] CreateUtf8Cache(ref byte[]? utf8Cache, string value)
+        {
+            byte[] utf8 = new byte[Encoding.UTF8.GetByteCount(value) + 1];
+            Encoding.UTF8.GetBytes(value, utf8);
+            return utf8Cache = utf8;
+        }
+
         public NumberFormatInfo()
         {
         }
@@ -269,7 +287,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_currencyDecimalSeparator) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_currencyDecimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_currencyDecimalSeparator));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _currencyDecimalSeparatorUtf8, _currencyDecimalSeparator));
         }
 
         public bool IsReadOnly => _isReadOnly;
@@ -361,7 +379,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_currencyGroupSeparator) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_currencyGroupSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_currencyGroupSeparator));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _currencyGroupSeparatorUtf8, _currencyGroupSeparator));
         }
 
         public string CurrencySymbol
@@ -383,10 +401,8 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_currencySymbol) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_currencySymbolUtf8 ??= Encoding.UTF8.GetBytes(_currencySymbol));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _currencySymbolUtf8, _currencySymbol));
         }
-
-        internal byte[]? CurrencySymbolUtf8 => _currencySymbolUtf8 ??= Encoding.UTF8.GetBytes(_currencySymbol);
 
         /// <summary>
         /// Returns the current culture's NumberFormatInfo. Used by Parse methods.
@@ -429,7 +445,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_nanSymbol) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_nanSymbolUtf8 ??= Encoding.UTF8.GetBytes(_nanSymbol));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _nanSymbolUtf8, _nanSymbol));
         }
 
         public int CurrencyNegativePattern
@@ -514,7 +530,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_negativeInfinitySymbol) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_negativeInfinitySymbolUtf8 ??= Encoding.UTF8.GetBytes(_negativeInfinitySymbol));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _negativeInfinitySymbolUtf8, _negativeInfinitySymbol));
         }
 
         public string NegativeSign
@@ -537,7 +553,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_negativeSign) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_negativeSignUtf8 ??= Encoding.UTF8.GetBytes(_negativeSign));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _negativeSignUtf8, _negativeSign));
         }
 
         public int NumberDecimalDigits
@@ -573,7 +589,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_numberDecimalSeparator) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_numberDecimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_numberDecimalSeparator));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _numberDecimalSeparatorUtf8, _numberDecimalSeparator));
         }
 
         public string NumberGroupSeparator
@@ -594,7 +610,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_numberGroupSeparator) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_numberGroupSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_numberGroupSeparator));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _numberGroupSeparatorUtf8, _numberGroupSeparator));
         }
 
         public int CurrencyPositivePattern
@@ -631,7 +647,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_positiveInfinitySymbol) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_positiveInfinitySymbolUtf8 ??= Encoding.UTF8.GetBytes(_positiveInfinitySymbol));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _positiveInfinitySymbolUtf8, _positiveInfinitySymbol));
         }
 
         public string PositiveSign
@@ -654,7 +670,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_positiveSign) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_positiveSignUtf8 ??= Encoding.UTF8.GetBytes(_positiveSign));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _positiveSignUtf8, _positiveSign));
         }
 
         public int PercentDecimalDigits
@@ -690,7 +706,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_percentDecimalSeparator) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_percentDecimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_percentDecimalSeparator));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _percentDecimalSeparatorUtf8, _percentDecimalSeparator));
         }
 
         public string PercentGroupSeparator
@@ -711,7 +727,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_percentGroupSeparator) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_percentGroupSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_percentGroupSeparator));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _percentGroupSeparatorUtf8, _percentGroupSeparator));
         }
 
         public string PercentSymbol
@@ -732,7 +748,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_percentSymbol) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_percentSymbolUtf8 ??= Encoding.UTF8.GetBytes(_percentSymbol));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _percentSymbolUtf8, _percentSymbol));
         }
 
         public string PerMilleSymbol
@@ -754,7 +770,7 @@ namespace System.Globalization
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
                 Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_perMilleSymbol) :
-                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_perMilleSymbolUtf8 ??= Encoding.UTF8.GetBytes(_perMilleSymbol));
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(GetUtf8Span(ref _perMilleSymbolUtf8, _perMilleSymbol));
         }
 
         public string[] NativeDigits

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DecimalTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DecimalTests.cs
@@ -894,6 +894,15 @@ namespace System.Tests
             yield return new object[] { "\u200E+1\u2009234\u066B5", defaultStyle, multiByteFormat, 1234.5m };
             yield return new object[] { "\u0631\u06CC\u0627\u06441\u2009234\u066B5", NumberStyles.Currency, multiByteFormat, 1234.5m };
             yield return new object[] { "\u200E-\u0631\u06CC\u0627\u06441\u2009234", NumberStyles.Currency, multiByteFormat, -1234m };
+
+            // Signs and separators containing embedded NUL bytes: the new length-bounded MatchChars must
+            // match them literally, neither stopping at the NUL nor reading past the pattern end.
+            var nullEmbeddedFormat = new NumberFormatInfo();
+            nullEmbeddedFormat.NegativeSign = "a\0b";
+            nullEmbeddedFormat.NumberDecimalSeparator = ".\0.";
+
+            yield return new object[] { "a\0b123", defaultStyle, nullEmbeddedFormat, -123m };
+            yield return new object[] { "1.\0.5", defaultStyle, nullEmbeddedFormat, 1.5m };
         }
 
         [Theory]
@@ -958,6 +967,13 @@ namespace System.Tests
 
             yield return new object[] { "ab", NumberStyles.None, null, typeof(FormatException) }; // Hex value
             yield return new object[] { "  123  ", NumberStyles.None, null, typeof(FormatException) }; // Trailing and leading whitespace
+
+            // A sign/separator with an embedded NUL must not match input that lacks the NUL.
+            var nullEmbeddedFormat = new NumberFormatInfo();
+            nullEmbeddedFormat.NegativeSign = "a\0b";
+            nullEmbeddedFormat.NumberDecimalSeparator = ".";
+
+            yield return new object[] { "-123", defaultStyle, nullEmbeddedFormat, typeof(FormatException) }; // '-' is not "a\0b"
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DecimalTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DecimalTests.cs
@@ -849,6 +849,17 @@ namespace System.Tests
             var customFormat4 = new NumberFormatInfo();
             customFormat4.NumberDecimalSeparator = ".";
 
+            // Signs, separators, and symbols that encode to more than one UTF-8 byte, modeled on
+            // he/ar (NegativeSign is "\u200E-") and fa-IR (CurrencySymbol is "\u0631\u06CC\u0627\u0644").
+            var multiByteFormat = new NumberFormatInfo();
+            multiByteFormat.NegativeSign = "\u200E-";
+            multiByteFormat.PositiveSign = "\u200E+";
+            multiByteFormat.NumberGroupSeparator = "\u2009";
+            multiByteFormat.NumberDecimalSeparator = "\u066B";
+            multiByteFormat.CurrencySymbol = "\u0631\u06CC\u0627\u0644";
+            multiByteFormat.CurrencyGroupSeparator = "\u2009";
+            multiByteFormat.CurrencyDecimalSeparator = "\u066B";
+
             yield return new object[] { "-123", defaultStyle, null, -123m };
             yield return new object[] { "0", defaultStyle, null, 0m };
             yield return new object[] { "123", defaultStyle, null, 123m };
@@ -878,6 +889,11 @@ namespace System.Tests
 
             // Number buffer limit ran out (string too long)
             yield return new object[] { "1234567890123456789012345.678456", defaultStyle, customFormat4, 1234567890123456789012345.6785m };
+
+            yield return new object[] { "\u200E-1\u2009234\u066B5", defaultStyle, multiByteFormat, -1234.5m };
+            yield return new object[] { "\u200E+1\u2009234\u066B5", defaultStyle, multiByteFormat, 1234.5m };
+            yield return new object[] { "\u0631\u06CC\u0627\u06441\u2009234\u066B5", NumberStyles.Currency, multiByteFormat, 1234.5m };
+            yield return new object[] { "\u200E-\u0631\u06CC\u0627\u06441\u2009234", NumberStyles.Currency, multiByteFormat, -1234m };
         }
 
         [Theory]


### PR DESCRIPTION
`MatchChars` scans the separator pattern for a NUL terminator. A `string` has one; the `byte[]` UTF-8
caches on `NumberFormatInfo` do not, so the UTF-8 path reads `value[value.Length]`. When that byte
matches the next input character the walk returns past the real separator and the parser eats the
following digits as part of the sign -- with an 8-byte `NegativeSign` (`fa-IR`'s `CurrencySymbol`),
`"-1234"` parses as `-234`.

Bound the walk by `value.Length`, which also makes it agree with the `StartsWith`-based matching used
everywhere else, and allocate the caches a byte longer than the text so a scan for a terminator can't
run off the end regardless.

> [!NOTE]
> Investigated and drafted with GitHub Copilot; changes reviewed and validated locally.
