### PR TITLE
Exclude WebSocketException from BinaryFormatter blob ToString comparison

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/EqualityExtensions.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/EqualityExtensions.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Net.WebSockets;
 using System.Reflection;
 using System.Security;
 using System.Threading;
@@ -1170,7 +1171,8 @@ namespace System.Runtime.Serialization.Formatters.Tests
                 {
                     if (!(@this is ActiveDirectoryServerDownException ||
                         @this is NetworkInformationException ||
-                        @this is SocketException))
+                        @this is SocketException ||
+                        @this is WebSocketException))
                     {
                         Assert.Equal(@this.ToString(), other.ToString());
                     }


### PR DESCRIPTION
WebSocketException derives from Win32Exception which sets NativeErrorCode from the ambient Marshal.GetLastPInvokeError(). Win32Exception.ToString() early-returns ExternalException.ToString() when NativeErrorCode is 0, so the live test object's ToString() flips shape depending on unrelated thread state, while the stored blob always deserializes with NativeErrorCode == 0.

The same exclusion already exists in the System.Resources.Extensions copy of EqualityExtensions; mirror it here.

Fixes #129981