### PR TITLE
Trim unused CoreCLR native components from dotnet-linker-tests build

### DIFF
--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -116,7 +116,11 @@ extends:
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
-            buildArgs: -s clr+libs+tools.illink+host.native -c $(_BuildConfig) /p:ToolsConfiguration=Debug
+            # This is the `clr` subset with `clr.native` (which builds every native component)
+            # narrowed to just the components the trimming/NativeAOT tests need. Most notably it
+            # drops `alljits` (the cross-target alt-JITs) and `spmi` (SuperPMI and its shims),
+            # none of which these tests use.
+            buildArgs: -s clr.runtime+clr.nativeaotruntime+clr.corelib+clr.tools+clr.nativecorelib+clr.nativeaotlibs+libs+tools.illink+host.native -c $(_BuildConfig) /p:ToolsConfiguration=Debug
             postBuildSteps:
               - template: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
                 parameters:

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -116,9 +116,9 @@ extends:
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
-            # This is the `clr` subset with `clr.native` (which builds every native component)
-            # narrowed to just the components the trimming/NativeAOT tests need. Most notably it
-            # drops `alljits` (the cross-target alt-JITs) and `spmi` (SuperPMI and its shims),
+            # This replaces the previous `clr` subset (which expands to `clr.native` and builds every native component)
+            # with a narrower CoreCLR subset list that the trimming/NativeAOT tests need.
+            # Most notably it drops `alljits` (cross-target alt-JITs) and `spmi` (SuperPMI and shims),
             # none of which these tests use.
             buildArgs: -s clr.runtime+clr.nativeaotruntime+clr.corelib+clr.tools+clr.nativecorelib+clr.nativeaotlibs+libs+tools.illink+host.native -c $(_BuildConfig) /p:ToolsConfiguration=Debug
             postBuildSteps:

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -771,6 +771,17 @@ if (CLR_CMAKE_TARGET_UNIX)
     endif()
 endif()
 
+# crossgen2 and ILC load the target-specific JIT (e.g. clrjit_win_x64_x64) rather than clrjit,
+# so it has to be part of the jit component for a build that only requests that component to be
+# able to run them. This mirrors what the block above already does for Unix targets.
+if (CLR_CMAKE_TARGET_WIN32)
+    if(CLR_CMAKE_TARGET_ARCH_ARM OR CLR_CMAKE_TARGET_ARCH_ARM64)
+      install_clr(TARGETS clrjit_universal_${ARCH_TARGET_NAME}_${ARCH_HOST_NAME} DESTINATIONS . COMPONENT jit)
+    else()
+      install_clr(TARGETS clrjit_win_${ARCH_TARGET_NAME}_${ARCH_HOST_NAME} DESTINATIONS . COMPONENT jit)
+    endif()
+endif()
+
 if (CLR_CMAKE_TARGET_WIN32 AND CLR_CMAKE_PGO_INSTRUMENT)
   # Copy PGO dependency to target dir
   set(PGORT_DLL "pgort140.dll")


### PR DESCRIPTION
The `Runtime_Release` jobs in the `dotnet-linker-tests` pipeline build the `clr` subset. That expands to a list of CoreCLR subsets (`eng/Subsets.props`, `DefaultCoreClrSubsets`) which includes `clr.native`, and `clr.native` performs a *full* CoreCLR native build. That pulls in components the trimming and NativeAOT tests never use — most notably the cross-target alt-JITs and SuperPMI.

This PR narrows the subset list to what those tests actually need, and fixes a Windows/Unix asymmetry in the JIT install rules that blocked doing so.

## 1. `src/coreclr/jit/CMakeLists.txt` — install the target-specific JIT into the `jit` component on Windows

crossgen2 and ILC don't load `clrjit`; they load the JIT named for the target they're compiling for, e.g. `clrjit_win_x64_x64` when targeting win-x64.

On Unix that JIT is already installed into the `jit` component alongside `clrjit`:

```cmake
if (CLR_CMAKE_TARGET_UNIX)
      ...
      install_clr(TARGETS clrjit_unix_${ARCH_TARGET_NAME}_${ARCH_HOST_NAME} DESTINATIONS . COMPONENT jit)
endif()
```

Windows had no equivalent rule, so there the target-specific JIT was only ever installed as part of `alljits`. Any Windows build that selects native components individually rather than doing a full native build therefore produces a crossgen2 that fails as soon as it runs:

```
EXEC : error : Dll was not found. [src\coreclr\crossgen-corelib.proj]
error MSB3073: ...crossgen2.exe ... System.Private.CoreLib.dll ... exited with code 1
```

This mirrors the existing Unix rule for Windows targets. **Full native builds are unaffected**, since `alljits` already installed these JITs — it only makes the `jit` component self-contained on Windows the way it already is on Unix.

## 2. `eng/pipelines/runtime-linker-tests.yml` — narrow the subset list

`clr.native` is replaced by `clr.runtime` + `clr.nativeaotruntime` (the `runtime` and `nativeaot` CMake components). `src/coreclr/components.cmake` shows `runtime` already depends on `jit`, `iltools`, `debug` and `hosts`, and with the fix above `jit` now also carries the JIT crossgen2/ILC need.

Dropped as a result:

- **`alljits`** — the cross-target alt-JITs. On win-x64 only `clrjit` and `clrjit_win_x64_x64` are now built; on linux-x64 only `clrjit` and `clrjit_unix_x64_x64`.
- **`spmi`** — SuperPMI and its shims.
- **`clr.packages`** — only produces the ILAsm/ILDAsm/TestHost/Sdk.IL nupkgs, referenced solely by `eng/Publishing.props` for official-build publishing. Packing them takes ~2.5s, so this is a cleanliness change, not a perf one.
- **`clr.crossarchtools`** — redundant here: `_BuildCrossComponents` is already set whenever `ClrRuntimeBuildSubsets` is non-empty for CoreCLR, and the cross-tool build is gated on `_BuildAnyCrossArch`, which is false for native windows-x64/linux-x64. Verified that no cross-arch build directory is produced either way.

## Measurements

Measured on CI, comparing build [1538104](https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_build/results?buildId=1538104) (this PR) against [1534932](https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_build/results?buildId=1534932) (a recent PR build of the unchanged pipeline):

| | ninja targets | "Build product" |
|---|---|---|
| **windows-x64** (critical path) | 2646 → **1901** (−28.2%) | 40.0m → **35.4m** (−4.6m) |
| linux-x64 | 2837 → **2132** (−24.8%) | 31.7m → **29.0m** (−2.7m) |
| browser-wasm | unaffected (builds `mono`) | 26.0m → 26.7m |

The windows-x64 job as a whole goes from 62.4m to 56.5m. Total build wall clock went from 75.0m to 68.0m, though that figure includes queue variance across runs — the "Build product" numbers are the reliable ones. linux-x64 saves time too but stays off the critical path.

Locally, isolating just the CoreCLR native build on linux-x64 at `ninja -j 4` (the parallelism CI uses) gives 4m03s → 3m05s, i.e. −24%, consistent with the CI result.

## Validation

Locally, from a clean tree with the narrowed subsets:

- Trimming tests: **88 tests pass**
- NativeAOT test apps: **57 tests pass**
- Artifacts verified: `libcoreclr.so`, `ilc`, `crossgen2`, `ilasm`/`ildasm`, DAC/mscordbi and the `aotsdk` all still present; superpmi and the unused alt-JITs gone

On CI, all three `dotnet-linker-tests` jobs (windows-x64, linux-x64, browser-wasm) pass, including the trimming and NativeAOT test app steps, with no change in test counts or coverage.

Two unrelated failures show up on this PR and are not caused by it:

- `runtime (Build openbsd-x64 Debug CoreCLR_Bootstrapped)` — fails with `NETSDK1203` on every recent PR (sampled 6/6); the leg only passes on `main` because rolling builds run it as Release.
- `System.Net.Security.Tests.TlsSessionTests.SslStreamServer_RejectsClientCert_ClientObservesAlert` on linux-arm64 — known flaky, tracked by #131755 (44 hits in the last month).

> [!NOTE]
> This content was created with assistance from AI.
