### PR TITLE
Fix Tar cleanup one-liners

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.Windows.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.Windows.cs
@@ -14,14 +14,14 @@ namespace System.Formats.Tar
         // Throws on Windows. Block devices are not supported on this platform.
         private void ExtractAsBlockDevice(string destinationFileName)
         {
-            Debug.Assert(EntryType is TarEntryType.BlockDevice or TarEntryType.CharacterDevice);
+            Debug.Assert(EntryType is TarEntryType.BlockDevice);
             throw new InvalidOperationException(SR.IO_DeviceFiles_NotSupported);
         }
 
         // Throws on Windows. Character devices are not supported on this platform.
         private void ExtractAsCharacterDevice(string destinationFileName)
         {
-            Debug.Assert(EntryType is TarEntryType.BlockDevice or TarEntryType.CharacterDevice);
+            Debug.Assert(EntryType is TarEntryType.CharacterDevice);
             throw new InvalidOperationException(SR.IO_DeviceFiles_NotSupported);
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -509,7 +509,7 @@ namespace System.Formats.Tar
 
         // Calculates how many data bytes should be written, depending on the position pointer of the stream.
         // Only works if the stream is seekable.
-        public long GetTotalDataBytesToWrite()
+        internal long GetTotalDataBytesToWrite()
         {
             if (_dataStream == null)
             {


### PR DESCRIPTION
- TarEntry.Windows.cs: fix Debug.Assert bug in ExtractAsBlockDevice/ExtractAsCharacterDevice (each asserted BlockDevice or CharacterDevice instead of its own specific type).
- TarHeader.Write.cs: change GetTotalDataBytesToWrite() from public to internal, matching its containing internal sealed type and sibling helpers.