### PR TITLE
Adopt issue-labeler v2.2.0 in runtime workflows

### DIFF
--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         type: ["issues", "pulls"]
     steps:
-      - uses: dotnet/issue-labeler/restore@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+      - uses: dotnet/issue-labeler/restore@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: ${{ matrix.type }}
           cache_key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: "Restore issues model from cache"
         id: restore-model
-        uses: dotnet/issue-labeler/restore@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/restore@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: issues
           fail-on-cache-miss: ${{ env.ALLOW_FAILURE }}
@@ -49,7 +49,7 @@ jobs:
       - name: "Predict issue labels"
         id: prediction
         if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
-        uses: dotnet/issue-labeler/predict@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/predict@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           issues: ${{ inputs.issues || github.event.issue.number }}
           label_prefix: ${{ env.LABEL_PREFIX }}

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -114,7 +114,7 @@ jobs:
       - name: "Restore pulls model from cache"
         id: restore-model
         if: ${{ steps.determine-pulls.outputs.pulls != '' }}
-        uses: dotnet/issue-labeler/restore@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/restore@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: pulls
           fail-on-cache-miss: ${{ env.ALLOW_FAILURE }}
@@ -123,7 +123,7 @@ jobs:
       - name: "Predict pull labels"
         id: prediction
         if: ${{ steps.determine-pulls.outputs.pulls != '' && steps.restore-model.outputs.cache-hit == 'true' }}
-        uses: dotnet/issue-labeler/predict@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/predict@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           pulls: ${{ steps.determine-pulls.outputs.pulls }}
           label_prefix: ${{ env.LABEL_PREFIX }}

--- a/.github/workflows/labeler-promote.yml
+++ b/.github/workflows/labeler-promote.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Promote Model for Issues"
-        uses: dotnet/issue-labeler/promote@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/promote@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: "issues"
           staged_key: ${{ inputs.staged_key }}
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Promote Model for Pull Requests"
-        uses: dotnet/issue-labeler/promote@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/promote@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: "pulls"
           staged_key: ${{ inputs.staged_key }}

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -71,7 +71,7 @@ jobs:
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
-          excluded_labels: ${{ format('{0}{1}{2}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && ',', inputs.excluded_labels || '') }}
+          excluded_labels: ${{ format('{0}{1}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && format(',{0}', inputs.excluded_labels) || '') }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
           page_limit: ${{ env.PAGE_LIMIT }}
@@ -91,7 +91,7 @@ jobs:
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
-          excluded_labels: ${{ format('{0}{1}{2}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && ',', inputs.excluded_labels || '') }}
+          excluded_labels: ${{ format('{0}{1}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && format(',{0}', inputs.excluded_labels) || '') }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
           page_limit: ${{ env.PAGE_LIMIT }}
@@ -138,7 +138,7 @@ jobs:
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
-          excluded_labels: ${{ format('{0}{1}{2}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && ',', inputs.excluded_labels || '') }}
+          excluded_labels: ${{ format('{0}{1}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && format(',{0}', inputs.excluded_labels) || '') }}
           threshold: ${{ env.THRESHOLD }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
@@ -160,7 +160,7 @@ jobs:
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
-          excluded_labels: ${{ format('{0}{1}{2}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && ',', inputs.excluded_labels || '') }}
+          excluded_labels: ${{ format('{0}{1}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && format(',{0}', inputs.excluded_labels) || '') }}
           threshold: ${{ env.THRESHOLD }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -43,11 +43,15 @@ on:
         description: "The cache key suffix to use for staged data/models (use 'ACTIVE' to bypass staging). Defaults to 'staged'."
         required: true
         default: "staged"
+      excluded_labels:
+        description: "Additional labels to exclude from training/testing datasets (comma-separated)."
+        required: false
 
 env:
   CACHE_KEY: ${{ inputs.cache_key_suffix }}
   REPOSITORY: ${{ github.repository }}
   LABEL_PREFIX: "area-"
+  DEFAULT_EXCLUDED_LABELS: "area-crossgen2-coreclr,area-AssemblyLoader-coreclr"
   THRESHOLD: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.05' }}
   LIMIT: ${{ inputs.limit }}
   PAGE_SIZE: ${{ inputs.page_size }}
@@ -61,12 +65,13 @@ jobs:
       issues: read
     steps:
       - name: "Download Issues"
-        uses: dotnet/issue-labeler/download@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/download@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: "issues"
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
+          excluded_labels: ${{ format('{0}{1}{2}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && ',', inputs.excluded_labels || '') }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
           page_limit: ${{ env.PAGE_LIMIT }}
@@ -80,12 +85,13 @@ jobs:
       pull-requests: read
     steps:
       - name: "Download Pull Requests"
-        uses: dotnet/issue-labeler/download@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/download@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: "pulls"
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
+          excluded_labels: ${{ format('{0}{1}{2}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && ',', inputs.excluded_labels || '') }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
           page_limit: ${{ env.PAGE_LIMIT }}
@@ -99,7 +105,7 @@ jobs:
     needs: download-issues
     steps:
       - name: "Train Model for Issues"
-        uses: dotnet/issue-labeler/train@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/train@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: "issues"
           data_cache_key: ${{ env.CACHE_KEY }}
@@ -112,7 +118,7 @@ jobs:
     needs: download-pulls
     steps:
       - name: "Train Model for Pull Requests"
-        uses: dotnet/issue-labeler/train@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/train@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: "pulls"
           data_cache_key: ${{ env.CACHE_KEY }}
@@ -126,12 +132,13 @@ jobs:
     needs: train-issues
     steps:
       - name: "Test Model for Issues"
-        uses: dotnet/issue-labeler/test@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/test@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: "issues"
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
+          excluded_labels: ${{ format('{0}{1}{2}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && ',', inputs.excluded_labels || '') }}
           threshold: ${{ env.THRESHOLD }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}
@@ -147,12 +154,13 @@ jobs:
     needs: train-pulls
     steps:
       - name: "Test Model for Pull Requests"
-        uses: dotnet/issue-labeler/test@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0-release
+        uses: dotnet/issue-labeler/test@160b6b1e1e8d36da09beb34ef1e4806d2c0520a3 # v2.2.0
         with:
           type: "pulls"
           cache_key: ${{ env.CACHE_KEY }}
           repository: ${{ env.REPOSITORY }}
           label_prefix: ${{ env.LABEL_PREFIX }}
+          excluded_labels: ${{ format('{0}{1}{2}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && ',', inputs.excluded_labels || '') }}
           threshold: ${{ env.THRESHOLD }}
           limit: ${{ env.LIMIT }}
           page_size: ${{ env.PAGE_SIZE }}


### PR DESCRIPTION
## Summary
- bump all runtime labeler workflows to `dotnet/issue-labeler` v2.2.0 (`160b6b1e1e8d36da09beb34ef1e4806d2c0520a3`)
- add default deprecated-label exclusions in `labeler-train.yml`:
  - `area-crossgen2-coreclr`
  - `area-AssemblyLoader-coreclr`
- add optional `workflow_dispatch` input (`excluded_labels`) and compose it with defaults so manual runs can append additional exclusions

## Details
`excluded_labels` passed to training dataset download and model test steps:

`${{ format('{0}{1}{2}', env.DEFAULT_EXCLUDED_LABELS, inputs.excluded_labels && ',', inputs.excluded_labels || '') }}`

This preserves existing behavior when no extra labels are provided while always including the default deprecated-label exclusions.

> [!NOTE]
> This PR description was created with GitHub Copilot.
