### PR TITLE
Fix CoreCLR browser-wasm native relink from a packaged SDK

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -266,6 +266,10 @@
     <PlatformManifestFileEntry Include="ILLink.Substitutions.WasmIntrinsics.xml" IsNative="true" />
     <PlatformManifestFileEntry Include="ILLink.Substitutions.NoWasmIntrinsics.xml" IsNative="true" />
     <!-- CoreCLR WASM-specific files -->
+    <!-- Headers included by the CoreCLR native relink generated sources -->
+    <PlatformManifestFileEntry Include="callhelpers.hpp" IsNative="true" />
+    <PlatformManifestFileEntry Include="entrypoints.h" IsNative="true" />
+    <PlatformManifestFileEntry Include="utils.h" IsNative="true" />
     <PlatformManifestFileEntry Include="libcoreclrminipal.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libcoreclrpal.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libgcinfo_unix_wasm.a" IsNative="true" />

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -563,13 +563,13 @@
     <PropertyGroup>
       <!-- WASM-TODO https://github.com/dotnet/runtime/issues/128362 -->
       <_MinipalIncludeDir Condition="'$(MINIPAL_INCLUDE_DIR)' != ''">$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$(MINIPAL_INCLUDE_DIR)'))))</_MinipalIncludeDir>
-      <!-- Restored SDK: headers ship next to the targets under Sdk/minipal. -->
-      <_MinipalIncludeDir Condition="'$(_MinipalIncludeDir)' == '' and Exists('$(MSBuildThisFileDirectory)minipal\utils.h')">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'minipal'))</_MinipalIncludeDir>
+      <!-- Restored SDK: headers ship in the runtime pack under native/include/minipal. -->
+      <_MinipalIncludeDir Condition="'$(_MinipalIncludeDir)' == '' and Exists('$(MicrosoftNetCoreAppRuntimePackRidNativeDir)include\minipal\utils.h')">$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackRidNativeDir)', 'include', 'minipal'))</_MinipalIncludeDir>
       <_MinipalIncludeDir Condition="'$(_MinipalIncludeDir)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..', '..', '..', 'native', 'minipal'))</_MinipalIncludeDir>
       <_MinipalIncludeRoot>$([MSBuild]::NormalizeDirectory('$(_MinipalIncludeDir)', '..'))</_MinipalIncludeRoot>
       <_VmWasmIncludeDir Condition="'$(CORECLR_VM_WASM_INCLUDE_DIR)' != ''">$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$(CORECLR_VM_WASM_INCLUDE_DIR)'))))</_VmWasmIncludeDir>
-      <!-- Restored SDK: callhelpers.hpp ships next to the targets under Sdk. -->
-      <_VmWasmIncludeDir Condition="'$(_VmWasmIncludeDir)' == '' and Exists('$(MSBuildThisFileDirectory)callhelpers.hpp')">$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</_VmWasmIncludeDir>
+      <!-- Restored SDK: callhelpers.hpp ships in the runtime pack under native/include. -->
+      <_VmWasmIncludeDir Condition="'$(_VmWasmIncludeDir)' == '' and Exists('$(MicrosoftNetCoreAppRuntimePackRidNativeDir)include\callhelpers.hpp')">$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackRidNativeDir)', 'include'))</_VmWasmIncludeDir>
       <_VmWasmIncludeDir Condition="'$(_VmWasmIncludeDir)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..', '..', '..', 'coreclr', 'vm', 'wasm'))</_VmWasmIncludeDir>
     </PropertyGroup>
     <ItemGroup>

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -492,6 +492,9 @@
       <EmscriptenEnvVars Include="EMSDK_PYTHON=$(EmscriptenPythonToolsPath)python.exe" Condition="'$(OS)' == 'Windows_NT'" />
       <EmscriptenEnvVars Include="PYTHONPATH=$(EmscriptenPythonToolsPath)" Condition="'$(OS)' == 'Windows_NT'" />
       <EmscriptenEnvVars Include="PYTHONHOME=" Condition="'$(OS)' == 'Windows_NT'" />
+      <EmscriptenEnvVars Include="EM_CACHE=$(WasmCachePath)" Condition="'$(WasmCachePath)' != ''" />
+      <EmscriptenEnvVars Include="EM_FROZEN_CACHE=1" Condition="'$(WasmCachePath)' == '$(EmscriptenCacheSdkCacheDir)'" />
+      <EmscriptenEnvVars Include="EM_FROZEN_CACHE=0" Condition="'$(WasmCachePath)' != '' and '$(WasmCachePath)' != '$(EmscriptenCacheSdkCacheDir)'" />
     </ItemGroup>
   </Target>
 

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -563,9 +563,13 @@
     <PropertyGroup>
       <!-- WASM-TODO https://github.com/dotnet/runtime/issues/128362 -->
       <_MinipalIncludeDir Condition="'$(MINIPAL_INCLUDE_DIR)' != ''">$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$(MINIPAL_INCLUDE_DIR)'))))</_MinipalIncludeDir>
+      <!-- Restored SDK: headers ship next to the targets under Sdk/minipal. -->
+      <_MinipalIncludeDir Condition="'$(_MinipalIncludeDir)' == '' and Exists('$(MSBuildThisFileDirectory)minipal\utils.h')">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'minipal'))</_MinipalIncludeDir>
       <_MinipalIncludeDir Condition="'$(_MinipalIncludeDir)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..', '..', '..', 'native', 'minipal'))</_MinipalIncludeDir>
       <_MinipalIncludeRoot>$([MSBuild]::NormalizeDirectory('$(_MinipalIncludeDir)', '..'))</_MinipalIncludeRoot>
       <_VmWasmIncludeDir Condition="'$(CORECLR_VM_WASM_INCLUDE_DIR)' != ''">$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$(CORECLR_VM_WASM_INCLUDE_DIR)'))))</_VmWasmIncludeDir>
+      <!-- Restored SDK: callhelpers.hpp ships next to the targets under Sdk. -->
+      <_VmWasmIncludeDir Condition="'$(_VmWasmIncludeDir)' == '' and Exists('$(MSBuildThisFileDirectory)callhelpers.hpp')">$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</_VmWasmIncludeDir>
       <_VmWasmIncludeDir Condition="'$(_VmWasmIncludeDir)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..', '..', '..', 'coreclr', 'vm', 'wasm'))</_VmWasmIncludeDir>
     </PropertyGroup>
     <ItemGroup>

--- a/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
@@ -18,6 +18,7 @@
     <PackageFile Include="$(BrowserProjectRoot)build\BrowserWasmApp.props" TargetPath="Sdk" />
     <PackageFile Include="$(BrowserProjectRoot)build\BrowserWasmApp.targets" TargetPath="Sdk" />
     <PackageFile Include="$(BrowserProjectRoot)build\BrowserWasmApp.CoreCLR.targets" TargetPath="Sdk" />
+    <PackageFile Include="$(BrowserProjectRoot)build\coreclr_compat.h" TargetPath="Sdk" />
 
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.props" TargetPath="Sdk" />
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.targets" TargetPath="Sdk" />

--- a/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
@@ -20,13 +20,6 @@
     <PackageFile Include="$(BrowserProjectRoot)build\BrowserWasmApp.CoreCLR.targets" TargetPath="Sdk" />
     <PackageFile Include="$(BrowserProjectRoot)build\coreclr_compat.h" TargetPath="Sdk" />
 
-    <!-- Headers force-included / included by the CoreCLR native relink generated sources.
-         Shipped next to BrowserWasmApp.CoreCLR.targets so native relink works from a
-         restored SDK (see _VmWasmIncludeDir / _MinipalIncludeDir fallbacks in the targets). -->
-    <PackageFile Include="$(CoreClrProjectRoot)vm\wasm\callhelpers.hpp" TargetPath="Sdk" />
-    <PackageFile Include="$(SharedNativeRoot)minipal\entrypoints.h" TargetPath="Sdk/minipal" />
-    <PackageFile Include="$(SharedNativeRoot)minipal\utils.h" TargetPath="Sdk/minipal" />
-
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.props" TargetPath="Sdk" />
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.targets" TargetPath="Sdk" />
 

--- a/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
@@ -20,6 +20,13 @@
     <PackageFile Include="$(BrowserProjectRoot)build\BrowserWasmApp.CoreCLR.targets" TargetPath="Sdk" />
     <PackageFile Include="$(BrowserProjectRoot)build\coreclr_compat.h" TargetPath="Sdk" />
 
+    <!-- Headers force-included / included by the CoreCLR native relink generated sources.
+         Shipped next to BrowserWasmApp.CoreCLR.targets so native relink works from a
+         restored SDK (see _VmWasmIncludeDir / _MinipalIncludeDir fallbacks in the targets). -->
+    <PackageFile Include="$(CoreClrProjectRoot)vm\wasm\callhelpers.hpp" TargetPath="Sdk" />
+    <PackageFile Include="$(SharedNativeRoot)minipal\entrypoints.h" TargetPath="Sdk/minipal" />
+    <PackageFile Include="$(SharedNativeRoot)minipal\utils.h" TargetPath="Sdk/minipal" />
+
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.props" TargetPath="Sdk" />
     <PackageFile Include="$(WasmProjectRoot)build\WasmApp.Common.targets" TargetPath="Sdk" />
 

--- a/src/native/corehost/browserhost/CMakeLists.txt
+++ b/src/native/corehost/browserhost/CMakeLists.txt
@@ -141,5 +141,10 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dotnet.native.wasm DESTINATION sharedF
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dotnet.native.js.symbols DESTINATION corehost COMPONENT runtime)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dotnet.native.js.symbols DESTINATION sharedFramework COMPONENT runtime)
 
+# Headers included by the CoreCLR native relink generated sources (see BrowserWasmApp.CoreCLR.targets).
+install(FILES ${CLR_REPO_ROOT_DIR}/src/coreclr/vm/wasm/callhelpers.hpp DESTINATION sharedFramework/include COMPONENT runtime)
+install(FILES ${CLR_SRC_NATIVE_DIR}/minipal/entrypoints.h DESTINATION sharedFramework/include/minipal COMPONENT runtime)
+install(FILES ${CLR_SRC_NATIVE_DIR}/minipal/utils.h DESTINATION sharedFramework/include/minipal COMPONENT runtime)
+
 set_source_files_properties(${BROWSERHOST_SOURCES} PROPERTIES OBJECT_DEPENDS
     "${JS_SYSTEM_NATIVE_BROWSER};${JS_SYSTEM_BROWSER_UTILS};${JS_SYSTEM_RUNTIME_INTEROPSERVICES_JAVASCRIPT_NATIVE};${JS_BROWSER_HOST};${JS_SYSTEM_NATIVE_BROWSER_EXPOST}")


### PR DESCRIPTION
Makes CoreCLR browser-wasm **native relink** work from a restored/packaged SDK (e.g. the daily `wasm-tools` workload). Found and validated end-to-end while diagnosing a failing `native-relink` benchmark build — after these fixes the CoreCLR app builds, loads in Chrome, and produces benchmark results.

## Fix 1 — Set `EM_CACHE` for CoreCLR native relink

`_CoreCLRSetupEmscripten` in `BrowserWasmApp.CoreCLR.targets` populated `EmscriptenEnvVars` without `EM_CACHE`/`EM_FROZEN_CACHE`. Because `FROZEN_CACHE` is forced on by the dotnet emscripten config, `emcc` fell back to the (empty) cache dir inside the Emscripten **SDK** pack instead of the prebuilt sysroot that ships in the separate Emscripten **Cache** pack, and aborted:

```
Exception: FROZEN_CACHE is set, but cache file is missing: "sysroot_install.stamp"
```

The Mono path (`BrowserWasmApp.targets`) already sets these. Fix mirrors it, pointing `EM_CACHE` at `$(WasmCachePath)`.

## Fix 2 — Package `coreclr_compat.h` in the WebAssembly.Sdk pack

`BrowserWasmApp.CoreCLR.targets` force-includes `$(MSBuildThisFileDirectory)coreclr_compat.h`, but the header was never added to the pack's `Sdk/` folder, so after Fix 1 the compile failed with `coreclr_compat.h file not found`. It's a build-time shim that lives next to the targets, so it's added to the `PackageFile` list in the SDK pack (not a runtime artifact → not in the platform manifest).

## Fix 3 — Ship the VM/minipal headers in the CoreCLR runtime pack

The generated managed-to-native sources include `<callhelpers.hpp>`, `<minipal/entrypoints.h>` and `<minipal/utils.h>`. These were only resolvable from the in-repo source tree or via `CORECLR_VM_WASM_INCLUDE_DIR` / `MINIPAL_INCLUDE_DIR` overrides, so a restored SDK failed with `'callhelpers.hpp' file not found`.

Mirroring how Mono ships its relink headers in the runtime pack (`runtime.h`/`pinvoke.h`/… under `native/include/wasm`, declared in the platform manifest):

- Install the three headers into the CoreCLR browser-wasm **runtime pack** under `native/include` (`callhelpers.hpp`) and `native/include/minipal` (`entrypoints.h`, `utils.h`) via the browserhost `CMakeLists.txt`.
- Declare them in the `Microsoft.NETCore.App` platform manifest (`PlatformManifestFileEntry`).
- Resolve `_VmWasmIncludeDir` / `_MinipalIncludeDir` from the runtime pack native dir (`$(MicrosoftNetCoreAppRuntimePackRidNativeDir)`), keeping the in-repo fallback and env-var overrides intact.

## Validation

Applied all edits to the restored SDK + runtime packs and ran native-relink build + measure end-to-end: the build completes, the CoreCLR wasm app loads in headless Chrome, and benchmarks run (`Measurement complete: 1/1 succeeded`). Each fix individually moved the build past its corresponding error (FROZEN_CACHE → `coreclr_compat.h` → `callhelpers.hpp` → success), with the headers resolved from the runtime pack `native/include`.

Related: https://github.com/dotnet/runtime/issues/128362
