### PR TITLE
[wasm][R2R] Create manifest token when type reference wasn't pre-registered

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -84,6 +84,19 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 {
                     return new ModuleToken(_manifestMutableModule, handle.Value);
                 }
+
+                // The reference wasn't pre-registered while resolving IL tokens. This happens on wasm when the
+                // method that would have registered it was skipped by the JIT (JitWasmNyiToR2RUnsupported) yet a
+                // fixup for the type still exists. Dynamically create the manifest reference while new tokens are
+                // still allowed (this runs before ManifestMetadataTableNode sets DisableNewTokens).
+                if (!_manifestMutableModule.DisableNewTokens)
+                {
+                    handle = _manifestMutableModule.TryGetEntityHandle(type);
+                    if (handle.HasValue)
+                    {
+                        return new ModuleToken(_manifestMutableModule, handle.Value);
+                    }
+                }
             }
 
             // Reverse lookup failed


### PR DESCRIPTION
## Summary

Fixes a crossgen2 ReadyToRun compilation failure that is specific to the WebAssembly target.

## Problem

When crossgen2 targets WebAssembly, a method that would normally register a type token during IL token resolution can be skipped by the JIT (`JitWasmNyiToR2RUnsupported`), while a `TypeFixupSignature` for that type is still emitted. At manifest emission time, `ModuleTokenResolver.GetModuleTokenForType` does a reverse lookup via `_manifestMutableModule.TryGetExistingEntityHandle(type)`, which returns `null` because nothing pre-registered the reference. The resolver then falls through to `throw new NotImplementedException(...)`, which aborts the R2R compile.

This was observed while R2R-compiling `System.Runtime.InteropServices.JavaScript.dll` for `browser-wasm`, where the reverse lookup fails for `[S.P.CoreLib]System.Reflection.MemberInfo`.

## Fix

In the `allowDynamicallyCreatedReference` branch, when the existing-handle lookup returns `null`, create the manifest reference on demand via `_manifestMutableModule.TryGetEntityHandle(type)`, guarded by `!DisableNewTokens` so it only runs while new tokens are still allowed (this path executes before `ManifestMetadataTableNode` sets `DisableNewTokens`). This mirrors how other manifest references are produced.

## Notes

- Scoped to a single method. The added code only runs when the pre-existing reverse lookup fails, so there is no behavior change for the PE/x64 path where the type is already registered.

> [!NOTE]
> This change and description were prepared with the assistance of GitHub Copilot.