### PR TITLE
Remove temporary array allocations in `ComVariant.As`.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
@@ -424,11 +424,11 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         public static ComVariant Null { get; } = new() { VarType = VarEnum.VT_NULL };
 
-        private readonly void ThrowIfNotVarType(params VarEnum[] requiredType)
+        private readonly void ThrowIfNotVarType(params ReadOnlySpan<VarEnum> requiredType)
         {
-            if (Array.IndexOf(requiredType, VarType) < 0)
+            if (!requiredType.Contains(VarType))
             {
-                throw new InvalidOperationException(SR.Format(SR.ComVariant_TypeIsNotSupportedType, VarType, string.Join(", ", requiredType)));
+                throw new InvalidOperationException(SR.Format(SR.ComVariant_TypeIsNotSupportedType, VarType, string.Join(", ", requiredType.ToArray())));
             }
         }
 


### PR DESCRIPTION
We use `params ReadOnlySpan<VarEnum>` in the `ThrowIfNotVarType` utility function, which when used in `As<T>()`, gets optimized to allocation-free references to RVA fields.