### PR TITLE
Vectorize PrintableStringEncoding and NumericStringEncoding

### DIFF
--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.cs
@@ -144,7 +144,7 @@ namespace System.Formats.Asn1
         }
     }
 
-    internal sealed class NumericStringEncoding : RestrictedAsciiStringEncoding
+    internal sealed partial class NumericStringEncoding : RestrictedAsciiSetEncoding
     {
         // T-REC-X.680-201508 sec 41.2 (Table 9)
         // 0, 1, ... 9 + space
@@ -154,7 +154,7 @@ namespace System.Formats.Asn1
         }
     }
 
-    internal sealed class PrintableStringEncoding : RestrictedAsciiStringEncoding
+    internal sealed partial class PrintableStringEncoding : RestrictedAsciiSetEncoding
     {
         // T-REC-X.680-201508 sec 41.4
         internal PrintableStringEncoding()
@@ -214,11 +214,13 @@ namespace System.Formats.Asn1
                 return 0;
             }
 
+            bool[] isAllowed = _isAllowed;
+
             for (int i = 0; i < chars.Length; i++)
             {
                 char c = chars[i];
 
-                if ((uint)c >= (uint)_isAllowed.Length || !_isAllowed[c])
+                if ((uint)c >= (uint)isAllowed.Length || !isAllowed[c])
                 {
                     EncoderFallback.CreateFallbackBuffer().Fallback(c, i);
 
@@ -235,6 +237,38 @@ namespace System.Formats.Asn1
             return chars.Length;
         }
 
+        // Keep the position-aware scalar remainder separate from the zero-based path above.
+        // Routing common sub-vector inputs through this generalized loop measurably regresses them.
+        protected int GetBytesScalar(ReadOnlySpan<char> chars, Span<byte> bytes, bool write, int position)
+        {
+            if (chars.IsEmpty)
+            {
+                return 0;
+            }
+
+            bool[] isAllowed = _isAllowed;
+
+            for (; position < chars.Length; position++)
+            {
+                char c = chars[position];
+
+                if ((uint)c >= (uint)isAllowed.Length || !isAllowed[c])
+                {
+                    EncoderFallback.CreateFallbackBuffer().Fallback(c, position);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new InvalidOperationException();
+                }
+
+                if (write)
+                {
+                    bytes[position] = (byte)c;
+                }
+            }
+
+            return chars.Length;
+        }
+
         protected override int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
         {
             if (bytes.IsEmpty)
@@ -242,11 +276,13 @@ namespace System.Formats.Asn1
                 return 0;
             }
 
+            bool[] isAllowed = _isAllowed;
+
             for (int i = 0; i < bytes.Length; i++)
             {
                 byte b = bytes[i];
 
-                if ((uint)b >= (uint)_isAllowed.Length || !_isAllowed[b])
+                if ((uint)b >= (uint)isAllowed.Length || !isAllowed[b])
                 {
                     DecoderFallback.CreateFallbackBuffer().Fallback(
                         new[] { b },
@@ -259,6 +295,40 @@ namespace System.Formats.Asn1
                 if (write)
                 {
                     chars[i] = (char)b;
+                }
+            }
+
+            return bytes.Length;
+        }
+
+        // Keep the position-aware scalar remainder separate from the zero-based path above.
+        // Routing common sub-vector inputs through this generalized loop measurably regresses them.
+        protected int GetCharsScalar(ReadOnlySpan<byte> bytes, Span<char> chars, bool write, int position)
+        {
+            if (bytes.IsEmpty)
+            {
+                return 0;
+            }
+
+            bool[] isAllowed = _isAllowed;
+
+            for (; position < bytes.Length; position++)
+            {
+                byte b = bytes[position];
+
+                if ((uint)b >= (uint)isAllowed.Length || !isAllowed[b])
+                {
+                    DecoderFallback.CreateFallbackBuffer().Fallback(
+                        new[] { b },
+                        position);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new InvalidOperationException();
+                }
+
+                if (write)
+                {
+                    chars[position] = (char)b;
                 }
             }
 

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.downlevel.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.downlevel.cs
@@ -6,6 +6,14 @@ using System.Diagnostics;
 
 namespace System.Formats.Asn1
 {
+    internal abstract class RestrictedAsciiSetEncoding : RestrictedAsciiStringEncoding
+    {
+        protected RestrictedAsciiSetEncoding(string allowedChars)
+            : base(allowedChars)
+        {
+        }
+    }
+
     internal abstract class RestrictedAsciiRangeEncoding : RestrictedAsciiStringEncoding
     {
         protected RestrictedAsciiRangeEncoding(byte minCharAllowed, byte maxCharAllowed)

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.net.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.net.cs
@@ -8,6 +8,188 @@ using System.Runtime.InteropServices;
 
 namespace System.Formats.Asn1
 {
+    internal abstract class RestrictedAsciiSetEncoding : RestrictedAsciiStringEncoding
+    {
+        protected RestrictedAsciiSetEncoding(string allowedChars)
+            : base(allowedChars)
+        {
+        }
+
+        protected override int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
+        {
+            if (chars.Length >= Vector<byte>.Count && Vector.IsHardwareAccelerated)
+            {
+                return GetBytesVectorized(chars, bytes, write);
+            }
+
+            return base.GetBytes(chars, bytes, write);
+        }
+
+        protected override int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
+        {
+            if (bytes.Length >= Vector<byte>.Count && Vector.IsHardwareAccelerated)
+            {
+                return GetCharsVectorized(bytes, chars, write);
+            }
+
+            return base.GetChars(bytes, chars, write);
+        }
+
+        // Keep the vectorization out of GetChars and GetBytes to avoid regressing code size
+        // and register allocation for small inputs.
+        private int GetBytesVectorized(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
+        {
+            int available = write ? Math.Min(chars.Length, bytes.Length) : chars.Length;
+            int position = 0;
+
+            Debug.Assert(Vector<byte>.Count == 2 * Vector<ushort>.Count);
+
+            // Revisit this cast when Vector<char> is supported: https://github.com/dotnet/runtime/issues/127611
+            ReadOnlySpan<ushort> source = MemoryMarshal.Cast<char, ushort>(chars).Slice(0, available);
+            Span<byte> destination = write ? bytes.Slice(0, available) : Span<byte>.Empty;
+
+            while (source.Length >= Vector<byte>.Count)
+            {
+                Vector<ushort> lower = new Vector<ushort>(source);
+                Vector<ushort> upper = new Vector<ushort>(source.Slice(Vector<ushort>.Count));
+
+                if (!IsAllowed(lower) || !IsAllowed(upper))
+                {
+                    // Do not advance the position so the scalar path can determine the exact invalid index.
+                    break;
+                }
+
+                if (write)
+                {
+                    Vector.Narrow(lower, upper).CopyTo(destination);
+                    destination = destination.Slice(Vector<byte>.Count);
+                }
+
+                source = source.Slice(Vector<byte>.Count);
+                position += Vector<byte>.Count;
+            }
+
+            return GetBytesScalar(chars, bytes, write, position);
+        }
+
+        private int GetCharsVectorized(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
+        {
+            int available = write ? Math.Min(bytes.Length, chars.Length) : bytes.Length;
+            int position = 0;
+
+            Debug.Assert(Vector<byte>.Count == 2 * Vector<ushort>.Count);
+
+            ReadOnlySpan<byte> source = bytes.Slice(0, available);
+            // Revisit this cast when Vector<char> is supported: https://github.com/dotnet/runtime/issues/127611
+            Span<ushort> destination = write ?
+                MemoryMarshal.Cast<char, ushort>(chars).Slice(0, available) :
+                Span<ushort>.Empty;
+
+            while (source.Length >= Vector<byte>.Count)
+            {
+                Vector<byte> value = new Vector<byte>(source);
+
+                if (!IsAllowed(value))
+                {
+                    // Do not advance the position so the scalar path can determine the exact invalid index.
+                    break;
+                }
+
+                if (write)
+                {
+                    Vector.Widen(value, out Vector<ushort> lower, out Vector<ushort> upper);
+                    lower.CopyTo(destination);
+                    upper.CopyTo(destination.Slice(Vector<ushort>.Count));
+                    destination = destination.Slice(Vector<byte>.Count);
+                }
+
+                source = source.Slice(Vector<byte>.Count);
+                position += Vector<byte>.Count;
+            }
+
+            return GetCharsScalar(bytes, chars, write, position);
+        }
+
+        protected abstract bool IsAllowed(Vector<byte> value);
+        protected abstract bool IsAllowed(Vector<ushort> value);
+    }
+
+    internal sealed partial class NumericStringEncoding
+    {
+        protected override bool IsAllowed(Vector<byte> value)
+        {
+            // Allow ASCII digits.
+            Vector<byte> allowed = Vector.LessThanOrEqual(
+                value - new Vector<byte>((byte)'0'),
+                new Vector<byte>('9' - '0'));
+
+            // Allow space.
+            allowed |= Vector.Equals(value, new Vector<byte>((byte)' '));
+
+            return Vector.AllWhereAllBitsSet(allowed);
+        }
+
+        protected override bool IsAllowed(Vector<ushort> value)
+        {
+            // Allow ASCII digits.
+            Vector<ushort> allowed = Vector.LessThanOrEqual(
+                value - new Vector<ushort>('0'),
+                new Vector<ushort>('9' - '0'));
+
+            // Allow space.
+            allowed |= Vector.Equals(value, new Vector<ushort>(' '));
+
+            return Vector.AllWhereAllBitsSet(allowed);
+        }
+    }
+
+    internal sealed partial class PrintableStringEncoding
+    {
+        private const byte EqualsQuestionMarkMask = (byte)('=' ^ '?');
+
+        protected override bool IsAllowed(Vector<byte> value)
+        {
+            // Allow uppercase and lowercase ASCII letters.
+            Vector<byte> allowed = Vector.LessThanOrEqual(
+                (value | new Vector<byte>(0b100000)) - new Vector<byte>((byte)'a'),
+                new Vector<byte>('z' - 'a'));
+
+            // Allow apostrophe through colon, excluding asterisk.
+            allowed |= Vector.LessThanOrEqual(
+                value - new Vector<byte>((byte)'\''),
+                new Vector<byte>(':' - '\'')) & ~Vector.Equals(value, new Vector<byte>((byte)'*'));
+
+            // Allow equals sign and question mark by setting their only differing bit before comparing with '?'.
+            allowed |= Vector.Equals(value | new Vector<byte>(EqualsQuestionMarkMask), new Vector<byte>((byte)'?'));
+
+            // Allow space.
+            allowed |= Vector.Equals(value, new Vector<byte>((byte)' '));
+
+            return Vector.AllWhereAllBitsSet(allowed);
+        }
+
+        protected override bool IsAllowed(Vector<ushort> value)
+        {
+            // Allow uppercase and lowercase ASCII letters.
+            Vector<ushort> allowed = Vector.LessThanOrEqual(
+                (value | new Vector<ushort>(0b100000)) - new Vector<ushort>('a'),
+                new Vector<ushort>('z' - 'a'));
+
+            // Allow apostrophe through colon, excluding asterisk.
+            allowed |= Vector.LessThanOrEqual(
+                value - new Vector<ushort>('\''),
+                new Vector<ushort>(':' - '\'')) & ~Vector.Equals(value, new Vector<ushort>('*'));
+
+            // Allow equals sign and question mark by setting their only differing bit before comparing with '?'.
+            allowed |= Vector.Equals(value | new Vector<ushort>(EqualsQuestionMarkMask), new Vector<ushort>('?'));
+
+            // Allow space.
+            allowed |= Vector.Equals(value, new Vector<ushort>(' '));
+
+            return Vector.AllWhereAllBitsSet(allowed);
+        }
+    }
+
     internal abstract class RestrictedAsciiRangeEncoding : SpanBasedEncoding
     {
         private readonly byte _minCharAllowed;

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ComprehensiveReadTests.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ComprehensiveReadTests.cs
@@ -25,6 +25,141 @@ namespace System.Formats.Asn1.Tests.Reader
             }
         }
 
+        public static IEnumerable<object[]> RestrictedAsciiVectorBoundaryData
+        {
+            get
+            {
+                foreach (UniversalTagNumber encodingType in new[] { UniversalTagNumber.NumericString, UniversalTagNumber.PrintableString })
+                {
+                    foreach (object[] length in VectorBoundaryLengths)
+                    {
+                        yield return new object[] { encodingType, length[0] };
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> RestrictedAsciiCharacterSets
+        {
+            get
+            {
+                yield return new object[] { UniversalTagNumber.NumericString, "0123456789 " };
+                yield return new object[]
+                {
+                    UniversalTagNumber.PrintableString,
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 '()+,-./:=?",
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> RestrictedAsciiInvalidData
+        {
+            get
+            {
+                byte[] numericInvalid = { (byte)'/', (byte)':', (byte)'A', 0x7F, 0xFF };
+                byte[] printableInvalid = { (byte)'!', (byte)'&', (byte)'*', (byte)';', (byte)'<', (byte)'>', (byte)'@', (byte)'[', (byte)'`', (byte)'{', 0x7F, 0xFF };
+
+                foreach (bool invalidInVector in new[] { true, false })
+                {
+                    foreach (byte invalidValue in numericInvalid)
+                    {
+                        yield return new object[] { UniversalTagNumber.NumericString, invalidInVector, invalidValue };
+                    }
+
+                    foreach (byte invalidValue in printableInvalid)
+                    {
+                        yield return new object[] { UniversalTagNumber.PrintableString, invalidInVector, invalidValue };
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RestrictedAsciiVectorBoundaryData))]
+        public static void ReadRestrictedAsciiString_DoesNotAccessOutsideBounds(
+            UniversalTagNumber encodingType,
+            int payloadLength)
+        {
+            AssertExtensions.LessThan(payloadLength, 128);
+
+            using BoundedMemory<byte> encoded = BoundedMemory.Allocate<byte>(payloadLength + 2);
+            using BoundedMemory<char> destination = BoundedMemory.Allocate<char>(payloadLength);
+
+            encoded.Span[0] = (byte)encodingType;
+            encoded.Span[1] = (byte)payloadLength;
+            encoded.Span.Slice(2).Fill((byte)'0');
+            encoded.MakeReadonly();
+
+            Assert.True(
+                AsnDecoder.TryReadCharacterString(
+                    encoded.Span,
+                    destination.Span,
+                    AsnEncodingRules.DER,
+                    encodingType,
+                    out int bytesConsumed,
+                    out int charsWritten));
+            Assert.Equal(encoded.Length, bytesConsumed);
+            Assert.Equal(payloadLength, charsWritten);
+            AssertExtensions.FilledWith('0', destination.Span);
+        }
+
+        [Theory]
+        [MemberData(nameof(RestrictedAsciiCharacterSets))]
+        public static void ReadRestrictedAsciiString_VectorSizedCharacterSet(
+            UniversalTagNumber encodingType,
+            string allowedCharacters)
+        {
+            const int PayloadLength = 128;
+            byte[] encoded = new byte[PayloadLength + 3];
+            char[] expected = new char[PayloadLength];
+            encoded[0] = (byte)encodingType;
+            encoded[1] = 0x81;
+            encoded[2] = PayloadLength;
+
+            for (int i = 0; i < PayloadLength; i++)
+            {
+                char value = allowedCharacters[i % allowedCharacters.Length];
+                encoded[i + 3] = (byte)value;
+                expected[i] = value;
+            }
+
+            Assert.Equal(
+                new string(expected),
+                AsnDecoder.ReadCharacterString(
+                    encoded,
+                    AsnEncodingRules.DER,
+                    encodingType,
+                    out int bytesConsumed));
+            Assert.Equal(encoded.Length, bytesConsumed);
+        }
+
+        [Theory]
+        [MemberData(nameof(RestrictedAsciiInvalidData))]
+        public static void ReadRestrictedAsciiString_Invalid(
+            UniversalTagNumber encodingType,
+            bool invalidInVector,
+            byte invalidValue)
+        {
+            int invalidIndex = invalidInVector ? 1 : Vector<byte>.Count;
+            int payloadLength = Vector<byte>.Count + 1;
+            AssertExtensions.LessThan(payloadLength, 128);
+
+            byte[] encoded = new byte[payloadLength + 2];
+            encoded[0] = (byte)encodingType;
+            encoded[1] = (byte)payloadLength;
+            encoded.AsSpan(2).Fill((byte)'0');
+            encoded[invalidIndex + 2] = invalidValue;
+
+            AsnContentException exception = Assert.Throws<AsnContentException>(
+                () => AsnDecoder.ReadCharacterString(
+                    encoded,
+                    AsnEncodingRules.DER,
+                    encodingType,
+                    out _));
+            DecoderFallbackException fallback = Assert.IsType<DecoderFallbackException>(exception.InnerException);
+            Assert.Equal(invalidIndex, fallback.Index);
+        }
+
         [Theory]
         [MemberData(nameof(VectorBoundaryLengths))]
         public static void ReadVisibleString_DoesNotAccessOutsideBounds(int payloadLength)

--- a/src/libraries/System.Formats.Asn1/tests/Writer/SimpleWriterTests.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/SimpleWriterTests.cs
@@ -22,6 +22,121 @@ namespace System.Formats.Asn1.Tests.Writer
             }
         }
 
+        public static IEnumerable<object[]> RestrictedAsciiVectorBoundaryData
+        {
+            get
+            {
+                foreach (UniversalTagNumber encodingType in new[] { UniversalTagNumber.NumericString, UniversalTagNumber.PrintableString })
+                {
+                    foreach (object[] length in VectorBoundaryLengths)
+                    {
+                        yield return new object[] { encodingType, length[0] };
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> RestrictedAsciiCharacterSets
+        {
+            get
+            {
+                yield return new object[] { UniversalTagNumber.NumericString, "0123456789 " };
+                yield return new object[]
+                {
+                    UniversalTagNumber.PrintableString,
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 '()+,-./:=?",
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> RestrictedAsciiInvalidData
+        {
+            get
+            {
+                char[] numericInvalid = { '/', ':', 'A', '\u007F', '\u00FF' };
+                char[] printableInvalid = { '!', '&', '*', ';', '<', '>', '@', '[', '`', '{', '\u007F', '\u00FF' };
+
+                foreach (bool invalidInVector in new[] { true, false })
+                {
+                    foreach (char invalidValue in numericInvalid)
+                    {
+                        yield return new object[] { UniversalTagNumber.NumericString, invalidInVector, invalidValue };
+                    }
+
+                    foreach (char invalidValue in printableInvalid)
+                    {
+                        yield return new object[] { UniversalTagNumber.PrintableString, invalidInVector, invalidValue };
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RestrictedAsciiVectorBoundaryData))]
+        public static void WriteRestrictedAsciiString_DoesNotAccessOutsideBounds(
+            UniversalTagNumber encodingType,
+            int payloadLength)
+        {
+            using BoundedMemory<char> value = BoundedMemory.Allocate<char>(payloadLength);
+            value.Span.Fill('0');
+            value.MakeReadonly();
+
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+            writer.WriteCharacterString(encodingType, value.Span);
+            byte[] encoded = writer.Encode();
+
+            string decoded = AsnDecoder.ReadCharacterString(
+                encoded,
+                AsnEncodingRules.DER,
+                encodingType,
+                out int bytesConsumed);
+            Assert.Equal(encoded.Length, bytesConsumed);
+            Assert.Equal(payloadLength, decoded.Length);
+            AssertExtensions.FilledWith('0', decoded);
+        }
+
+        [Theory]
+        [MemberData(nameof(RestrictedAsciiCharacterSets))]
+        public static void WriteRestrictedAsciiString_VectorSizedCharacterSet(
+            UniversalTagNumber encodingType,
+            string allowedCharacters)
+        {
+            const int PayloadLength = 128;
+            char[] value = new char[PayloadLength];
+
+            for (int i = 0; i < PayloadLength; i++)
+            {
+                value[i] = allowedCharacters[i % allowedCharacters.Length];
+            }
+
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+            writer.WriteCharacterString(encodingType, value);
+            byte[] encoded = writer.Encode();
+
+            Assert.Equal((byte)encodingType, encoded[0]);
+            Assert.Equal(0x81, encoded[1]);
+            Assert.Equal(PayloadLength, encoded[2]);
+            Assert.Equal(new string(value), Encoding.ASCII.GetString(encoded, 3, PayloadLength));
+        }
+
+        [Theory]
+        [MemberData(nameof(RestrictedAsciiInvalidData))]
+        public static void WriteRestrictedAsciiString_Invalid(
+            UniversalTagNumber encodingType,
+            bool invalidInVector,
+            char invalidValue)
+        {
+            int invalidIndex = invalidInVector ? 1 : Vector<byte>.Count;
+            char[] value = new string('0', Vector<byte>.Count + 1).ToCharArray();
+            value[invalidIndex] = invalidValue;
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+
+            EncoderFallbackException exception = Assert.Throws<EncoderFallbackException>(
+                () => writer.WriteCharacterString(encodingType, value));
+            Assert.Equal(invalidIndex, exception.Index);
+            Assert.Equal(0, writer.GetEncodedLength());
+        }
+
         [Theory]
         [MemberData(nameof(VectorBoundaryLengths))]
         public static void WriteVisibleString_DoesNotAccessOutsideBounds(int payloadLength)


### PR DESCRIPTION
A follow up to previous vectorizations for ASN.1 strings, this does PrintableString and NumericString. These are more "bespoke" because they do not have contiguous ranges of characters, rather they are made up of multiple ranges and characters, so a single vectorization range check is not sufficient.

The vectorization did regress small inputs, but this was won back by making the scalar path a little bit faster - so even the non-vectorized path is a bit faster now.

These encodings use their existing table lookup approach for the scalars, and have vectorized checks for large enough inputs.

<details>
<summary>PrintableString Benchmarks</summary>

| Method                 | Job    | Toolchain | Length | Mean        | Error    | Ratio |
|----------------------- |------- |---------- |------- |------------:|---------:|------:|
| **WriteCharacterString**   | **branch** | **branch**    | **2**      |    **11.77 ns** | **0.016 ns** |  **0.70** |
| WriteCharacterString   | main   | main      | 2      |    16.83 ns | 0.083 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 2      |    11.92 ns | 0.011 ns |  0.97 |
| TryReadCharacterString | main   | main      | 2      |    12.29 ns | 0.038 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **7**      |    **16.16 ns** | **0.023 ns** |  **0.70** |
| WriteCharacterString   | main   | main      | 7      |    23.22 ns | 0.031 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 7      |    16.32 ns | 0.019 ns |  0.89 |
| TryReadCharacterString | main   | main      | 7      |    18.24 ns | 0.014 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **8**      |    **17.02 ns** | **0.021 ns** |  **0.69** |
| WriteCharacterString   | main   | main      | 8      |    24.73 ns | 0.083 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 8      |    17.25 ns | 0.093 ns |  0.88 |
| TryReadCharacterString | main   | main      | 8      |    19.52 ns | 0.069 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **15**     |    **23.52 ns** | **0.026 ns** |  **0.70** |
| WriteCharacterString   | main   | main      | 15     |    33.81 ns | 0.164 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 15     |    23.86 ns | 0.096 ns |  0.85 |
| TryReadCharacterString | main   | main      | 15     |    28.14 ns | 0.083 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **16**     |    **17.86 ns** | **0.039 ns** |  **0.50** |
| WriteCharacterString   | main   | main      | 16     |    35.38 ns | 0.125 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 16     |    14.65 ns | 0.051 ns |  0.50 |
| TryReadCharacterString | main   | main      | 16     |    29.48 ns | 0.143 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **63**     |    **45.48 ns** | **0.058 ns** |  **0.43** |
| WriteCharacterString   | main   | main      | 63     |   106.50 ns | 0.613 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 63     |    36.68 ns | 0.078 ns |  0.38 |
| TryReadCharacterString | main   | main      | 63     |    95.88 ns | 0.355 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **64**     |    **38.48 ns** | **0.138 ns** |  **0.35** |
| WriteCharacterString   | main   | main      | 64     |   109.88 ns | 0.517 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 64     |    26.98 ns | 0.037 ns |  0.28 |
| TryReadCharacterString | main   | main      | 64     |    95.80 ns | 0.199 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **255**    |   **128.51 ns** | **0.244 ns** |  **0.33** |
| WriteCharacterString   | main   | main      | 255    |   390.09 ns | 0.281 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 255    |    87.15 ns | 0.262 ns |  0.25 |
| TryReadCharacterString | main   | main      | 255    |   347.64 ns | 0.379 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **256**    |   **122.32 ns** | **0.206 ns** |  **0.31** |
| WriteCharacterString   | main   | main      | 256    |   392.71 ns | 0.517 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 256    |    78.00 ns | 0.048 ns |  0.22 |
| TryReadCharacterString | main   | main      | 256    |   347.03 ns | 0.506 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **1023**   |   **466.70 ns** | **0.444 ns** |  **0.31** |
| WriteCharacterString   | main   | main      | 1023   | 1,523.45 ns | 5.969 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 1023   |   288.94 ns | 1.136 ns |  0.22 |
| TryReadCharacterString | main   | main      | 1023   | 1,313.19 ns | 2.315 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **1024**   |   **463.09 ns** | **1.999 ns** |  **0.30** |
| WriteCharacterString   | main   | main      | 1024   | 1,524.24 ns | 7.262 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 1024   |   279.07 ns | 0.623 ns |  0.21 |
| TryReadCharacterString | main   | main      | 1024   | 1,313.84 ns | 2.791 ns |  1.00 |
</details>

<details>
<summary>NumericString Benchmarks</summary>

| Method                 | Job    | Toolchain | Length | Mean        | Error    | Ratio |
|----------------------- |------- |---------- |------- |------------:|---------:|------:|
| **WriteCharacterString**   | **branch** | **branch**    | **2**      |    **11.78 ns** | **0.013 ns** |  **0.70** |
| WriteCharacterString   | main   | main      | 2      |    16.74 ns | 0.019 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 2      |    11.90 ns | 0.010 ns |  0.97 |
| TryReadCharacterString | main   | main      | 2      |    12.25 ns | 0.008 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **7**      |    **16.14 ns** | **0.026 ns** |  **0.69** |
| WriteCharacterString   | main   | main      | 7      |    23.23 ns | 0.025 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 7      |    16.30 ns | 0.023 ns |  0.89 |
| TryReadCharacterString | main   | main      | 7      |    18.22 ns | 0.017 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **8**      |    **16.98 ns** | **0.023 ns** |  **0.69** |
| WriteCharacterString   | main   | main      | 8      |    24.50 ns | 0.018 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 8      |    17.16 ns | 0.021 ns |  0.88 |
| TryReadCharacterString | main   | main      | 8      |    19.39 ns | 0.011 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **15**     |    **23.57 ns** | **0.027 ns** |  **0.70** |
| WriteCharacterString   | main   | main      | 15     |    33.64 ns | 0.038 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 15     |    23.75 ns | 0.027 ns |  0.85 |
| TryReadCharacterString | main   | main      | 15     |    27.99 ns | 0.016 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **16**     |    **13.65 ns** | **0.004 ns** |  **0.39** |
| WriteCharacterString   | main   | main      | 16     |    35.11 ns | 0.189 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 16     |    12.92 ns | 0.044 ns |  0.44 |
| TryReadCharacterString | main   | main      | 16     |    29.46 ns | 0.103 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **63**     |    **34.48 ns** | **0.201 ns** |  **0.32** |
| WriteCharacterString   | main   | main      | 63     |   106.13 ns | 0.216 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 63     |    32.46 ns | 0.418 ns |  0.32 |
| TryReadCharacterString | main   | main      | 63     |   102.14 ns | 0.518 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **64**     |    **23.81 ns** | **0.091 ns** |  **0.21** |
| WriteCharacterString   | main   | main      | 64     |   110.84 ns | 0.427 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 64     |    19.13 ns | 0.080 ns |  0.20 |
| TryReadCharacterString | main   | main      | 64     |    96.57 ns | 1.164 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **255**    |    **74.67 ns** | **0.347 ns** |  **0.19** |
| WriteCharacterString   | main   | main      | 255    |   392.64 ns | 1.178 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 255    |    57.97 ns | 0.184 ns |  0.16 |
| TryReadCharacterString | main   | main      | 255    |   351.81 ns | 3.648 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **256**    |    **65.00 ns** | **0.294 ns** |  **0.16** |
| WriteCharacterString   | main   | main      | 256    |   395.43 ns | 0.899 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 256    |    47.06 ns | 0.112 ns |  0.13 |
| TryReadCharacterString | main   | main      | 256    |   349.66 ns | 0.978 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **1023**   |   **246.12 ns** | **1.317 ns** |  **0.16** |
| WriteCharacterString   | main   | main      | 1023   | 1,524.13 ns | 5.078 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 1023   |   168.48 ns | 3.190 ns |  0.13 |
| TryReadCharacterString | main   | main      | 1023   | 1,323.03 ns | 7.395 ns |  1.00 |
|                        |        |           |        |             |          |       |
| **WriteCharacterString**   | **branch** | **branch**    | **1024**   |   **230.73 ns** | **0.594 ns** |  **0.15** |
| WriteCharacterString   | main   | main      | 1024   | 1,516.09 ns | 3.215 ns |  1.00 |
|                        |        |           |        |             |          |       |
| TryReadCharacterString | branch | branch    | 1024   |   152.72 ns | 0.163 ns |  0.12 |
| TryReadCharacterString | main   | main      | 1024   | 1,315.11 ns | 1.681 ns |  1.00 |
</details>