### PR TITLE
Avoid inlining Random.InternalSample

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Random.CompatImpl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.CompatImpl.cs
@@ -335,6 +335,8 @@ namespace System
                 }
             }
 
+            // Inlining this into hot caller loops can produce branch-heavy code that is slower than the standalone method.
+            [MethodImpl(MethodImplOptions.NoInlining)]
             internal int InternalSample()
             {
                 Debug.Assert(_seedArray is not null);


### PR DESCRIPTION
This method contains an inherently unpredictable branch that benefits from if conversion. If inlined into a caller with a loop we lose the if conversion and performance suffers, and there does not appear to be other inlining benefit.

We can reconsider if/when we've freed up if-conversion from its current "not in loop" constraint.

Fixes #117787
Fixes #130359 