### PR TITLE
Don't share a value number between raw addresses taken in different pinned regions

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -12909,10 +12909,11 @@ void Compiler::fgValueNumberStore(GenTree* store)
 
             valueVNPair.SetBoth(initObjVN);
         }
-        else if (value->TypeIs(TYP_REF))
+        else if (varTypeIsGC(value))
         {
-            // If we have an unsafe IL store of a TYP_REF to a non-ref (typically a TYP_BYREF)
-            // then don't propagate this ValueNumber to the lhs, instead create a new unique VN.
+            // A GC reference reinterpreted as another type (an unsafe IL store of a TYP_REF, or one of
+            // morph's "Cast away GC" temps) is a raw address snapshot that is only valid until the
+            // referent can next move, so give each store its own VN rather than letting CSE share one.
             valueVNPair.SetBoth(vnStore->VNForExpr(compCurBB, store->TypeGet()));
         }
         else

--- a/src/tests/JIT/Regression/JitBlue/Runtime_131226/Runtime_131226.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_131226/Runtime_131226.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Each fixed region re-pins the span and derives 'p + Length' from the pointer that region
+// established. Value numbering gave every "Cast away GC" temp holding those pointers the same
+// number, so CSE computed the sum once and reused it in the later regions, by which point the
+// GC had moved the array out from under it.
+
+namespace Runtime_131226;
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public static unsafe class Runtime_131226
+{
+    private static object s_garbage;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Relocate()
+    {
+        s_garbage = new byte[8192];
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.KeepAlive(s_garbage);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Spans(byte* start, byte* end, int length) => (end - start) == length;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int PinSequentially(ReadOnlySpan<byte> span)
+    {
+        int mismatches = 0;
+
+        fixed (byte* p = &MemoryMarshal.GetReference(span))
+        {
+            if (!Spans(p, p + span.Length, span.Length)) { mismatches++; }
+        }
+
+        Relocate();
+
+        fixed (byte* p = &MemoryMarshal.GetReference(span))
+        {
+            if (!Spans(p, p + span.Length, span.Length)) { mismatches++; }
+        }
+
+        Relocate();
+
+        fixed (byte* p = &MemoryMarshal.GetReference(span))
+        {
+            if (!Spans(p, p + span.Length, span.Length)) { mismatches++; }
+        }
+
+        return mismatches;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int PinInLoop(ReadOnlySpan<byte> span)
+    {
+        int mismatches = 0;
+
+        for (int i = 0; i < 4; i++)
+        {
+            fixed (byte* p = &MemoryMarshal.GetReference(span))
+            {
+                if (!Spans(p, p + span.Length, span.Length)) { mismatches++; }
+            }
+
+            Relocate();
+        }
+
+        return mismatches;
+    }
+
+    [Fact]
+    public static void SequentialRegions()
+    {
+        int mismatches = 0;
+
+        for (int i = 0; i < 8; i++)
+        {
+            mismatches += PinSequentially(new byte[38]);
+        }
+
+        Assert.Equal(0, mismatches);
+    }
+
+    [Fact]
+    public static void RegionInLoop()
+    {
+        int mismatches = 0;
+
+        for (int i = 0; i < 8; i++)
+        {
+            mismatches += PinInLoop(new byte[38]);
+        }
+
+        Assert.Equal(0, mismatches);
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -120,6 +120,7 @@
     <Compile Include="JitBlue\Runtime_130830\Runtime_130830.cs" />
     <Compile Include="JitBlue\Runtime_130831\Runtime_130831.cs" />
     <Compile Include="JitBlue\Runtime_131137\Runtime_131137.cs" />
+    <Compile Include="JitBlue\Runtime_131226\Runtime_131226.cs" />
     <Compile Include="JitBlue\Runtime_131459\Runtime_131459.cs" />
     <Compile Include="JitBlue\Runtime_10337\Runtime_10337.cs" />
     <Compile Include="JitBlue\Runtime_125160\Runtime_125160.cs" />


### PR DESCRIPTION
This fixes the JIT value-numbering bug behind #131226. When morph spills a GC value into a non-GC temp to cast away GC information, the JIT was giving equivalent stores from distinct `fixed` regions the same value number, which let CSE reuse a stale raw address after a compacting GC had moved the object. Give each of those stores its own value number instead, and add regression coverage for both sequential pinned regions and the looped form.

> [!NOTE]
> This pull request description was created by GitHub Copilot.
