### PR TITLE
JIT: Recover CSE of Cast-away-GC temps across same GcHeap epoch

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6556,6 +6556,13 @@ public:
     // memory yields an unknown value.
     ValueNum fgCurMemoryVN[MemoryKindCount];
 
+    // A VN that advances at every GC safepoint (any call for which IsNoGC() is false).
+    // This is distinct from fgCurMemoryVN[GcHeap], which only advances on heap mutations;
+    // allocations and pure arithmetic helpers are GC safepoints but do not mutate the heap.
+    // Used as the epoch argument to VNF_GCRefToPtrWithEpoch to prevent CSE of cast-away-GC
+    // address snapshots across GC safepoints where the GC could compact the heap.
+    ValueNum fgCurGcEpochVN;
+
     // Return a "pseudo"-class handle for an array element type. If `elemType` is TYP_STRUCT,
     // `elemStructType` is the struct handle (it must be non-null and have a low-order zero bit).
     // Otherwise, `elemTyp` is encoded by left-shifting by 1 and setting the low-order bit to 1.

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -12911,10 +12911,13 @@ void Compiler::fgValueNumberStore(GenTree* store)
         }
         else if (varTypeIsGC(value))
         {
-            // A GC reference reinterpreted as another type (an unsafe IL store of a TYP_REF, or one of
-            // morph's "Cast away GC" temps) is a raw address snapshot that is only valid until the
-            // referent can next move, so give each store its own VN rather than letting CSE share one.
-            valueVNPair.SetBoth(vnStore->VNForExpr(compCurBB, store->TypeGet()));
+            // A GC reference reinterpreted as a raw address (an unsafe IL store of TYP_REF/BYREF, or
+            // morph's "Cast away GC" temps) is only valid until the referent can next move.  Use a VN
+            // that is deterministic given (source byref VN, current GcHeap epoch): two stores from the
+            // same ref with no intervening GC safepoint share the same epoch VN and can be CSE'd;
+            // stores separated by a safepoint get distinct epoch VNs and are kept separate.
+            valueVNPair.SetBoth(vnStore->VNForFunc(store->TypeGet(), VNF_GCRefToPtrWithEpoch, valueVNPair.GetLiberal(),
+                                                   fgCurMemoryVN[GcHeap]));
         }
         else
         {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -12206,6 +12206,11 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 #endif // DEBUG
     }
 
+    // Initialize the GC safepoint epoch for this block. A fresh VN per block is conservative
+    // (prevents cross-block CSE of cast-away-GC temps) but correct; within the block the
+    // epoch is advanced at every non-NoGC call via fgValueNumberCall.
+    fgCurGcEpochVN = vnStore->VNForExpr(blk, TYP_I_IMPL);
+
     // Now iterate over the remaining statements, and their trees.
     for (; stmt != nullptr; stmt = stmt->GetNextStmt())
     {
@@ -12913,11 +12918,11 @@ void Compiler::fgValueNumberStore(GenTree* store)
         {
             // A GC reference reinterpreted as a raw address (an unsafe IL store of TYP_REF/BYREF, or
             // morph's "Cast away GC" temps) is only valid until the referent can next move.  Use a VN
-            // that is deterministic given (source byref VN, current GcHeap epoch): two stores from the
-            // same ref with no intervening GC safepoint share the same epoch VN and can be CSE'd;
-            // stores separated by a safepoint get distinct epoch VNs and are kept separate.
+            // that is deterministic given (source byref VN, current GC safepoint epoch): two stores from
+            // the same ref with no intervening GC safepoint share the same epoch VN and can be CSE'd;
+            // stores separated by any non-NoGC call (including allocations) get distinct epoch VNs.
             valueVNPair.SetBoth(vnStore->VNForFunc(store->TypeGet(), VNF_GCRefToPtrWithEpoch, valueVNPair.GetLiberal(),
-                                                   fgCurMemoryVN[GcHeap]));
+                                                   fgCurGcEpochVN));
         }
         else
         {
@@ -14925,6 +14930,16 @@ bool Compiler::fgValueNumberSpecialIntrinsic(GenTreeCall* call)
 
 void Compiler::fgValueNumberCall(GenTreeCall* call)
 {
+    // Advance the GC safepoint epoch at every call that is not in a NoGC region.
+    // Allocations and pure arithmetic helpers are GC safepoints but do not mutate
+    // the heap, so fgMutateGcHeap is not called for them; the separate epoch VN
+    // ensures cast-away-GC address snapshots are not CSE'd across such calls.
+    bool isNoGCCall = call->IsHelperCall() && s_helperCallProperties.IsNoGC(call->GetHelperNum());
+    if (!isNoGCCall)
+    {
+        fgCurGcEpochVN = vnStore->VNForExpr(compCurBB, TYP_I_IMPL);
+    }
+
     if (call->IsHelperCall())
     {
         bool modHeap = fgValueNumberHelperCall(call);

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -32,7 +32,8 @@ ValueNumFuncDef(Cast, 2, false, false)           // VNF_Cast: Cast Operation cha
 ValueNumFuncDef(CastOvf, 2, false, false)        // Same as a VNF_Cast but also can throw an overflow exception.
 ValueNumFuncDef(GCRefToPtrWithEpoch, 2, false, false)   // A GC ref/byref reinterpreted as a raw address (BYREF/REF -> I_IMPL).
                                                                 //   Args: 0: Source GC ref/byref VN.
-                                                                //         1: GcHeap memory epoch VN (advances at each GC safepoint).
+                                                                //         1: GC safepoint epoch VN (advances at every call for which IsNoGC() is false,
+                                                                //            including allocations and pure arithmetic helpers).
                                                                 //   Two stores from the same ref in the same epoch get identical VNs
                                                                 //   (CSE is safe; no compacting GC can occur between them).
 

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -30,6 +30,11 @@ ValueNumFuncDef(Cast, 2, false, false)           // VNF_Cast: Cast Operation cha
                                                                //                 1: Constant integer representing the operation .
                                                                //                    Use VNForCastOper() to construct.
 ValueNumFuncDef(CastOvf, 2, false, false)        // Same as a VNF_Cast but also can throw an overflow exception.
+ValueNumFuncDef(GCRefToPtrWithEpoch, 2, false, false)   // A GC ref/byref reinterpreted as a raw address (BYREF/REF -> I_IMPL).
+                                                                //   Args: 0: Source GC ref/byref VN.
+                                                                //         1: GcHeap memory epoch VN (advances at each GC safepoint).
+                                                                //   Two stores from the same ref in the same epoch get identical VNs
+                                                                //   (CSE is safe; no compacting GC can occur between them).
 
 ValueNumFuncDef(CastClass, 2, false, false)          // Args: 0: Handle of class being cast to, 1: object being cast.
 ValueNumFuncDef(IsInstanceOf, 2, false, false)       // Args: 0: Handle of class being queried, 1: object being queried.

--- a/src/tests/JIT/Regression/JitBlue/Runtime_131226/Runtime_131226.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_131226/Runtime_131226.cs
@@ -28,6 +28,40 @@ public static unsafe class Runtime_131226
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool Spans(byte* start, byte* end, int length) => (end - start) == length;
 
+    // Variant where an allocation (not a managed call) is the only operation between the two
+    // fixed regions.  The GC safepoint epoch must advance at the allocation so CSE does not
+    // merge the raw-address snapshot from the first region into the second.  No managed calls
+    // are made inside the first fixed block to ensure the epoch has not already advanced before
+    // the cast-away-GC store; the Relocate() that follows the allocation uses a managed call to
+    // guarantee the object actually moves, so the compaction that exposes any stale-address CSE
+    // is still reliable.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int PinAroundAllocation(ReadOnlySpan<byte> span)
+    {
+        int mismatches = 0;
+
+        fixed (byte* p = &MemoryMarshal.GetReference(span))
+        {
+            // No managed calls inside: the cast-away-GC epoch is exactly the block-entry epoch.
+            // 'p + span.Length' establishes a CSE candidate with this epoch.
+            if (p + span.Length - p != span.Length) { mismatches++; }
+        }
+
+        // Allocation only between the two fixed regions.  This helper call is a GC safepoint
+        // (IsNoGC is false for CORINFO_HELP_NEWSFAST) so fgCurGcEpochVN must advance here,
+        // giving the second region's cast-away-GC temp a different epoch and a different VN.
+        s_garbage = new byte[1];
+
+        Relocate();
+
+        fixed (byte* p = &MemoryMarshal.GetReference(span))
+        {
+            if (!Spans(p, p + span.Length, span.Length)) { mismatches++; }
+        }
+
+        return mismatches;
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
     private static int PinSequentially(ReadOnlySpan<byte> span)
     {
@@ -94,6 +128,19 @@ public static unsafe class Runtime_131226
         for (int i = 0; i < 8; i++)
         {
             mismatches += PinInLoop(new byte[38]);
+        }
+
+        Assert.Equal(0, mismatches);
+    }
+
+    [Fact]
+    public static void RegionAroundAllocation()
+    {
+        int mismatches = 0;
+
+        for (int i = 0; i < 8; i++)
+        {
+            mismatches += PinAroundAllocation(new byte[38]);
         }
 
         Assert.Equal(0, mismatches);


### PR DESCRIPTION
Follow-up to #131625, which fixed a correctness bug where morph's "Cast away GC" temps received the same VN regardless of intervening GC safepoints, allowing CSE to reuse a stale raw address after a compacting GC moved the object.

The fix in #131625 was conservative -- `VNForExpr` gives every such store its own unique VN, preventing all CSE. This recovers the cases that are safe to CSE.

## What this does

Introduces a dedicated `fgCurGcEpochVN` field (distinct from `fgCurMemoryVN[GcHeap]`) and uses it as the epoch in `VNF_GCRefToPtrWithEpoch(byrefVN, fgCurGcEpochVN)`.

`fgCurMemoryVN[GcHeap]` advances only when the heap is mutated (`fgMutateGcHeap`). Allocators (`CORINFO_HELP_NEWSFAST` etc.) have `MutatesHeap = false` -- they create new objects, not modify existing ones -- so `fgCurMemoryVN[GcHeap]` does not advance at an allocation. But allocators are not `IsNoGC`, meaning the GC can compact the heap during the call. This is a soundness gap for the epoch mechanism: two `fixed` regions separated only by `new T[n]` would share the same epoch VN, making CSE of the raw-address snapshot incorrect after a compacting GC.

`fgCurGcEpochVN` is initialized to a fresh unique VN at each basic block entry (conservative for cross-block: no cross-block CSE of cast-away-GC temps) and is advanced at every call where `!IsNoGC`. The only calls that don't advance it are the pure arithmetic helpers declared `isNoGC` (`CORINFO_HELP_LLSH`, `CORINFO_HELP_LRSH`, `CORINFO_HELP_LRSZ`), for which the GC genuinely cannot run. This correctly handles the allocation case:

```csharp
fixed (T* x = arr) { }   // epoch E0
T[] dst = new T[5];      // NEWSFAST: !IsNoGC → epoch advances to E1
fixed (T* x = arr) { }   // epoch E1 → different VN, no CSE (correct)
```

## SPMI asmdiffs (6 collections, 2.78M contexts, base = #131625)

| | Methods | Bytes |
|---|---|---|
| Improvements | 154 | -1,196 |
| Regressions | 7 | +28 |

The 7 regressions are each +4 bytes in cold blocks (bbWeight=0), all cases where two stores are separated by a call that advances the epoch but doesn't actually collect. Conservatively correct; PerfScore delta is 0 for all of them.

Net PerfScore: -831 in `libraries_tests` alone.

----------

Out of scope: `fgValueNumberByrefExposedLoad` already passes `fgCurMemoryVN[ByrefExposed]` to `VNF_ByrefExposedLoad` -- loads are already epoch-keyed by construction. `fgValueNumberCastTree` never sees a GC-to-non-GC cast because morph converts those to stores before VN runs.

> [!NOTE]
> This PR description was drafted with GitHub Copilot.
