### PR TITLE
Fix mono handling of SwiftError

### DIFF
--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -1124,10 +1124,13 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 				ainfo->pair_size [0] = size;
 				continue;
 			} else if (klass == swift_error || klass == swift_error_ptr) {
-				if (sig->pinvoke)
+				if (sig->pinvoke) {
 					ainfo->reg = GINT32_TO_UINT8 (AMD64_R12);
-				else
+					ainfo->swift_error_in_reg = TRUE;
+				} else {
 					add_general (&gr, &stack_size, ainfo);
+					ainfo->swift_error_in_reg = ainfo->storage == ArgInIReg;
+				}
 				ainfo->storage = ArgSwiftError;
 				cinfo->swift_error_index = i;
 				continue;
@@ -1824,7 +1827,10 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 	for (guint i = 0; i < sig->param_count + sig->hasthis; ++i) {
 		ArgInfo *ainfo = &cinfo->args [i];
 
-		if (ainfo->storage == ArgOnStack || ainfo->storage == ArgValuetypeAddrInIReg || ainfo->storage == ArgValuetypeAddrOnStack) {
+		if (ainfo->storage == ArgOnStack ||
+			ainfo->storage == ArgValuetypeAddrInIReg ||
+			ainfo->storage == ArgValuetypeAddrOnStack ||
+			(ainfo->storage == ArgSwiftError && !ainfo->swift_error_in_reg)) {
 			/*
 			 * The stack offset can only be determined when the frame
 			 * size is known.
@@ -2165,8 +2171,9 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 			}
 			case ArgSwiftError: {
 				inreg = FALSE;
-				if (ainfo->offset)
+				if (!ainfo->swift_error_in_reg)
 				{
+					g_assert (!cfg->arch.omit_fp);
 					ins->opcode = OP_REGOFFSET;
 					ins->inst_basereg = cfg->frame_reg;
 					ins->inst_offset = ainfo->offset + ARGS_OFFSET;
@@ -8578,7 +8585,7 @@ MONO_RESTORE_WARNING
 				break;
 			case ArgSwiftError:
 				if (cfg->method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {
-					if (ainfo->offset == 0) {
+					if (ainfo->swift_error_in_reg) {
 						amd64_mov_membase_reg (code, cfg->arch.swift_error_var->inst_basereg, cfg->arch.swift_error_var->inst_offset, ainfo->reg, sizeof (target_mgreg_t));
 					}
 				} else if (cfg->method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED) {

--- a/src/mono/mono/mini/mini-amd64.h
+++ b/src/mono/mono/mini/mini-amd64.h
@@ -345,6 +345,7 @@ typedef struct {
 	int byte_arg_size;
 	guint8 pass_empty_struct : 1; // Set in scenarios when empty structs needs to be represented as argument.
 	guint8 is_signed : 1;
+	guint8 swift_error_in_reg : 1;
 } ArgInfo;
 
 struct CallInfo {

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -1929,10 +1929,13 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 				ainfo->size = size;
 				continue;
 			} else if (klass == swift_error || klass == swift_error_ptr) {
-				if (sig->pinvoke)
+				if (sig->pinvoke) {
 					ainfo->reg = ARMREG_R21;
-				else
+					ainfo->swift_error_in_reg = TRUE;
+				} else {
 					add_param (cinfo, ainfo, sig->params [pindex], FALSE);
+					ainfo->swift_error_in_reg = ainfo->storage == ArgInIReg;
+				}
 				ainfo->storage = ArgSwiftError;
 				continue;
 			}
@@ -2996,7 +2999,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 		case ArgSwiftError: {
 			ins->flags |= MONO_INST_VOLATILE;
 			ins->opcode = OP_REGOFFSET;
-			if (ainfo->offset) {
+			if (!ainfo->swift_error_in_reg) {
 				g_assert (cfg->arch.args_reg);
 				ins->inst_basereg = cfg->arch.args_reg;
 				ins->inst_offset = ainfo->offset;
@@ -6162,7 +6165,7 @@ emit_move_args (MonoCompile *cfg, guint8 *code)
 				break;
 			case ArgSwiftError:
 				if (cfg->method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {
-					if (ainfo->offset == 0) {
+					if (ainfo->swift_error_in_reg) {
 						code = emit_strx (code, ainfo->reg, cfg->arch.swift_error_var->inst_basereg, GTMREG_TO_INT (cfg->arch.swift_error_var->inst_offset));
 					}
 				} else if (cfg->method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED) {

--- a/src/mono/mono/mini/mini-arm64.h
+++ b/src/mono/mono/mini/mini-arm64.h
@@ -270,6 +270,7 @@ typedef struct {
 	gboolean sign;
 	gboolean gsharedvt;
 	gboolean hfa;
+	gboolean swift_error_in_reg;
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	/* ArgSwiftVtypeLoweredRet */
 	ArgStorage struct_storage [4];

--- a/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.cs
+++ b/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.cs
@@ -30,22 +30,6 @@ public class ErrorHandlingTests
         internal nint Count => _count;
     }
 
-    private sealed class SwiftAbiSafeHandle : SafeHandle
-    {
-        public SwiftAbiSafeHandle() : base(IntPtr.Zero, ownsHandle: true)
-        {
-        }
-
-        internal SwiftAbiSafeHandle(IntPtr handle) : this()
-        {
-            SetHandle(handle);
-        }
-
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        protected override bool ReleaseHandle() => true;
-    }
-
     [DllImport(SwiftLib, EntryPoint = "$s18SwiftErrorHandling05setMyB7Message7message6lengthySPys6UInt16VG_s5Int32VtF", CharSet = CharSet.Unicode)]
     public static extern void SetErrorMessage(string message, int length);
 
@@ -64,7 +48,7 @@ public class ErrorHandlingTests
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(SwiftLib, EntryPoint = "validateSwiftAbiOneWord")]
     private static extern nuint ValidateSwiftAbiOneWord(
-        SwiftAbiSafeHandle key,
+        nint key,
         BufferPointer buffer1,
         BufferPointer buffer2,
         BufferPointer buffer3,
@@ -198,20 +182,17 @@ public class ErrorHandlingTests
         BufferPointer buffer4 = new BufferPointer(values + 4, 55);
         BufferPointer buffer5 = new BufferPointer(values + 5, 66);
 
-        using (var key = new SwiftAbiSafeHandle((IntPtr)values))
-        {
-            nuint actual = ValidateSwiftAbiOneWord(
-                key,
-                buffer1,
-                buffer2,
-                buffer3,
-                buffer4,
-                buffer5,
-                out SwiftError error);
+        nuint actual = ValidateSwiftAbiOneWord(
+            (nint)values,
+            buffer1,
+            buffer2,
+            buffer3,
+            buffer4,
+            buffer5,
+            out SwiftError error);
 
-            Assert.Equal(Hash((nuint)values, buffer1, buffer2, buffer3, buffer4, buffer5), actual);
-            Assert.True(error.Value == null, "No Swift error was expected to be thrown.");
-        }
+        Assert.Equal(Hash((nuint)values, buffer1, buffer2, buffer3, buffer4, buffer5), actual);
+        Assert.True(error.Value == null, "No Swift error was expected to be thrown.");
     }
 
     [Fact]

--- a/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.cs
+++ b/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.cs
@@ -46,6 +46,10 @@ public class ErrorHandlingTests
     public static extern nint conditionallyThrowErrorInFirstStackSlot(int willThrow, int dummy1, int dummy2, int dummy3, int dummy4, int dummy5, int dummy6, int dummy7, ref SwiftError error);
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    [DllImport(SwiftLib, EntryPoint = "conditionallyThrowErrorAfterSixArguments")]
+    public static extern nint conditionallyThrowErrorAfterSixArguments(int willThrow, int dummy1, int dummy2, int dummy3, int dummy4, int dummy5, ref SwiftError error);
+
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(SwiftLib, EntryPoint = "validateSwiftAbiOneWord")]
     private static extern nuint ValidateSwiftAbiOneWord(
         nint key,
@@ -167,6 +171,34 @@ public class ErrorHandlingTests
 
         int i = 0;
         int result = (int)conditionallyThrowErrorInFirstStackSlot(0, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6, i + 7, ref error);
+
+        Assert.True(error.Value == null, "No Swift error was expected to be thrown.");
+        Assert.True(result == 42, "The result from Swift does not match the expected value.");
+    }
+
+    [Fact]
+    public static unsafe void TestSwiftErrorAfterSixArgumentsThrown()
+    {
+        const string expectedErrorMessage = "Catch me if you can!";
+        SetErrorMessageForSwift(expectedErrorMessage);
+
+        SwiftError error = new SwiftError();
+
+        int i = 0;
+        conditionallyThrowErrorAfterSixArguments(1, i + 1, i + 2, i + 3, i + 4, i + 5, ref error);
+        Assert.True(error.Value != null, "A Swift error was expected to be thrown.");
+
+        string errorMessage = GetErrorMessageFromSwift(error);
+        Assert.True(errorMessage == expectedErrorMessage, string.Format("The error message retrieved from Swift does not match the expected message. Expected: {0}, Actual: {1}", expectedErrorMessage, errorMessage));
+    }
+
+    [Fact]
+    public static unsafe void TestSwiftErrorAfterSixArgumentsNotThrown()
+    {
+        SwiftError error = new SwiftError();
+
+        int i = 0;
+        int result = (int)conditionallyThrowErrorAfterSixArguments(0, i + 1, i + 2, i + 3, i + 4, i + 5, ref error);
 
         Assert.True(error.Value == null, "No Swift error was expected to be thrown.");
         Assert.True(result == 42, "The result from Swift does not match the expected value.");

--- a/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.cs
+++ b/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.cs
@@ -14,6 +14,38 @@ public class ErrorHandlingTests
 {
     private const string SwiftLib = "libSwiftErrorHandling.dylib";
 
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly unsafe struct BufferPointer
+    {
+        private readonly byte* _baseAddress;
+        private readonly nint _count;
+
+        internal BufferPointer(byte* baseAddress, nint count)
+        {
+            _baseAddress = baseAddress;
+            _count = count;
+        }
+
+        internal byte* BaseAddress => _baseAddress;
+        internal nint Count => _count;
+    }
+
+    private sealed class SwiftAbiSafeHandle : SafeHandle
+    {
+        public SwiftAbiSafeHandle() : base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        internal SwiftAbiSafeHandle(IntPtr handle) : this()
+        {
+            SetHandle(handle);
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected override bool ReleaseHandle() => true;
+    }
+
     [DllImport(SwiftLib, EntryPoint = "$s18SwiftErrorHandling05setMyB7Message7message6lengthySPys6UInt16VG_s5Int32VtF", CharSet = CharSet.Unicode)]
     public static extern void SetErrorMessage(string message, int length);
 
@@ -24,6 +56,21 @@ public class ErrorHandlingTests
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(SwiftLib, EntryPoint = "$s18SwiftErrorHandling018conditionallyThrowB004willE0s5Int32VAE_tKF")]
     public static extern nint conditionallyThrowErrorOnStack(int willThrow, int dummy1, int dummy2, int dummy3, int dummy4, int dummy5, int dummy6, int dummy7, int dummy8, int dummy9, ref SwiftError error);
+
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    [DllImport(SwiftLib, EntryPoint = "conditionallyThrowErrorInFirstStackSlot")]
+    public static extern nint conditionallyThrowErrorInFirstStackSlot(int willThrow, int dummy1, int dummy2, int dummy3, int dummy4, int dummy5, int dummy6, int dummy7, ref SwiftError error);
+
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    [DllImport(SwiftLib, EntryPoint = "validateSwiftAbiOneWord")]
+    private static extern nuint ValidateSwiftAbiOneWord(
+        SwiftAbiSafeHandle key,
+        BufferPointer buffer1,
+        BufferPointer buffer2,
+        BufferPointer buffer3,
+        BufferPointer buffer4,
+        BufferPointer buffer5,
+        out SwiftError error);
 
     [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
     [DllImport(SwiftLib, EntryPoint = "$s18SwiftErrorHandling26nativeFunctionWithCallback03setB0_ys5Int32V_yAEXEtF")]
@@ -130,6 +177,44 @@ public class ErrorHandlingTests
     }
 
     [Fact]
+    public static unsafe void TestSwiftErrorInFirstStackSlotNotThrown()
+    {
+        SwiftError error = new SwiftError();
+
+        int i = 0;
+        int result = (int)conditionallyThrowErrorInFirstStackSlot(0, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6, i + 7, ref error);
+
+        Assert.True(error.Value == null, "No Swift error was expected to be thrown.");
+        Assert.True(result == 42, "The result from Swift does not match the expected value.");
+    }
+
+    [Fact]
+    public static unsafe void TestSwiftAbiOneWordArgument()
+    {
+        byte* values = stackalloc byte[6];
+        BufferPointer buffer1 = new BufferPointer(values + 1, 22);
+        BufferPointer buffer2 = new BufferPointer(values + 2, 33);
+        BufferPointer buffer3 = new BufferPointer(values + 3, 44);
+        BufferPointer buffer4 = new BufferPointer(values + 4, 55);
+        BufferPointer buffer5 = new BufferPointer(values + 5, 66);
+
+        using (var key = new SwiftAbiSafeHandle((IntPtr)values))
+        {
+            nuint actual = ValidateSwiftAbiOneWord(
+                key,
+                buffer1,
+                buffer2,
+                buffer3,
+                buffer4,
+                buffer5,
+                out SwiftError error);
+
+            Assert.Equal(Hash((nuint)values, buffer1, buffer2, buffer3, buffer4, buffer5), actual);
+            Assert.True(error.Value == null, "No Swift error was expected to be thrown.");
+        }
+    }
+
+    [Fact]
     public static unsafe void TestUnmanagedCallersOnly()
     {
         SwiftError error;
@@ -173,4 +258,32 @@ public class ErrorHandlingTests
         FreeErrorMessageBuffer(pointer);
         return errorMessage;
     }
+
+    private static unsafe nuint Hash(
+        nuint key,
+        BufferPointer buffer1,
+        BufferPointer buffer2,
+        BufferPointer buffer3,
+        BufferPointer buffer4,
+        BufferPointer buffer5)
+    {
+        nuint hash = Mix(FnvOffsetBasis, key);
+        hash = HashBuffer(hash, buffer1);
+        hash = HashBuffer(hash, buffer2);
+        hash = HashBuffer(hash, buffer3);
+        hash = HashBuffer(hash, buffer4);
+        return HashBuffer(hash, buffer5);
+    }
+
+    private static unsafe nuint HashBuffer(nuint hash, BufferPointer buffer)
+    {
+        hash = Mix(hash, (nuint)buffer.BaseAddress);
+        return Mix(hash, (nuint)buffer.Count);
+    }
+
+    private static nuint Mix(nuint hash, nuint value) =>
+        unchecked((hash ^ value) * (nuint)1099511628211);
+
+    private static nuint FnvOffsetBasis =>
+        unchecked((nuint)14695981039346656037UL);
 }

--- a/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.swift
+++ b/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.swift
@@ -35,6 +35,18 @@ public func conditionallyThrowErrorInFirstStackSlot(
     return try conditionallyThrowError(willThrow: willThrow)
 }
 
+@_silgen_name("conditionallyThrowErrorAfterSixArguments")
+public func conditionallyThrowErrorAfterSixArguments(
+    willThrow: Int32,
+    dummy1: Int32,
+    dummy2: Int32,
+    dummy3: Int32,
+    dummy4: Int32,
+    dummy5: Int32
+) throws -> Int32 {
+    return try conditionallyThrowError(willThrow: willThrow)
+}
+
 private let fnvOffsetBasis: UInt = 14695981039346656037
 private let fnvPrime: UInt = 1099511628211
 

--- a/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.swift
+++ b/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.swift
@@ -21,6 +21,49 @@ public func conditionallyThrowError(willThrow: Int32) throws -> Int32 {
     }
 }
 
+@_silgen_name("conditionallyThrowErrorInFirstStackSlot")
+public func conditionallyThrowErrorInFirstStackSlot(
+    willThrow: Int32,
+    dummy1: Int32,
+    dummy2: Int32,
+    dummy3: Int32,
+    dummy4: Int32,
+    dummy5: Int32,
+    dummy6: Int32,
+    dummy7: Int32
+) throws -> Int32 {
+    return try conditionallyThrowError(willThrow: willThrow)
+}
+
+private let fnvOffsetBasis: UInt = 14695981039346656037
+private let fnvPrime: UInt = 1099511628211
+
+private func mix(_ hash: UInt, _ value: UInt) -> UInt {
+    return (hash ^ value) &* fnvPrime
+}
+
+private func hashBuffer(_ hash: UInt, _ buffer: UnsafeBufferPointer<UInt8>) -> UInt {
+    let baseAddress = buffer.baseAddress.map { UInt(bitPattern: $0) } ?? 0
+    return mix(mix(hash, baseAddress), UInt(buffer.count))
+}
+
+@_silgen_name("validateSwiftAbiOneWord")
+public func validateSwiftAbiOneWord(
+    key: UnsafeRawPointer,
+    buffer1: UnsafeBufferPointer<UInt8>,
+    buffer2: UnsafeBufferPointer<UInt8>,
+    buffer3: UnsafeBufferPointer<UInt8>,
+    buffer4: UnsafeBufferPointer<UInt8>,
+    buffer5: UnsafeBufferPointer<UInt8>
+) throws -> UInt {
+    var hash = mix(fnvOffsetBasis, UInt(bitPattern: key))
+    hash = hashBuffer(hash, buffer1)
+    hash = hashBuffer(hash, buffer2)
+    hash = hashBuffer(hash, buffer3)
+    hash = hashBuffer(hash, buffer4)
+    return hashBuffer(hash, buffer5)
+}
+
 public func getMyErrorMessage(from error: Error, messageLength: inout Int32) -> UnsafePointer<unichar>? {
     if let myError = error as? MyError {
         switch myError {


### PR DESCRIPTION
There appear to be two problems with the Swift calling convention implementation in Mono for how it handles `SwiftError`.

On x64, structs can spill to the stack while a later scalar argument still has an available register. Consequently, `SwiftError` can be register passed while carrying a nonzero accumulated stack offset. Mono mistakes that offset for a stack location and reads an invalid pointer.

On ARM64, the first argument placed on the stack naturally has offset zero. Mono mistakes that stack location for a register passed argument and uses the wrong value. `offset == 0`  is ambiguous: it can mean either "passed in a register" or "passed in the first stack slot." Right now it doesn't look like it can tell the difference.

The fix records whether `SwiftError` was originally passed in a register before replacing its argument classification with `ArgSwiftError`, rather than inferring its location from the stack offset. On x64, stack-passed `SwiftError` arguments also disable frame-pointer omission so their incoming stack slots remain addressable.

The tests that have been added would fail without the fixes, and I confirmed this locally on an x64 macOS 26 machine.

This was originally found in https://github.com/dotnet/runtime/pull/131630, where changes at the p/invoke boundary caused the `SwiftError` to be identified as register passed but carried a nonzero accumulated stack offset because preceding two word buffer structs had spilled.

This is a follow up to https://github.com/dotnet/runtime/pull/103043, where it appears the fix was incomplete.