### PR TITLE
Run large array test exclusively

### DIFF
--- a/src/tests/GC/GC.csproj
+++ b/src/tests/GC/GC.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <MergedWrapperProjectReference Include="*/**/*.??proj" />
+    <MergedWrapperProjectReference Remove="LargeMemory/Regressions/largearraytest.csproj" />
     <MergedWrapperProjectReference Remove="Features/**/*.??proj" />
     <MergedWrapperProjectReference Remove="Scenarios/**/*.??proj" />
   </ItemGroup>

--- a/src/tests/GC/LargeMemory/Regressions/largearraytest.csproj
+++ b/src/tests/GC/LargeMemory/Regressions/largearraytest.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CLRTestTargetUnsupported -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <HasMergedInTests>true</HasMergedInTests>
     <!--
         Test unsupported outside of windows
@@ -12,9 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="largearraytest.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />

--- a/src/tests/GC/LargeMemory/Regressions/largearraytest.csproj
+++ b/src/tests/GC/LargeMemory/Regressions/largearraytest.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <HasMergedInTests>true</HasMergedInTests>
     <!--
         Test unsupported outside of windows
         On platform other than Windows, this test could get killed by the OOM killer
@@ -15,4 +16,6 @@
   <ItemGroup>
     <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
+
+  <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Move `largearraytest` into its own merged runner and Helix work item so it does not compete for memory with other GC tests.

Thanks to @jkoritzinsky for the test infrastructure guidance.

Fixes #114222

> [!NOTE]
> This PR description was created with GitHub Copilot.