### PR TITLE
Add dataflow support for deconstruction assignments

### DIFF
--- a/src/coreclr/tools/ILTrim.Tests/ILTrimExpectedFailures.txt
+++ b/src/coreclr/tools/ILTrim.Tests/ILTrimExpectedFailures.txt
@@ -82,8 +82,9 @@ DataFlow.CompilerGeneratedTypes
 DataFlow.CompilerGeneratedTypesNet90
 DataFlow.CompilerGeneratedTypesRelease
 DataFlow.CompilerGeneratedTypesReleaseNet90
-DataFlow.ConstructedTypesDataFlow
 DataFlow.ConstructorDataFlow
+DataFlow.DeconstructFieldTarget
+DataFlow.DeconstructUserDefinedConversion
 DataFlow.DependencyInjectionPattern
 DataFlow.DynamicDependencyDataflow
 DataFlow.ExponentialDataFlow

--- a/src/coreclr/tools/ILTrim.Tests/ILTrimExpectedFailures.txt
+++ b/src/coreclr/tools/ILTrim.Tests/ILTrimExpectedFailures.txt
@@ -82,6 +82,7 @@ DataFlow.CompilerGeneratedTypes
 DataFlow.CompilerGeneratedTypesNet90
 DataFlow.CompilerGeneratedTypesRelease
 DataFlow.CompilerGeneratedTypesReleaseNet90
+DataFlow.ConstructedTypesDataFlow
 DataFlow.ConstructorDataFlow
 DataFlow.DependencyInjectionPattern
 DataFlow.DynamicDependencyDataflow

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -9,8 +9,11 @@ using System.Linq;
 using ILLink.RoslynAnalyzer.TrimAnalysis;
 using ILLink.Shared.DataFlow;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.Operations;
+
 namespace ILLink.RoslynAnalyzer.DataFlow
 {
     // Visitor which tracks the values of locals in a block. It provides extension points that get called
@@ -44,6 +47,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
         private readonly ControlFlowGraph ControlFlowGraph;
 
+        private readonly SemanticModel _semanticModel;
+
         protected TValue TopValue => LocalStateAndContextLattice.LocalStateLattice.Lattice.ValueLattice.Top;
 
         private readonly ImmutableDictionary<CaptureId, FlowCaptureKind> lValueFlowCaptures;
@@ -69,6 +74,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             InterproceduralStateLattice = default;
             OwningSymbol = owningSymbol;
             ControlFlowGraph = cfg;
+            _semanticModel = cfg.OriginalOperation.SemanticModel ??
+                compilation.GetSemanticModel(cfg.OriginalOperation.Syntax.SyntaxTree);
             this.lValueFlowCaptures = lValueFlowCaptures;
             InterproceduralState = interproceduralState;
         }
@@ -132,6 +139,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         public abstract TValue GetFieldTargetValue(IFieldReferenceOperation fieldReference, in TContext context);
 
         public abstract TValue GetBackingFieldTargetValue(IPropertyReferenceOperation propertyReference, in TContext context);
+
+        public abstract TValue GetTupleElementValue(IFieldSymbol tupleElement);
 
         public abstract TValue GetParameterTargetValue(IParameterSymbol parameter);
 
@@ -255,6 +264,30 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             bool merge
         )
         {
+            return ProcessSingleTargetAssignment(targetOperation, valueOperation, default, valueIsKnown: false, assignmentOperation, state, merge);
+        }
+
+        private TValue ProcessSingleTargetAssignment(
+            IOperation targetOperation,
+            TValue value,
+            IOperation assignmentOperation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
+            bool merge
+        )
+        {
+            return ProcessSingleTargetAssignment(targetOperation, valueOperation: null, value, valueIsKnown: true, assignmentOperation, state, merge);
+        }
+
+        private TValue ProcessSingleTargetAssignment(
+            IOperation targetOperation,
+            IOperation? valueOperation,
+            TValue value,
+            bool valueIsKnown,
+            IOperation assignmentOperation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
+            bool merge
+        )
+        {
             switch (targetOperation)
             {
                 case IFieldReferenceOperation fieldRef:
@@ -264,7 +297,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     Visit(fieldRef.Instance, state);
                     var current = state.Current;
                     TValue targetValue = GetFieldTargetValue(fieldRef, in current.Context);
-                    TValue value = Visit(valueOperation, state);
+                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleAssignment(value, targetValue, assignmentOperation, in current.Context);
                     return value;
                 }
@@ -272,7 +305,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     var current = state.Current;
                     TValue targetValue = GetParameterTargetValue(parameterRef.Parameter);
-                    TValue value = Visit(valueOperation, state);
+                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleAssignment(value, targetValue, assignmentOperation, in current.Context);
                     return value;
                 }
@@ -285,7 +318,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
                     // https://github.com/dotnet/roslyn/issues/25057
                     TValue instanceValue = Visit(propertyRef.Instance, state);
-                    TValue value = Visit(valueOperation, state);
+                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     IMethodSymbol? setMethod = propertyRef.Property.GetSetMethod();
 
                     if (setMethod == null ||
@@ -335,14 +368,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // not a call to an event accessor method. There is no Roslyn API to access the field,
                     // so just visit the instance and the value. https://github.com/dotnet/roslyn/issues/40103
                     Visit(eventRef.Instance, state);
-                    return Visit(valueOperation, state);
+                    return GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                 }
                 case IImplicitIndexerReferenceOperation indexerRef:
                 {
                     // An implicit reference to an indexer where the argument is a System.Index
                     TValue instanceValue = Visit(indexerRef.Instance, state);
                     TValue indexArgumentValue = Visit(indexerRef.Argument, state);
-                    TValue value = Visit(valueOperation, state);
+                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
 
                     var property = (IPropertySymbol)indexerRef.IndexerSymbol;
 
@@ -365,7 +398,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 // TODO: when setting a property in an attribute, target is an IPropertyReference.
                 case ILocalReferenceOperation localRef:
                 {
-                    TValue value = Visit(valueOperation, state);
+                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     SetLocal(localRef.Local, value, state, merge);
                     return value;
                 }
@@ -373,7 +406,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     if (declPattern.DeclaredSymbol is not ILocalSymbol declaredSymbol)
                         break;
-                    var value = Visit(valueOperation, state);
+                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     SetLocal(declaredSymbol, value, state, merge);
                     return value;
                 }
@@ -384,7 +417,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
                     TValue arrayRef = Visit(arrayElementRef.ArrayReference, state);
                     TValue index = Visit(arrayElementRef.Indices[0], state);
-                    TValue value = Visit(valueOperation, state);
+                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
@@ -392,7 +425,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     TValue arrayRef = Visit(inlineArrayAccess.Instance, state);
                     TValue index = Visit(inlineArrayAccess.Argument, state);
-                    TValue value = Visit(valueOperation, state);
+                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
@@ -424,7 +457,20 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     UnexpectedOperationHandler.Handle(targetOperation);
                     break;
             }
-            return Visit(valueOperation, state);
+            return GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+        }
+
+        private TValue GetAssignmentValue(
+            IOperation? valueOperation,
+            TValue value,
+            bool valueIsKnown,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            if (valueIsKnown)
+                return value;
+
+            Debug.Assert(valueOperation is not null);
+            return valueOperation is null ? TopValue : Visit(valueOperation, state);
         }
 
         public override TValue VisitSimpleAssignment(ISimpleAssignmentOperation operation, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
@@ -518,6 +564,307 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             return value;
         }
 
+        private TValue ProcessAssignment(
+            IOperation targetOperation,
+            TValue value,
+            IOperation assignmentOperation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            if (targetOperation is not IFlowCaptureReferenceOperation flowCaptureReference)
+                return ProcessSingleTargetAssignment(targetOperation, value, assignmentOperation, state, merge: false);
+
+            Debug.Assert(IsLValueFlowCapture(flowCaptureReference.Id));
+
+            var capturedReferences = state.Current.LocalState.CapturedReferences.Get(flowCaptureReference.Id);
+            Debug.Assert(!capturedReferences.IsUnknown());
+            if (!capturedReferences.HasMultipleValues)
+            {
+                var enumerator = capturedReferences.GetKnownValues().GetEnumerator();
+                enumerator.MoveNext();
+                return ProcessSingleTargetAssignment(enumerator.Current.Reference, value, assignmentOperation, state, merge: false);
+            }
+
+            TValue result = TopValue;
+            foreach (var capturedReference in capturedReferences.GetKnownValues())
+            {
+                TValue singleValue = ProcessSingleTargetAssignment(capturedReference.Reference, value, assignmentOperation, state, merge: true);
+                result = LocalStateAndContextLattice.LocalStateLattice.Lattice.ValueLattice.Meet(result, singleValue);
+            }
+
+            return result;
+        }
+
+        public override TValue VisitDeconstructionAssignment(
+            IDeconstructionAssignmentOperation operation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            DeconstructionInfo deconstructionInfo;
+            if (operation.Syntax is AssignmentExpressionSyntax assignmentSyntax)
+            {
+                deconstructionInfo = _semanticModel.GetDeconstructionInfo(assignmentSyntax);
+            }
+            else if (operation.Syntax.FirstAncestorOrSelf<ForEachVariableStatementSyntax>() is ForEachVariableStatementSyntax foreachSyntax)
+            {
+                deconstructionInfo = _semanticModel.GetDeconstructionInfo(foreachSyntax);
+            }
+            else
+            {
+                UnexpectedOperationHandler.Handle(operation);
+                return Visit(operation.Value, state);
+            }
+
+            ITypeSymbol? sourceType = operation.Value.Type;
+            IOperation source = UnwrapDeconstructionSource(operation.Value);
+            bool sourceValueIsKnown = source is not ITupleOperation;
+            TValue sourceValue = sourceValueIsKnown ? Visit(source, state) : TopValue;
+
+            // Deconstruction evaluates all source values before assigning any target. Keeping these
+            // phases separate is required for assignments such as (first, second) = (second, first).
+            DeconstructionValue deconstructionValue = EvaluateDeconstruction(
+                UnwrapDeconstructionTarget(operation.Target),
+                source,
+                sourceType,
+                sourceValue,
+                sourceValueIsKnown,
+                deconstructionInfo,
+                operation,
+                state);
+            AssignDeconstruction(
+                UnwrapDeconstructionTarget(operation.Target),
+                deconstructionValue,
+                operation,
+                state);
+
+            return sourceValue;
+        }
+
+        private readonly struct DeconstructionValue
+        {
+            public TValue Value { get; }
+
+            public ImmutableArray<DeconstructionValue> Nested { get; }
+
+            public bool IsInvalid { get; }
+
+            public DeconstructionValue(TValue value)
+            {
+                Value = value;
+                Nested = default;
+                IsInvalid = false;
+            }
+
+            public DeconstructionValue(ImmutableArray<DeconstructionValue> nested)
+            {
+                Value = default;
+                Nested = nested;
+                IsInvalid = false;
+            }
+
+            private DeconstructionValue(bool isInvalid)
+            {
+                Value = default;
+                Nested = default;
+                IsInvalid = isInvalid;
+            }
+
+            public static DeconstructionValue Invalid => new(isInvalid: true);
+        }
+
+        private DeconstructionValue EvaluateDeconstruction(
+            IOperation target,
+            IOperation? source,
+            ITypeSymbol? sourceType,
+            TValue sourceValue,
+            bool sourceValueIsKnown,
+            DeconstructionInfo deconstructionInfo,
+            IDeconstructionAssignmentOperation operation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            target = UnwrapDeconstructionTarget(target);
+
+            if (deconstructionInfo.Nested.IsDefaultOrEmpty)
+            {
+                if (target is ITupleOperation)
+                {
+                    UnexpectedOperationHandler.Handle(target);
+                    return DeconstructionValue.Invalid;
+                }
+
+                sourceValue = GetDeconstructionSourceValue(source, sourceValue, sourceValueIsKnown, state);
+                return new DeconstructionValue(
+                    deconstructionInfo.Conversion is { MethodSymbol: not null } ? TopValue : sourceValue);
+            }
+
+            if (target is not ITupleOperation targetTuple ||
+                targetTuple.Elements.Length != deconstructionInfo.Nested.Length)
+            {
+                UnexpectedOperationHandler.Handle(target);
+                return DeconstructionValue.Invalid;
+            }
+
+            if (deconstructionInfo.Method is IMethodSymbol deconstructMethod)
+            {
+                sourceValue = GetDeconstructionSourceValue(source, sourceValue, sourceValueIsKnown, state);
+                bool isExtensionMethod = deconstructMethod.IsExtensionMethod;
+                int outputParameterOffset = isExtensionMethod ? 1 : 0;
+                if (deconstructMethod.Parameters.Length != targetTuple.Elements.Length + outputParameterOffset)
+                {
+                    UnexpectedOperationHandler.Handle(operation);
+                    return DeconstructionValue.Invalid;
+                }
+
+                var arguments = ImmutableArray.CreateBuilder<TValue>(deconstructMethod.Parameters.Length);
+
+                TValue instanceValue = sourceValue;
+                if (isExtensionMethod)
+                {
+                    instanceValue = TopValue;
+                    arguments.Add(sourceValue);
+                }
+
+                while (arguments.Count < deconstructMethod.Parameters.Length)
+                    arguments.Add(TopValue);
+
+                HandleMethodCallHelper(
+                    deconstructMethod,
+                    instanceValue,
+                    arguments.MoveToImmutable(),
+                    source ?? target,
+                    state);
+
+                var nestedValues = ImmutableArray.CreateBuilder<DeconstructionValue>(targetTuple.Elements.Length);
+                for (int i = 0; i < targetTuple.Elements.Length; i++)
+                {
+                    IParameterSymbol outputParameter = deconstructMethod.Parameters[i + outputParameterOffset];
+                    nestedValues.Add(EvaluateDeconstruction(
+                        targetTuple.Elements[i],
+                        source: null,
+                        outputParameter.Type,
+                        GetParameterTargetValue(outputParameter),
+                        sourceValueIsKnown: true,
+                        deconstructionInfo.Nested[i],
+                        operation,
+                        state));
+                }
+
+                return new DeconstructionValue(nestedValues.MoveToImmutable());
+            }
+
+            if (source is ITupleOperation sourceTuple &&
+                sourceTuple.Elements.Length == targetTuple.Elements.Length)
+            {
+                var nestedValues = ImmutableArray.CreateBuilder<DeconstructionValue>(targetTuple.Elements.Length);
+                for (int i = 0; i < targetTuple.Elements.Length; i++)
+                {
+                    IOperation sourceElement = UnwrapDeconstructionSource(sourceTuple.Elements[i]);
+                    nestedValues.Add(EvaluateDeconstruction(
+                        targetTuple.Elements[i],
+                        sourceElement,
+                        sourceElement.Type,
+                        default,
+                        sourceValueIsKnown: false,
+                        deconstructionInfo.Nested[i],
+                        operation,
+                        state));
+                }
+
+                return new DeconstructionValue(nestedValues.MoveToImmutable());
+            }
+
+            if (sourceType is not INamedTypeSymbol { IsTupleType: true } tupleType ||
+                tupleType.TupleElements.Length != targetTuple.Elements.Length)
+            {
+                UnexpectedOperationHandler.Handle(operation.Value);
+                return DeconstructionValue.Invalid;
+            }
+
+            var tupleValues = ImmutableArray.CreateBuilder<DeconstructionValue>(targetTuple.Elements.Length);
+            for (int i = 0; i < targetTuple.Elements.Length; i++)
+            {
+                IFieldSymbol tupleElement = tupleType.TupleElements[i];
+                tupleValues.Add(EvaluateDeconstruction(
+                    targetTuple.Elements[i],
+                    source: null,
+                    tupleElement.Type,
+                    GetTupleElementValue(tupleElement),
+                    sourceValueIsKnown: true,
+                    deconstructionInfo.Nested[i],
+                    operation,
+                    state));
+            }
+
+            return new DeconstructionValue(tupleValues.MoveToImmutable());
+        }
+
+        private void AssignDeconstruction(
+            IOperation target,
+            DeconstructionValue value,
+            IDeconstructionAssignmentOperation operation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            if (value.IsInvalid)
+                return;
+
+            target = UnwrapDeconstructionTarget(target);
+            if (value.Nested.IsDefaultOrEmpty)
+            {
+                ProcessAssignment(target, value.Value, target, state);
+                return;
+            }
+
+            if (target is not ITupleOperation targetTuple ||
+                targetTuple.Elements.Length != value.Nested.Length)
+            {
+                UnexpectedOperationHandler.Handle(operation);
+                return;
+            }
+
+            for (int i = 0; i < targetTuple.Elements.Length; i++)
+                AssignDeconstruction(targetTuple.Elements[i], value.Nested[i], operation, state);
+        }
+
+        private TValue GetDeconstructionSourceValue(
+            IOperation? source,
+            TValue sourceValue,
+            bool sourceValueIsKnown,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            if (sourceValueIsKnown)
+                return sourceValue;
+
+            Debug.Assert(source is not null);
+            return source is null ? TopValue : Visit(source, state);
+        }
+
+        private static IOperation UnwrapDeconstructionTarget(IOperation target)
+        {
+            while (true)
+            {
+                switch (target)
+                {
+                    case IDeclarationExpressionOperation declaration:
+                        target = declaration.Expression;
+                        continue;
+                    case IConversionOperation conversion:
+                        target = conversion.Operand;
+                        continue;
+                    case IParenthesizedOperation parenthesized:
+                        target = parenthesized.Operand;
+                        continue;
+                    default:
+                        return target;
+                }
+            }
+        }
+
+        private static IOperation UnwrapDeconstructionSource(IOperation source)
+        {
+            while (source is IConversionOperation { OperatorMethod: null } conversion)
+                source = conversion.Operand;
+
+            return source;
+        }
+
         public override TValue VisitEventAssignment(IEventAssignmentOperation operation, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
         {
             var eventReference = (IEventReferenceOperation)operation.EventReference;
@@ -585,11 +932,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 // turns both arguments into flow capture references, instead of just passing a local
                 // reference for s.
 
-                // This can also happen for a deconstruction assignments, where the write is not to a byref.
-                // Once the analyzer implements support for deconstruction assignments (https://github.com/dotnet/linker/issues/3158),
-                // we can try enabling this assert to ensure that this case is only hit for byrefs.
-                // Debug.Assert(operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Reference),
-                //     $"{operation.Syntax.GetLocation().GetLineSpan()}");
+                Debug.Assert(operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Reference),
+                    $"{operation.Syntax.GetLocation().GetLineSpan()}");
                 return TopValue;
             }
 
@@ -708,10 +1052,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             if (operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Write))
             {
                 // Property references may be passed as ref/out parameters.
-                // Enable this assert once we have support for deconstruction assignments.
-                // https://github.com/dotnet/linker/issues/3158
-                // Debug.Assert(operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Reference),
-                //   $"{operation.Syntax.GetLocation().GetLineSpan()}");
+                Debug.Assert(operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Reference),
+                    $"{operation.Syntax.GetLocation().GetLineSpan()}");
                 return TopValue;
             }
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -318,7 +318,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     VisitTargetSubExpression(fieldRef.Instance, state, savedTargetValues);
                     var current = state.Current;
                     TValue targetValue = GetFieldTargetValue(fieldRef, in current.Context);
-                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
+                    TValue value = GetAssignmentValue();
                     HandleAssignment(value, targetValue, assignmentOperation, in current.Context);
                     return value;
                 }
@@ -326,7 +326,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     var current = state.Current;
                     TValue targetValue = GetParameterTargetValue(parameterRef.Parameter);
-                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
+                    TValue value = GetAssignmentValue();
                     HandleAssignment(value, targetValue, assignmentOperation, in current.Context);
                     return value;
                 }
@@ -339,7 +339,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
                     // https://github.com/dotnet/roslyn/issues/25057
                     TValue instanceValue = VisitTargetSubExpression(propertyRef.Instance, state, savedTargetValues);
-                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
+                    TValue value = GetAssignmentValue();
                     IMethodSymbol? setMethod = propertyRef.Property.GetSetMethod();
 
                     if (setMethod == null ||
@@ -389,14 +389,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // not a call to an event accessor method. There is no Roslyn API to access the field,
                     // so just visit the instance and the value. https://github.com/dotnet/roslyn/issues/40103
                     VisitTargetSubExpression(eventRef.Instance, state, savedTargetValues);
-                    return GetAssignmentValue(valueOperation, precomputedValue, state);
+                    return GetAssignmentValue();
                 }
                 case IImplicitIndexerReferenceOperation indexerRef:
                 {
                     // An implicit reference to an indexer where the argument is a System.Index
                     TValue instanceValue = VisitTargetSubExpression(indexerRef.Instance, state, savedTargetValues);
                     TValue indexArgumentValue = VisitTargetSubExpression(indexerRef.Argument, state, savedTargetValues);
-                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
+                    TValue value = GetAssignmentValue();
 
                     var property = (IPropertySymbol)indexerRef.IndexerSymbol;
 
@@ -419,7 +419,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 // TODO: when setting a property in an attribute, target is an IPropertyReference.
                 case ILocalReferenceOperation localRef:
                 {
-                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
+                    TValue value = GetAssignmentValue();
                     SetLocal(localRef.Local, value, state, merge);
                     return value;
                 }
@@ -427,7 +427,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     if (declPattern.DeclaredSymbol is not ILocalSymbol declaredSymbol)
                         break;
-                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
+                    TValue value = GetAssignmentValue();
                     SetLocal(declaredSymbol, value, state, merge);
                     return value;
                 }
@@ -438,7 +438,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
                     TValue arrayRef = VisitTargetSubExpression(arrayElementRef.ArrayReference, state, savedTargetValues);
                     TValue index = VisitTargetSubExpression(arrayElementRef.Indices[0], state, savedTargetValues);
-                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
+                    TValue value = GetAssignmentValue();
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
@@ -446,7 +446,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     TValue arrayRef = VisitTargetSubExpression(inlineArrayAccess.Instance, state, savedTargetValues);
                     TValue index = VisitTargetSubExpression(inlineArrayAccess.Argument, state, savedTargetValues);
-                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
+                    TValue value = GetAssignmentValue();
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
@@ -478,19 +478,16 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     UnexpectedOperationHandler.Handle(targetOperation);
                     break;
             }
-            return GetAssignmentValue(valueOperation, precomputedValue, state);
-        }
+            return GetAssignmentValue();
 
-        private TValue GetAssignmentValue(
-            IOperation? valueOperation,
-            TValue? precomputedValue,
-            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
-        {
-            if (precomputedValue.HasValue)
-                return precomputedValue.Value;
+            TValue GetAssignmentValue()
+            {
+                if (precomputedValue.HasValue)
+                    return precomputedValue.Value;
 
-            Debug.Assert(valueOperation is not null);
-            return valueOperation is null ? TopValue : Visit(valueOperation, state);
+                Debug.Assert(valueOperation is not null);
+                return valueOperation is null ? TopValue : Visit(valueOperation, state);
+            }
         }
 
         public override TValue VisitSimpleAssignment(ISimpleAssignmentOperation operation, LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -659,6 +659,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 deconstructionInfo,
                 operation,
                 state);
+            if (deconstructionValue.DoesNotReturn)
+            {
+                state.Current = LocalStateAndContextLattice.Top;
+                return sourceValue;
+            }
+
             AssignDeconstruction(
                 operation.Target,
                 deconstructionValue,
@@ -677,11 +683,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
             public bool IsInvalid { get; }
 
+            public bool DoesNotReturn { get; }
+
             public DeconstructionValue(TValue value)
             {
                 Value = value;
                 Nested = default;
                 IsInvalid = false;
+                DoesNotReturn = false;
             }
 
             public DeconstructionValue(ImmutableArray<DeconstructionValue> nested)
@@ -689,16 +698,20 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 Value = default;
                 Nested = nested;
                 IsInvalid = false;
+                DoesNotReturn = false;
             }
 
-            private DeconstructionValue(bool isInvalid)
+            private DeconstructionValue(bool isInvalid, bool doesNotReturn)
             {
                 Value = default;
                 Nested = default;
                 IsInvalid = isInvalid;
+                DoesNotReturn = doesNotReturn;
             }
 
-            public static DeconstructionValue Invalid => new(isInvalid: true);
+            public static DeconstructionValue Invalid => new(isInvalid: true, doesNotReturn: false);
+
+            public static DeconstructionValue NonReturning => new(isInvalid: false, doesNotReturn: true);
         }
 
         private DeconstructionValue EvaluateDeconstruction(
@@ -770,11 +783,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     target,
                     state.Current.Context);
 
+                if (deconstructMethod.TryGetAttribute(nameof(DoesNotReturnAttribute), out _))
+                    return DeconstructionValue.NonReturning;
+
                 var nestedValues = ImmutableArray.CreateBuilder<DeconstructionValue>(targetTuple.Elements.Length);
                 for (int i = 0; i < targetTuple.Elements.Length; i++)
                 {
                     IParameterSymbol outputParameter = deconstructMethod.Parameters[i + outputParameterOffset];
-                    nestedValues.Add(EvaluateDeconstruction(
+                    DeconstructionValue nestedValue = EvaluateDeconstruction(
                         targetTuple.Elements[i],
                         source: null,
                         outputParameter.Type,
@@ -782,7 +798,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                         sourceValueIsKnown: true,
                         deconstructionInfo.Nested[i],
                         operation,
-                        state));
+                        state);
+                    if (nestedValue.DoesNotReturn)
+                        return DeconstructionValue.NonReturning;
+                    nestedValues.Add(nestedValue);
                 }
 
                 return new DeconstructionValue(nestedValues.MoveToImmutable());
@@ -795,7 +814,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 for (int i = 0; i < targetTuple.Elements.Length; i++)
                 {
                     IOperation sourceElement = UnwrapDeconstructionSource(sourceTuple.Elements[i]);
-                    nestedValues.Add(EvaluateDeconstruction(
+                    DeconstructionValue nestedValue = EvaluateDeconstruction(
                         targetTuple.Elements[i],
                         sourceElement,
                         sourceElement.Type,
@@ -803,7 +822,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                         sourceValueIsKnown: false,
                         deconstructionInfo.Nested[i],
                         operation,
-                        state));
+                        state);
+                    if (nestedValue.DoesNotReturn)
+                        return DeconstructionValue.NonReturning;
+                    nestedValues.Add(nestedValue);
                 }
 
                 return new DeconstructionValue(nestedValues.MoveToImmutable());
@@ -820,7 +842,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             for (int i = 0; i < targetTuple.Elements.Length; i++)
             {
                 IFieldSymbol tupleElement = tupleType.TupleElements[i];
-                tupleValues.Add(EvaluateDeconstruction(
+                DeconstructionValue tupleValue = EvaluateDeconstruction(
                     targetTuple.Elements[i],
                     source: null,
                     tupleElement.Type,
@@ -828,7 +850,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     sourceValueIsKnown: true,
                     deconstructionInfo.Nested[i],
                     operation,
-                    state));
+                    state);
+                if (tupleValue.DoesNotReturn)
+                    return DeconstructionValue.NonReturning;
+                tupleValues.Add(tupleValue);
             }
 
             return new DeconstructionValue(tupleValues.MoveToImmutable());

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -50,9 +50,6 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
         private readonly SemanticModel _semanticModel;
 
-        // Values of target sub-expressions evaluated before the deconstruction source.
-        private Dictionary<IOperation, TValue>? _deconstructionTargetValues;
-
         protected TValue TopValue => LocalStateAndContextLattice.LocalStateLattice.Lattice.ValueLattice.Top;
 
         private readonly ImmutableDictionary<CaptureId, FlowCaptureKind> lValueFlowCaptures;
@@ -281,10 +278,19 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             TValue value,
             IOperation assignmentOperation,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
-            bool merge
+            bool merge,
+            IReadOnlyDictionary<IOperation, TValue>? savedTargetValues = null
         )
         {
-            return ProcessSingleTargetAssignment(targetOperation, valueOperation: null, value, valueIsKnown: true, assignmentOperation, state, merge);
+            return ProcessSingleTargetAssignment(
+                targetOperation,
+                valueOperation: null,
+                value,
+                valueIsKnown: true,
+                assignmentOperation,
+                state,
+                merge,
+                savedTargetValues);
         }
 
         private TValue ProcessSingleTargetAssignment(
@@ -294,7 +300,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             bool valueIsKnown,
             IOperation assignmentOperation,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
-            bool merge
+            bool merge,
+            IReadOnlyDictionary<IOperation, TValue>? savedTargetValues = null
         )
         {
             switch (targetOperation)
@@ -303,7 +310,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     // Visit the instance to ensure that method calls or other operations
                     // used as the instance are properly analyzed for diagnostics.
-                    VisitTargetSubExpression(fieldRef.Instance, state);
+                    VisitTargetSubExpression(fieldRef.Instance, state, savedTargetValues);
                     var current = state.Current;
                     TValue targetValue = GetFieldTargetValue(fieldRef, in current.Context);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
@@ -326,7 +333,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // Avoid visiting the property reference because for captured properties, we can't
                     // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
                     // https://github.com/dotnet/roslyn/issues/25057
-                    TValue instanceValue = VisitTargetSubExpression(propertyRef.Instance, state);
+                    TValue instanceValue = VisitTargetSubExpression(propertyRef.Instance, state, savedTargetValues);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     IMethodSymbol? setMethod = propertyRef.Property.GetSetMethod();
 
@@ -376,14 +383,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // Handles assignment to an event like 'Event = Handler;', which is a write to the underlying field,
                     // not a call to an event accessor method. There is no Roslyn API to access the field,
                     // so just visit the instance and the value. https://github.com/dotnet/roslyn/issues/40103
-                    VisitTargetSubExpression(eventRef.Instance, state);
+                    VisitTargetSubExpression(eventRef.Instance, state, savedTargetValues);
                     return GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                 }
                 case IImplicitIndexerReferenceOperation indexerRef:
                 {
                     // An implicit reference to an indexer where the argument is a System.Index
-                    TValue instanceValue = VisitTargetSubExpression(indexerRef.Instance, state);
-                    TValue indexArgumentValue = VisitTargetSubExpression(indexerRef.Argument, state);
+                    TValue instanceValue = VisitTargetSubExpression(indexerRef.Instance, state, savedTargetValues);
+                    TValue indexArgumentValue = VisitTargetSubExpression(indexerRef.Argument, state, savedTargetValues);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
 
                     var property = (IPropertySymbol)indexerRef.IndexerSymbol;
@@ -424,16 +431,16 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     if (arrayElementRef.Indices.Length != 1)
                         break;
 
-                    TValue arrayRef = VisitTargetSubExpression(arrayElementRef.ArrayReference, state);
-                    TValue index = VisitTargetSubExpression(arrayElementRef.Indices[0], state);
+                    TValue arrayRef = VisitTargetSubExpression(arrayElementRef.ArrayReference, state, savedTargetValues);
+                    TValue index = VisitTargetSubExpression(arrayElementRef.Indices[0], state, savedTargetValues);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
                 case IInlineArrayAccessOperation inlineArrayAccess:
                 {
-                    TValue arrayRef = VisitTargetSubExpression(inlineArrayAccess.Instance, state);
-                    TValue index = VisitTargetSubExpression(inlineArrayAccess.Argument, state);
+                    TValue arrayRef = VisitTargetSubExpression(inlineArrayAccess.Instance, state, savedTargetValues);
+                    TValue index = VisitTargetSubExpression(inlineArrayAccess.Argument, state, savedTargetValues);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
@@ -577,10 +584,11 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             IOperation targetOperation,
             TValue value,
             IOperation assignmentOperation,
-            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
+            IReadOnlyDictionary<IOperation, TValue> savedTargetValues)
         {
             if (targetOperation is not IFlowCaptureReferenceOperation flowCaptureReference)
-                return ProcessSingleTargetAssignment(targetOperation, value, assignmentOperation, state, merge: false);
+                return ProcessSingleTargetAssignment(targetOperation, value, assignmentOperation, state, merge: false, savedTargetValues);
 
             Debug.Assert(IsLValueFlowCapture(flowCaptureReference.Id));
 
@@ -590,13 +598,13 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             {
                 var enumerator = capturedReferences.GetKnownValues().GetEnumerator();
                 enumerator.MoveNext();
-                return ProcessSingleTargetAssignment(enumerator.Current.Reference, value, assignmentOperation, state, merge: false);
+                return ProcessSingleTargetAssignment(enumerator.Current.Reference, value, assignmentOperation, state, merge: false, savedTargetValues);
             }
 
             TValue result = TopValue;
             foreach (var capturedReference in capturedReferences.GetKnownValues())
             {
-                TValue singleValue = ProcessSingleTargetAssignment(capturedReference.Reference, value, assignmentOperation, state, merge: true);
+                TValue singleValue = ProcessSingleTargetAssignment(capturedReference.Reference, value, assignmentOperation, state, merge: true, savedTargetValues);
                 result = LocalStateAndContextLattice.LocalStateLattice.Lattice.ValueLattice.Meet(result, singleValue);
             }
 
@@ -622,42 +630,36 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 return Visit(operation.Value, state);
             }
 
-            Dictionary<IOperation, TValue>? previousDeconstructionTargetValues = _deconstructionTargetValues;
-            _deconstructionTargetValues = null;
-            try
-            {
-                // Identify target locations before evaluating the source, then reuse those values
-                // when writing instead of evaluating their sub-expressions again.
-                VisitDeconstructionTargetSideEffects(operation.Target, state);
+            var savedTargetValues = new Dictionary<IOperation, TValue>();
 
-                ITypeSymbol? sourceType = operation.Value.Type;
-                IOperation source = UnwrapDeconstructionSource(operation.Value);
-                bool sourceValueIsKnown = source is not ITupleOperation;
-                TValue sourceValue = sourceValueIsKnown ? Visit(source, state) : TopValue;
+            // Identify target locations before evaluating the source, then reuse those values
+            // when writing instead of evaluating their sub-expressions again.
+            VisitDeconstructionTargetSideEffects(operation.Target, state, savedTargetValues);
 
-                // Deconstruction evaluates all source values before assigning any target. Keeping these
-                // phases separate is required for assignments such as (first, second) = (second, first).
-                DeconstructionValue deconstructionValue = EvaluateDeconstruction(
-                    operation.Target,
-                    source,
-                    sourceType,
-                    sourceValue,
-                    sourceValueIsKnown,
-                    deconstructionInfo,
-                    operation,
-                    state);
-                AssignDeconstruction(
-                    operation.Target,
-                    deconstructionValue,
-                    operation,
-                    state);
+            ITypeSymbol? sourceType = operation.Value.Type;
+            IOperation source = UnwrapDeconstructionSource(operation.Value);
+            bool sourceValueIsKnown = source is not ITupleOperation;
+            TValue sourceValue = sourceValueIsKnown ? Visit(source, state) : TopValue;
 
-                return sourceValue;
-            }
-            finally
-            {
-                _deconstructionTargetValues = previousDeconstructionTargetValues;
-            }
+            // Deconstruction evaluates all source values before assigning any target. Keeping these
+            // phases separate is required for assignments such as (first, second) = (second, first).
+            DeconstructionValue deconstructionValue = EvaluateDeconstruction(
+                operation.Target,
+                source,
+                sourceType,
+                sourceValue,
+                sourceValueIsKnown,
+                deconstructionInfo,
+                operation,
+                state);
+            AssignDeconstruction(
+                operation.Target,
+                deconstructionValue,
+                operation,
+                state,
+                savedTargetValues);
+
+            return sourceValue;
         }
 
         private readonly struct DeconstructionValue
@@ -827,7 +829,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             IOperation target,
             DeconstructionValue value,
             IDeconstructionAssignmentOperation operation,
-            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
+            IReadOnlyDictionary<IOperation, TValue> savedTargetValues)
         {
             if (value.IsInvalid)
                 return;
@@ -835,7 +838,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             target = UnwrapDeconstructionTarget(target);
             if (value.Nested.IsDefaultOrEmpty)
             {
-                ProcessAssignment(target, value.Value, target, state);
+                ProcessAssignment(target, value.Value, target, state, savedTargetValues);
                 return;
             }
 
@@ -847,7 +850,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             }
 
             for (int i = 0; i < targetTuple.Elements.Length; i++)
-                AssignDeconstruction(targetTuple.Elements[i], value.Nested[i], operation, state);
+                AssignDeconstruction(targetTuple.Elements[i], value.Nested[i], operation, state, savedTargetValues);
         }
 
         private TValue GetDeconstructionSourceValue(
@@ -867,13 +870,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         // write can reuse it later instead of evaluating the expression a second time.
         private void EvaluateTargetSubExpression(
             IOperation? operation,
-            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
+            Dictionary<IOperation, TValue> savedTargetValues)
         {
             if (operation is null)
                 return;
 
             TValue value = Visit(operation, state);
-            (_deconstructionTargetValues ??= new Dictionary<IOperation, TValue>())[operation] = value;
+            savedTargetValues[operation] = value;
         }
 
         // Returns the value of an assignment target's sub-expression, reusing the value from
@@ -881,11 +885,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         // ordinary assignment nothing was evaluated ahead of time, so this just visits it.
         private TValue VisitTargetSubExpression(
             IOperation? operation,
-            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
+            IReadOnlyDictionary<IOperation, TValue>? savedTargetValues)
         {
             if (operation is not null &&
-                _deconstructionTargetValues is Dictionary<IOperation, TValue> targetValues &&
-                targetValues.TryGetValue(operation, out TValue value))
+                savedTargetValues is not null &&
+                savedTargetValues.TryGetValue(operation, out TValue value))
             {
                 return value;
             }
@@ -907,38 +912,39 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         // in ProcessSingleTargetAssignment, this case should be updated to match.
         private void VisitDeconstructionTargetSideEffects(
             IOperation target,
-            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
+            Dictionary<IOperation, TValue> savedTargetValues)
         {
             target = UnwrapDeconstructionTarget(target);
             if (target is ITupleOperation targetTuple)
             {
                 foreach (var element in targetTuple.Elements)
-                    VisitDeconstructionTargetSideEffects(element, state);
+                    VisitDeconstructionTargetSideEffects(element, state, savedTargetValues);
                 return;
             }
 
             switch (target)
             {
                 case IFieldReferenceOperation fieldRef:
-                    EvaluateTargetSubExpression(fieldRef.Instance, state);
+                    EvaluateTargetSubExpression(fieldRef.Instance, state, savedTargetValues);
                     break;
                 case IPropertyReferenceOperation propertyRef:
                     // Avoid visiting the property reference itself; see the similar comment in
                     // ProcessSingleTargetAssignment about https://github.com/dotnet/roslyn/issues/25057.
-                    EvaluateTargetSubExpression(propertyRef.Instance, state);
+                    EvaluateTargetSubExpression(propertyRef.Instance, state, savedTargetValues);
                     break;
                 case IArrayElementReferenceOperation arrayElementRef:
-                    EvaluateTargetSubExpression(arrayElementRef.ArrayReference, state);
+                    EvaluateTargetSubExpression(arrayElementRef.ArrayReference, state, savedTargetValues);
                     foreach (var index in arrayElementRef.Indices)
-                        EvaluateTargetSubExpression(index, state);
+                        EvaluateTargetSubExpression(index, state, savedTargetValues);
                     break;
                 case IInlineArrayAccessOperation inlineArrayAccess:
-                    EvaluateTargetSubExpression(inlineArrayAccess.Instance, state);
-                    EvaluateTargetSubExpression(inlineArrayAccess.Argument, state);
+                    EvaluateTargetSubExpression(inlineArrayAccess.Instance, state, savedTargetValues);
+                    EvaluateTargetSubExpression(inlineArrayAccess.Argument, state, savedTargetValues);
                     break;
                 case IImplicitIndexerReferenceOperation indexerRef:
-                    EvaluateTargetSubExpression(indexerRef.Instance, state);
-                    EvaluateTargetSubExpression(indexerRef.Argument, state);
+                    EvaluateTargetSubExpression(indexerRef.Instance, state, savedTargetValues);
+                    EvaluateTargetSubExpression(indexerRef.Argument, state, savedTargetValues);
                     break;
                 default:
                     // Locals, parameters, discards, and declaration expressions have no

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -54,6 +54,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
         private readonly ImmutableDictionary<CaptureId, FlowCaptureKind> lValueFlowCaptures;
 
+        private readonly ImmutableHashSet<CaptureId> _deconstructionLValueFlowCaptures;
+
         public InterproceduralState<TValue, TValueLattice> InterproceduralState;
 
         private bool IsLValueFlowCapture(CaptureId captureId)
@@ -78,6 +80,11 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             _semanticModel = cfg.OriginalOperation.SemanticModel ??
                 compilation.GetSemanticModel(cfg.OriginalOperation.Syntax.SyntaxTree);
             this.lValueFlowCaptures = lValueFlowCaptures;
+            _deconstructionLValueFlowCaptures = cfg
+                .DescendantOperations<IFlowCaptureReferenceOperation>(OperationKind.FlowCaptureReference)
+                .Where(reference => reference.IsInLeftOfDeconstructionAssignment(out _))
+                .Select(reference => reference.Id)
+                .ToImmutableHashSet();
             InterproceduralState = interproceduralState;
         }
 
@@ -871,12 +878,19 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         private void EvaluateTargetSubExpression(
             IOperation? operation,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
-            Dictionary<IOperation, TValue> savedTargetValues)
+            Dictionary<IOperation, TValue> savedTargetValues,
+            bool useCapturedTargetValues)
         {
             if (operation is null)
                 return;
 
-            TValue value = Visit(operation, state);
+            TValue value;
+            CapturedTargetValue<TValue> capturedTargetValue = state.Current.LocalState.CapturedTargetValues.Get(new CapturedTargetKey(operation));
+            if (useCapturedTargetValues && capturedTargetValue.HasValue)
+                value = capturedTargetValue.Value;
+            else
+                value = Visit(operation, state);
+
             savedTargetValues[operation] = value;
         }
 
@@ -893,6 +907,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 savedTargetValues.TryGetValue(operation, out TValue value))
             {
                 return value;
+            }
+
+            if (operation is not null &&
+                state.Current.LocalState.CapturedTargetValues.Get(new CapturedTargetKey(operation)) is { HasValue: true } capturedValue)
+            {
+                return capturedValue.Value;
             }
 
             return Visit(operation, state);
@@ -913,38 +933,49 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         private void VisitDeconstructionTargetSideEffects(
             IOperation target,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
-            Dictionary<IOperation, TValue> savedTargetValues)
+            Dictionary<IOperation, TValue> savedTargetValues,
+            bool useCapturedTargetValues = true)
         {
             target = UnwrapDeconstructionTarget(target);
             if (target is ITupleOperation targetTuple)
             {
                 foreach (var element in targetTuple.Elements)
-                    VisitDeconstructionTargetSideEffects(element, state, savedTargetValues);
+                    VisitDeconstructionTargetSideEffects(element, state, savedTargetValues, useCapturedTargetValues);
                 return;
             }
 
             switch (target)
             {
+                case IFlowCaptureReferenceOperation flowCaptureReference:
+                    Debug.Assert(IsLValueFlowCapture(flowCaptureReference.Id));
+                    var capturedReferences = state.Current.LocalState.CapturedReferences.Get(flowCaptureReference.Id);
+                    Debug.Assert(!capturedReferences.IsUnknown());
+                    foreach (var capturedReference in capturedReferences.GetKnownValues())
+                        VisitDeconstructionTargetSideEffects(capturedReference.Reference, state, savedTargetValues, useCapturedTargetValues);
+                    break;
                 case IFieldReferenceOperation fieldRef:
-                    EvaluateTargetSubExpression(fieldRef.Instance, state, savedTargetValues);
+                    EvaluateTargetSubExpression(fieldRef.Instance, state, savedTargetValues, useCapturedTargetValues);
                     break;
                 case IPropertyReferenceOperation propertyRef:
                     // Avoid visiting the property reference itself; see the similar comment in
                     // ProcessSingleTargetAssignment about https://github.com/dotnet/roslyn/issues/25057.
-                    EvaluateTargetSubExpression(propertyRef.Instance, state, savedTargetValues);
+                    EvaluateTargetSubExpression(propertyRef.Instance, state, savedTargetValues, useCapturedTargetValues);
+                    break;
+                case IEventReferenceOperation eventRef:
+                    EvaluateTargetSubExpression(eventRef.Instance, state, savedTargetValues, useCapturedTargetValues);
                     break;
                 case IArrayElementReferenceOperation arrayElementRef:
-                    EvaluateTargetSubExpression(arrayElementRef.ArrayReference, state, savedTargetValues);
+                    EvaluateTargetSubExpression(arrayElementRef.ArrayReference, state, savedTargetValues, useCapturedTargetValues);
                     foreach (var index in arrayElementRef.Indices)
-                        EvaluateTargetSubExpression(index, state, savedTargetValues);
+                        EvaluateTargetSubExpression(index, state, savedTargetValues, useCapturedTargetValues);
                     break;
                 case IInlineArrayAccessOperation inlineArrayAccess:
-                    EvaluateTargetSubExpression(inlineArrayAccess.Instance, state, savedTargetValues);
-                    EvaluateTargetSubExpression(inlineArrayAccess.Argument, state, savedTargetValues);
+                    EvaluateTargetSubExpression(inlineArrayAccess.Instance, state, savedTargetValues, useCapturedTargetValues);
+                    EvaluateTargetSubExpression(inlineArrayAccess.Argument, state, savedTargetValues, useCapturedTargetValues);
                     break;
                 case IImplicitIndexerReferenceOperation indexerRef:
-                    EvaluateTargetSubExpression(indexerRef.Instance, state, savedTargetValues);
-                    EvaluateTargetSubExpression(indexerRef.Argument, state, savedTargetValues);
+                    EvaluateTargetSubExpression(indexerRef.Instance, state, savedTargetValues, useCapturedTargetValues);
+                    EvaluateTargetSubExpression(indexerRef.Argument, state, savedTargetValues, useCapturedTargetValues);
                     break;
                 default:
                     // Locals, parameters, discards, and declaration expressions have no
@@ -1073,12 +1104,29 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 if (operation.Value is IFlowCaptureReferenceOperation)
                     return TopValue;
 
-                // Note: technically we should save some information about the value for LValue flow captures
-                // (for example, the object instance of a property reference) and avoid re-computing it when
-                // assigning to the FlowCaptureReference.
+                Dictionary<IOperation, TValue>? capturedTargetValues = null;
+                if (_deconstructionLValueFlowCaptures.Contains(operation.Id))
+                {
+                    capturedTargetValues = new Dictionary<IOperation, TValue>();
+                    VisitDeconstructionTargetSideEffects(
+                        operation.Value,
+                        state,
+                        capturedTargetValues,
+                        useCapturedTargetValues: false);
+                }
+
                 var capturedRef = new CapturedReferenceValue(operation.Value);
                 var currentState = state.Current;
                 currentState.LocalState.CapturedReferences.Set(operation.Id, capturedRef);
+                if (capturedTargetValues is not null)
+                {
+                    foreach (var capturedTargetValue in capturedTargetValues)
+                    {
+                        currentState.LocalState.CapturedTargetValues.Set(
+                            new CapturedTargetKey(capturedTargetValue.Key),
+                            new CapturedTargetValue<TValue>(capturedTargetValue.Value));
+                    }
+                }
                 state.Current = currentState;
                 return TopValue;
             }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -278,61 +278,6 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             return ProcessSingleTargetAssignment(targetOperation, valueOperation: null, value, valueIsKnown: true, assignmentOperation, state, merge);
         }
 
-        // Visits the side-effecting sub-expressions of an assignment target that identify *where*
-        // the assignment writes (the receiver instance, and/or index/argument sub-expressions),
-        // covering exactly the subset and order that ProcessSingleTargetAssignment visits before
-        // evaluating the value being assigned. Note that IPropertyReferenceOperation's explicit
-        // indexer Arguments are intentionally NOT covered here: today they are visited only after
-        // the value, inside ProcessSingleTargetAssignment's IPropertyReferenceOperation case. This
-        // method is shared by ProcessSingleTargetAssignment and VisitDeconstructionTargetSideEffects
-        // so that ordinary and deconstruction assignment evaluate target locations identically,
-        // including this known gap - fixing the evaluation order in this one place will fix it for
-        // both assignment forms.
-        private bool TryVisitAssignmentTargetInstance(
-            IOperation targetOperation,
-            out TValue instanceValue,
-            out ImmutableArray<TValue> indexValues,
-            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
-        {
-            switch (targetOperation)
-            {
-                case IFieldReferenceOperation fieldRef:
-                    // Visit the instance to ensure that method calls or other operations
-                    // used as the instance are properly analyzed for diagnostics.
-                    instanceValue = Visit(fieldRef.Instance, state);
-                    indexValues = default;
-                    return true;
-                case IEventReferenceOperation eventRef:
-                    instanceValue = Visit(eventRef.Instance, state);
-                    indexValues = default;
-                    return true;
-                case IPropertyReferenceOperation propertyRef:
-                    // Avoid visiting the property reference because for captured properties, we can't
-                    // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
-                    // https://github.com/dotnet/roslyn/issues/25057
-                    instanceValue = Visit(propertyRef.Instance, state);
-                    indexValues = default;
-                    return true;
-                case IImplicitIndexerReferenceOperation indexerRef:
-                    // An implicit reference to an indexer where the argument is a System.Index
-                    instanceValue = Visit(indexerRef.Instance, state);
-                    indexValues = ImmutableArray.Create(Visit(indexerRef.Argument, state));
-                    return true;
-                case IArrayElementReferenceOperation arrayElementRef when arrayElementRef.Indices.Length == 1:
-                    instanceValue = Visit(arrayElementRef.ArrayReference, state);
-                    indexValues = ImmutableArray.Create(Visit(arrayElementRef.Indices[0], state));
-                    return true;
-                case IInlineArrayAccessOperation inlineArrayAccess:
-                    instanceValue = Visit(inlineArrayAccess.Instance, state);
-                    indexValues = ImmutableArray.Create(Visit(inlineArrayAccess.Argument, state));
-                    return true;
-                default:
-                    instanceValue = default!;
-                    indexValues = default;
-                    return false;
-            }
-        }
-
         private TValue ProcessSingleTargetAssignment(
             IOperation targetOperation,
             IOperation? valueOperation,
@@ -347,7 +292,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             {
                 case IFieldReferenceOperation fieldRef:
                 {
-                    TryVisitAssignmentTargetInstance(fieldRef, out _, out _, state);
+                    // Visit the instance to ensure that method calls or other operations
+                    // used as the instance are properly analyzed for diagnostics.
+                    Visit(fieldRef.Instance, state);
                     var current = state.Current;
                     TValue targetValue = GetFieldTargetValue(fieldRef, in current.Context);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
@@ -367,7 +314,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 // to handle the LHS specially.
                 case IPropertyReferenceOperation propertyRef:
                 {
-                    TryVisitAssignmentTargetInstance(propertyRef, out TValue instanceValue, out _, state);
+                    // Avoid visiting the property reference because for captured properties, we can't
+                    // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
+                    // https://github.com/dotnet/roslyn/issues/25057
+                    TValue instanceValue = Visit(propertyRef.Instance, state);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     IMethodSymbol? setMethod = propertyRef.Property.GetSetMethod();
 
@@ -417,13 +367,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // Handles assignment to an event like 'Event = Handler;', which is a write to the underlying field,
                     // not a call to an event accessor method. There is no Roslyn API to access the field,
                     // so just visit the instance and the value. https://github.com/dotnet/roslyn/issues/40103
-                    TryVisitAssignmentTargetInstance(eventRef, out _, out _, state);
+                    Visit(eventRef.Instance, state);
                     return GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                 }
                 case IImplicitIndexerReferenceOperation indexerRef:
                 {
-                    TryVisitAssignmentTargetInstance(indexerRef, out TValue instanceValue, out ImmutableArray<TValue> indexValues, state);
-                    TValue indexArgumentValue = indexValues[0];
+                    // An implicit reference to an indexer where the argument is a System.Index
+                    TValue instanceValue = Visit(indexerRef.Instance, state);
+                    TValue indexArgumentValue = Visit(indexerRef.Argument, state);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
 
                     var property = (IPropertySymbol)indexerRef.IndexerSymbol;
@@ -461,18 +412,19 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 }
                 case IArrayElementReferenceOperation arrayElementRef:
                 {
-                    if (!TryVisitAssignmentTargetInstance(arrayElementRef, out TValue arrayRef, out ImmutableArray<TValue> indexValues, state))
+                    if (arrayElementRef.Indices.Length != 1)
                         break;
 
-                    TValue index = indexValues[0];
+                    TValue arrayRef = Visit(arrayElementRef.ArrayReference, state);
+                    TValue index = Visit(arrayElementRef.Indices[0], state);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
                 case IInlineArrayAccessOperation inlineArrayAccess:
                 {
-                    TryVisitAssignmentTargetInstance(inlineArrayAccess, out TValue arrayRef, out ImmutableArray<TValue> indexValues, state);
-                    TValue index = indexValues[0];
+                    TValue arrayRef = Visit(inlineArrayAccess.Instance, state);
+                    TValue index = Visit(inlineArrayAccess.Argument, state);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
@@ -661,16 +613,16 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 return Visit(operation.Value, state);
             }
 
-            // Like ordinary assignments (see ProcessSingleTargetAssignment), the side-effecting
-            // sub-expression that identifies a target location (a property/indexer/array-element
-            // receiver) must be evaluated before the source, matching left-to-right evaluation
-            // order. Unlike ordinary assignments, the actual write can't happen until every target
-            // location has been identified and every source value has been read, so this
-            // sub-expression gets visited again for effect when performing the write in
-            // AssignDeconstruction. Revisiting the same IOperation node for its side effect is safe:
-            // the pattern store used for intrinsic method calls merges patterns keyed by the same
-            // IOperation instance (see the analogous existing tolerance in ProcessAssignment for
-            // flow-capture targets with multiple captured references).
+            // Like ordinary assignments (see ProcessSingleTargetAssignment), any side-effecting
+            // sub-expressions that identify a target location (a property/indexer receiver and its
+            // index arguments, or an array reference and its index) must be evaluated before the
+            // source, matching left-to-right evaluation order. Unlike ordinary assignments, the
+            // actual write can't happen until every target location has been identified and every
+            // source value has been read, so these sub-expressions get visited again for effect
+            // when performing the write in AssignDeconstruction. Revisiting the same IOperation node
+            // for its side effect is safe: the pattern store used for intrinsic method calls merges
+            // patterns keyed by the same IOperation instance (see the analogous existing tolerance
+            // in ProcessAssignment for flow-capture targets with multiple captured references).
             VisitDeconstructionTargetSideEffects(UnwrapDeconstructionTarget(operation.Target), state);
 
             ITypeSymbol? sourceType = operation.Value.Type;
@@ -897,14 +849,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         }
 
         // Visits the side-effecting sub-expressions that identify a deconstruction target location
-        // (a property/indexer/array-element receiver, and any index sub-expressions that
-        // ProcessSingleTargetAssignment already visits before the value - see
-        // TryVisitAssignmentTargetInstance), without performing any write. This runs before the
-        // source is visited, so that e.g. 'arr' in '(arr[i], b) = (x, y)' is evaluated before 'x'/'y'
-        // are read, matching left-to-right evaluation order and Roslyn's own lowering
-        // (GetAssignmentTargetsAndSideEffects). Uses the same shared helper as
-        // ProcessSingleTargetAssignment so both assignment forms evaluate target locations
-        // identically, including any gaps in that shared logic (see TryVisitAssignmentTargetInstance).
+        // (a property/indexer receiver and its index arguments, or an array reference and its index),
+        // without performing any write. This runs before the source is visited, so that expressions
+        // like arr[F()] in '(arr[F()], b) = (x, y)' evaluate 'arr' and 'F()' before 'x'/'y' are read,
+        // matching left-to-right evaluation order and Roslyn's own lowering (GetAssignmentTargetsAndSideEffects).
         private void VisitDeconstructionTargetSideEffects(
             IOperation target,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
@@ -917,7 +865,36 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 return;
             }
 
-            TryVisitAssignmentTargetInstance(target, out _, out _, state);
+            switch (target)
+            {
+                case IFieldReferenceOperation fieldRef:
+                    Visit(fieldRef.Instance, state);
+                    break;
+                case IPropertyReferenceOperation propertyRef:
+                    // Avoid visiting the property reference itself; see the similar comment in
+                    // ProcessSingleTargetAssignment about https://github.com/dotnet/roslyn/issues/25057.
+                    Visit(propertyRef.Instance, state);
+                    foreach (var argument in propertyRef.Arguments)
+                        Visit(argument, state);
+                    break;
+                case IArrayElementReferenceOperation arrayElementRef:
+                    Visit(arrayElementRef.ArrayReference, state);
+                    foreach (var index in arrayElementRef.Indices)
+                        Visit(index, state);
+                    break;
+                case IInlineArrayAccessOperation inlineArrayAccess:
+                    Visit(inlineArrayAccess.Instance, state);
+                    Visit(inlineArrayAccess.Argument, state);
+                    break;
+                case IImplicitIndexerReferenceOperation indexerRef:
+                    Visit(indexerRef.Instance, state);
+                    Visit(indexerRef.Argument, state);
+                    break;
+                default:
+                    // Locals, parameters, discards, and declaration expressions have no
+                    // side-effecting sub-expression to evaluate ahead of the source.
+                    break;
+            }
         }
 
         private static IOperation UnwrapDeconstructionTarget(IOperation target)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -737,12 +737,15 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 while (arguments.Count < deconstructMethod.Parameters.Length)
                     arguments.Add(TopValue);
 
-                HandleMethodCallHelper(
+                // Key this synthesized Deconstruct() call on 'target', not 'source': 'source' may
+                // already be registered elsewhere under its own unrelated call pattern (e.g. if it's
+                // a method call), and reusing it here would incorrectly merge the two.
+                HandleMethodCall(
                     deconstructMethod,
                     instanceValue,
                     arguments.MoveToImmutable(),
-                    source ?? target,
-                    state);
+                    target,
+                    state.Current.Context);
 
                 var nestedValues = ImmutableArray.CreateBuilder<DeconstructionValue>(targetTuple.Elements.Length);
                 for (int i = 0; i < targetTuple.Elements.Length; i++)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -909,14 +909,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             IOperation? operation,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
             Dictionary<IOperation, TValue> savedTargetValues,
-            bool useCapturedTargetValues)
+            bool useStateCapturedTargetValues)
         {
             if (operation is null)
                 return;
 
             TValue value;
             CapturedTargetValue<TValue> capturedTargetValue = state.Current.LocalState.CapturedTargetValues.Get(new CapturedTargetKey(operation));
-            if (useCapturedTargetValues && capturedTargetValue.HasValue)
+            if (useStateCapturedTargetValues && capturedTargetValue.HasValue)
                 value = capturedTargetValue.Value;
             else
                 value = Visit(operation, state);
@@ -964,13 +964,13 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             IOperation target,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
             Dictionary<IOperation, TValue> savedTargetValues,
-            bool useCapturedTargetValues = true)
+            bool useStateCapturedTargetValues = true)
         {
             target = UnwrapDeconstructionTarget(target);
             if (target is ITupleOperation targetTuple)
             {
                 foreach (var element in targetTuple.Elements)
-                    VisitDeconstructionTargetSideEffects(element, state, savedTargetValues, useCapturedTargetValues);
+                    VisitDeconstructionTargetSideEffects(element, state, savedTargetValues, useStateCapturedTargetValues);
                 return;
             }
 
@@ -981,31 +981,31 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     var capturedReferences = state.Current.LocalState.CapturedReferences.Get(flowCaptureReference.Id);
                     Debug.Assert(!capturedReferences.IsUnknown());
                     foreach (var capturedReference in capturedReferences.GetKnownValues())
-                        VisitDeconstructionTargetSideEffects(capturedReference.Reference, state, savedTargetValues, useCapturedTargetValues);
+                        VisitDeconstructionTargetSideEffects(capturedReference.Reference, state, savedTargetValues, useStateCapturedTargetValues);
                     break;
                 case IFieldReferenceOperation fieldRef:
-                    EvaluateTargetSubExpression(fieldRef.Instance, state, savedTargetValues, useCapturedTargetValues);
+                    EvaluateTargetSubExpression(fieldRef.Instance, state, savedTargetValues, useStateCapturedTargetValues);
                     break;
                 case IPropertyReferenceOperation propertyRef:
                     // Avoid visiting the property reference itself; see the similar comment in
                     // ProcessSingleTargetAssignment about https://github.com/dotnet/roslyn/issues/25057.
-                    EvaluateTargetSubExpression(propertyRef.Instance, state, savedTargetValues, useCapturedTargetValues);
+                    EvaluateTargetSubExpression(propertyRef.Instance, state, savedTargetValues, useStateCapturedTargetValues);
                     break;
                 case IEventReferenceOperation eventRef:
-                    EvaluateTargetSubExpression(eventRef.Instance, state, savedTargetValues, useCapturedTargetValues);
+                    EvaluateTargetSubExpression(eventRef.Instance, state, savedTargetValues, useStateCapturedTargetValues);
                     break;
                 case IArrayElementReferenceOperation arrayElementRef:
-                    EvaluateTargetSubExpression(arrayElementRef.ArrayReference, state, savedTargetValues, useCapturedTargetValues);
+                    EvaluateTargetSubExpression(arrayElementRef.ArrayReference, state, savedTargetValues, useStateCapturedTargetValues);
                     foreach (var index in arrayElementRef.Indices)
-                        EvaluateTargetSubExpression(index, state, savedTargetValues, useCapturedTargetValues);
+                        EvaluateTargetSubExpression(index, state, savedTargetValues, useStateCapturedTargetValues);
                     break;
                 case IInlineArrayAccessOperation inlineArrayAccess:
-                    EvaluateTargetSubExpression(inlineArrayAccess.Instance, state, savedTargetValues, useCapturedTargetValues);
-                    EvaluateTargetSubExpression(inlineArrayAccess.Argument, state, savedTargetValues, useCapturedTargetValues);
+                    EvaluateTargetSubExpression(inlineArrayAccess.Instance, state, savedTargetValues, useStateCapturedTargetValues);
+                    EvaluateTargetSubExpression(inlineArrayAccess.Argument, state, savedTargetValues, useStateCapturedTargetValues);
                     break;
                 case IImplicitIndexerReferenceOperation indexerRef:
-                    EvaluateTargetSubExpression(indexerRef.Instance, state, savedTargetValues, useCapturedTargetValues);
-                    EvaluateTargetSubExpression(indexerRef.Argument, state, savedTargetValues, useCapturedTargetValues);
+                    EvaluateTargetSubExpression(indexerRef.Instance, state, savedTargetValues, useStateCapturedTargetValues);
+                    EvaluateTargetSubExpression(indexerRef.Argument, state, savedTargetValues, useStateCapturedTargetValues);
                     break;
                 default:
                     // Locals, parameters, discards, and declaration expressions have no
@@ -1134,27 +1134,27 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 if (operation.Value is IFlowCaptureReferenceOperation)
                     return TopValue;
 
-                Dictionary<IOperation, TValue>? capturedTargetValues = null;
+                Dictionary<IOperation, TValue>? evaluatedTargetValues = null;
                 if (_deconstructionLValueFlowCaptures.Contains(operation.Id))
                 {
-                    capturedTargetValues = new Dictionary<IOperation, TValue>();
+                    evaluatedTargetValues = new Dictionary<IOperation, TValue>();
                     VisitDeconstructionTargetSideEffects(
                         operation.Value,
                         state,
-                        capturedTargetValues,
-                        useCapturedTargetValues: false);
+                        evaluatedTargetValues,
+                        useStateCapturedTargetValues: false);
                 }
 
                 var capturedRef = new CapturedReferenceValue(operation.Value);
                 var currentState = state.Current;
                 currentState.LocalState.CapturedReferences.Set(operation.Id, capturedRef);
-                if (capturedTargetValues is not null)
+                if (evaluatedTargetValues is not null)
                 {
-                    foreach (var capturedTargetValue in capturedTargetValues)
+                    foreach (var evaluatedTargetValue in evaluatedTargetValues)
                     {
                         currentState.LocalState.CapturedTargetValues.Set(
-                            new CapturedTargetKey(capturedTargetValue.Key),
-                            new CapturedTargetValue<TValue>(capturedTargetValue.Value));
+                            new CapturedTargetKey(evaluatedTargetValue.Key),
+                            new CapturedTargetValue<TValue>(evaluatedTargetValue.Value));
                     }
                 }
                 state.Current = currentState;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -849,10 +849,17 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         }
 
         // Visits the side-effecting sub-expressions that identify a deconstruction target location
-        // (a property/indexer receiver and its index arguments, or an array reference and its index),
-        // without performing any write. This runs before the source is visited, so that expressions
-        // like arr[F()] in '(arr[F()], b) = (x, y)' evaluate 'arr' and 'F()' before 'x'/'y' are read,
-        // matching left-to-right evaluation order and Roslyn's own lowering (GetAssignmentTargetsAndSideEffects).
+        // (a property/indexer receiver, or an array reference and its index), without performing
+        // any write. This runs before the source is visited, so that e.g. 'arr' in
+        // '(arr[i], b) = (x, y)' is evaluated before 'x'/'y' are read, matching left-to-right
+        // evaluation order and Roslyn's own lowering (GetAssignmentTargetsAndSideEffects).
+        //
+        // Note: IPropertyReferenceOperation's explicit indexer Arguments are intentionally NOT
+        // visited here, to match ProcessSingleTargetAssignment's IPropertyReferenceOperation case,
+        // which today only visits those Arguments after the value (a known, pre-existing ordering
+        // quirk - unlike the implicit System.Index-based indexer and array-element cases below,
+        // which already visit their index arguments before the value). If that quirk is ever fixed
+        // in ProcessSingleTargetAssignment, this case should be updated to match.
         private void VisitDeconstructionTargetSideEffects(
             IOperation target,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
@@ -874,8 +881,6 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // Avoid visiting the property reference itself; see the similar comment in
                     // ProcessSingleTargetAssignment about https://github.com/dotnet/roslyn/issues/25057.
                     Visit(propertyRef.Instance, state);
-                    foreach (var argument in propertyRef.Arguments)
-                        Visit(argument, state);
                     break;
                 case IArrayElementReferenceOperation arrayElementRef:
                     Visit(arrayElementRef.ArrayReference, state);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -142,6 +142,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
         public abstract TValue GetTupleElementValue(IFieldSymbol tupleElement);
 
+        // Returns the value produced by applying a user-defined conversion operator to a value.
+        // This mirrors the handling of IConversionOperation with an OperatorMethod, which the
+        // deconstruction path doesn't go through because the conversion is described by the
+        // DeconstructionInfo rather than by an operation in the tree.
+        public abstract TValue GetConversionValue(IMethodSymbol conversionOperator, TValue operandValue);
+
         public abstract TValue GetParameterTargetValue(IParameterSymbol parameter);
 
         public abstract void HandleAssignment(
@@ -704,7 +710,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
                 sourceValue = GetDeconstructionSourceValue(source, sourceValue, sourceValueIsKnown, state);
                 return new DeconstructionValue(
-                    deconstructionInfo.Conversion is { MethodSymbol: not null } ? TopValue : sourceValue);
+                    deconstructionInfo.Conversion is { MethodSymbol: IMethodSymbol conversionOperator }
+                        ? GetConversionValue(conversionOperator, sourceValue)
+                        : sourceValue);
             }
 
             if (target is not ITupleOperation targetTuple ||
@@ -1001,8 +1009,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 // turns both arguments into flow capture references, instead of just passing a local
                 // reference for s.
 
-                Debug.Assert(operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Reference),
-                    $"{operation.Syntax.GetLocation().GetLineSpan()}");
+                // This is also reachable for writes which are not byrefs, because increment/decrement
+                // (IIncrementOrDecrementOperation) and coalescing assignment (ICoalesceAssignmentOperation)
+                // are not handled here and fall back to the base visitor, which visits the write target
+                // directly. Enabling the following assert requires handling those first.
+                // Debug.Assert(operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Reference),
+                //     $"{operation.Syntax.GetLocation().GetLineSpan()}");
                 return TopValue;
             }
 
@@ -1121,8 +1133,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             if (operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Write))
             {
                 // Property references may be passed as ref/out parameters.
-                Debug.Assert(operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Reference),
-                    $"{operation.Syntax.GetLocation().GetLineSpan()}");
+                // This is also reachable for writes which are not byrefs, because increment/decrement
+                // (IIncrementOrDecrementOperation) and coalescing assignment (ICoalesceAssignmentOperation)
+                // are not handled here and fall back to the base visitor, which visits the write target
+                // directly. Enabling the following assert requires handling those first.
+                // Debug.Assert(operation.GetValueUsageInfo(OwningSymbol).HasFlag(ValueUsageInfo.Reference),
+                //     $"{operation.Syntax.GetLocation().GetLineSpan()}");
                 return TopValue;
             }
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -623,7 +623,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             // for its side effect is safe: the pattern store used for intrinsic method calls merges
             // patterns keyed by the same IOperation instance (see the analogous existing tolerance
             // in ProcessAssignment for flow-capture targets with multiple captured references).
-            VisitDeconstructionTargetSideEffects(UnwrapDeconstructionTarget(operation.Target), state);
+            VisitDeconstructionTargetSideEffects(operation.Target, state);
 
             ITypeSymbol? sourceType = operation.Value.Type;
             IOperation source = UnwrapDeconstructionSource(operation.Value);
@@ -633,7 +633,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             // Deconstruction evaluates all source values before assigning any target. Keeping these
             // phases separate is required for assignments such as (first, second) = (second, first).
             DeconstructionValue deconstructionValue = EvaluateDeconstruction(
-                UnwrapDeconstructionTarget(operation.Target),
+                operation.Target,
                 source,
                 sourceType,
                 sourceValue,
@@ -642,7 +642,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 operation,
                 state);
             AssignDeconstruction(
-                UnwrapDeconstructionTarget(operation.Target),
+                operation.Target,
                 deconstructionValue,
                 operation,
                 state);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -277,7 +277,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             bool merge
         )
         {
-            return ProcessSingleTargetAssignment(targetOperation, valueOperation, default, valueIsKnown: false, assignmentOperation, state, merge);
+            return ProcessSingleTargetAssignment(targetOperation, valueOperation, precomputedValue: null, assignmentOperation, state, merge);
         }
 
         private TValue ProcessSingleTargetAssignment(
@@ -292,8 +292,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             return ProcessSingleTargetAssignment(
                 targetOperation,
                 valueOperation: null,
-                value,
-                valueIsKnown: true,
+                precomputedValue: value,
                 assignmentOperation,
                 state,
                 merge,
@@ -303,8 +302,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         private TValue ProcessSingleTargetAssignment(
             IOperation targetOperation,
             IOperation? valueOperation,
-            TValue value,
-            bool valueIsKnown,
+            TValue? precomputedValue,
             IOperation assignmentOperation,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state,
             bool merge,
@@ -320,7 +318,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     VisitTargetSubExpression(fieldRef.Instance, state, savedTargetValues);
                     var current = state.Current;
                     TValue targetValue = GetFieldTargetValue(fieldRef, in current.Context);
-                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
                     HandleAssignment(value, targetValue, assignmentOperation, in current.Context);
                     return value;
                 }
@@ -328,7 +326,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     var current = state.Current;
                     TValue targetValue = GetParameterTargetValue(parameterRef.Parameter);
-                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
                     HandleAssignment(value, targetValue, assignmentOperation, in current.Context);
                     return value;
                 }
@@ -341,7 +339,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
                     // https://github.com/dotnet/roslyn/issues/25057
                     TValue instanceValue = VisitTargetSubExpression(propertyRef.Instance, state, savedTargetValues);
-                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
                     IMethodSymbol? setMethod = propertyRef.Property.GetSetMethod();
 
                     if (setMethod == null ||
@@ -391,14 +389,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // not a call to an event accessor method. There is no Roslyn API to access the field,
                     // so just visit the instance and the value. https://github.com/dotnet/roslyn/issues/40103
                     VisitTargetSubExpression(eventRef.Instance, state, savedTargetValues);
-                    return GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+                    return GetAssignmentValue(valueOperation, precomputedValue, state);
                 }
                 case IImplicitIndexerReferenceOperation indexerRef:
                 {
                     // An implicit reference to an indexer where the argument is a System.Index
                     TValue instanceValue = VisitTargetSubExpression(indexerRef.Instance, state, savedTargetValues);
                     TValue indexArgumentValue = VisitTargetSubExpression(indexerRef.Argument, state, savedTargetValues);
-                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
 
                     var property = (IPropertySymbol)indexerRef.IndexerSymbol;
 
@@ -421,7 +419,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 // TODO: when setting a property in an attribute, target is an IPropertyReference.
                 case ILocalReferenceOperation localRef:
                 {
-                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
                     SetLocal(localRef.Local, value, state, merge);
                     return value;
                 }
@@ -429,7 +427,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     if (declPattern.DeclaredSymbol is not ILocalSymbol declaredSymbol)
                         break;
-                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
                     SetLocal(declaredSymbol, value, state, merge);
                     return value;
                 }
@@ -440,7 +438,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
                     TValue arrayRef = VisitTargetSubExpression(arrayElementRef.ArrayReference, state, savedTargetValues);
                     TValue index = VisitTargetSubExpression(arrayElementRef.Indices[0], state, savedTargetValues);
-                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
@@ -448,7 +446,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     TValue arrayRef = VisitTargetSubExpression(inlineArrayAccess.Instance, state, savedTargetValues);
                     TValue index = VisitTargetSubExpression(inlineArrayAccess.Argument, state, savedTargetValues);
-                    value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+                    TValue value = GetAssignmentValue(valueOperation, precomputedValue, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
@@ -480,17 +478,16 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     UnexpectedOperationHandler.Handle(targetOperation);
                     break;
             }
-            return GetAssignmentValue(valueOperation, value, valueIsKnown, state);
+            return GetAssignmentValue(valueOperation, precomputedValue, state);
         }
 
         private TValue GetAssignmentValue(
             IOperation? valueOperation,
-            TValue value,
-            bool valueIsKnown,
+            TValue? precomputedValue,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
         {
-            if (valueIsKnown)
-                return value;
+            if (precomputedValue.HasValue)
+                return precomputedValue.Value;
 
             Debug.Assert(valueOperation is not null);
             return valueOperation is null ? TopValue : Visit(valueOperation, state);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -613,6 +613,18 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 return Visit(operation.Value, state);
             }
 
+            // Like ordinary assignments (see ProcessSingleTargetAssignment), any side-effecting
+            // sub-expressions that identify a target location (a property/indexer receiver and its
+            // index arguments, or an array reference and its index) must be evaluated before the
+            // source, matching left-to-right evaluation order. Unlike ordinary assignments, the
+            // actual write can't happen until every target location has been identified and every
+            // source value has been read, so these sub-expressions get visited again for effect
+            // when performing the write in AssignDeconstruction. Revisiting the same IOperation node
+            // for its side effect is safe: the pattern store used for intrinsic method calls merges
+            // patterns keyed by the same IOperation instance (see the analogous existing tolerance
+            // in ProcessAssignment for flow-capture targets with multiple captured references).
+            VisitDeconstructionTargetSideEffects(UnwrapDeconstructionTarget(operation.Target), state);
+
             ITypeSymbol? sourceType = operation.Value.Type;
             IOperation source = UnwrapDeconstructionSource(operation.Value);
             bool sourceValueIsKnown = source is not ITupleOperation;
@@ -834,6 +846,55 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
             Debug.Assert(source is not null);
             return source is null ? TopValue : Visit(source, state);
+        }
+
+        // Visits the side-effecting sub-expressions that identify a deconstruction target location
+        // (a property/indexer receiver and its index arguments, or an array reference and its index),
+        // without performing any write. This runs before the source is visited, so that expressions
+        // like arr[F()] in '(arr[F()], b) = (x, y)' evaluate 'arr' and 'F()' before 'x'/'y' are read,
+        // matching left-to-right evaluation order and Roslyn's own lowering (GetAssignmentTargetsAndSideEffects).
+        private void VisitDeconstructionTargetSideEffects(
+            IOperation target,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            target = UnwrapDeconstructionTarget(target);
+            if (target is ITupleOperation targetTuple)
+            {
+                foreach (var element in targetTuple.Elements)
+                    VisitDeconstructionTargetSideEffects(element, state);
+                return;
+            }
+
+            switch (target)
+            {
+                case IFieldReferenceOperation fieldRef:
+                    Visit(fieldRef.Instance, state);
+                    break;
+                case IPropertyReferenceOperation propertyRef:
+                    // Avoid visiting the property reference itself; see the similar comment in
+                    // ProcessSingleTargetAssignment about https://github.com/dotnet/roslyn/issues/25057.
+                    Visit(propertyRef.Instance, state);
+                    foreach (var argument in propertyRef.Arguments)
+                        Visit(argument, state);
+                    break;
+                case IArrayElementReferenceOperation arrayElementRef:
+                    Visit(arrayElementRef.ArrayReference, state);
+                    foreach (var index in arrayElementRef.Indices)
+                        Visit(index, state);
+                    break;
+                case IInlineArrayAccessOperation inlineArrayAccess:
+                    Visit(inlineArrayAccess.Instance, state);
+                    Visit(inlineArrayAccess.Argument, state);
+                    break;
+                case IImplicitIndexerReferenceOperation indexerRef:
+                    Visit(indexerRef.Instance, state);
+                    Visit(indexerRef.Argument, state);
+                    break;
+                default:
+                    // Locals, parameters, discards, and declaration expressions have no
+                    // side-effecting sub-expression to evaluate ahead of the source.
+                    break;
+            }
         }
 
         private static IOperation UnwrapDeconstructionTarget(IOperation target)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -143,9 +143,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         public abstract TValue GetTupleElementValue(IFieldSymbol tupleElement);
 
         // Returns the value produced by applying a user-defined conversion operator to a value.
-        // This mirrors the handling of IConversionOperation with an OperatorMethod, which the
-        // deconstruction path doesn't go through because the conversion is described by the
-        // DeconstructionInfo rather than by an operation in the tree.
+        // The deconstruction path needs this because there the conversion is described by the
+        // DeconstructionInfo rather than by a conversion operation in the tree.
         public abstract TValue GetConversionValue(IMethodSymbol conversionOperator, TValue operandValue);
 
         public abstract TValue GetParameterTargetValue(IParameterSymbol parameter);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -48,6 +49,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         private readonly ControlFlowGraph ControlFlowGraph;
 
         private readonly SemanticModel _semanticModel;
+
+        // Values of target sub-expressions evaluated before the deconstruction source.
+        private Dictionary<IOperation, TValue>? _deconstructionTargetValues;
 
         protected TValue TopValue => LocalStateAndContextLattice.LocalStateLattice.Lattice.ValueLattice.Top;
 
@@ -299,7 +303,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 {
                     // Visit the instance to ensure that method calls or other operations
                     // used as the instance are properly analyzed for diagnostics.
-                    Visit(fieldRef.Instance, state);
+                    VisitTargetSubExpression(fieldRef.Instance, state);
                     var current = state.Current;
                     TValue targetValue = GetFieldTargetValue(fieldRef, in current.Context);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
@@ -322,7 +326,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // Avoid visiting the property reference because for captured properties, we can't
                     // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
                     // https://github.com/dotnet/roslyn/issues/25057
-                    TValue instanceValue = Visit(propertyRef.Instance, state);
+                    TValue instanceValue = VisitTargetSubExpression(propertyRef.Instance, state);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     IMethodSymbol? setMethod = propertyRef.Property.GetSetMethod();
 
@@ -372,14 +376,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // Handles assignment to an event like 'Event = Handler;', which is a write to the underlying field,
                     // not a call to an event accessor method. There is no Roslyn API to access the field,
                     // so just visit the instance and the value. https://github.com/dotnet/roslyn/issues/40103
-                    Visit(eventRef.Instance, state);
+                    VisitTargetSubExpression(eventRef.Instance, state);
                     return GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                 }
                 case IImplicitIndexerReferenceOperation indexerRef:
                 {
                     // An implicit reference to an indexer where the argument is a System.Index
-                    TValue instanceValue = Visit(indexerRef.Instance, state);
-                    TValue indexArgumentValue = Visit(indexerRef.Argument, state);
+                    TValue instanceValue = VisitTargetSubExpression(indexerRef.Instance, state);
+                    TValue indexArgumentValue = VisitTargetSubExpression(indexerRef.Argument, state);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
 
                     var property = (IPropertySymbol)indexerRef.IndexerSymbol;
@@ -420,16 +424,16 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     if (arrayElementRef.Indices.Length != 1)
                         break;
 
-                    TValue arrayRef = Visit(arrayElementRef.ArrayReference, state);
-                    TValue index = Visit(arrayElementRef.Indices[0], state);
+                    TValue arrayRef = VisitTargetSubExpression(arrayElementRef.ArrayReference, state);
+                    TValue index = VisitTargetSubExpression(arrayElementRef.Indices[0], state);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
                 case IInlineArrayAccessOperation inlineArrayAccess:
                 {
-                    TValue arrayRef = Visit(inlineArrayAccess.Instance, state);
-                    TValue index = Visit(inlineArrayAccess.Argument, state);
+                    TValue arrayRef = VisitTargetSubExpression(inlineArrayAccess.Instance, state);
+                    TValue index = VisitTargetSubExpression(inlineArrayAccess.Argument, state);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
@@ -618,41 +622,42 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 return Visit(operation.Value, state);
             }
 
-            // Like ordinary assignments (see ProcessSingleTargetAssignment), any side-effecting
-            // sub-expressions that identify a target location (a property/indexer receiver and its
-            // index arguments, or an array reference and its index) must be evaluated before the
-            // source, matching left-to-right evaluation order. Unlike ordinary assignments, the
-            // actual write can't happen until every target location has been identified and every
-            // source value has been read, so these sub-expressions get visited again for effect
-            // when performing the write in AssignDeconstruction. Revisiting the same IOperation node
-            // for its side effect is safe: the pattern store used for intrinsic method calls merges
-            // patterns keyed by the same IOperation instance (see the analogous existing tolerance
-            // in ProcessAssignment for flow-capture targets with multiple captured references).
-            VisitDeconstructionTargetSideEffects(operation.Target, state);
+            Dictionary<IOperation, TValue>? previousDeconstructionTargetValues = _deconstructionTargetValues;
+            _deconstructionTargetValues = null;
+            try
+            {
+                // Identify target locations before evaluating the source, then reuse those values
+                // when writing instead of evaluating their sub-expressions again.
+                VisitDeconstructionTargetSideEffects(operation.Target, state);
 
-            ITypeSymbol? sourceType = operation.Value.Type;
-            IOperation source = UnwrapDeconstructionSource(operation.Value);
-            bool sourceValueIsKnown = source is not ITupleOperation;
-            TValue sourceValue = sourceValueIsKnown ? Visit(source, state) : TopValue;
+                ITypeSymbol? sourceType = operation.Value.Type;
+                IOperation source = UnwrapDeconstructionSource(operation.Value);
+                bool sourceValueIsKnown = source is not ITupleOperation;
+                TValue sourceValue = sourceValueIsKnown ? Visit(source, state) : TopValue;
 
-            // Deconstruction evaluates all source values before assigning any target. Keeping these
-            // phases separate is required for assignments such as (first, second) = (second, first).
-            DeconstructionValue deconstructionValue = EvaluateDeconstruction(
-                operation.Target,
-                source,
-                sourceType,
-                sourceValue,
-                sourceValueIsKnown,
-                deconstructionInfo,
-                operation,
-                state);
-            AssignDeconstruction(
-                operation.Target,
-                deconstructionValue,
-                operation,
-                state);
+                // Deconstruction evaluates all source values before assigning any target. Keeping these
+                // phases separate is required for assignments such as (first, second) = (second, first).
+                DeconstructionValue deconstructionValue = EvaluateDeconstruction(
+                    operation.Target,
+                    source,
+                    sourceType,
+                    sourceValue,
+                    sourceValueIsKnown,
+                    deconstructionInfo,
+                    operation,
+                    state);
+                AssignDeconstruction(
+                    operation.Target,
+                    deconstructionValue,
+                    operation,
+                    state);
 
-            return sourceValue;
+                return sourceValue;
+            }
+            finally
+            {
+                _deconstructionTargetValues = previousDeconstructionTargetValues;
+            }
         }
 
         private readonly struct DeconstructionValue
@@ -858,6 +863,36 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             return source is null ? TopValue : Visit(source, state);
         }
 
+        // Evaluates a deconstruction target sub-expression and remembers its value, so that the
+        // write can reuse it later instead of evaluating the expression a second time.
+        private void EvaluateTargetSubExpression(
+            IOperation? operation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            if (operation is null)
+                return;
+
+            TValue value = Visit(operation, state);
+            (_deconstructionTargetValues ??= new Dictionary<IOperation, TValue>())[operation] = value;
+        }
+
+        // Returns the value of an assignment target's sub-expression, reusing the value from
+        // EvaluateTargetSubExpression if it was already evaluated for a deconstruction. For an
+        // ordinary assignment nothing was evaluated ahead of time, so this just visits it.
+        private TValue VisitTargetSubExpression(
+            IOperation? operation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            if (operation is not null &&
+                _deconstructionTargetValues is Dictionary<IOperation, TValue> targetValues &&
+                targetValues.TryGetValue(operation, out TValue value))
+            {
+                return value;
+            }
+
+            return Visit(operation, state);
+        }
+
         // Visits the side-effecting sub-expressions that identify a deconstruction target location
         // (a property/indexer receiver, or an array reference and its index), without performing
         // any write. This runs before the source is visited, so that e.g. 'arr' in
@@ -885,25 +920,25 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             switch (target)
             {
                 case IFieldReferenceOperation fieldRef:
-                    Visit(fieldRef.Instance, state);
+                    EvaluateTargetSubExpression(fieldRef.Instance, state);
                     break;
                 case IPropertyReferenceOperation propertyRef:
                     // Avoid visiting the property reference itself; see the similar comment in
                     // ProcessSingleTargetAssignment about https://github.com/dotnet/roslyn/issues/25057.
-                    Visit(propertyRef.Instance, state);
+                    EvaluateTargetSubExpression(propertyRef.Instance, state);
                     break;
                 case IArrayElementReferenceOperation arrayElementRef:
-                    Visit(arrayElementRef.ArrayReference, state);
+                    EvaluateTargetSubExpression(arrayElementRef.ArrayReference, state);
                     foreach (var index in arrayElementRef.Indices)
-                        Visit(index, state);
+                        EvaluateTargetSubExpression(index, state);
                     break;
                 case IInlineArrayAccessOperation inlineArrayAccess:
-                    Visit(inlineArrayAccess.Instance, state);
-                    Visit(inlineArrayAccess.Argument, state);
+                    EvaluateTargetSubExpression(inlineArrayAccess.Instance, state);
+                    EvaluateTargetSubExpression(inlineArrayAccess.Argument, state);
                     break;
                 case IImplicitIndexerReferenceOperation indexerRef:
-                    Visit(indexerRef.Instance, state);
-                    Visit(indexerRef.Argument, state);
+                    EvaluateTargetSubExpression(indexerRef.Instance, state);
+                    EvaluateTargetSubExpression(indexerRef.Argument, state);
                     break;
                 default:
                     // Locals, parameters, discards, and declaration expressions have no

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -278,6 +278,61 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             return ProcessSingleTargetAssignment(targetOperation, valueOperation: null, value, valueIsKnown: true, assignmentOperation, state, merge);
         }
 
+        // Visits the side-effecting sub-expressions of an assignment target that identify *where*
+        // the assignment writes (the receiver instance, and/or index/argument sub-expressions),
+        // covering exactly the subset and order that ProcessSingleTargetAssignment visits before
+        // evaluating the value being assigned. Note that IPropertyReferenceOperation's explicit
+        // indexer Arguments are intentionally NOT covered here: today they are visited only after
+        // the value, inside ProcessSingleTargetAssignment's IPropertyReferenceOperation case. This
+        // method is shared by ProcessSingleTargetAssignment and VisitDeconstructionTargetSideEffects
+        // so that ordinary and deconstruction assignment evaluate target locations identically,
+        // including this known gap - fixing the evaluation order in this one place will fix it for
+        // both assignment forms.
+        private bool TryVisitAssignmentTargetInstance(
+            IOperation targetOperation,
+            out TValue instanceValue,
+            out ImmutableArray<TValue> indexValues,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            switch (targetOperation)
+            {
+                case IFieldReferenceOperation fieldRef:
+                    // Visit the instance to ensure that method calls or other operations
+                    // used as the instance are properly analyzed for diagnostics.
+                    instanceValue = Visit(fieldRef.Instance, state);
+                    indexValues = default;
+                    return true;
+                case IEventReferenceOperation eventRef:
+                    instanceValue = Visit(eventRef.Instance, state);
+                    indexValues = default;
+                    return true;
+                case IPropertyReferenceOperation propertyRef:
+                    // Avoid visiting the property reference because for captured properties, we can't
+                    // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
+                    // https://github.com/dotnet/roslyn/issues/25057
+                    instanceValue = Visit(propertyRef.Instance, state);
+                    indexValues = default;
+                    return true;
+                case IImplicitIndexerReferenceOperation indexerRef:
+                    // An implicit reference to an indexer where the argument is a System.Index
+                    instanceValue = Visit(indexerRef.Instance, state);
+                    indexValues = ImmutableArray.Create(Visit(indexerRef.Argument, state));
+                    return true;
+                case IArrayElementReferenceOperation arrayElementRef when arrayElementRef.Indices.Length == 1:
+                    instanceValue = Visit(arrayElementRef.ArrayReference, state);
+                    indexValues = ImmutableArray.Create(Visit(arrayElementRef.Indices[0], state));
+                    return true;
+                case IInlineArrayAccessOperation inlineArrayAccess:
+                    instanceValue = Visit(inlineArrayAccess.Instance, state);
+                    indexValues = ImmutableArray.Create(Visit(inlineArrayAccess.Argument, state));
+                    return true;
+                default:
+                    instanceValue = default!;
+                    indexValues = default;
+                    return false;
+            }
+        }
+
         private TValue ProcessSingleTargetAssignment(
             IOperation targetOperation,
             IOperation? valueOperation,
@@ -292,9 +347,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             {
                 case IFieldReferenceOperation fieldRef:
                 {
-                    // Visit the instance to ensure that method calls or other operations
-                    // used as the instance are properly analyzed for diagnostics.
-                    Visit(fieldRef.Instance, state);
+                    TryVisitAssignmentTargetInstance(fieldRef, out _, out _, state);
                     var current = state.Current;
                     TValue targetValue = GetFieldTargetValue(fieldRef, in current.Context);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
@@ -314,10 +367,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 // to handle the LHS specially.
                 case IPropertyReferenceOperation propertyRef:
                 {
-                    // Avoid visiting the property reference because for captured properties, we can't
-                    // correctly detect whether it is used for reading or writing inside of VisitPropertyReference.
-                    // https://github.com/dotnet/roslyn/issues/25057
-                    TValue instanceValue = Visit(propertyRef.Instance, state);
+                    TryVisitAssignmentTargetInstance(propertyRef, out TValue instanceValue, out _, state);
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     IMethodSymbol? setMethod = propertyRef.Property.GetSetMethod();
 
@@ -367,14 +417,13 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                     // Handles assignment to an event like 'Event = Handler;', which is a write to the underlying field,
                     // not a call to an event accessor method. There is no Roslyn API to access the field,
                     // so just visit the instance and the value. https://github.com/dotnet/roslyn/issues/40103
-                    Visit(eventRef.Instance, state);
+                    TryVisitAssignmentTargetInstance(eventRef, out _, out _, state);
                     return GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                 }
                 case IImplicitIndexerReferenceOperation indexerRef:
                 {
-                    // An implicit reference to an indexer where the argument is a System.Index
-                    TValue instanceValue = Visit(indexerRef.Instance, state);
-                    TValue indexArgumentValue = Visit(indexerRef.Argument, state);
+                    TryVisitAssignmentTargetInstance(indexerRef, out TValue instanceValue, out ImmutableArray<TValue> indexValues, state);
+                    TValue indexArgumentValue = indexValues[0];
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
 
                     var property = (IPropertySymbol)indexerRef.IndexerSymbol;
@@ -412,19 +461,18 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 }
                 case IArrayElementReferenceOperation arrayElementRef:
                 {
-                    if (arrayElementRef.Indices.Length != 1)
+                    if (!TryVisitAssignmentTargetInstance(arrayElementRef, out TValue arrayRef, out ImmutableArray<TValue> indexValues, state))
                         break;
 
-                    TValue arrayRef = Visit(arrayElementRef.ArrayReference, state);
-                    TValue index = Visit(arrayElementRef.Indices[0], state);
+                    TValue index = indexValues[0];
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
                 }
                 case IInlineArrayAccessOperation inlineArrayAccess:
                 {
-                    TValue arrayRef = Visit(inlineArrayAccess.Instance, state);
-                    TValue index = Visit(inlineArrayAccess.Argument, state);
+                    TryVisitAssignmentTargetInstance(inlineArrayAccess, out TValue arrayRef, out ImmutableArray<TValue> indexValues, state);
+                    TValue index = indexValues[0];
                     value = GetAssignmentValue(valueOperation, value, valueIsKnown, state);
                     HandleArrayElementWrite(arrayRef, index, value, assignmentOperation, merge: merge);
                     return value;
@@ -613,16 +661,16 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 return Visit(operation.Value, state);
             }
 
-            // Like ordinary assignments (see ProcessSingleTargetAssignment), any side-effecting
-            // sub-expressions that identify a target location (a property/indexer receiver and its
-            // index arguments, or an array reference and its index) must be evaluated before the
-            // source, matching left-to-right evaluation order. Unlike ordinary assignments, the
-            // actual write can't happen until every target location has been identified and every
-            // source value has been read, so these sub-expressions get visited again for effect
-            // when performing the write in AssignDeconstruction. Revisiting the same IOperation node
-            // for its side effect is safe: the pattern store used for intrinsic method calls merges
-            // patterns keyed by the same IOperation instance (see the analogous existing tolerance
-            // in ProcessAssignment for flow-capture targets with multiple captured references).
+            // Like ordinary assignments (see ProcessSingleTargetAssignment), the side-effecting
+            // sub-expression that identifies a target location (a property/indexer/array-element
+            // receiver) must be evaluated before the source, matching left-to-right evaluation
+            // order. Unlike ordinary assignments, the actual write can't happen until every target
+            // location has been identified and every source value has been read, so this
+            // sub-expression gets visited again for effect when performing the write in
+            // AssignDeconstruction. Revisiting the same IOperation node for its side effect is safe:
+            // the pattern store used for intrinsic method calls merges patterns keyed by the same
+            // IOperation instance (see the analogous existing tolerance in ProcessAssignment for
+            // flow-capture targets with multiple captured references).
             VisitDeconstructionTargetSideEffects(UnwrapDeconstructionTarget(operation.Target), state);
 
             ITypeSymbol? sourceType = operation.Value.Type;
@@ -849,10 +897,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         }
 
         // Visits the side-effecting sub-expressions that identify a deconstruction target location
-        // (a property/indexer receiver and its index arguments, or an array reference and its index),
-        // without performing any write. This runs before the source is visited, so that expressions
-        // like arr[F()] in '(arr[F()], b) = (x, y)' evaluate 'arr' and 'F()' before 'x'/'y' are read,
-        // matching left-to-right evaluation order and Roslyn's own lowering (GetAssignmentTargetsAndSideEffects).
+        // (a property/indexer/array-element receiver, and any index sub-expressions that
+        // ProcessSingleTargetAssignment already visits before the value - see
+        // TryVisitAssignmentTargetInstance), without performing any write. This runs before the
+        // source is visited, so that e.g. 'arr' in '(arr[i], b) = (x, y)' is evaluated before 'x'/'y'
+        // are read, matching left-to-right evaluation order and Roslyn's own lowering
+        // (GetAssignmentTargetsAndSideEffects). Uses the same shared helper as
+        // ProcessSingleTargetAssignment so both assignment forms evaluate target locations
+        // identically, including any gaps in that shared logic (see TryVisitAssignmentTargetInstance).
         private void VisitDeconstructionTargetSideEffects(
             IOperation target,
             LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
@@ -865,36 +917,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 return;
             }
 
-            switch (target)
-            {
-                case IFieldReferenceOperation fieldRef:
-                    Visit(fieldRef.Instance, state);
-                    break;
-                case IPropertyReferenceOperation propertyRef:
-                    // Avoid visiting the property reference itself; see the similar comment in
-                    // ProcessSingleTargetAssignment about https://github.com/dotnet/roslyn/issues/25057.
-                    Visit(propertyRef.Instance, state);
-                    foreach (var argument in propertyRef.Arguments)
-                        Visit(argument, state);
-                    break;
-                case IArrayElementReferenceOperation arrayElementRef:
-                    Visit(arrayElementRef.ArrayReference, state);
-                    foreach (var index in arrayElementRef.Indices)
-                        Visit(index, state);
-                    break;
-                case IInlineArrayAccessOperation inlineArrayAccess:
-                    Visit(inlineArrayAccess.Instance, state);
-                    Visit(inlineArrayAccess.Argument, state);
-                    break;
-                case IImplicitIndexerReferenceOperation indexerRef:
-                    Visit(indexerRef.Instance, state);
-                    Visit(indexerRef.Argument, state);
-                    break;
-                default:
-                    // Locals, parameters, discards, and declaration expressions have no
-                    // side-effecting sub-expression to evaluate ahead of the source.
-                    break;
-            }
+            TryVisitAssignmentTargetInstance(target, out _, out _, state);
         }
 
         private static IOperation UnwrapDeconstructionTarget(IOperation target)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -739,23 +739,25 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             {
                 sourceValue = GetDeconstructionSourceValue(source, sourceValue, sourceValueIsKnown, state);
                 bool isExtensionMethod = deconstructMethod.IsExtensionMethod;
+                bool hasReceiverArgument = isExtensionMethod || deconstructMethod.HasExtensionParameterOnType();
                 int outputParameterOffset = isExtensionMethod ? 1 : 0;
-                if (deconstructMethod.Parameters.Length != targetTuple.Elements.Length + outputParameterOffset)
+                int metadataParameterCount = deconstructMethod.GetMetadataParametersCount();
+                if (metadataParameterCount != targetTuple.Elements.Length + (hasReceiverArgument ? 1 : 0))
                 {
                     UnexpectedOperationHandler.Handle(operation);
                     return DeconstructionValue.Invalid;
                 }
 
-                var arguments = ImmutableArray.CreateBuilder<TValue>(deconstructMethod.Parameters.Length);
+                var arguments = ImmutableArray.CreateBuilder<TValue>(metadataParameterCount);
 
                 TValue instanceValue = sourceValue;
-                if (isExtensionMethod)
+                if (hasReceiverArgument)
                 {
                     instanceValue = TopValue;
                     arguments.Add(sourceValue);
                 }
 
-                while (arguments.Count < deconstructMethod.Parameters.Length)
+                while (arguments.Count < metadataParameterCount)
                     arguments.Add(TopValue);
 
                 // Key this synthesized Deconstruct() call on 'target', not 'source': 'source' may

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -786,6 +786,12 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 if (deconstructMethod.TryGetAttribute(nameof(DoesNotReturnAttribute), out _))
                     return DeconstructionValue.NonReturning;
 
+                IParameterSymbol? receiverParameter = isExtensionMethod
+                    ? deconstructMethod.Parameters[0]
+                    : deconstructMethod.ContainingType.ExtensionParameter;
+                if (receiverParameter is not null && source is not null)
+                    ApplyDoesNotReturnIfCondition(receiverParameter, source, state);
+
                 var nestedValues = ImmutableArray.CreateBuilder<DeconstructionValue>(targetTuple.Elements.Length);
                 for (int i = 0; i < targetTuple.Elements.Length; i++)
                 {
@@ -1415,21 +1421,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 if (parameterProxy.ParameterSymbol is not IParameterSymbol parameter)
                     continue;
 
-                if (!parameter.TryGetAttribute(nameof(DoesNotReturnIfAttribute), out var attributeData))
-                    continue;
-
-                if (attributeData.ConstructorArguments.Length != 1)
-                    continue;
-
-                var attributeArgument = attributeData.ConstructorArguments[0];
-                if (attributeArgument.Kind != TypedConstantKind.Primitive)
-                    continue;
-
-                if (attributeArgument.Value is not bool doesNotReturnIfConditionValue)
+                if (!parameter.TryGetAttribute(nameof(DoesNotReturnIfAttribute), out _))
                     continue;
 
                 var argumentIndex = parameterProxy.MetadataIndex;
-                var argument = arguments[argumentIndex];
 
                 IArgumentOperation argumentOperation;
                 switch (operation)
@@ -1446,19 +1441,38 @@ namespace ILLink.RoslynAnalyzer.DataFlow
                 }
                 ;
 
-                // Get the condition value that is being asserted. If the attribute is DoesNotReturnIf(true),
-                // the condition value needs to be negated so that we can assert the false condition.
-                TConditionValue conditionValue = GetConditionValue(argumentOperation, state);
-                var current = state.Current;
-                ApplyCondition(
-                    !doesNotReturnIfConditionValue
-                        ? conditionValue
-                        : conditionValue.Negate(),
-                    ref current);
-                state.Current = current;
+                ApplyDoesNotReturnIfCondition(parameter, argumentOperation, state);
             }
 
             return value;
+        }
+
+        private void ApplyDoesNotReturnIfCondition(
+            IParameterSymbol parameter,
+            IOperation argumentOperation,
+            LocalDataFlowState<TValue, TContext, TValueLattice, TContextLattice> state)
+        {
+            if (!parameter.TryGetAttribute(nameof(DoesNotReturnIfAttribute), out var attributeData) ||
+                attributeData.ConstructorArguments.Length != 1 ||
+                attributeData.ConstructorArguments[0] is not
+                {
+                    Kind: TypedConstantKind.Primitive,
+                    Value: bool doesNotReturnIfConditionValue
+                })
+            {
+                return;
+            }
+
+            // Get the condition value that is being asserted. If the attribute is DoesNotReturnIf(true),
+            // the condition value needs to be negated so that we can assert the false condition.
+            TConditionValue conditionValue = GetConditionValue(argumentOperation, state);
+            var current = state.Current;
+            ApplyCondition(
+                !doesNotReturnIfConditionValue
+                    ? conditionValue
+                    : conditionValue.Negate(),
+                ref current);
+            state.Current = current;
         }
 
         private TValue ProcessMethodCall(

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateAndContextLattice.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateAndContextLattice.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using ILLink.Shared;
 using ILLink.Shared.DataFlow;
 
 namespace ILLink.RoslynAnalyzer.DataFlow
@@ -25,7 +24,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
             LocalState.Equals(other.LocalState) && Context.Equals(other.Context);
 
         public override bool Equals(object? obj) => obj is LocalStateAndContext<TValue, TContext> other && Equals(other);
-        public override int GetHashCode() => HashUtils.Combine(LocalState, Context);
+
+        // Local dataflow states are mutable and should never be used as dictionary keys.
+        public override int GetHashCode() => throw new NotImplementedException();
     }
 
     public readonly struct LocalStateAndContextLattice<TValue, TContext, TValueLattice, TContextLattice> : ILattice<LocalStateAndContext<TValue, TContext>>

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
@@ -128,6 +128,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
         public bool Equals(LocalState<TValue> other) =>
             Dictionary.Equals(other.Dictionary) &&
+            CapturedReferences.Equals(other.CapturedReferences) &&
             CapturedTargetValues.Equals(other.CapturedTargetValues);
 
         public override bool Equals(object obj)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using ILLink.Shared.DataFlow;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis;
@@ -35,6 +36,65 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         }
     }
 
+    public readonly struct CapturedTargetKey : IEquatable<CapturedTargetKey>
+    {
+        private readonly IOperation Operation;
+
+        public CapturedTargetKey(IOperation operation) => Operation = operation;
+
+        public bool Equals(CapturedTargetKey other) => Operation == other.Operation;
+
+        public override bool Equals(object obj)
+            => obj is CapturedTargetKey inst && Equals(inst);
+
+        public override int GetHashCode() => Operation.GetHashCode();
+    }
+
+    public readonly struct CapturedTargetValue<TValue> : IEquatable<CapturedTargetValue<TValue>>, IDeepCopyValue<CapturedTargetValue<TValue>>
+        where TValue : IEquatable<TValue>
+    {
+        public readonly bool HasValue;
+
+        public readonly TValue Value;
+
+        public CapturedTargetValue(TValue value) => (HasValue, Value) = (true, value);
+
+        public bool Equals(CapturedTargetValue<TValue> other) =>
+            HasValue == other.HasValue &&
+            (!HasValue || EqualityComparer<TValue>.Default.Equals(Value, other.Value));
+
+        public override bool Equals(object obj)
+            => obj is CapturedTargetValue<TValue> inst && Equals(inst);
+
+        public override int GetHashCode() => HasValue ? EqualityComparer<TValue>.Default.GetHashCode(Value) : 0;
+
+        public CapturedTargetValue<TValue> DeepCopy() =>
+            HasValue
+                ? new CapturedTargetValue<TValue>(
+                    Value is IDeepCopyValue<TValue> copyValue ? copyValue.DeepCopy() : Value)
+                : default;
+    }
+
+    public readonly struct CapturedTargetValueLattice<TValue, TValueLattice> : ILattice<CapturedTargetValue<TValue>>
+        where TValue : IEquatable<TValue>
+        where TValueLattice : ILattice<TValue>
+    {
+        private readonly TValueLattice _valueLattice;
+
+        public CapturedTargetValueLattice(TValueLattice valueLattice) => _valueLattice = valueLattice;
+
+        public CapturedTargetValue<TValue> Top => default;
+
+        public CapturedTargetValue<TValue> Meet(CapturedTargetValue<TValue> left, CapturedTargetValue<TValue> right)
+        {
+            if (!left.HasValue)
+                return right.DeepCopy();
+            if (!right.HasValue)
+                return left.DeepCopy();
+            return new CapturedTargetValue<TValue>(_valueLattice.Meet(left.Value, right.Value));
+        }
+    }
+
     public struct LocalState<TValue> : IEquatable<LocalState<TValue>>
         where TValue : IEquatable<TValue>
     {
@@ -45,18 +105,30 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         // are tracked as part of the dictionary of values, keyed by LocalKey.
         public DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>> CapturedReferences;
 
-        public LocalState(DefaultValueDictionary<LocalKey, TValue> dictionary, DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>> capturedReferences)
+        // Stores target receiver and index values evaluated by deconstruction l-value captures.
+        public DefaultValueDictionary<CapturedTargetKey, CapturedTargetValue<TValue>> CapturedTargetValues;
+
+        public LocalState(
+            DefaultValueDictionary<LocalKey, TValue> dictionary,
+            DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>> capturedReferences,
+            DefaultValueDictionary<CapturedTargetKey, CapturedTargetValue<TValue>> capturedTargetValues)
         {
             Dictionary = dictionary;
             CapturedReferences = capturedReferences;
+            CapturedTargetValues = capturedTargetValues;
         }
 
         public LocalState(DefaultValueDictionary<LocalKey, TValue> dictionary)
-            : this(dictionary, new DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>>(default(ValueSet<CapturedReferenceValue>)))
+            : this(
+                dictionary,
+                new DefaultValueDictionary<CaptureId, ValueSet<CapturedReferenceValue>>(default(ValueSet<CapturedReferenceValue>)),
+                new DefaultValueDictionary<CapturedTargetKey, CapturedTargetValue<TValue>>(default(CapturedTargetValue<TValue>)))
         {
         }
 
-        public bool Equals(LocalState<TValue> other) => Dictionary.Equals(other.Dictionary);
+        public bool Equals(LocalState<TValue> other) =>
+            Dictionary.Equals(other.Dictionary) &&
+            CapturedTargetValues.Equals(other.CapturedTargetValues);
 
         public override bool Equals(object obj)
             => obj is LocalState<TValue> inst && Equals(inst);
@@ -78,11 +150,14 @@ namespace ILLink.RoslynAnalyzer.DataFlow
     {
         public readonly DictionaryLattice<LocalKey, TValue, TValueLattice> Lattice;
         public readonly DictionaryLattice<CaptureId, ValueSet<CapturedReferenceValue>, ValueSetLattice<CapturedReferenceValue>> CapturedReferenceLattice;
+        public readonly DictionaryLattice<CapturedTargetKey, CapturedTargetValue<TValue>, CapturedTargetValueLattice<TValue, TValueLattice>> CapturedTargetValueLattice;
 
         public LocalStateLattice(TValueLattice valueLattice)
         {
             Lattice = new DictionaryLattice<LocalKey, TValue, TValueLattice>(valueLattice);
             CapturedReferenceLattice = new DictionaryLattice<CaptureId, ValueSet<CapturedReferenceValue>, ValueSetLattice<CapturedReferenceValue>>(default(ValueSetLattice<CapturedReferenceValue>));
+            CapturedTargetValueLattice = new DictionaryLattice<CapturedTargetKey, CapturedTargetValue<TValue>, CapturedTargetValueLattice<TValue, TValueLattice>>(
+                new CapturedTargetValueLattice<TValue, TValueLattice>(valueLattice));
             Top = new(Lattice.Top);
         }
 
@@ -92,7 +167,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
         {
             var dictionary = Lattice.Meet(left.Dictionary, right.Dictionary);
             var capturedProperties = CapturedReferenceLattice.Meet(left.CapturedReferences, right.CapturedReferences);
-            return new LocalState<TValue>(dictionary, capturedProperties);
+            var capturedTargetValues = CapturedTargetValueLattice.Meet(left.CapturedTargetValues, right.CapturedTargetValues);
+            return new LocalState<TValue>(dictionary, capturedProperties, capturedTargetValues);
         }
     }
 }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateLattice.cs
@@ -135,6 +135,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
         public TValue Get(LocalKey key) => Dictionary.Get(key);
 
+        // Local dataflow states are mutable and should never be used as dictionary keys.
         public override int GetHashCode()
             => throw new NotImplementedException();
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -129,7 +129,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             var value = base.VisitConversion(operation, state);
 
             if (operation.OperatorMethod is IMethodSymbol method)
-                return method.ReturnType.IsTypeInterestingForDataflow(isByRef: method.ReturnsByRef) ? new MethodReturnValue(method, isNewObj: false) : value;
+                return GetConversionValue(method, value);
 
             // TODO - is it possible to have annotation on the operator method parameters?
             // if so, will these be checked here?
@@ -267,8 +267,6 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
         public override MultiValue GetConversionValue(IMethodSymbol conversionOperator, MultiValue operandValue)
         {
-            // Keep this in sync with VisitConversion, which handles the same conversion when it
-            // appears as an IConversionOperation in the operation tree.
             return conversionOperator.ReturnType.IsTypeInterestingForDataflow(isByRef: conversionOperator.ReturnsByRef)
                 ? new MethodReturnValue(conversionOperator, isNewObj: false)
                 : operandValue;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -265,6 +265,15 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             return new FieldValue(tupleElement);
         }
 
+        public override MultiValue GetConversionValue(IMethodSymbol conversionOperator, MultiValue operandValue)
+        {
+            // Keep this in sync with VisitConversion, which handles the same conversion when it
+            // appears as an IConversionOperation in the operation tree.
+            return conversionOperator.ReturnType.IsTypeInterestingForDataflow(isByRef: conversionOperator.ReturnsByRef)
+                ? new MethodReturnValue(conversionOperator, isNewObj: false)
+                : operandValue;
+        }
+
         public override MultiValue GetParameterTargetValue(IParameterSymbol parameter)
         {
             var parameterMethod = parameter.ContainingSymbol as IMethodSymbol ?? OwningSymbol as IMethodSymbol;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -260,6 +260,10 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
             return new FieldValue(property);
         }
 
+        public override MultiValue GetTupleElementValue(IFieldSymbol tupleElement)
+        {
+            return new FieldValue(tupleElement);
+        }
 
         public override MultiValue GetParameterTargetValue(IParameterSymbol parameter)
         {

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -149,6 +149,18 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task DeconstructFieldTarget()
+        {
+            return RunTest();
+        }
+
+        [Fact]
+        public Task DeconstructUserDefinedConversion()
+        {
+            return RunTest();
+        }
+
+        [Fact]
         public Task DependencyInjectionPattern()
         {
             return RunTest();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -193,6 +193,35 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             [RequiresUnreferencedCode(nameof(GetPropertyHolder))]
             static PropertyHolder GetPropertyHolder() => new();
 
+            static PropertyHolder GetPropertyHolderForType(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type) => new();
+
+            static T Box<T>(T value) => value;
+
+            // The target's receiver is evaluated before the source, so only the annotated value can
+            // reach GetPropertyHolderForType, even though the source assigns an unannotated value to
+            // the same local. The receiver must not be evaluated a second time when performing the
+            // write, because by then the local holds the unannotated value.
+            static void DeconstructTargetReceiverEvaluatedBeforeSource(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type annotated,
+                Type unannotated)
+            {
+                Type type = annotated;
+                object other;
+                (GetPropertyHolderForType(type).AnnotatedProperty, other) = ((type = unannotated), new object());
+            }
+
+            static void DeconstructTargetReceiverWithNestedDeconstructionSource(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type annotated,
+                Type unannotated)
+            {
+                Type type = annotated;
+                object other;
+
+                (GetPropertyHolderForType(type).AnnotatedProperty, other) =
+                    Box(((type, other) = (unannotated, new object())));
+            }
+
             // The property target's receiver (GetPropertyHolder()) is a side-effecting expression that
             // must be evaluated exactly once, and (to match left-to-right evaluation order) before the
             // source values are read - not only after, as part of performing the write.
@@ -356,6 +385,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructTupleSwapSuccess(typeof(string), typeof(string));
                 DeconstructTupleSwap(typeof(string), typeof(string));
                 DeconstructPropertyTargetSideEffect(typeof(string), typeof(string));
+                DeconstructTargetReceiverEvaluatedBeforeSource(typeof(string), typeof(string));
+                DeconstructTargetReceiverWithNestedDeconstructionSource(typeof(string), typeof(string));
                 DeconstructIndexerTargetSideEffect(typeof(string), typeof(string));
                 DeconstructFieldTarget();
                 DeconstructParameterTarget(typeof(string), null);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -107,6 +107,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 type.RequiresPublicMethods();
             }
 
+
             record TypeAndInstanceRecordManual(
                 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
                 [property: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
@@ -304,18 +305,31 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 public static implicit operator ConversionTarget(Type type) => default;
             }
 
-            // Deconstructing an element through a user-defined conversion operator (Type ->
-            // ConversionTarget here) can't be modeled by the analyzer - the operator body is opaque -
-            // so EvaluateDeconstruction treats the converted value as unknown (top) rather than
-            // reusing the source's own tracked value, which would no longer make sense once its type
-            // has changed. ConversionTarget isn't itself a dataflow-tracked type, so this mainly
-            // verifies the conversion-operator code path in EvaluateDeconstruction runs without
-            // hitting UnexpectedOperationHandler or otherwise producing an unexpected warning (see
-            // [ExpectedNoWarnings] on the containing class).
+            // Deconstructing an element through a user-defined conversion operator. ConversionTarget
+            // isn't a dataflow-tracked type, so this only verifies the conversion path runs without
+            // producing an unexpected warning (see [ExpectedNoWarnings] on the containing class).
             static void DeconstructWithUserDefinedConversion(
                 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type typeWithMethods)
             {
                 (ConversionTarget converted, object instance) = (typeWithMethods, new object());
+            }
+
+            struct ConversionSource
+            {
+                public static implicit operator Type(ConversionSource value) => null;
+            }
+
+            // The converted value must be modeled as the conversion operator's return value, not as
+            // the source value and not as an unknown/empty value. The operator's return type has no
+            // annotations, so assigning it to an annotated target has to warn - the same way the
+            // equivalent non-deconstruction assignment does. Note the conversion here is described
+            // by the DeconstructionInfo (not by a conversion operation in the tree) because the
+            // source is a tuple-typed value rather than a tuple literal.
+            [ExpectedWarning("IL2074", nameof(ConversionSource))]
+            static void DeconstructUserDefinedConversionToAnnotatedTarget((ConversionSource value, object instance) input)
+            {
+                object instance;
+                (annotatedFieldTarget, instance) = input;
             }
 
             [ExpectedWarning("IL2077")]
@@ -349,6 +363,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructArrayElementTargetSideEffect(typeof(string), typeof(string));
                 DeconstructImplicitIndexerTargetSideEffect(typeof(string), typeof(string));
                 DeconstructWithUserDefinedConversion(typeof(string));
+                DeconstructUserDefinedConversionToAnnotatedTarget(default);
                 DeconstructForeach(new[] { (typeof(string), (object)null) });
             }
         }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -93,6 +93,20 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 type.RequiresPublicMethods();
             }
 
+            [RequiresUnreferencedCode(nameof(GetTypeAndInstance))]
+            static TypeAndInstance GetTypeAndInstance() => null;
+
+            // The deconstruction source here is itself a method call, unlike the other Deconstruct()
+            // test cases above. The source call and the synthesized Deconstruct() call must be
+            // tracked as two independent calls, not merged together.
+            [ExpectedWarning("IL2026", nameof(GetTypeAndInstance))]
+            [ExpectedWarning("IL2067")]
+            static void DeconstructMethodCallSource()
+            {
+                var (type, instance) = GetTypeAndInstance();
+                type.RequiresPublicMethods();
+            }
+
             record TypeAndInstanceRecordManual(
                 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
                 [property: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
@@ -318,6 +332,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructVariablePropertyReference((typeof(string), null));
                 DeconstructRecordWithAnnotation(new(typeof(string), null));
                 DeconstructClassWithAnnotation(new(typeof(string), null));
+                DeconstructMethodCallSource();
                 DeconstructRecordManualWithAnnotation(new(typeof(string), null));
                 DeconstructRecordManualWithMismatchAnnotation(new(typeof(string), null));
                 DeconstructExtensionWithAnnotation(new());

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -20,7 +20,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
         class DeconstructedVariable
         {
-            [ExpectedWarning("IL2077", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/3158")]
+            [ExpectedWarning("IL2077")]
             static void DeconstructVariableNoAnnotation((Type type, object instance) input)
             {
                 var (type, instance) = input;
@@ -29,7 +29,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
             static (Type type, object instance) GetInput(int unused) => (typeof(string), null);
 
-            [ExpectedWarning("IL2077", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/3158")]
+            [ExpectedWarning("IL2077")]
             static void DeconstructVariableFlowCapture(bool b = true)
             {
                 // This creates a control-flow graph where the tuple elements assigned to
@@ -48,8 +48,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
             static ref Type AnnotatedProperty => ref annotatedfield;
 
-            [ExpectedWarning("IL2062", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/3158")]
-            [ExpectedWarning("IL2078", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/3158")]
+            [ExpectedWarning("IL2062", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/2158")]
+            [ExpectedWarning("IL2078", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/2158")]
             static void DeconstructVariablePropertyReference((Type type, object instance) input)
             {
                 object instance;
@@ -66,10 +66,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             // In IL based tools this is a behavior of the compiler. The attribute on the record declaration parameter
             // is only propagated to the .ctor constructor parameter. The property and field attributes are applied to the
             // generated property and field respectively. But none of the attributes is propagated to the Deconstruct method parameters.
-            // For analyzer, this is currently
-            // https://github.com/dotnet/linker/issues/3158
-            //   But it's possible that with that fixed there won't be a warning from the analyzer anyway (depends on the implementation)
-            [ExpectedWarning("IL2067", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/3158")]
+            [ExpectedWarning("IL2067")]
             static void DeconstructRecordWithAnnotation(TypeAndInstance value)
             {
                 var (type, instance) = value;
@@ -115,11 +112,69 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 type.RequiresPublicMethods();
             }
 
-            [ExpectedWarning("IL2067", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/linker/issues/3158")]
+            [ExpectedWarning("IL2067")]
             static void DeconstructRecordManualWithMismatchAnnotation(TypeAndInstanceRecordManual value)
             {
                 var (type, instance) = value;
                 type.RequiresPublicFields();
+            }
+
+            static void DeconstructExtensionWithAnnotation(TypeAndInstanceExtension value)
+            {
+                var (type, instance) = value;
+                type.RequiresPublicMethods();
+            }
+
+            [ExpectedWarning("IL2067")]
+            static void DeconstructExtensionWithMismatchAnnotation(TypeAndInstanceExtension value)
+            {
+                var (type, instance) = value;
+                type.RequiresPublicFields();
+            }
+
+            [ExpectedWarning("IL2077")]
+            static void DeconstructNestedTuple(((Type type, object instance) nested, object instance) input)
+            {
+                var ((type, instance), outerInstance) = input;
+                type.RequiresPublicMethods();
+            }
+
+            static void DeconstructTupleLiteral(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type input)
+            {
+                var (type, instance) = (input, new object());
+                type.RequiresPublicMethods();
+            }
+
+            // The swap correctly propagates the annotation from typeWithMethods to first (via second),
+            // so no warning is produced here.
+            static void DeconstructTupleSwapSuccess(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type typeWithMethods,
+                Type typeWithoutMethods)
+            {
+                Type first = typeWithoutMethods;
+                Type second = typeWithMethods;
+                (first, second) = (second, first);
+                first.RequiresPublicMethods();
+            }
+
+            [ExpectedWarning("IL2067", nameof(DataFlowTypeExtensions.RequiresPublicMethods))]
+            static void DeconstructTupleSwap(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type typeWithMethods,
+                Type typeWithoutMethods)
+            {
+                Type first = typeWithMethods;
+                Type second = typeWithoutMethods;
+                (first, second) = (second, first);
+                first.RequiresPublicMethods();
+                second.RequiresPublicMethods();
+            }
+
+            [ExpectedWarning("IL2077")]
+            static void DeconstructForeach((Type type, object instance)[] inputs)
+            {
+                foreach (var (type, instance) in inputs)
+                    type.RequiresPublicMethods();
             }
 
             public static void Test()
@@ -131,6 +186,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructClassWithAnnotation(new(typeof(string), null));
                 DeconstructRecordManualWithAnnotation(new(typeof(string), null));
                 DeconstructRecordManualWithMismatchAnnotation(new(typeof(string), null));
+                DeconstructExtensionWithAnnotation(new());
+                DeconstructExtensionWithMismatchAnnotation(new());
+                DeconstructNestedTuple(((typeof(string), null), null));
+                DeconstructTupleLiteral(typeof(string));
+                DeconstructTupleSwapSuccess(typeof(string), typeof(string));
+                DeconstructTupleSwap(typeof(string), typeof(string));
+                DeconstructForeach(new[] { (typeof(string), (object)null) });
             }
         }
 
@@ -218,6 +280,22 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
                 RecordConstruction(typeof(string), typeof(string));
             }
+        }
+    }
+
+    class TypeAndInstanceExtension
+    {
+    }
+
+    static class TypeAndInstanceExtensions
+    {
+        public static void Deconstruct(
+            this TypeAndInstanceExtension value,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] out Type type,
+            out object instance)
+        {
+            type = typeof(string);
+            instance = null;
         }
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -351,6 +351,33 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                     type.RequiresPublicMethods();
             }
 
+            [ExpectedWarning("IL2067", Tool.Trimmer | Tool.NativeAot, "IL-based tools don't model DoesNotReturn on Deconstruct methods")]
+            static void DeconstructDoesNotReturn(
+                bool condition,
+                DoesNotReturnDeconstruct input,
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type annotated)
+            {
+                Type type = annotated;
+                object instance;
+                if (condition)
+                    (type, instance) = input;
+                type.RequiresPublicMethods();
+            }
+
+            [ExpectedWarning("IL2067", Tool.Trimmer | Tool.NativeAot, "IL-based tools don't model DoesNotReturn on Deconstruct methods")]
+            static void DeconstructNestedDoesNotReturn(
+                bool condition,
+                NestedDoesNotReturnDeconstruct input,
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type annotated)
+            {
+                Type type = annotated;
+                object instance;
+                object outerInstance;
+                if (condition)
+                    ((type, instance), outerInstance) = input;
+                type.RequiresPublicMethods();
+            }
+
             public static void Test()
             {
                 DeconstructVariableNoAnnotation((typeof(string), null));
@@ -378,6 +405,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructImplicitIndexerTargetSideEffect(typeof(string), typeof(string));
                 DeconstructWithUserDefinedConversion(typeof(string));
                 DeconstructForeach(new[] { (typeof(string), (object)null) });
+                DeconstructDoesNotReturn(true, new(), typeof(string));
+                DeconstructNestedDoesNotReturn(true, new(), typeof(string));
             }
         }
 
@@ -480,6 +509,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             out object instance)
         {
             type = typeof(string);
+            instance = null;
+        }
+    }
+
+    class DoesNotReturnDeconstruct
+    {
+        [DoesNotReturn]
+        public void Deconstruct(out Type type, out object instance) => throw new Exception();
+    }
+
+    class NestedDoesNotReturnDeconstruct
+    {
+        public void Deconstruct(out DoesNotReturnDeconstruct nested, out object instance)
+        {
+            nested = new();
             instance = null;
         }
     }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -188,6 +188,35 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 (GetPropertyHolder().AnnotatedProperty, other) = (first, second);
             }
 
+            class IndexerHolder
+            {
+                public Type this[int index]
+                {
+                    get => null;
+                    set { }
+                }
+            }
+
+            [RequiresUnreferencedCode(nameof(GetIndexerHolder))]
+            static IndexerHolder GetIndexerHolder() => new();
+
+            [RequiresUnreferencedCode(nameof(GetIndex))]
+            static int GetIndex() => 0;
+
+            // Like DeconstructPropertyTargetSideEffect, but for an explicit indexer target. The
+            // receiver (GetIndexerHolder()) and index argument (GetIndex()) are each side-effecting
+            // expressions that must be evaluated exactly once, even though they're visited from two
+            // different places: the receiver ahead of the source (VisitDeconstructionTargetSideEffects),
+            // and the index argument as part of performing the write (ProcessSingleTargetAssignment),
+            // matching the same (pre-existing) evaluation order used for an ordinary indexer assignment.
+            [ExpectedWarning("IL2026", nameof(GetIndexerHolder))]
+            [ExpectedWarning("IL2026", nameof(GetIndex))]
+            static void DeconstructIndexerTargetSideEffect(Type first, Type second)
+            {
+                object other;
+                (GetIndexerHolder()[GetIndex()], other) = (first, second);
+            }
+
             [ExpectedWarning("IL2077")]
             static void DeconstructForeach((Type type, object instance)[] inputs)
             {
@@ -211,6 +240,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructTupleSwapSuccess(typeof(string), typeof(string));
                 DeconstructTupleSwap(typeof(string), typeof(string));
                 DeconstructPropertyTargetSideEffect(typeof(string), typeof(string));
+                DeconstructIndexerTargetSideEffect(typeof(string), typeof(string));
                 DeconstructForeach(new[] { (typeof(string), (object)null) });
             }
         }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -263,20 +263,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
             static Type GetUnannotatedType() => null;
 
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
-            static Type annotatedFieldTarget;
-
-            // A field target (IFieldReferenceOperation) is handled directly by ProcessAssignment/
-            // ProcessSingleTargetAssignment (it has no side-effecting sub-expression pre-visit of its
-            // own; a static field has no instance to evaluate). This just verifies the assigned value
-            // is correctly checked against the field's DynamicallyAccessedMembers requirement.
-            [ExpectedWarning("IL2074", nameof(GetUnannotatedType))]
-            static void DeconstructFieldTarget()
-            {
-                object other;
-                (annotatedFieldTarget, other) = (GetUnannotatedType(), new object());
-            }
-
             // A parameter target (IParameterReferenceOperation) reassigns an existing parameter
             // directly (no declaration expression), unlike DeconstructVariableFlowCapture's locals.
             [ExpectedWarning("IL2067")]
@@ -343,24 +329,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 (ConversionTarget converted, object instance) = (typeWithMethods, new object());
             }
 
-            struct ConversionSource
-            {
-                public static implicit operator Type(ConversionSource value) => null;
-            }
-
-            // The converted value must be modeled as the conversion operator's return value, not as
-            // the source value and not as an unknown/empty value. The operator's return type has no
-            // annotations, so assigning it to an annotated target has to warn - the same way the
-            // equivalent non-deconstruction assignment does. Note the conversion here is described
-            // by the DeconstructionInfo (not by a conversion operation in the tree) because the
-            // source is a tuple-typed value rather than a tuple literal.
-            [ExpectedWarning("IL2074", nameof(ConversionSource))]
-            static void DeconstructUserDefinedConversionToAnnotatedTarget((ConversionSource value, object instance) input)
-            {
-                object instance;
-                (annotatedFieldTarget, instance) = input;
-            }
-
             [ExpectedWarning("IL2077")]
             static void DeconstructForeach((Type type, object instance)[] inputs)
             {
@@ -388,13 +356,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructTargetReceiverEvaluatedBeforeSource(typeof(string), typeof(string));
                 DeconstructTargetReceiverWithNestedDeconstructionSource(typeof(string), typeof(string));
                 DeconstructIndexerTargetSideEffect(typeof(string), typeof(string));
-                DeconstructFieldTarget();
                 DeconstructParameterTarget(typeof(string), null);
                 DeconstructDiscardTarget();
                 DeconstructArrayElementTargetSideEffect(typeof(string), typeof(string));
                 DeconstructImplicitIndexerTargetSideEffect(typeof(string), typeof(string));
                 DeconstructWithUserDefinedConversion(typeof(string));
-                DeconstructUserDefinedConversionToAnnotatedTarget(default);
                 DeconstructForeach(new[] { (typeof(string), (object)null) });
             }
         }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -170,6 +170,24 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 second.RequiresPublicMethods();
             }
 
+            class PropertyHolder
+            {
+                public Type AnnotatedProperty;
+            }
+
+            [RequiresUnreferencedCode(nameof(GetPropertyHolder))]
+            static PropertyHolder GetPropertyHolder() => new();
+
+            // The property target's receiver (GetPropertyHolder()) is a side-effecting expression that
+            // must be evaluated exactly once, and (to match left-to-right evaluation order) before the
+            // source values are read - not only after, as part of performing the write.
+            [ExpectedWarning("IL2026", nameof(GetPropertyHolder))]
+            static void DeconstructPropertyTargetSideEffect(Type first, Type second)
+            {
+                object other;
+                (GetPropertyHolder().AnnotatedProperty, other) = (first, second);
+            }
+
             [ExpectedWarning("IL2077")]
             static void DeconstructForeach((Type type, object instance)[] inputs)
             {
@@ -192,6 +210,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructTupleLiteral(typeof(string));
                 DeconstructTupleSwapSuccess(typeof(string), typeof(string));
                 DeconstructTupleSwap(typeof(string), typeof(string));
+                DeconstructPropertyTargetSideEffect(typeof(string), typeof(string));
                 DeconstructForeach(new[] { (typeof(string), (object)null) });
             }
         }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -217,6 +217,93 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 (GetIndexerHolder()[GetIndex()], other) = (first, second);
             }
 
+            static Type GetUnannotatedType() => null;
+
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+            static Type annotatedFieldTarget;
+
+            // A field target (IFieldReferenceOperation) is handled directly by ProcessAssignment/
+            // ProcessSingleTargetAssignment (it has no side-effecting sub-expression pre-visit of its
+            // own; a static field has no instance to evaluate). This just verifies the assigned value
+            // is correctly checked against the field's DynamicallyAccessedMembers requirement.
+            [ExpectedWarning("IL2074", nameof(GetUnannotatedType))]
+            static void DeconstructFieldTarget()
+            {
+                object other;
+                (annotatedFieldTarget, other) = (GetUnannotatedType(), new object());
+            }
+
+            // A parameter target (IParameterReferenceOperation) reassigns an existing parameter
+            // directly (no declaration expression), unlike DeconstructVariableFlowCapture's locals.
+            [ExpectedWarning("IL2067")]
+            static void DeconstructParameterTarget(Type type, object instance)
+            {
+                (type, instance) = (GetUnannotatedType(), new object());
+                type.RequiresPublicMethods();
+            }
+
+            // A discard target (IDiscardOperation) drops the corresponding source value entirely -
+            // there's nothing to check dataflow-wise, and it must not affect tracking of the other
+            // target in the same deconstruction.
+            [ExpectedWarning("IL2072")]
+            static void DeconstructDiscardTarget()
+            {
+                (_, Type type) = (new object(), GetUnannotatedType());
+                type.RequiresPublicMethods();
+            }
+
+            [RequiresUnreferencedCode(nameof(GetArrayForElementTarget))]
+            static Type[] GetArrayForElementTarget() => new Type[2];
+
+            [RequiresUnreferencedCode(nameof(GetArrayIndex))]
+            static int GetArrayIndex() => 0;
+
+            // Like DeconstructIndexerTargetSideEffect, but for an array element target
+            // (IArrayElementReferenceOperation). Unlike the explicit indexer case, both the array
+            // reference and the index are pre-visited by VisitDeconstructionTargetSideEffects (there's
+            // no equivalent to the indexer-Arguments ordering quirk here), so both are visited twice
+            // (once ahead of the source, once again performing the write) - verifying each still
+            // produces exactly one warning despite the double-visit.
+            [ExpectedWarning("IL2026", nameof(GetArrayForElementTarget))]
+            [ExpectedWarning("IL2026", nameof(GetArrayIndex))]
+            static void DeconstructArrayElementTargetSideEffect(Type first, Type second)
+            {
+                object other;
+                (GetArrayForElementTarget()[GetArrayIndex()], other) = (first, second);
+            }
+
+            [RequiresUnreferencedCode(nameof(GetArrayForImplicitIndexerTarget))]
+            static Type[] GetArrayForImplicitIndexerTarget() => new Type[2];
+
+            // An implicit System.Index-based indexer target (IImplicitIndexerReferenceOperation),
+            // e.g. 'arr[^1]'. The receiver is a side-effecting expression visited ahead of the source,
+            // same as the explicit indexer and array element cases above.
+            [ExpectedWarning("IL2026", nameof(GetArrayForImplicitIndexerTarget))]
+            static void DeconstructImplicitIndexerTargetSideEffect(Type first, Type second)
+            {
+                object other;
+                (GetArrayForImplicitIndexerTarget()[^1], other) = (first, second);
+            }
+
+            struct ConversionTarget
+            {
+                public static implicit operator ConversionTarget(Type type) => default;
+            }
+
+            // Deconstructing an element through a user-defined conversion operator (Type ->
+            // ConversionTarget here) can't be modeled by the analyzer - the operator body is opaque -
+            // so EvaluateDeconstruction treats the converted value as unknown (top) rather than
+            // reusing the source's own tracked value, which would no longer make sense once its type
+            // has changed. ConversionTarget isn't itself a dataflow-tracked type, so this mainly
+            // verifies the conversion-operator code path in EvaluateDeconstruction runs without
+            // hitting UnexpectedOperationHandler or otherwise producing an unexpected warning (see
+            // [ExpectedNoWarnings] on the containing class).
+            static void DeconstructWithUserDefinedConversion(
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type typeWithMethods)
+            {
+                (ConversionTarget converted, object instance) = (typeWithMethods, new object());
+            }
+
             [ExpectedWarning("IL2077")]
             static void DeconstructForeach((Type type, object instance)[] inputs)
             {
@@ -241,6 +328,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructTupleSwap(typeof(string), typeof(string));
                 DeconstructPropertyTargetSideEffect(typeof(string), typeof(string));
                 DeconstructIndexerTargetSideEffect(typeof(string), typeof(string));
+                DeconstructFieldTarget();
+                DeconstructParameterTarget(typeof(string), null);
+                DeconstructDiscardTarget();
+                DeconstructArrayElementTargetSideEffect(typeof(string), typeof(string));
+                DeconstructImplicitIndexerTargetSideEffect(typeof(string), typeof(string));
+                DeconstructWithUserDefinedConversion(typeof(string));
                 DeconstructForeach(new[] { (typeof(string), (object)null) });
             }
         }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructedTypesDataFlow.cs
@@ -29,6 +29,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
             static (Type type, object instance) GetInput(int unused) => (typeof(string), null);
 
+            static (Type type, object instance) GetInput(Type type, int unused) => (type, null);
+
             [ExpectedWarning("IL2077")]
             static void DeconstructVariableFlowCapture(bool b = true)
             {
@@ -222,6 +224,19 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                     Box(((type, other) = (unannotated, new object())));
             }
 
+            static void DeconstructFlowCapturedTargetReceiverEvaluatedBeforeSource(
+                bool condition,
+                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type annotated,
+                Type unannotated)
+            {
+                Type type = annotated;
+                object other;
+
+                // Control flow in the source causes Roslyn to capture the target location.
+                (GetPropertyHolderForType(type).AnnotatedProperty, other) =
+                    GetInput(type = unannotated, condition ? 0 : 1);
+            }
+
             // The property target's receiver (GetPropertyHolder()) is a side-effecting expression that
             // must be evaluated exactly once, and (to match left-to-right evaluation order) before the
             // source values are read - not only after, as part of performing the write.
@@ -355,6 +370,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 DeconstructPropertyTargetSideEffect(typeof(string), typeof(string));
                 DeconstructTargetReceiverEvaluatedBeforeSource(typeof(string), typeof(string));
                 DeconstructTargetReceiverWithNestedDeconstructionSource(typeof(string), typeof(string));
+                DeconstructFlowCapturedTargetReceiverEvaluatedBeforeSource(true, typeof(string), typeof(string));
                 DeconstructIndexerTargetSideEffect(typeof(string), typeof(string));
                 DeconstructParameterTarget(typeof(string), null);
                 DeconstructDiscardTarget();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DeconstructFieldTarget.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DeconstructFieldTarget.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+    [ExpectedNoWarnings]
+    [SkipKeptItemsValidation]
+    class DeconstructFieldTarget
+    {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        static Type _annotatedField;
+
+        static Type GetUnannotatedType() => null;
+
+        // Verify that assigning a deconstructed value to an annotated static field is validated.
+        [ExpectedWarning("IL2074", nameof(GetUnannotatedType))]
+        public static void Main()
+        {
+            object other;
+            (_annotatedField, other) = (GetUnannotatedType(), new object());
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DeconstructUserDefinedConversion.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DeconstructUserDefinedConversion.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+    [ExpectedNoWarnings]
+    [SkipKeptItemsValidation]
+    class DeconstructUserDefinedConversion
+    {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        static Type _annotatedField;
+
+        struct ConversionSource
+        {
+            public static implicit operator Type(ConversionSource value) => null;
+        }
+
+        // The converted value is the conversion operator's return value, whose type is unannotated.
+        [ExpectedWarning("IL2074", nameof(ConversionSource))]
+        static void Test((ConversionSource value, object instance) input)
+        {
+            object instance;
+            (_annotatedField, instance) = input;
+        }
+
+        public static void Main() => Test(default);
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExtensionMembersDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExtensionMembersDataFlow.cs
@@ -25,6 +25,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             TestExtensionMethodWithParams();
             TestExtensionMethodWithParamsMismatch();
             TestExtensionDeconstructMismatch();
+            TestExtensionDeconstructDoesNotReturnIf();
             TestExtensionStaticMethodRequires();
             TestExtensionMethodAnnotation();
             TestExtensionStaticMethodAnnotation();
@@ -71,6 +72,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         static void TestExtensionDeconstructMismatch()
         {
             var (first, second) = GetWithMethods();
+        }
+
+        [ExpectedWarning("IL3050", nameof(RequiresDynamicCode), Tool.NativeAot, "NativeAOT doesn't model DoesNotReturnIf on Deconstruct methods")]
+        static void TestExtensionDeconstructDoesNotReturnIf()
+        {
+            (_, _) = !RuntimeFeature.IsDynamicCodeSupported;
+            RequiresDynamicCode();
         }
 
         [ExpectedWarning("IL2026", nameof(ExtensionMembers.ExtensionMembersStaticMethodRequires))]
@@ -164,6 +172,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
         public static Type GetWithMethods() => null;
+
+        [RequiresDynamicCode(nameof(RequiresDynamicCode))]
+        static void RequiresDynamicCode() { }
     }
 
     [ExpectedNoWarnings]
@@ -296,6 +307,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 left.RequiresPublicMethods();
                 right.RequiresPublicMethods();
                 return ExtensionMembersDataFlow.GetWithMethods();
+            }
+        }
+
+        extension([DoesNotReturnIf(true)] bool value)
+        {
+            public void Deconstruct(out object first, out object second)
+            {
+                first = null;
+                second = null;
             }
         }
     }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExtensionMembersDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExtensionMembersDataFlow.cs
@@ -24,6 +24,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             TestExtensionMethodRequires();
             TestExtensionMethodWithParams();
             TestExtensionMethodWithParamsMismatch();
+            TestExtensionDeconstructMismatch();
             TestExtensionStaticMethodRequires();
             TestExtensionMethodAnnotation();
             TestExtensionStaticMethodAnnotation();
@@ -64,6 +65,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         static void TestExtensionMethodWithParamsMismatch()
         {
             GetWithMethods().ExtensionMembersMethodWithParamsMismatch(GetWithFields());
+        }
+
+        [ExpectedWarning("IL2072", nameof(GetWithMethods), nameof(ExtensionMembers.Deconstruct))]
+        static void TestExtensionDeconstructMismatch()
+        {
+            var (first, second) = GetWithMethods();
         }
 
         [ExpectedWarning("IL2026", nameof(ExtensionMembers.ExtensionMembersStaticMethodRequires))]
@@ -184,6 +191,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             {
                 type.RequiresPublicMethods();
                 typeParam.RequiresPublicFields();
+            }
+
+            public void Deconstruct(out object first, out object second)
+            {
+                first = null;
+                second = null;
             }
 
             [RequiresUnreferencedCode(nameof(ExtensionMembersStaticMethodRequires))]


### PR DESCRIPTION
Fixes #123767.

The ILLink Roslyn analyzer's dataflow visitor did not handle `IDeconstructionAssignmentOperation`, so `RequiresUnreferencedCode` and `DynamicallyAccessedMembers` diagnostics were silently skipped for values flowing through deconstruction, including assignments and deconstruction in `foreach`.

## Summary of changes

- Add dataflow support for tuple expressions, tuple-typed values, instance and extension `Deconstruct` methods, nested deconstruction, and user-defined conversions.
- Support local, field, property, parameter, discard, array-element, explicit-indexer, implicit-indexer, and nested tuple targets.
- Preserve C# evaluation order by evaluating target locations before source values and performing target writes only after all source values and nested `Deconstruct` calls have been evaluated.
- Preserve flow-captured target receivers and index arguments so target locations are evaluated once and retain the values selected before source-side mutations.
- Correctly map receivers for classic extension methods and C# 14 extension-block `Deconstruct` methods.
- Treat outer or nested `[DoesNotReturn] Deconstruct` calls as unreachable and suppress every target assignment on that path.

## Testing

Added regression coverage for deconstruction sources, targets, evaluation ordering, flow captures, extension receivers, user-defined conversions, and direct and nested `[DoesNotReturn]` methods. The DataFlow suites pass across:

- `ILLink.RoslynAnalyzer.Tests`
- `Mono.Linker.Tests`
- `ILCompiler.Trimming.Tests`
- `ILTrim.Tests`

Two unsupported ILTrim scenarios are isolated as standalone expected failures instead of excluding the shared deconstruction coverage:

- `DeconstructFieldTarget` exposes an existing ILTrim.Core gap in static-field write dataflow.
- `DeconstructUserDefinedConversion` exposes an existing ILTrim.Core gap in tracking a user-defined conversion operator's return value.

The Roslyn analyzer, linker, and NativeAOT tests retain coverage for both cases. ILLink/ILTrim and NativeAOT also conservatively report the expected warning after `[DoesNotReturn]` calls because the IL-based tools do not treat that attribute as a reachability contract; those expectations are scoped to the IL-based tools while the Roslyn analyzer verifies the path is unreachable.

> [!NOTE]
> This content was created with assistance from AI.
