### PR TITLE
JIT: Opportunistically lower `value & ((1 << k) - 1)` to BMI2 `bzhi`

### DIFF
--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -499,6 +499,7 @@ private:
     GenTree* TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode);
     GenTree* TryLowerAndOpToExtractLowestSetBit(GenTreeOp* andNode);
     GenTree* TryLowerAndOpToAndNot(GenTreeOp* andNode);
+    GenTree* TryLowerAndOpToZeroHighBits(GenTreeOp* andNode);
     GenTree* TryLowerXorOpToGetMaskUpToLowestSetBit(GenTreeOp* xorNode);
     void     LowerBswapOp(GenTreeOp* node);
     GenTree* LowerHWIntrinsicDotInnerMulSum(GenTreeHWIntrinsic* node);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6345,8 +6345,9 @@ GenTree* Lowering::TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
         return nullptr;
     }
 
+    // An overflow-checking ADD cannot be removed: it must still throw when X is the minimum value
     GenTree* op2 = andNode->gtGetOp2();
-    if (!op2->OperIs(GT_ADD))
+    if (!op2->OperIs(GT_ADD) || op2->gtOverflow())
     {
         return nullptr;
     }
@@ -6741,8 +6742,9 @@ GenTree* Lowering::TryLowerXorOpToGetMaskUpToLowestSetBit(GenTreeOp* xorNode)
         return nullptr;
     }
 
+    // An overflow-checking ADD cannot be removed: it must still throw when X is the minimum value
     GenTree* op2 = xorNode->gtGetOp2();
-    if (!op2->OperIs(GT_ADD))
+    if (!op2->OperIs(GT_ADD) || op2->gtOverflow())
     {
         return nullptr;
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -282,6 +282,12 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
             {
                 return replacementNode->gtNext;
             }
+
+            replacementNode = TryLowerAndOpToZeroHighBits(binOp);
+            if (replacementNode != nullptr)
+            {
+                return replacementNode->gtNext;
+            }
         }
         else if (binOp->OperIs(GT_XOR))
         {
@@ -6572,6 +6578,145 @@ GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
     ContainCheckHWIntrinsic(andnNode);
 
     return andnNode;
+}
+
+//----------------------------------------------------------------------------------------------
+// Lowering::TryLowerAndOpToZeroHighBits: Lowers a tree AND(X, SUB(LSH(1, CNT), 1)) to
+// HWIntrinsic::ZeroHighBits
+//
+// Arguments:
+//    andNode - GT_AND node of integral type
+//
+// Return Value:
+//    Returns the replacement node if one is created else nullptr indicating no replacement
+//
+// Notes:
+//    BZHI keeps the source unchanged when its index is greater than or equal to the operand
+//    size, while the shift in the original tree masks its count to (operand size - 1), making
+//    the mask zero for such counts. The transform is only valid when the count is provably in
+//    [0, operand size); otherwise an AND reproducing the shift count masking is inserted.
+//
+//    Performs containment checks on the replacement node if one is created
+GenTree* Lowering::TryLowerAndOpToZeroHighBits(GenTreeOp* andNode)
+{
+    assert(andNode->OperIs(GT_AND) && varTypeIsIntegral(andNode));
+
+    if (!andNode->TypeIs(TYP_INT, TYP_LONG))
+    {
+        return nullptr;
+    }
+
+    // Morph usually transforms SUB(X, 1) into ADD(X, -1), but the SUB form can survive as well.
+    // An overflow-checking SUB/ADD cannot be removed: it must still throw for counts that make
+    // the subtraction overflow (e.g. a signed "checked((1 << 31) - 1)").
+    auto isMaskShape = [](GenTree* node) {
+        if (!node->OperIs(GT_SUB, GT_ADD) || node->gtOverflow() ||
+            !node->gtGetOp2()->IsIntegralConst(node->OperIs(GT_SUB) ? 1 : -1))
+        {
+            return false;
+        }
+
+        GenTree* lsh = node->gtGetOp1();
+        return lsh->OperIs(GT_LSH) && lsh->gtGetOp1()->IsIntegralConst(1);
+    };
+
+    GenTree* value = nullptr;
+    GenTree* mask  = nullptr;
+
+    if (isMaskShape(andNode->gtGetOp2()))
+    {
+        value = andNode->gtGetOp1();
+        mask  = andNode->gtGetOp2();
+    }
+    else if (isMaskShape(andNode->gtGetOp1()))
+    {
+        value = andNode->gtGetOp2();
+        mask  = andNode->gtGetOp1();
+    }
+    else
+    {
+        return nullptr;
+    }
+
+    GenTree* maskOp2 = mask->gtGetOp2();
+    GenTree* lsh     = mask->gtGetOp1();
+    GenTree* lshOp1  = lsh->gtGetOp1();
+    GenTree* count   = lsh->gtGetOp2();
+
+    // Subsequent nodes may rely on CPU flags set by these nodes in which case we cannot remove them
+    if (((andNode->gtFlags & GTF_SET_FLAGS) != 0) || ((mask->gtFlags & GTF_SET_FLAGS) != 0) ||
+        ((lsh->gtFlags & GTF_SET_FLAGS) != 0))
+    {
+        return nullptr;
+    }
+
+    NamedIntrinsic intrinsic;
+    unsigned       operandSize;
+    if (andNode->TypeIs(TYP_LONG) && m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX2_X64))
+    {
+        intrinsic   = NamedIntrinsic::NI_AVX2_X64_ZeroHighBits;
+        operandSize = 64;
+    }
+    else if (andNode->TypeIs(TYP_INT) && m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX2))
+    {
+        intrinsic   = NamedIntrinsic::NI_AVX2_ZeroHighBits;
+        operandSize = 32;
+    }
+    else
+    {
+        return nullptr;
+    }
+
+    LIR::Use use;
+    if (!BlockRange().TryGetUse(andNode, &use))
+    {
+        return nullptr;
+    }
+
+    // A count of the shape AND(X, CNS) with 0 <= CNS < operandSize is known to be in range.
+    // Counts masked to exactly (operandSize - 1) don't take this form here because LowerShift
+    // has already removed such masks from the shift count.
+    bool countInRange = false;
+    if (count->OperIs(GT_AND) && count->gtGetOp2()->IsIntegralConst())
+    {
+        int64_t countMask = count->gtGetOp2()->AsIntConCommon()->IntegralValue();
+        countInRange      = (countMask >= 0) && (static_cast<uint64_t>(countMask) < operandSize);
+    }
+
+    GenTree* index = count;
+    if (!countInRange)
+    {
+        var_types indexType = genActualType(count);
+        GenTree*  widthCns  = m_compiler->gtNewIconNode(static_cast<ssize_t>(operandSize - 1), indexType);
+        index               = m_compiler->gtNewOperNode(GT_AND, indexType, count, widthCns);
+        BlockRange().InsertBefore(andNode, widthCns, index);
+    }
+
+    // The importer swaps the operands of ZeroHighBits such that op1 is the index
+    GenTreeHWIntrinsic* bzhiNode = m_compiler->gtNewScalarHWIntrinsicNode(andNode->TypeGet(), index, value, intrinsic);
+
+    JITDUMP("Lower: optimize AND(X, SUB(LSH(1, CNT), 1))\n");
+    DISPNODE(andNode);
+    JITDUMP("to:\n");
+    DISPNODE(bzhiNode);
+
+    BlockRange().InsertBefore(andNode, bzhiNode);
+    use.ReplaceWith(bzhiNode);
+
+    BlockRange().Remove(andNode);
+    BlockRange().Remove(mask);
+    BlockRange().Remove(maskOp2);
+    BlockRange().Remove(lsh);
+    BlockRange().Remove(lshOp1);
+
+    if (index != count)
+    {
+        LowerNode(index);
+    }
+
+    ContainCheckHWIntrinsic(bzhiNode);
+
+    return bzhiNode;
 }
 
 //----------------------------------------------------------------------------------------------

--- a/src/tests/JIT/Regression/JitBlue/Runtime_129368/Runtime_129368.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_129368/Runtime_129368.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Lowering value & ((1 << k) - 1) to BZHI must keep the IL shift semantics for every k:
+// the IL shift masks its count to (operand size - 1), so the mask is 0 when k >= the
+// operand size, while BZHI would keep the value unchanged for such counts. The reference
+// methods are compiled with NoOptimization so they can never take the BZHI path themselves.
+
+namespace Runtime_129368;
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Runtime_129368
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint Mask32(uint v, int k) => v & ((1u << k) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint Mask32Commuted(uint v, int k) => ((1u << k) - 1) & v;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint Mask32CommutedDecrement(uint v, int k) => ((1u << k) - 1) & (v - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Mask32Signed(int v, int k) => v & ((1 << k) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint Mask32Premasked(uint v, int k) => v & ((1u << (k & 31)) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint Mask32NarrowMask(uint v, int k) => v & ((1u << (k & 15)) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Mask32Checked(int v, int k) => v & checked((1 << k) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint Mask32ConstantCount(uint v) => v & ((1u << 5) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint Mask32MultiUse(uint v, int k)
+    {
+        uint m = (1u << k) - 1;
+        return (v & m) ^ m;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Mask32Rmw(uint[] a, int k) => a[0] &= (1u << k) - 1;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ulong Mask64(ulong v, int k) => v & ((1ul << k) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ulong Mask64LongCount(ulong v, long k) => v & ((1ul << (int)k) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ulong Mask64Premasked(ulong v, int k) => v & ((1ul << (k & 31)) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long Mask64Checked(long v, int k) => v & checked((1L << k) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int BlsrChecked(int x) => x & checked(x + (-1));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int BlsmskChecked(int x) => x ^ checked(x + (-1));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long BlsrChecked64(long x) => x & checked(x + (-1L));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long BlsmskChecked64(long x) => x ^ checked(x + (-1L));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    private static uint Reference32(uint v, int k) => v & ((1u << k) - 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    private static uint ReferenceMask32(int k) => (1u << k) - 1;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    private static ulong Reference64(ulong v, int k) => v & ((1ul << k) - 1);
+
+    [Fact]
+    public static void Test32Bit()
+    {
+        uint[] values = { 0u, 1u, 0xAA55AA55u, 0x80000000u, ~0u };
+
+        for (int k = -4; k <= 36; k++)
+        {
+            foreach (uint v in values)
+            {
+                uint expected = Reference32(v, k);
+                Assert.Equal(expected, Mask32(v, k));
+                Assert.Equal(expected, Mask32Commuted(v, k));
+                Assert.Equal(Reference32(v - 1, k), Mask32CommutedDecrement(v, k));
+                Assert.Equal((int)expected, Mask32Signed((int)v, k));
+                Assert.Equal(Reference32(v, k & 31), Mask32Premasked(v, k));
+                Assert.Equal(Reference32(v, k & 15), Mask32NarrowMask(v, k));
+                Assert.Equal(expected ^ ReferenceMask32(k), Mask32MultiUse(v, k));
+
+                // The overflow-checked mask must still throw when (1 << k) is int.MinValue
+                if ((k & 31) == 31)
+                {
+                    int value = (int)v;
+                    Assert.Throws<OverflowException>(() => Mask32Checked(value, k));
+                }
+                else
+                {
+                    Assert.Equal((int)expected, Mask32Checked((int)v, k));
+                }
+
+                uint[] a = { v };
+                Mask32Rmw(a, k);
+                Assert.Equal(expected, a[0]);
+            }
+
+            Assert.Equal(Reference32(0xAA55AA55u, 5), Mask32ConstantCount(0xAA55AA55u));
+        }
+
+        // The blsr/blsmsk patterns must also keep their overflow checks
+        Assert.Equal(0x30 & 0x2F, BlsrChecked(0x30));
+        Assert.Equal(0x30 ^ 0x2F, BlsmskChecked(0x30));
+        Assert.Throws<OverflowException>(() => BlsrChecked(int.MinValue));
+        Assert.Throws<OverflowException>(() => BlsmskChecked(int.MinValue));
+    }
+
+    [Fact]
+    public static void Test64Bit()
+    {
+        ulong[] values = { 0ul, 1ul, 0xAA55AA55AA55AA55ul, 0x8000000000000000ul, ~0ul };
+
+        for (int k = -4; k <= 68; k++)
+        {
+            foreach (ulong v in values)
+            {
+                ulong expected = Reference64(v, k);
+                Assert.Equal(expected, Mask64(v, k));
+                Assert.Equal(expected, Mask64LongCount(v, k));
+                Assert.Equal(Reference64(v, k & 31), Mask64Premasked(v, k));
+
+                if ((k & 63) == 63)
+                {
+                    long value = (long)v;
+                    Assert.Throws<OverflowException>(() => Mask64Checked(value, k));
+                }
+                else
+                {
+                    Assert.Equal((long)expected, Mask64Checked((long)v, k));
+                }
+            }
+        }
+
+        Assert.Equal(0x30L & 0x2FL, BlsrChecked64(0x30L));
+        Assert.Equal(0x30L ^ 0x2FL, BlsmskChecked64(0x30L));
+        Assert.Throws<OverflowException>(() => BlsrChecked64(long.MinValue));
+        Assert.Throws<OverflowException>(() => BlsmskChecked64(long.MinValue));
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -126,6 +126,7 @@
     <Compile Include="JitBlue\Runtime_125160\Runtime_125160.cs" />
     <Compile Include="JitBlue\GitHub_131472\GitHub_131472.cs" />
     <Compile Include="JitBlue\Runtime_122237\Runtime_122237.cs" />
+    <Compile Include="JitBlue\Runtime_129368\Runtime_129368.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Fixes #129368

Lowers `value & ((1 << k) - 1)` (and the `ADD(..., -1)` form) to BMI2 `bzhi` when available.

BZHI leaves the source alone when `k >= width`, IL shifts mask the count. If we can't prove `k` is in range, insert `and k, width-1` so the behavior stays the same.

Based on @AndyAyersMS's prototype. Left out the `IntegralRange` fallback - it almost never fires in lowering, and the issue already calls that out as follow-up.

```diff
-       mov      r10d, 1
-       shlx     r10d, r10d, r15d
-       dec      r10d
-       and      r10d, eax
+       and      r15d, 31
+       bzhi     r10d, eax, r15d
```

SPMI windows-x64 Checked: 45 diffs, -315 bytes, 0 size regressions.

Test: `Runtime_129368` sweeps edge `k` values against `NoOptimization` oracles.

Update: overflow-checked masks (`checked((1 << k) - 1)`) now bail instead of dropping the throw, and the existing blsr/blsmsk lowers turned out to have the same hole - guarded those too.
