### PR TITLE
Fix CrossGen2 TypeMap blob-only type references

### DIFF
--- a/src/coreclr/tools/Common/Compiler/INativeFormatTypeReferenceProvider.cs
+++ b/src/coreclr/tools/Common/Compiler/INativeFormatTypeReferenceProvider.cs
@@ -8,7 +8,7 @@ namespace ILCompiler.DependencyAnalysis
 {
     public interface INativeFormatTypeReferenceProvider
     {
-        internal Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module = null);
+        internal Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module);
         internal Vertex EncodeReferenceToMethod(NativeWriter writer, MethodDesc method);
     }
 }

--- a/src/coreclr/tools/Common/Compiler/INativeFormatTypeReferenceProvider.cs
+++ b/src/coreclr/tools/Common/Compiler/INativeFormatTypeReferenceProvider.cs
@@ -8,7 +8,7 @@ namespace ILCompiler.DependencyAnalysis
 {
     public interface INativeFormatTypeReferenceProvider
     {
-        internal Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type);
+        internal Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module = null);
         internal Vertex EncodeReferenceToMethod(NativeWriter writer, MethodDesc method);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AnalyzedExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AnalyzedExternalTypeMapNode.cs
@@ -21,13 +21,13 @@ namespace ILCompiler.DependencyAnalysis
             foreach ((string key, TypeDesc type) in entries)
             {
                 Vertex keyVertex = writer.GetStringConstant(key);
-                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, type);
+                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, type, null);
                 Vertex entry = writer.GetTuple(keyVertex, valueVertex);
                 typeMapHashTable.Append((uint)TypeHashingAlgorithms.ComputeNameHashCode(key), section.Place(entry));
             }
 
             Vertex typeMapStateVertex = writer.GetUnsignedConstant(1); // Valid type map state
-            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup);
+            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup, null);
             Vertex tuple = writer.GetTuple(typeMapGroupVertex, typeMapStateVertex, typeMapHashTable);
             return section.Place(tuple);
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AnalyzedProxyTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/AnalyzedProxyTypeMapNode.cs
@@ -20,14 +20,14 @@ namespace ILCompiler.DependencyAnalysis
 
             foreach ((TypeDesc key, TypeDesc type) in entries)
             {
-                Vertex keyVertex = externalReferences.EncodeReferenceToType(writer, key);
-                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, type);
+                Vertex keyVertex = externalReferences.EncodeReferenceToType(writer, key, null);
+                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, type, null);
                 Vertex entry = writer.GetTuple(keyVertex, valueVertex);
                 typeMapHashTable.Append((uint)key.GetHashCode(), section.Place(entry));
             }
 
             Vertex typeMapStateVertex = writer.GetUnsignedConstant(1); // Valid type map state
-            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup);
+            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup, null);
             Vertex tuple = writer.GetTuple(typeMapGroupVertex, typeMapStateVertex, typeMapHashTable);
             return section.Place(tuple);
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
@@ -105,13 +105,13 @@ namespace ILCompiler.DependencyAnalysis
             foreach ((string key, IEETypeNode valueNode) in GetMarkedEntries(factory))
             {
                 Vertex keyVertex = writer.GetStringConstant(key);
-                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, valueNode.Type);
+                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, valueNode.Type, null);
                 Vertex entry = writer.GetTuple(keyVertex, valueVertex);
                 typeMapHashTable.Append((uint)TypeHashingAlgorithms.ComputeNameHashCode(key), section.Place(entry));
             }
 
             Vertex typeMapStateVertex = writer.GetUnsignedConstant(1); // Valid type map state
-            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup);
+            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup, null);
             Vertex tuple = writer.GetTuple(typeMapGroupVertex, typeMapStateVertex, typeMapHashTable);
             return section.Place(tuple);
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InvalidExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InvalidExternalTypeMapNode.cs
@@ -41,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis
         public Vertex CreateTypeMap(NodeFactory factory, NativeWriter writer, Section section, INativeFormatTypeReferenceProvider externalReferences)
         {
             Vertex typeMapStateVertex = writer.GetUnsignedConstant(0); // Invalid type map state
-            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup);
+            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup, null);
             Vertex throwingMethodStubVertex = externalReferences.EncodeReferenceToMethod(writer, ThrowingMethodStub);
             Vertex tuple = writer.GetTuple(typeMapGroupVertex, typeMapStateVertex, throwingMethodStubVertex);
             return section.Place(tuple);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InvalidProxyTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InvalidProxyTypeMapNode.cs
@@ -40,7 +40,7 @@ namespace ILCompiler.DependencyAnalysis
         public Vertex CreateTypeMap(NodeFactory factory, NativeWriter writer, Section section, INativeFormatTypeReferenceProvider externalReferences)
         {
             Vertex typeMapStateVertex = writer.GetUnsignedConstant(0); // Invalid type map state
-            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup);
+            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup, null);
             Vertex throwingMethodStubVertex = externalReferences.EncodeReferenceToMethod(writer, ThrowingMethodStub);
             Vertex tuple = writer.GetTuple(typeMapGroupVertex, typeMapStateVertex, throwingMethodStubVertex);
             return section.Place(tuple);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -1703,7 +1703,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             public Vertex EncodeReferenceToMethod(NativeWriter writer, MethodDesc method)
                 => writer.GetUnsignedConstant(table.GetIndex(factory.MethodEntrypoint(method)));
-            public Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module = null)
+            public Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module)
                 => writer.GetUnsignedConstant(table.GetIndex(factory.NecessaryTypeSymbol(type)));
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -1703,7 +1703,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             public Vertex EncodeReferenceToMethod(NativeWriter writer, MethodDesc method)
                 => writer.GetUnsignedConstant(table.GetIndex(factory.MethodEntrypoint(method)));
-            public Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type)
+            public Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module = null)
                 => writer.GetUnsignedConstant(table.GetIndex(factory.NecessaryTypeSymbol(type)));
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ProxyTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ProxyTypeMapNode.cs
@@ -84,14 +84,14 @@ namespace ILCompiler.DependencyAnalysis
 
             foreach ((IEETypeNode keyNode, IEETypeNode valueNode) in GetMarkedEntries(factory))
             {
-                Vertex keyVertex = externalReferences.EncodeReferenceToType(writer, keyNode.Type);
-                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, valueNode.Type);
+                Vertex keyVertex = externalReferences.EncodeReferenceToType(writer, keyNode.Type, null);
+                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, valueNode.Type, null);
                 Vertex entry = writer.GetTuple(keyVertex, valueVertex);
                 typeMapHashTable.Append((uint)keyNode.Type.GetHashCode(), section.Place(entry));
             }
 
             Vertex typeMapStateVertex = writer.GetUnsignedConstant(1); // Valid type map state
-            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup);
+            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup, null);
             Vertex tuple = writer.GetTuple(typeMapGroupVertex, typeMapStateVertex, typeMapHashTable);
             return section.Place(tuple);
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ImportReferenceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ImportReferenceProvider.cs
@@ -46,7 +46,7 @@ namespace ILCompiler.DependencyAnalysis
             return writer.GetTuple(writer.GetUnsignedConstant((uint)typeImport.Table.IndexFromBeginningOfArray), writer.GetUnsignedConstant((uint)typeImport.IndexFromBeginningOfArray));
         }
 
-        internal Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module = null)
+        internal Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module)
         {
             Debug.Assert(module is not null);
             Import typeImport = GetImportToType(type, module);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ImportReferenceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ImportReferenceProvider.cs
@@ -18,11 +18,11 @@ namespace ILCompiler.DependencyAnalysis
         private ReadyToRunSymbolNodeFactory _symbolNodeFactory;
         private ExternalReferenceTokenManager _externalReferenceTokenManager;
 
-        public Import GetImportToType(TypeDesc type, ModuleDesc module = null)
+        public Import GetImportToType(TypeDesc type, ModuleDesc moduleRequiringImport = null)
         {
-            if (module is not null)
+            if (moduleRequiringImport is not null)
             {
-                _externalReferenceTokenManager.EnsureDefTokensAreAvailable(type, module, referencesAreForAsyncMethod: false);
+                _externalReferenceTokenManager.EnsureDefTokensAreAvailable(type, moduleRequiringImport, referencesAreForAsyncMethod: false);
             }
 
             return _symbolNodeFactory.CreateReadyToRunHelper(ReadyToRunHelperId.TypeHandle, type);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ImportReferenceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ImportReferenceProvider.cs
@@ -4,6 +4,7 @@
 using System;
 
 using ILCompiler.DependencyAnalysis.ReadyToRun;
+using ILCompiler.ReadyToRun;
 using Internal.TypeSystem;
 using Internal.NativeFormat;
 using Internal.ReadyToRunConstants;
@@ -15,9 +16,15 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class ImportReferenceProvider : INativeFormatTypeReferenceProvider
     {
         private ReadyToRunSymbolNodeFactory _symbolNodeFactory;
+        private ExternalReferenceTokenManager _externalReferenceTokenManager;
 
-        public Import GetImportToType(TypeDesc type)
+        public Import GetImportToType(TypeDesc type, ModuleDesc module = null)
         {
+            if (module is not null)
+            {
+                _externalReferenceTokenManager.EnsureDefTokensAreAvailable(type, module, referencesAreForAsyncMethod: false);
+            }
+
             return _symbolNodeFactory.CreateReadyToRunHelper(ReadyToRunHelperId.TypeHandle, type);
         }
 
@@ -27,9 +34,10 @@ namespace ILCompiler.DependencyAnalysis
             return _symbolNodeFactory.ModuleLookup((IEcmaModule)module);
         }
 
-        public void Initialize(ReadyToRunSymbolNodeFactory symbolNodeFactory)
+        internal void Initialize(ReadyToRunSymbolNodeFactory symbolNodeFactory, ExternalReferenceTokenManager externalReferenceTokenManager)
         {
             _symbolNodeFactory = symbolNodeFactory;
+            _externalReferenceTokenManager = externalReferenceTokenManager;
         }
 
         internal Vertex EncodeReferenceToModule(NativeWriter writer, ModuleDesc module)
@@ -38,13 +46,14 @@ namespace ILCompiler.DependencyAnalysis
             return writer.GetTuple(writer.GetUnsignedConstant((uint)typeImport.Table.IndexFromBeginningOfArray), writer.GetUnsignedConstant((uint)typeImport.IndexFromBeginningOfArray));
         }
 
-        internal Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type)
+        internal Vertex EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module = null)
         {
-            Import typeImport = GetImportToType(type);
+            Debug.Assert(module is not null);
+            Import typeImport = GetImportToType(type, module);
             return writer.GetTuple(writer.GetUnsignedConstant((uint)typeImport.Table.IndexFromBeginningOfArray), writer.GetUnsignedConstant((uint)typeImport.IndexFromBeginningOfArray));
         }
 
         Vertex INativeFormatTypeReferenceProvider.EncodeReferenceToMethod(NativeWriter writer, MethodDesc method) => throw new NotImplementedException();
-        Vertex INativeFormatTypeReferenceProvider.EncodeReferenceToType(NativeWriter writer, TypeDesc type) => EncodeReferenceToType(writer, type);
+        Vertex INativeFormatTypeReferenceProvider.EncodeReferenceToType(NativeWriter writer, TypeDesc type, ModuleDesc module) => EncodeReferenceToType(writer, type, module);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -370,12 +370,13 @@ namespace ILCompiler
             _customPESectionAlignment = customPESectionAlignment;
             _format = format;
             SymbolNodeFactory = new ReadyToRunSymbolNodeFactory(nodeFactory, verifyTypeAndFieldLayout);
+            _tokenManager = new ExternalReferenceTokenManager(_nodeFactory.ManifestMetadataTable._mutableModule, _nodeFactory.Resolver);
             if (nodeFactory.InstrumentationDataTable != null)
                 nodeFactory.InstrumentationDataTable.Initialize(SymbolNodeFactory);
             if (nodeFactory.CrossModuleInlningInfo != null)
                 nodeFactory.CrossModuleInlningInfo.Initialize(SymbolNodeFactory);
             if (nodeFactory.ImportReferenceProvider != null)
-                nodeFactory.ImportReferenceProvider.Initialize(SymbolNodeFactory);
+                nodeFactory.ImportReferenceProvider.Initialize(SymbolNodeFactory, _tokenManager);
             _inputFiles = inputFiles;
             _compositeRootPath = compositeRootPath;
             _printReproInstructions = printReproInstructions;
@@ -393,7 +394,6 @@ namespace ILCompiler
             _profileData = profileData;
 
             _fileLayoutOptimizer = new FileLayoutOptimizer(logger, methodLayoutAlgorithm, fileLayoutAlgorithm, profileData, _nodeFactory);
-            _tokenManager = new ExternalReferenceTokenManager(_nodeFactory.ManifestMetadataTable._mutableModule, _nodeFactory.Resolver);
         }
 
         private readonly static string s_folderUpPrefix = ".." + Path.DirectorySeparatorChar;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunExternalTypeMapNode.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.ReadyToRun
 
         public Vertex CreateTypeMap(NodeFactory factory, NativeWriter writer, Section section, INativeFormatTypeReferenceProvider externalReferences)
         {
-            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup);
+            Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup, TriggeringModule);
             if (map.ThrowingMethodStub is not null)
             {
                 // We don't write out the throwing method stub for R2R
@@ -56,7 +56,7 @@ namespace ILCompiler.ReadyToRun
             foreach ((string key, (TypeDesc type, _)) in map.TypeMap)
             {
                 Vertex keyVertex = writer.GetStringConstant(key);
-                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, type);
+                Vertex valueVertex = externalReferences.EncodeReferenceToType(writer, type, TriggeringModule);
                 Vertex entry = writer.GetTuple(keyVertex, valueVertex);
                 typeMapHashTable.Append((uint)VersionResilientHashCode.NameHashCode(Encoding.UTF8.GetBytes(key)), typeMapEntriesSection.Place(entry));
             }
@@ -69,7 +69,7 @@ namespace ILCompiler.ReadyToRun
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => [];
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
-            yield return new DependencyListEntry(importProvider.GetImportToType(TypeMapGroup), $"Type map '{TypeMapGroup}' key type");
+            yield return new DependencyListEntry(importProvider.GetImportToType(TypeMapGroup, TriggeringModule), $"Type map '{TypeMapGroup}' key type");
 
             if (map.ThrowingMethodStub is not null)
             {
@@ -78,7 +78,7 @@ namespace ILCompiler.ReadyToRun
 
             foreach (var entry in map.TypeMap)
             {
-                yield return new DependencyListEntry(importProvider.GetImportToType(entry.Value.type), $"External type map entry target for key '{entry.Key}'");
+                yield return new DependencyListEntry(importProvider.GetImportToType(entry.Value.type, TriggeringModule), $"External type map entry target for key '{entry.Key}'");
             }
         }
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => [];

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunProxyTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunProxyTypeMapNode.cs
@@ -37,7 +37,7 @@ namespace ILCompiler.ReadyToRun
 
         public Vertex CreateTypeMap(NodeFactory factory, NativeWriter writer, Section section, INativeFormatTypeReferenceProvider ProxyReferences)
         {
-            Vertex typeMapGroupVertex = ProxyReferences.EncodeReferenceToType(writer, TypeMapGroup);
+            Vertex typeMapGroupVertex = ProxyReferences.EncodeReferenceToType(writer, TypeMapGroup, TriggeringModule);
             if (map.ThrowingMethodStub is not null)
             {
                 // We don't write out the throwing method stub for R2R
@@ -55,8 +55,8 @@ namespace ILCompiler.ReadyToRun
 
             foreach ((TypeDesc type, TypeDesc targetType) in map.TypeMap)
             {
-                Vertex keyVertex = ProxyReferences.EncodeReferenceToType(writer, type);
-                Vertex valueVertex = ProxyReferences.EncodeReferenceToType(writer, targetType);
+                Vertex keyVertex = ProxyReferences.EncodeReferenceToType(writer, type, TriggeringModule);
+                Vertex valueVertex = ProxyReferences.EncodeReferenceToType(writer, targetType, TriggeringModule);
                 Vertex entry = writer.GetTuple(keyVertex, valueVertex);
                 typeMapHashTable.Append((uint)type.GetHashCode(), typeMapEntriesSection.Place(entry));
             }
@@ -69,7 +69,7 @@ namespace ILCompiler.ReadyToRun
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => [];
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
         {
-            yield return new DependencyListEntry(importProvider.GetImportToType(TypeMapGroup), $"Type map '{TypeMapGroup}' key type");
+            yield return new DependencyListEntry(importProvider.GetImportToType(TypeMapGroup, TriggeringModule), $"Type map '{TypeMapGroup}' key type");
 
             if (map.ThrowingMethodStub is not null)
             {
@@ -78,8 +78,8 @@ namespace ILCompiler.ReadyToRun
 
             foreach (var entry in map.TypeMap)
             {
-                yield return new DependencyListEntry(importProvider.GetImportToType(entry.Key), $"Key type of Proxy type map entry");
-                yield return new DependencyListEntry(importProvider.GetImportToType(entry.Value), $"Proxy type map entry target for key '{entry.Key}'");
+                yield return new DependencyListEntry(importProvider.GetImportToType(entry.Key, TriggeringModule), $"Key type of Proxy type map entry");
+                yield return new DependencyListEntry(importProvider.GetImportToType(entry.Value, TriggeringModule), $"Proxy type map entry target for key '{entry.Key}'");
             }
         }
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => [];

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/TypeMapAssemblyTargetsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/TypeMapAssemblyTargetsNode.cs
@@ -48,7 +48,7 @@ namespace ILCompiler.ReadyToRun
                     continue;
 
                 var groupType = map.Key;
-                dependencies.Add(new DependencyListEntry(_importReferenceProvider.GetImportToType(groupType), "Type Map Assembly Target"));
+                dependencies.Add(new DependencyListEntry(_importReferenceProvider.GetImportToType(groupType, _assemblyTypeMaps.AssociatedModule), "Type Map Assembly Target"));
                 foreach (var targetModule in map.Value.TargetModules)
                 {
                     dependencies.Add(new DependencyListEntry(_importReferenceProvider.GetImportToModule(targetModule), "Type Map Assembly Target"));
@@ -79,7 +79,7 @@ namespace ILCompiler.ReadyToRun
                     continue;
 
                 var groupType = map.Key;
-                Vertex groupTypeVertex = _importReferenceProvider.EncodeReferenceToType(writer, groupType);
+                Vertex groupTypeVertex = _importReferenceProvider.EncodeReferenceToType(writer, groupType, _assemblyTypeMaps.AssociatedModule);
                 VertexSequence modules = new();
                 foreach (var targetModule in map.Value.TargetModules)
                 {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -142,18 +142,6 @@ namespace Internal.TypeSystem.Ecma
                 if (module is EcmaModule ecmaModule && type.Module is EcmaModule targetTypeModule)
                 {
                     string targetAssemblyName = targetTypeModule.Assembly.GetName().Name;
-                    MetadataReader reader = ecmaModule.MetadataReader;
-                    foreach (AssemblyReferenceHandle assemblyRefHandle in reader.AssemblyReferences)
-                    {
-                        string referencedAssemblyName = reader.GetString(reader.GetAssemblyReference(assemblyRefHandle).Name);
-                        if (string.Equals(referencedAssemblyName, targetAssemblyName, StringComparison.Ordinal))
-                        {
-                            return targetAssemblyName;
-                        }
-                    }
-
-                    // The assembly name in a custom attribute type argument is valid even when there is no
-                    // corresponding AssemblyRef row in the source module metadata.
                     return targetAssemblyName;
                 }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -142,10 +142,20 @@ namespace Internal.TypeSystem.Ecma
                 if (module is EcmaModule ecmaModule && type.Module is EcmaModule targetTypeModule)
                 {
                     string targetAssemblyName = targetTypeModule.Assembly.GetName().Name;
+                    MetadataReader reader = ecmaModule.MetadataReader;
+                    foreach (AssemblyReferenceHandle assemblyRefHandle in reader.AssemblyReferences)
+                    {
+                        string referencedAssemblyName = reader.GetString(reader.GetAssemblyReference(assemblyRefHandle).Name);
+                        if (string.Equals(referencedAssemblyName, targetAssemblyName, StringComparison.Ordinal))
+                        {
+                            return targetAssemblyName;
+                        }
+                    }
 
                     // The assembly name in a custom attribute type argument is valid even when there is no
                     // corresponding AssemblyRef row in the source module metadata.
                     return targetAssemblyName;
+                }
 
                 throw new KeyNotFoundException($"Unable to resolve an assembly reference from module '{module}' to type '{type}'.");
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -132,7 +132,32 @@ namespace Internal.TypeSystem.Ecma
                     s_assemblyNameFromTypeLookups.AddOrUpdate(module, lookupTable);
                 }
 
-                return lookupTable[type];
+                if (lookupTable.TryGetValue(type, out string assemblyName))
+                {
+                    return assemblyName;
+                }
+
+                // Some producers encode type map custom attributes without emitting matching TypeRef rows
+                // for the referenced types. In that case, fall back to the target type's defining assembly.
+                if (module is EcmaModule ecmaModule && type.Module is EcmaModule targetTypeModule)
+                {
+                    string targetAssemblyName = targetTypeModule.Assembly.GetName().Name;
+                    MetadataReader reader = ecmaModule.MetadataReader;
+                    foreach (AssemblyReferenceHandle assemblyRefHandle in reader.AssemblyReferences)
+                    {
+                        string referencedAssemblyName = reader.GetString(reader.GetAssemblyReference(assemblyRefHandle).Name);
+                        if (string.Equals(referencedAssemblyName, targetAssemblyName, StringComparison.Ordinal))
+                        {
+                            return targetAssemblyName;
+                        }
+                    }
+
+                    // The assembly name in a custom attribute type argument is valid even when there is no
+                    // corresponding AssemblyRef row in the source module metadata.
+                    return targetAssemblyName;
+                }
+
+                throw new KeyNotFoundException($"Unable to resolve an assembly reference from module '{module}' to type '{type}'.");
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -142,20 +142,10 @@ namespace Internal.TypeSystem.Ecma
                 if (module is EcmaModule ecmaModule && type.Module is EcmaModule targetTypeModule)
                 {
                     string targetAssemblyName = targetTypeModule.Assembly.GetName().Name;
-                    MetadataReader reader = ecmaModule.MetadataReader;
-                    foreach (AssemblyReferenceHandle assemblyRefHandle in reader.AssemblyReferences)
-                    {
-                        string referencedAssemblyName = reader.GetString(reader.GetAssemblyReference(assemblyRefHandle).Name);
-                        if (string.Equals(referencedAssemblyName, targetAssemblyName, StringComparison.Ordinal))
-                        {
-                            return targetAssemblyName;
-                        }
-                    }
 
                     // The assembly name in a custom attribute type argument is valid even when there is no
                     // corresponding AssemblyRef row in the source module metadata.
                     return targetAssemblyName;
-                }
 
                 throw new KeyNotFoundException($"Unable to resolve an assembly reference from module '{module}' to type '{type}'.");
             }

--- a/src/tests/Interop/TypeMap/GroupTypes.cs
+++ b/src/tests/Interop/TypeMap/GroupTypes.cs
@@ -26,3 +26,5 @@ public class MultipleTypeMapAssemblies { }
 public class DuplicateTypeMapEntriesAcrossAssemblies { }
 
 public class UnknownAssemblyReference { }
+
+public class BlobOnlyAttributeTypeNames { }

--- a/src/tests/Interop/TypeMap/TypeMapApp.cs
+++ b/src/tests/Interop/TypeMap/TypeMapApp.cs
@@ -19,6 +19,7 @@ using DupType_MapString = Lib.AliasedName;
 [assembly: TypeMapAssemblyTarget<DuplicateTypeMapEntriesAcrossAssemblies>("TypeMapLib3")]
 
 [assembly: TypeMapAssemblyTarget<UnknownAssemblyReference>("DoesNotExist")]
+[assembly: TypeMapAssemblyTarget<BlobOnlyAttributeTypeNames>("TypeMapBlobOnlyLib")]
 
 [assembly: TypeMap<TypicalUseCase>("1", typeof(C1))]
 [assembly: TypeMap<TypicalUseCase>("2", typeof(S1))]
@@ -311,6 +312,20 @@ public class TypeMap
                 Assert.True(hasTypeMapAssemblyTargets, "R2R image should contain TypeMapAssemblyTargets section");
             }
         }
+    }
+
+    [Fact]
+    public static void Validate_BlobOnlyAttributeTypeNames()
+    {
+        Console.WriteLine(nameof(Validate_BlobOnlyAttributeTypeNames));
+
+        IReadOnlyDictionary<string, Type> externalMap = TypeMapping.GetOrCreateExternalTypeMapping<BlobOnlyAttributeTypeNames>();
+        Assert.Equal(typeof(C1), externalMap["blob_only_c1"]);
+        Assert.Equal(typeof(S1), externalMap["blob_only_s1"]);
+
+        IReadOnlyDictionary<Type, Type> proxyMap = TypeMapping.GetOrCreateProxyTypeMapping<BlobOnlyAttributeTypeNames>();
+        Assert.Equal(typeof(S1), proxyMap[typeof(C1)]);
+        Assert.Equal(typeof(C1), proxyMap[typeof(S1)]);
     }
 
     [Fact]

--- a/src/tests/Interop/TypeMap/TypeMapApp.cs
+++ b/src/tests/Interop/TypeMap/TypeMapApp.cs
@@ -322,10 +322,12 @@ public class TypeMap
         IReadOnlyDictionary<string, Type> externalMap = TypeMapping.GetOrCreateExternalTypeMapping<BlobOnlyAttributeTypeNames>();
         Assert.Equal(typeof(C1), externalMap["blob_only_c1"]);
         Assert.Equal(typeof(S1), externalMap["blob_only_s1"]);
+        Assert.Equal(typeof(Lib5Type1), externalMap["lib5_type1"]);
 
         IReadOnlyDictionary<Type, Type> proxyMap = TypeMapping.GetOrCreateProxyTypeMapping<BlobOnlyAttributeTypeNames>();
         Assert.Equal(typeof(S1), proxyMap[typeof(C1)]);
         Assert.Equal(typeof(C1), proxyMap[typeof(S1)]);
+        Assert.Equal(typeof(Lib5Type1), proxyMap[typeof(Lib5Proxy1)]);
     }
 
     [Fact]

--- a/src/tests/Interop/TypeMap/TypeMapApp.csproj
+++ b/src/tests/Interop/TypeMap/TypeMapApp.csproj
@@ -18,6 +18,7 @@
     </ProjectReference>
     <ProjectReference Include="TypeMapLib3.csproj" />
     <ProjectReference Include="TypeMapLib4.csproj" />
+    <ProjectReference Include="TypeMapBlobOnlyLib.ilproj" />
     <ProjectReference Include="NoTypeMapEntries.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/TypeMap/TypeMapApp.csproj
+++ b/src/tests/Interop/TypeMap/TypeMapApp.csproj
@@ -18,6 +18,7 @@
     </ProjectReference>
     <ProjectReference Include="TypeMapLib3.csproj" />
     <ProjectReference Include="TypeMapLib4.csproj" />
+    <ProjectReference Include="TypeMapLib5.csproj" />
     <ProjectReference Include="TypeMapBlobOnlyLib.ilproj" />
     <ProjectReference Include="NoTypeMapEntries.csproj" />
   </ItemGroup>

--- a/src/tests/Interop/TypeMap/TypeMapBlobOnlyLib.il
+++ b/src/tests/Interop/TypeMap/TypeMapBlobOnlyLib.il
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime { }
+.assembly extern System.Runtime.InteropServices { }
+.assembly extern TypeMapLib1 { }
+
+.assembly TypeMapBlobOnlyLib
+{
+    // Keys and mapped types are encoded directly in the custom attribute blob as SerString values.
+    // This intentionally avoids any IL usage of C1/S1 so there is no requirement for TypeRef rows
+    // for the mapped types outside of custom attribute blobs.
+    .custom instance void class [System.Runtime.InteropServices]System.Runtime.InteropServices.TypeMapAttribute`1<class [TypeMapLib1]BlobOnlyAttributeTypeNames>::.ctor(string, class [System.Runtime]System.Type)
+           = {string('blob_only_c1')
+              type(class 'C1, TypeMapLib1')}
+
+    .custom instance void class [System.Runtime.InteropServices]System.Runtime.InteropServices.TypeMapAttribute`1<class [TypeMapLib1]BlobOnlyAttributeTypeNames>::.ctor(string, class [System.Runtime]System.Type)
+           = {string('blob_only_s1')
+              type(class 'S1, TypeMapLib1')}
+
+    .custom instance void class [System.Runtime.InteropServices]System.Runtime.InteropServices.TypeMapAssociationAttribute`1<class [TypeMapLib1]BlobOnlyAttributeTypeNames>::.ctor(class [System.Runtime]System.Type, class [System.Runtime]System.Type)
+           = {type(class 'C1, TypeMapLib1')
+              type(class 'S1, TypeMapLib1')}
+
+    .custom instance void class [System.Runtime.InteropServices]System.Runtime.InteropServices.TypeMapAssociationAttribute`1<class [TypeMapLib1]BlobOnlyAttributeTypeNames>::.ctor(class [System.Runtime]System.Type, class [System.Runtime]System.Type)
+           = {type(class 'S1, TypeMapLib1')
+              type(class 'C1, TypeMapLib1')}
+
+    .ver 0:0:0:0
+}

--- a/src/tests/Interop/TypeMap/TypeMapBlobOnlyLib.il
+++ b/src/tests/Interop/TypeMap/TypeMapBlobOnlyLib.il
@@ -26,5 +26,13 @@
            = {type(class 'S1, TypeMapLib1')
               type(class 'C1, TypeMapLib1')}
 
+    .custom instance void class [System.Runtime.InteropServices]System.Runtime.InteropServices.TypeMapAttribute`1<class [TypeMapLib1]BlobOnlyAttributeTypeNames>::.ctor(string, class [System.Runtime]System.Type)
+           = {string('lib5_type1')
+              type(class 'Lib5Type1, TypeMapLib5')}
+
+    .custom instance void class [System.Runtime.InteropServices]System.Runtime.InteropServices.TypeMapAssociationAttribute`1<class [TypeMapLib1]BlobOnlyAttributeTypeNames>::.ctor(class [System.Runtime]System.Type, class [System.Runtime]System.Type)
+           = {type(class 'Lib5Type1, TypeMapLib5')
+              type(class 'Lib5Proxy1, TypeMapLib5')}
+
     .ver 0:0:0:0
 }

--- a/src/tests/Interop/TypeMap/TypeMapBlobOnlyLib.ilproj
+++ b/src/tests/Interop/TypeMap/TypeMapBlobOnlyLib.ilproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>library</OutputType>
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TypeMapBlobOnlyLib.il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Add support for resolving types referenced only by custom attribute arguments (no TypeRef rows, no AssemblyRef rows for the type's containing assembly).

Fixes https://github.com/dotnet/runtime/issues/131527

> [!NOTE]
> This PR description was generated with assistance from AI/Copilot.