### PR TITLE
Ship hosting layer error codes as a public header

### DIFF
--- a/src/installer/pkg/archives/dotnet-nethost.proj
+++ b/src/installer/pkg/archives/dotnet-nethost.proj
@@ -21,6 +21,8 @@
             Destination="$(OutputPath)$(LibPrefix)nethost.lib" />
       <FilesToPublish Include="$(DotNetHostBinDir)\nethost.h"
             Destination="$(OutputPath)$(LibPrefix)nethost.h" />
+      <FilesToPublish Include="$(DotNetHostBinDir)\host_error_codes.h"
+            Destination="$(OutputPath)$(LibPrefix)host_error_codes.h" />
     </ItemGroup>
 
     <Copy SourceFiles="@(FilesToPublish)"

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/Microsoft.NETCore.DotNetAppHost.pkgproj
@@ -9,6 +9,7 @@
     <NativeBinary Include="$(DotNetHostBinDir)/$(LibPrefix)nethost$(StaticLibSuffix)" />
     <NativeBinary Include="$(DotNetHostBinDir)/coreclr_delegates.h" />
     <NativeBinary Include="$(DotNetHostBinDir)/hostfxr.h" />
+    <NativeBinary Include="$(DotNetHostBinDir)/host_error_codes.h" />
     <NativeBinary Include="$(DotNetHostBinDir)/nethost.h" />
   </ItemGroup>
   <ItemGroup Condition="'$(RuntimeFlavor)' != 'Mono' and '$(TargetsLinuxBionic)' != 'true'">

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
@@ -28,6 +28,7 @@
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/$(LibPrefix)nethost$(StaticLibSuffix)" />
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/nethost.h" />
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/hostfxr.h" />
+    <NativeRuntimeAsset Include="$(DotNetHostBinDir)/host_error_codes.h" />
     <NativeRuntimeAsset Include="$(DotNetHostBinDir)/coreclr_delegates.h" />
   </ItemGroup>
   <ItemGroup Condition="'$(RuntimeFlavor)' != 'Mono'">

--- a/src/native/corehost/error_codes.h
+++ b/src/native/corehost/error_codes.h
@@ -54,6 +54,8 @@ enum StatusCode
     HostFeatureDisabled                 = 0x800080a7,   // Support for a requested feature is disabled
 };
 
+#ifdef __cplusplus
 #define STATUS_CODE_SUCCEEDED(status_code) ((static_cast<int>(static_cast<StatusCode>(status_code))) >= 0)
+#endif // __cplusplus
 
 #endif // __ERROR_CODES_H__

--- a/src/native/corehost/error_codes.h
+++ b/src/native/corehost/error_codes.h
@@ -56,6 +56,8 @@ enum StatusCode
 
 #ifdef __cplusplus
 #define STATUS_CODE_SUCCEEDED(status_code) ((static_cast<int>(static_cast<StatusCode>(status_code))) >= 0)
+#else
+#define STATUS_CODE_SUCCEEDED(status_code) (((int)(status_code)) >= 0)
 #endif // __cplusplus
 
 #endif // __ERROR_CODES_H__

--- a/src/native/corehost/error_codes.h
+++ b/src/native/corehost/error_codes.h
@@ -54,10 +54,6 @@ enum StatusCode
     HostFeatureDisabled                 = 0x800080a7,   // Support for a requested feature is disabled
 };
 
-#ifdef __cplusplus
-#define STATUS_CODE_SUCCEEDED(status_code) ((static_cast<int>(static_cast<StatusCode>(status_code))) >= 0)
-#else
 #define STATUS_CODE_SUCCEEDED(status_code) (((int)(status_code)) >= 0)
-#endif // __cplusplus
 
 #endif // __ERROR_CODES_H__

--- a/src/native/corehost/nethost/CMakeLists.txt
+++ b/src/native/corehost/nethost/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries (libnethost PUBLIC ${CMAKE_DL_LIBS})
 
 install(FILES ../coreclr_delegates.h DESTINATION corehost)
 install(FILES ../hostfxr.h DESTINATION corehost)
+install(FILES ../error_codes.h DESTINATION corehost RENAME host_error_codes.h)
 install(FILES nethost.h DESTINATION corehost)
 install_with_stripped_symbols(nethost TARGETS corehost)
 

--- a/src/native/corehost/test/mockhostfxr/test_c_api.c
+++ b/src/native/corehost/test/mockhostfxr/test_c_api.c
@@ -6,5 +6,6 @@
 // Since the runtime repository primarily uses these APIs in C++ code, such issues
 // might not be caught during regular development or testing.
 #include <coreclr_delegates.h>
+#include <error_codes.h>
 #include <hostfxr.h>
 #include <nethost/nethost.h>


### PR DESCRIPTION
Ships the hosting `StatusCode` enum as a public `host_error_codes.h` header (alongside `nethost.h` and `hostfxr.h`) so native host consumers no longer need to manually redefine the error/exit codes returned by the hostfxr, hostpolicy, and nethost APIs. The header is packaged in the `Microsoft.NETCore.DotNetAppHost` package and is validated to compile as pure C.

Resolves #110891 

cc @dotnet/appmodel @AaronRobinsonMSFT 

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.