### PR TITLE
Fix runtime async context restore after EnC remap

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -231,7 +231,7 @@ PhaseStatus Compiler::SaveAsyncContexts()
     else
     {
         GenTree* continuation = gtNewLclVarNode(lvaAsyncContinuationArg, TYP_REF);
-        resumed = gtNewOperNode(GT_NE, TYP_INT, continuation, gtNewNull());
+        resumed               = gtNewOperNode(GT_NE, TYP_INT, continuation, gtNewNull());
     }
 
     GenTreeCall* restoreCall = gtNewUserCallNode(asyncInfo->restoreContextsMethHnd, TYP_VOID);
@@ -405,7 +405,7 @@ BasicBlock* Compiler::CreateReturnBB(unsigned* mergedReturnLcl)
     else
     {
         GenTree* continuation = gtNewLclVarNode(lvaAsyncContinuationArg, TYP_REF);
-        resumed = gtNewOperNode(GT_NE, TYP_INT, continuation, gtNewNull());
+        resumed               = gtNewOperNode(GT_NE, TYP_INT, continuation, gtNewNull());
     }
 
     GenTreeCall* restoreCall = gtNewUserCallNode(asyncInfo->restoreContextsMethHnd, TYP_VOID);

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -220,9 +220,19 @@ PhaseStatus Compiler::SaveAsyncContexts()
         }
     }
 
-    // Insert RestoreContexts call in fault (exceptional case)
-    // First argument: resumed = (continuation != null)
-    GenTree* resumed = gtNewLclvNode(lvaResumedIndicator, TYP_INT);
+    // Inlinees need an explicit indicator because they do not have a continuation
+    // argument. Root methods can use the continuation argument directly, which also
+    // remains correct when EnC remaps directly into a resumed method body.
+    GenTree* resumed;
+    if (compIsForInlining())
+    {
+        resumed = gtNewLclvNode(lvaResumedIndicator, TYP_INT);
+    }
+    else
+    {
+        GenTree* continuation = gtNewLclVarNode(lvaAsyncContinuationArg, TYP_REF);
+        resumed = gtNewOperNode(GT_NE, TYP_INT, continuation, gtNewNull());
+    }
 
     GenTreeCall* restoreCall = gtNewUserCallNode(asyncInfo->restoreContextsMethHnd, TYP_VOID);
     restoreCall->gtArgs.PushFront(this,
@@ -387,7 +397,16 @@ BasicBlock* Compiler::CreateReturnBB(unsigned* mergedReturnLcl)
     // Insert "restore" call
     CORINFO_ASYNC_INFO* asyncInfo = eeGetAsyncInfo();
 
-    GenTree* resumed = gtNewLclvNode(lvaResumedIndicator, TYP_INT);
+    GenTree* resumed;
+    if (compIsForInlining())
+    {
+        resumed = gtNewLclvNode(lvaResumedIndicator, TYP_INT);
+    }
+    else
+    {
+        GenTree* continuation = gtNewLclVarNode(lvaAsyncContinuationArg, TYP_REF);
+        resumed = gtNewOperNode(GT_NE, TYP_INT, continuation, gtNewNull());
+    }
 
     GenTreeCall* restoreCall = gtNewUserCallNode(asyncInfo->restoreContextsMethHnd, TYP_VOID);
     restoreCall->gtArgs.PushFront(this,


### PR DESCRIPTION
Use the continuation argument for root-method context restoration so Edit-and-Continue remaps do not depend on a synthesized resumed indicator that is not preserved in the remapped frame.