### PR TITLE
[cDAC] bug fix in DacDbi GetModulePath

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -342,10 +342,6 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
 
             if (string.IsNullOrEmpty(path))
             {
-                path = loader.GetFileName(handle);
-            }
-            if (string.IsNullOrEmpty(path))
-            {
                 // pStrFilename needs to be set for ICorDebugModule::GetName to succeed.
                 hr = StringHolderAssignCopy(pStrFilename, string.Empty);
                 *pResult = Interop.BOOL.FALSE;


### PR DESCRIPTION
This API should only return module paths that represent actual files on disk, not for example diagnostic hints that exist outside of an actual file. Found in internal diagnostic testing.