### PR TITLE
[android] Skip internal arm device test sends

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1160,11 +1160,18 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+                  # Don't send arm/arm64 tests to Helix on internal: there is no internal Android
+                  # device queue, so those APKs fail with DEVICE_NOT_FOUND on the x86_64 emulator
+                  # queue. Keep building them, and keep sending x64 (its emulator queue works).
                   condition: >-
+                    and(
                     or(
                     eq(variables['librariesContainsChange'], true),
                     eq(variables['coreclrContainsChange'], true),
-                    eq(variables['isRollingBuild'], true))
+                    eq(variables['isRollingBuild'], true)),
+                    or(
+                    eq(variables['System.TeamProject'], 'public'),
+                    eq(variables['_archParameter'], '-arch x64')))
 
       #
       # iOS Simulator


### PR DESCRIPTION
context #130852

## Summary

- Keep building Android arm and arm64 in internal runtime CI.
- Skip sending those test payloads to Helix because there is no internal Android device queue and the x86_64 emulator queue cannot run them.
- Preserve internal Android x64 emulator testing and all public Android device testing.

## Validation

[Internal runtime build 3035781](https://dev.azure.com/dnceng/internal/_build/results?buildId=3035781&view=results):

- `android-arm`: build succeeded; `Send to Helix` skipped.
- `android-arm64`: build succeeded; `Send to Helix` skipped.
- `android-x64`: build succeeded; `Send to Helix` succeeded.

[Public runtime build 1534565](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1534565&view=results):

- `android-arm`: build and `Send to Helix` succeeded.
- `android-arm64`: build and `Send to Helix` succeeded.
- `android-x64`: build and `Send to Helix` succeeded.

> [!NOTE]
> This pull request description was generated by GitHub Copilot.