### PR TITLE
Configure Server GC for NativeAOT regression test

### DIFF
--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.csproj
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.csproj
@@ -3,6 +3,8 @@
     <!-- Needed for CLRTestEnvironmentVariable and GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- NativeAOT selects the Server GC implementation at link time -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
     <!-- DATAS heap-count adaptation is a CoreCLR Server GC behavior -->
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #131669.

PR #131069 added a Server GC regression test, but NativeAOT selects the GC implementation at link time. Set `ServerGarbageCollection` so the test runs correctly in NativeAOT outerloop.

> [!NOTE]
> This pull request was created with GitHub Copilot assistance.