### PR TITLE
Compile ref-assemblies with updated-memory-safety-rules

### DIFF
--- a/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics.SymbolStore
     }
     public partial interface ISymbolBinder1
     {
-        System.Diagnostics.SymbolStore.ISymbolReader? GetReader(System.IntPtr importer, string filename, string searchPath);
+        unsafe System.Diagnostics.SymbolStore.ISymbolReader? GetReader(System.IntPtr importer, string filename, string searchPath);
     }
     public partial interface ISymbolDocument
     {
@@ -95,14 +95,14 @@ namespace System.Diagnostics.SymbolStore
         void DefineLocalVariable(string name, System.Reflection.FieldAttributes attributes, byte[] signature, System.Diagnostics.SymbolStore.SymAddressKind addrKind, int addr1, int addr2, int addr3, int startOffset, int endOffset);
         void DefineParameter(string name, System.Reflection.ParameterAttributes attributes, int sequence, System.Diagnostics.SymbolStore.SymAddressKind addrKind, int addr1, int addr2, int addr3);
         void DefineSequencePoints(System.Diagnostics.SymbolStore.ISymbolDocumentWriter document, int[] offsets, int[] lines, int[] columns, int[] endLines, int[] endColumns);
-        void Initialize(System.IntPtr emitter, string filename, bool fFullBuild);
+        unsafe void Initialize(System.IntPtr emitter, string filename, bool fFullBuild);
         void OpenMethod(System.Diagnostics.SymbolStore.SymbolToken method);
         void OpenNamespace(string name);
         int OpenScope(int startOffset);
         void SetMethodSourceRange(System.Diagnostics.SymbolStore.ISymbolDocumentWriter startDoc, int startLine, int startColumn, System.Diagnostics.SymbolStore.ISymbolDocumentWriter endDoc, int endLine, int endColumn);
         void SetScopeRange(int scopeID, int startOffset, int endOffset);
         void SetSymAttribute(System.Diagnostics.SymbolStore.SymbolToken parent, string name, byte[] data);
-        void SetUnderlyingWriter(System.IntPtr underlyingWriter);
+        unsafe void SetUnderlyingWriter(System.IntPtr underlyingWriter);
         void SetUserEntryPoint(System.Diagnostics.SymbolStore.SymbolToken entryMethod);
         void UsingNamespace(string fullName);
     }

--- a/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.csproj
+++ b/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Diagnostics.StackTrace.cs" />

--- a/src/libraries/System.Memory/ref/System.Memory.cs
+++ b/src/libraries/System.Memory/ref/System.Memory.cs
@@ -195,7 +195,7 @@ namespace System.Runtime.InteropServices
         public static bool TryGetArray<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ArraySegment<T> segment) { throw null; }
         public static bool TryGetReadOnlyMemory<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ReadOnlyMemory<T> memory) { throw null; }
         public static bool TryGetReadOnlySequenceSegment<T>(System.Buffers.ReadOnlySequence<T> sequence, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Buffers.ReadOnlySequenceSegment<T>? startSegment, out int startIndex, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Buffers.ReadOnlySequenceSegment<T>? endSegment, out int endIndex) { throw null; }
-        public static bool TryRead<T>(ref System.Buffers.SequenceReader<byte> reader, out T value) where T : unmanaged { throw null; }
+        public unsafe static bool TryRead<T>(ref System.Buffers.SequenceReader<byte> reader, out T value) where T : unmanaged { throw null; }
     }
 }
 namespace System.Text

--- a/src/libraries/System.Memory/ref/System.Memory.csproj
+++ b/src/libraries/System.Memory/ref/System.Memory.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
+++ b/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
@@ -251,13 +251,13 @@ namespace System.Numerics
         public static System.Numerics.Vector2 AsVector2(this System.Numerics.Vector4 value) { throw null; }
         public static System.Numerics.Vector3 AsVector3(this System.Numerics.Vector2 value) { throw null; }
         public static System.Numerics.Vector3 AsVector3(this System.Numerics.Vector4 value) { throw null; }
-        public static System.Numerics.Vector3 AsVector3Unsafe(this System.Numerics.Vector2 value) { throw null; }
+        public unsafe static System.Numerics.Vector3 AsVector3Unsafe(this System.Numerics.Vector2 value) { throw null; }
         public static System.Numerics.Vector4 AsVector4(this System.Numerics.Plane value) { throw null; }
         public static System.Numerics.Vector4 AsVector4(this System.Numerics.Quaternion value) { throw null; }
         public static System.Numerics.Vector4 AsVector4(this System.Numerics.Vector2 value) { throw null; }
         public static System.Numerics.Vector4 AsVector4(this System.Numerics.Vector3 value) { throw null; }
-        public static System.Numerics.Vector4 AsVector4Unsafe(this System.Numerics.Vector2 value) { throw null; }
-        public static System.Numerics.Vector4 AsVector4Unsafe(this System.Numerics.Vector3 value) { throw null; }
+        public unsafe static System.Numerics.Vector4 AsVector4Unsafe(this System.Numerics.Vector2 value) { throw null; }
+        public unsafe static System.Numerics.Vector4 AsVector4Unsafe(this System.Numerics.Vector3 value) { throw null; }
         public static System.Numerics.Vector<byte> AsVectorByte<T>(System.Numerics.Vector<T> value) { throw null; }
         public static System.Numerics.Vector<double> AsVectorDouble<T>(System.Numerics.Vector<T> value) { throw null; }
         public static System.Numerics.Vector<short> AsVectorInt16<T>(System.Numerics.Vector<T> value) { throw null; }
@@ -310,7 +310,7 @@ namespace System.Numerics
         public static System.Numerics.Vector<T> Create<T>(T value) { throw null; }
         public static System.Numerics.Vector<T> Create<T>(System.ReadOnlySpan<T> values) { throw null; }
         public static System.Numerics.Vector<T> CreateScalar<T>(T value) { throw null; }
-        public static System.Numerics.Vector<T> CreateScalarUnsafe<T>(T value) { throw null; }
+        public unsafe static System.Numerics.Vector<T> CreateScalarUnsafe<T>(T value) { throw null; }
         public static System.Numerics.Vector<T> CreateSequence<T>(T start, T step) { throw null; }
         public static System.Numerics.Vector<T> CreateGeometricSequence<T>(T initial, [System.Diagnostics.CodeAnalysis.ConstantExpected] T multiplier) { throw null; }
         public static System.Numerics.Vector<T> CreateAlternatingSequence<T>(T even, T odd) { throw null; }
@@ -409,9 +409,9 @@ namespace System.Numerics
         public static unsafe System.Numerics.Vector<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Numerics.Vector<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-        public static System.Numerics.Vector<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
+        public unsafe static System.Numerics.Vector<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Numerics.Vector<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
+        public unsafe static System.Numerics.Vector<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
         public static System.Numerics.Vector<double> Log(System.Numerics.Vector<double> vector) { throw null; }
         public static System.Numerics.Vector<float> Log(System.Numerics.Vector<float> vector) { throw null; }
         public static System.Numerics.Vector<double> Log2(System.Numerics.Vector<double> vector) { throw null; }
@@ -528,18 +528,18 @@ namespace System.Numerics
         public static unsafe void StoreAlignedNonTemporal(this System.Numerics.Vector3 source, float* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal(this System.Numerics.Vector4 source, float* destination) { throw null; }
-        public static void StoreUnsafe<T>(this System.Numerics.Vector<T> source, ref T destination) { throw null; }
-        public static void StoreUnsafe(this System.Numerics.Vector2 source, ref float destination) { throw null; }
-        public static void StoreUnsafe(this System.Numerics.Vector3 source, ref float destination) { throw null; }
-        public static void StoreUnsafe(this System.Numerics.Vector4 source, ref float destination) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Numerics.Vector<T> source, ref T destination) { throw null; }
+        public unsafe static void StoreUnsafe(this System.Numerics.Vector2 source, ref float destination) { throw null; }
+        public unsafe static void StoreUnsafe(this System.Numerics.Vector3 source, ref float destination) { throw null; }
+        public unsafe static void StoreUnsafe(this System.Numerics.Vector4 source, ref float destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static void StoreUnsafe<T>(this System.Numerics.Vector<T> source, ref T destination, nuint elementOffset) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Numerics.Vector<T> source, ref T destination, nuint elementOffset) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static void StoreUnsafe(this System.Numerics.Vector2 source, ref float destination, nuint elementOffset) { throw null; }
+        public unsafe static void StoreUnsafe(this System.Numerics.Vector2 source, ref float destination, nuint elementOffset) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static void StoreUnsafe(this System.Numerics.Vector3 source, ref float destination, nuint elementOffset) { throw null; }
+        public unsafe static void StoreUnsafe(this System.Numerics.Vector3 source, ref float destination, nuint elementOffset) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static void StoreUnsafe(this System.Numerics.Vector4 source, ref float destination, nuint elementOffset) { throw null; }
+        public unsafe static void StoreUnsafe(this System.Numerics.Vector4 source, ref float destination, nuint elementOffset) { throw null; }
         public static System.Numerics.Vector<T> Subtract<T>(System.Numerics.Vector<T> left, System.Numerics.Vector<T> right) { throw null; }
         public static System.Numerics.Vector<T> SubtractSaturate<T>(System.Numerics.Vector<T> left, System.Numerics.Vector<T> right) { throw null; }
         public static T Sum<T>(System.Numerics.Vector<T> value) { throw null; }
@@ -651,7 +651,7 @@ namespace System.Numerics
         public static System.Numerics.Vector2 Create(float x, float y) { throw null; }
         public static System.Numerics.Vector2 Create(System.ReadOnlySpan<float> values) { throw null; }
         public static System.Numerics.Vector2 CreateScalar(float x) { throw null; }
-        public static System.Numerics.Vector2 CreateScalarUnsafe(float x) { throw null; }
+        public unsafe static System.Numerics.Vector2 CreateScalarUnsafe(float x) { throw null; }
         public readonly bool TryCopyTo(System.Span<float> destination) { throw null; }
         public static System.Numerics.Vector2 DegreesToRadians(System.Numerics.Vector2 degrees) { throw null; }
         public static float Distance(System.Numerics.Vector2 value1, System.Numerics.Vector2 value2) { throw null; }
@@ -708,9 +708,9 @@ namespace System.Numerics
         public static unsafe System.Numerics.Vector2 LoadAligned(float* source) { throw null; }
         [CLSCompliant(false)]
         public static unsafe System.Numerics.Vector2 LoadAlignedNonTemporal(float* source) { throw null; }
-        public static System.Numerics.Vector2 LoadUnsafe(ref readonly float source) { throw null; }
+        public unsafe static System.Numerics.Vector2 LoadUnsafe(ref readonly float source) { throw null; }
         [CLSCompliant(false)]
-        public static System.Numerics.Vector2 LoadUnsafe(ref readonly float source, nuint elementOffset) { throw null; }
+        public unsafe static System.Numerics.Vector2 LoadUnsafe(ref readonly float source, nuint elementOffset) { throw null; }
         public static System.Numerics.Vector2 Log(System.Numerics.Vector2 vector) { throw null; }
         public static System.Numerics.Vector2 Log2(System.Numerics.Vector2 vector) { throw null; }
         public static System.Numerics.Vector2 Max(System.Numerics.Vector2 value1, System.Numerics.Vector2 value2) { throw null; }
@@ -819,7 +819,7 @@ namespace System.Numerics
         public static System.Numerics.Vector3 Create(float x, float y, float z) { throw null; }
         public static System.Numerics.Vector3 Create(System.ReadOnlySpan<float> values) { throw null; }
         public static System.Numerics.Vector3 CreateScalar(float x) { throw null; }
-        public static System.Numerics.Vector3 CreateScalarUnsafe(float x) { throw null; }
+        public unsafe static System.Numerics.Vector3 CreateScalarUnsafe(float x) { throw null; }
         public readonly bool TryCopyTo(System.Span<float> destination) { throw null; }
         public static System.Numerics.Vector3 Cross(System.Numerics.Vector3 vector1, System.Numerics.Vector3 vector2) { throw null; }
         public static System.Numerics.Vector3 DegreesToRadians(System.Numerics.Vector3 degrees) { throw null; }
@@ -876,9 +876,9 @@ namespace System.Numerics
         public static unsafe System.Numerics.Vector3 LoadAligned(float* source) { throw null; }
         [CLSCompliant(false)]
         public static unsafe System.Numerics.Vector3 LoadAlignedNonTemporal(float* source) { throw null; }
-        public static System.Numerics.Vector3 LoadUnsafe(ref readonly float source) { throw null; }
+        public unsafe static System.Numerics.Vector3 LoadUnsafe(ref readonly float source) { throw null; }
         [CLSCompliant(false)]
-        public static System.Numerics.Vector3 LoadUnsafe(ref readonly float source, nuint elementOffset) { throw null; }
+        public unsafe static System.Numerics.Vector3 LoadUnsafe(ref readonly float source, nuint elementOffset) { throw null; }
         public static System.Numerics.Vector3 Log(System.Numerics.Vector3 vector) { throw null; }
         public static System.Numerics.Vector3 Log2(System.Numerics.Vector3 vector) { throw null; }
         public static System.Numerics.Vector3 Max(System.Numerics.Vector3 value1, System.Numerics.Vector3 value2) { throw null; }
@@ -989,7 +989,7 @@ namespace System.Numerics
         public static System.Numerics.Vector4 Create(float x, float y, float z, float w) { throw null; }
         public static System.Numerics.Vector4 Create(System.ReadOnlySpan<float> values) { throw null; }
         public static System.Numerics.Vector4 CreateScalar(float x) { throw null; }
-        public static System.Numerics.Vector4 CreateScalarUnsafe(float x) { throw null; }
+        public unsafe static System.Numerics.Vector4 CreateScalarUnsafe(float x) { throw null; }
         public readonly bool TryCopyTo(System.Span<float> destination) { throw null; }
         public static System.Numerics.Vector4 DegreesToRadians(System.Numerics.Vector4 degrees) { throw null; }
         public static float Distance(System.Numerics.Vector4 value1, System.Numerics.Vector4 value2) { throw null; }
@@ -1048,9 +1048,9 @@ namespace System.Numerics
         public static unsafe System.Numerics.Vector4 LoadAligned(float* source) { throw null; }
         [CLSCompliant(false)]
         public static unsafe System.Numerics.Vector4 LoadAlignedNonTemporal(float* source) { throw null; }
-        public static System.Numerics.Vector4 LoadUnsafe(ref readonly float source) { throw null; }
+        public unsafe static System.Numerics.Vector4 LoadUnsafe(ref readonly float source) { throw null; }
         [CLSCompliant(false)]
-        public static System.Numerics.Vector4 LoadUnsafe(ref readonly float source, nuint elementOffset) { throw null; }
+        public unsafe static System.Numerics.Vector4 LoadUnsafe(ref readonly float source, nuint elementOffset) { throw null; }
         public static System.Numerics.Vector4 Max(System.Numerics.Vector4 value1, System.Numerics.Vector4 value2) { throw null; }
         public static System.Numerics.Vector4 MaxMagnitude(System.Numerics.Vector4 value1, System.Numerics.Vector4 value2) { throw null; }
         public static System.Numerics.Vector4 MaxMagnitudeNumber(System.Numerics.Vector4 value1, System.Numerics.Vector4 value2) { throw null; }

--- a/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.csproj
+++ b/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.csproj
@@ -4,6 +4,7 @@
     <!-- https://github.com/dotnet/dotnet/issues/5640 -->
     <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Numerics.Vectors.cs" />

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -339,7 +339,7 @@ namespace System.Runtime.InteropServices.Marshalling
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute.GenericPlaceholder), System.Runtime.InteropServices.Marshalling.MarshalMode.Default, typeof(System.Runtime.InteropServices.Marshalling.ComInterfaceMarshaller<>))]
-    public static unsafe class ComInterfaceMarshaller<T>
+    public static class ComInterfaceMarshaller<T>
     {
         public static void* ConvertToUnmanaged(T? managed) { throw null; }
         public static T? ConvertToManaged(void* unmanaged) { throw null; }
@@ -493,7 +493,7 @@ namespace System.Runtime.InteropServices.Marshalling
         protected virtual System.Runtime.InteropServices.Marshalling.IIUnknownCacheStrategy CreateCacheStrategy() { throw null; }
         protected static System.Runtime.InteropServices.Marshalling.IIUnknownCacheStrategy CreateDefaultCacheStrategy() { throw null; }
         protected sealed override object CreateObject(nint externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags) { throw null; }
-        protected sealed override object? CreateObject(nint externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object? userState, out System.Runtime.InteropServices.CreatedWrapperFlags wrapperFlags) { throw null; }
+        unsafe protected sealed override object? CreateObject(nint externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object? userState, out System.Runtime.InteropServices.CreatedWrapperFlags wrapperFlags) { throw null; }
         protected virtual System.Runtime.InteropServices.Marshalling.IIUnknownInterfaceDetailsStrategy GetOrCreateInterfaceDetailsStrategy() { throw null; }
         protected virtual System.Runtime.InteropServices.Marshalling.IIUnknownStrategy GetOrCreateIUnknownStrategy() { throw null; }
         protected sealed override void ReleaseObjects(System.Collections.IEnumerable objects) { }
@@ -504,7 +504,7 @@ namespace System.Runtime.InteropServices.Marshalling
     [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
     [System.CLSCompliantAttribute(false)]
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute.GenericPlaceholder), System.Runtime.InteropServices.Marshalling.MarshalMode.Default, typeof(System.Runtime.InteropServices.Marshalling.UniqueComInterfaceMarshaller<>))]
-    public static unsafe class UniqueComInterfaceMarshaller<T>
+    public static class UniqueComInterfaceMarshaller<T>
     {
         public static void* ConvertToUnmanaged(T? managed) { throw null; }
         public static T? ConvertToManaged(void* unmanaged) { throw null; }
@@ -767,16 +767,16 @@ namespace System.Runtime.InteropServices
         public struct ComInterfaceDispatch
         {
             public System.IntPtr Vtable;
-            public unsafe static T GetInstance<T>(ComInterfaceDispatch* dispatchPtr) where T : class { throw null; }
+            public static T GetInstance<T>(ComInterfaceDispatch* dispatchPtr) where T : class { throw null; }
         }
         public System.IntPtr GetOrCreateComInterfaceForObject(object instance, System.Runtime.InteropServices.CreateComInterfaceFlags flags) { throw null; }
         protected unsafe abstract ComInterfaceEntry* ComputeVtables(object obj, System.Runtime.InteropServices.CreateComInterfaceFlags flags, out int count);
-        public object GetOrCreateObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags) { throw null; }
-        public object GetOrCreateObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object? userState) { throw null; }
-        protected abstract object? CreateObject(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags);
-        protected virtual object? CreateObject(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object? userState, out System.Runtime.InteropServices.CreatedWrapperFlags wrapperFlags) { throw null; }
-        public object GetOrRegisterObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object wrapper) { throw null; }
-        public object GetOrRegisterObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object wrapper, System.IntPtr inner) { throw null; }
+        public unsafe object GetOrCreateObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags) { throw null; }
+        public unsafe object GetOrCreateObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object? userState) { throw null; }
+        unsafe protected abstract object? CreateObject(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags);
+        unsafe protected virtual object? CreateObject(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object? userState, out System.Runtime.InteropServices.CreatedWrapperFlags wrapperFlags) { throw null; }
+        public unsafe object GetOrRegisterObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object wrapper) { throw null; }
+        public unsafe object GetOrRegisterObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object wrapper, System.IntPtr inner) { throw null; }
         protected abstract void ReleaseObjects(System.Collections.IEnumerable objects);
         public static void RegisterForTrackerSupport(ComWrappers instance) { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
@@ -936,10 +936,10 @@ namespace System.Runtime.InteropServices
     public partial interface ICustomMarshaler
     {
         void CleanUpManagedData(object ManagedObj);
-        void CleanUpNativeData(System.IntPtr pNativeData);
+        unsafe void CleanUpNativeData(System.IntPtr pNativeData);
         int GetNativeDataSize();
         System.IntPtr MarshalManagedToNative(object ManagedObj);
-        object MarshalNativeToManaged(System.IntPtr pNativeData);
+        unsafe object MarshalNativeToManaged(System.IntPtr pNativeData);
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial interface ICustomQueryInterface
@@ -996,7 +996,7 @@ namespace System.Runtime.InteropServices
     {
         public static readonly int SystemDefaultCharSize;
         public static readonly int SystemMaxDBCSCharSize;
-        public static int AddRef(System.IntPtr pUnk) { throw null; }
+        public unsafe static int AddRef(System.IntPtr pUnk) { throw null; }
         public static System.IntPtr AllocCoTaskMem(int cb) { throw null; }
         public static System.IntPtr AllocHGlobal(int cb) { throw null; }
         public static System.IntPtr AllocHGlobal(System.IntPtr cb) { throw null; }
@@ -1007,27 +1007,27 @@ namespace System.Runtime.InteropServices
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static void ChangeWrapperHandleStrength(object otp, bool fIsWeak) { }
         public static void CleanupUnusedObjectsInCurrentContext() { }
-        public static void Copy(byte[] source, int startIndex, System.IntPtr destination, int length) { }
-        public static void Copy(char[] source, int startIndex, System.IntPtr destination, int length) { }
-        public static void Copy(double[] source, int startIndex, System.IntPtr destination, int length) { }
-        public static void Copy(short[] source, int startIndex, System.IntPtr destination, int length) { }
-        public static void Copy(int[] source, int startIndex, System.IntPtr destination, int length) { }
-        public static void Copy(long[] source, int startIndex, System.IntPtr destination, int length) { }
-        public static void Copy(System.IntPtr source, byte[] destination, int startIndex, int length) { }
-        public static void Copy(System.IntPtr source, char[] destination, int startIndex, int length) { }
-        public static void Copy(System.IntPtr source, double[] destination, int startIndex, int length) { }
-        public static void Copy(System.IntPtr source, short[] destination, int startIndex, int length) { }
-        public static void Copy(System.IntPtr source, int[] destination, int startIndex, int length) { }
-        public static void Copy(System.IntPtr source, long[] destination, int startIndex, int length) { }
-        public static void Copy(System.IntPtr source, System.IntPtr[] destination, int startIndex, int length) { }
-        public static void Copy(System.IntPtr source, float[] destination, int startIndex, int length) { }
-        public static void Copy(System.IntPtr[] source, int startIndex, System.IntPtr destination, int length) { }
-        public static void Copy(float[] source, int startIndex, System.IntPtr destination, int length) { }
+        public unsafe static void Copy(byte[] source, int startIndex, System.IntPtr destination, int length) { }
+        public unsafe static void Copy(char[] source, int startIndex, System.IntPtr destination, int length) { }
+        public unsafe static void Copy(double[] source, int startIndex, System.IntPtr destination, int length) { }
+        public unsafe static void Copy(short[] source, int startIndex, System.IntPtr destination, int length) { }
+        public unsafe static void Copy(int[] source, int startIndex, System.IntPtr destination, int length) { }
+        public unsafe static void Copy(long[] source, int startIndex, System.IntPtr destination, int length) { }
+        public unsafe static void Copy(System.IntPtr source, byte[] destination, int startIndex, int length) { }
+        public unsafe static void Copy(System.IntPtr source, char[] destination, int startIndex, int length) { }
+        public unsafe static void Copy(System.IntPtr source, double[] destination, int startIndex, int length) { }
+        public unsafe static void Copy(System.IntPtr source, short[] destination, int startIndex, int length) { }
+        public unsafe static void Copy(System.IntPtr source, int[] destination, int startIndex, int length) { }
+        public unsafe static void Copy(System.IntPtr source, long[] destination, int startIndex, int length) { }
+        public unsafe static void Copy(System.IntPtr source, System.IntPtr[] destination, int startIndex, int length) { }
+        public unsafe static void Copy(System.IntPtr source, float[] destination, int startIndex, int length) { }
+        public unsafe static void Copy(System.IntPtr[] source, int startIndex, System.IntPtr destination, int length) { }
+        public unsafe static void Copy(float[] source, int startIndex, System.IntPtr destination, int length) { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static System.IntPtr CreateAggregatedObject(System.IntPtr pOuter, object o) { throw null; }
+        public unsafe static System.IntPtr CreateAggregatedObject(System.IntPtr pOuter, object o) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
-        public static System.IntPtr CreateAggregatedObject<T>(System.IntPtr pOuter, T o) where T : notnull { throw null; }
+        public unsafe static System.IntPtr CreateAggregatedObject<T>(System.IntPtr pOuter, T o) where T : notnull { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("o")]
@@ -1036,13 +1036,13 @@ namespace System.Runtime.InteropServices
         public static TWrapper CreateWrapperOfType<T, TWrapper>(T? o) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available. Use the DestroyStructure<T> overload instead.")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static void DestroyStructure(System.IntPtr ptr, System.Type structuretype) { }
-        public static void DestroyStructure<T>(System.IntPtr ptr) { }
+        public unsafe static void DestroyStructure(System.IntPtr ptr, System.Type structuretype) { }
+        public unsafe static void DestroyStructure<T>(System.IntPtr ptr) { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static int FinalReleaseComObject(object o) { throw null; }
-        public static void FreeBSTR(System.IntPtr ptr) { }
-        public static void FreeCoTaskMem(System.IntPtr ptr) { }
-        public static void FreeHGlobal(System.IntPtr hglobal) { }
+        public unsafe static void FreeBSTR(System.IntPtr ptr) { }
+        public unsafe static void FreeCoTaskMem(System.IntPtr ptr) { }
+        public unsafe static void FreeHGlobal(System.IntPtr hglobal) { }
         public static System.Guid GenerateGuidForType(System.Type type) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Built-in COM support is not trim compatible", Url = "https://aka.ms/dotnet-illink/com")]
         public static string? GenerateProgIdForType(System.Type type) { throw null; }
@@ -1058,16 +1058,16 @@ namespace System.Runtime.InteropServices
         public static object? GetComObjectData(object obj, object key) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the delegate might not be available. Use the GetDelegateForFunctionPointer<TDelegate> overload instead.")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static System.Delegate GetDelegateForFunctionPointer(System.IntPtr ptr, System.Type t) { throw null; }
-        public static TDelegate GetDelegateForFunctionPointer<TDelegate>(System.IntPtr ptr) { throw null; }
+        public unsafe static System.Delegate GetDelegateForFunctionPointer(System.IntPtr ptr, System.Type t) { throw null; }
+        public unsafe static TDelegate GetDelegateForFunctionPointer<TDelegate>(System.IntPtr ptr) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static int GetEndComSlot(System.Type t) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("GetExceptionCode() may be unavailable in future releases.")]
         public static int GetExceptionCode() { throw null; }
         public static System.Exception? GetExceptionForHR(int errorCode) { throw null; }
-        public static System.Exception? GetExceptionForHR(int errorCode, System.IntPtr errorInfo) { throw null; }
-        public static System.Exception? GetExceptionForHR(int errorCode, in System.Guid iid, System.IntPtr pUnk) { throw null; }
+        public unsafe static System.Exception? GetExceptionForHR(int errorCode, System.IntPtr errorInfo) { throw null; }
+        public unsafe static System.Exception? GetExceptionForHR(int errorCode, in System.Guid iid, System.IntPtr pUnk) { throw null; }
         public static System.IntPtr GetExceptionPointers() { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the delegate might not be available. Use the GetFunctionPointerForDelegate<TDelegate> overload instead.")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -1088,34 +1088,34 @@ namespace System.Runtime.InteropServices
         public static string GetPInvokeErrorMessage(int error) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static void GetNativeVariantForObject(object? obj, System.IntPtr pDstNativeVariant) { }
+        public unsafe static void GetNativeVariantForObject(object? obj, System.IntPtr pDstNativeVariant) { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static void GetNativeVariantForObject<T>(T? obj, System.IntPtr pDstNativeVariant) { }
+        public unsafe static void GetNativeVariantForObject<T>(T? obj, System.IntPtr pDstNativeVariant) { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
-        public static object GetObjectForIUnknown(System.IntPtr pUnk) { throw null; }
-        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static object? GetObjectForNativeVariant(System.IntPtr pSrcNativeVariant) { throw null; }
+        public unsafe static object GetObjectForIUnknown(System.IntPtr pUnk) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static T? GetObjectForNativeVariant<T>(System.IntPtr pSrcNativeVariant) { throw null; }
+        public unsafe static object? GetObjectForNativeVariant(System.IntPtr pSrcNativeVariant) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static object?[] GetObjectsForNativeVariants(System.IntPtr aSrcNativeVariant, int cVars) { throw null; }
+        public unsafe static T? GetObjectForNativeVariant<T>(System.IntPtr pSrcNativeVariant) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static T[] GetObjectsForNativeVariants<T>(System.IntPtr aSrcNativeVariant, int cVars) { throw null; }
+        public unsafe static object?[] GetObjectsForNativeVariants(System.IntPtr aSrcNativeVariant, int cVars) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public unsafe static T[] GetObjectsForNativeVariants<T>(System.IntPtr aSrcNativeVariant, int cVars) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static int GetStartComSlot(System.Type t) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
-        public static object GetTypedObjectForIUnknown(System.IntPtr pUnk, System.Type t) { throw null; }
+        public unsafe static object GetTypedObjectForIUnknown(System.IntPtr pUnk, System.Type t) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static System.Type? GetTypeFromCLSID(System.Guid clsid) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static string GetTypeInfoName(System.Runtime.InteropServices.ComTypes.ITypeInfo typeInfo) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
-        public static object GetUniqueObjectForIUnknown(System.IntPtr unknown) { throw null; }
+        public unsafe static object GetUniqueObjectForIUnknown(System.IntPtr unknown) { throw null; }
         public static void InitHandle(SafeHandle safeHandle, IntPtr handle) { }
         public static bool IsComObject(object o) { throw null; }
         public static bool IsTypeVisibleFromCom(System.Type t) { throw null; }
@@ -1124,57 +1124,57 @@ namespace System.Runtime.InteropServices
         public static System.IntPtr OffsetOf<T>(string fieldName) { throw null; }
         public static void Prelink(System.Reflection.MethodInfo m) { }
         public static void PrelinkAll(System.Type c) { }
-        public static string? PtrToStringAnsi(System.IntPtr ptr) { throw null; }
-        public static string PtrToStringAnsi(System.IntPtr ptr, int len) { throw null; }
-        public static string? PtrToStringAuto(System.IntPtr ptr) { throw null; }
-        public static string? PtrToStringAuto(System.IntPtr ptr, int len) { throw null; }
-        public static string PtrToStringBSTR(System.IntPtr ptr) { throw null; }
-        public static string? PtrToStringUni(System.IntPtr ptr) { throw null; }
-        public static string PtrToStringUni(System.IntPtr ptr, int len) { throw null; }
-        public static string? PtrToStringUTF8(System.IntPtr ptr) { throw null; }
-        public static string PtrToStringUTF8(System.IntPtr ptr, int byteLen) { throw null; }
+        public unsafe static string? PtrToStringAnsi(System.IntPtr ptr) { throw null; }
+        public unsafe static string PtrToStringAnsi(System.IntPtr ptr, int len) { throw null; }
+        public unsafe static string? PtrToStringAuto(System.IntPtr ptr) { throw null; }
+        public unsafe static string? PtrToStringAuto(System.IntPtr ptr, int len) { throw null; }
+        public unsafe static string PtrToStringBSTR(System.IntPtr ptr) { throw null; }
+        public unsafe static string? PtrToStringUni(System.IntPtr ptr) { throw null; }
+        public unsafe static string PtrToStringUni(System.IntPtr ptr, int len) { throw null; }
+        public unsafe static string? PtrToStringUTF8(System.IntPtr ptr) { throw null; }
+        public unsafe static string PtrToStringUTF8(System.IntPtr ptr, int byteLen) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static void PtrToStructure(System.IntPtr ptr, object structure) { }
+        public unsafe static void PtrToStructure(System.IntPtr ptr, object structure) { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static object? PtrToStructure(System.IntPtr ptr, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors| System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type structureType) { throw null; }
-        public static T? PtrToStructure<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]T>(System.IntPtr ptr) { throw null; }
-        public static void PtrToStructure<T>(System.IntPtr ptr, [System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T structure) { }
-        public static int QueryInterface(System.IntPtr pUnk, in System.Guid iid, out System.IntPtr ppv) { throw null; }
-        public static byte ReadByte(System.IntPtr ptr) { throw null; }
-        public static byte ReadByte(System.IntPtr ptr, int ofs) { throw null; }
+        public unsafe static object? PtrToStructure(System.IntPtr ptr, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors| System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type structureType) { throw null; }
+        public unsafe static T? PtrToStructure<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]T>(System.IntPtr ptr) { throw null; }
+        public unsafe static void PtrToStructure<T>(System.IntPtr ptr, [System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T structure) { }
+        public unsafe static int QueryInterface(System.IntPtr pUnk, in System.Guid iid, out System.IntPtr ppv) { throw null; }
+        public unsafe static byte ReadByte(System.IntPtr ptr) { throw null; }
+        public unsafe static byte ReadByte(System.IntPtr ptr, int ofs) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("ReadByte(Object, Int32) may be unavailable in future releases.")]
-        public static byte ReadByte(object ptr, int ofs) { throw null; }
-        public static short ReadInt16(System.IntPtr ptr) { throw null; }
-        public static short ReadInt16(System.IntPtr ptr, int ofs) { throw null; }
+        public unsafe static byte ReadByte(object ptr, int ofs) { throw null; }
+        public unsafe static short ReadInt16(System.IntPtr ptr) { throw null; }
+        public unsafe static short ReadInt16(System.IntPtr ptr, int ofs) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("ReadInt16(Object, Int32) may be unavailable in future releases.")]
-        public static short ReadInt16(object ptr, int ofs) { throw null; }
-        public static int ReadInt32(System.IntPtr ptr) { throw null; }
-        public static int ReadInt32(System.IntPtr ptr, int ofs) { throw null; }
+        public unsafe static short ReadInt16(object ptr, int ofs) { throw null; }
+        public unsafe static int ReadInt32(System.IntPtr ptr) { throw null; }
+        public unsafe static int ReadInt32(System.IntPtr ptr, int ofs) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("ReadInt32(Object, Int32) may be unavailable in future releases.")]
-        public static int ReadInt32(object ptr, int ofs) { throw null; }
-        public static long ReadInt64(System.IntPtr ptr) { throw null; }
-        public static long ReadInt64(System.IntPtr ptr, int ofs) { throw null; }
+        public unsafe static int ReadInt32(object ptr, int ofs) { throw null; }
+        public unsafe static long ReadInt64(System.IntPtr ptr) { throw null; }
+        public unsafe static long ReadInt64(System.IntPtr ptr, int ofs) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("ReadInt64(Object, Int32) may be unavailable in future releases.")]
-        public static long ReadInt64(object ptr, int ofs) { throw null; }
-        public static System.IntPtr ReadIntPtr(System.IntPtr ptr) { throw null; }
-        public static System.IntPtr ReadIntPtr(System.IntPtr ptr, int ofs) { throw null; }
+        public unsafe static long ReadInt64(object ptr, int ofs) { throw null; }
+        public unsafe static System.IntPtr ReadIntPtr(System.IntPtr ptr) { throw null; }
+        public unsafe static System.IntPtr ReadIntPtr(System.IntPtr ptr, int ofs) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("ReadIntPtr(Object, Int32) may be unavailable in future releases.")]
-        public static System.IntPtr ReadIntPtr(object ptr, int ofs) { throw null; }
-        public static System.IntPtr ReAllocCoTaskMem(System.IntPtr pv, int cb) { throw null; }
-        public static System.IntPtr ReAllocHGlobal(System.IntPtr pv, System.IntPtr cb) { throw null; }
-        public static int Release(System.IntPtr pUnk) { throw null; }
+        public unsafe static System.IntPtr ReadIntPtr(object ptr, int ofs) { throw null; }
+        public unsafe static System.IntPtr ReAllocCoTaskMem(System.IntPtr pv, int cb) { throw null; }
+        public unsafe static System.IntPtr ReAllocHGlobal(System.IntPtr pv, System.IntPtr cb) { throw null; }
+        public unsafe static int Release(System.IntPtr pUnk) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static int ReleaseComObject(object o) { throw null; }
         public static System.IntPtr SecureStringToBSTR(System.Security.SecureString s) { throw null; }
@@ -1204,56 +1204,56 @@ namespace System.Runtime.InteropServices
         public static System.IntPtr StringToHGlobalUni(string? s) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available. Use the StructureToPtr<T> overload instead.")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public static void StructureToPtr(object structure, System.IntPtr ptr, bool fDeleteOld) { }
-        public static void StructureToPtr<T>([System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T structure, System.IntPtr ptr, bool fDeleteOld) { }
+        public unsafe static void StructureToPtr(object structure, System.IntPtr ptr, bool fDeleteOld) { }
+        public unsafe static void StructureToPtr<T>([System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T structure, System.IntPtr ptr, bool fDeleteOld) { }
         public static void ThrowExceptionForHR(int errorCode) { }
-        public static void ThrowExceptionForHR(int errorCode, System.IntPtr errorInfo) { }
-        public static void ThrowExceptionForHR(int errorCode, in System.Guid iid, System.IntPtr pUnk) { }
+        public unsafe static void ThrowExceptionForHR(int errorCode, System.IntPtr errorInfo) { }
+        public unsafe static void ThrowExceptionForHR(int errorCode, in System.Guid iid, System.IntPtr pUnk) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public static System.IntPtr UnsafeAddrOfPinnedArrayElement(System.Array arr, int index) { throw null; }
         public static System.IntPtr UnsafeAddrOfPinnedArrayElement<T>(T[] arr, int index) { throw null; }
-        public static void WriteByte(System.IntPtr ptr, byte val) { }
-        public static void WriteByte(System.IntPtr ptr, int ofs, byte val) { }
+        public unsafe static void WriteByte(System.IntPtr ptr, byte val) { }
+        public unsafe static void WriteByte(System.IntPtr ptr, int ofs, byte val) { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("WriteByte(Object, Int32, Byte) may be unavailable in future releases.")]
-        public static void WriteByte(object ptr, int ofs, byte val) { }
-        public static void WriteInt16(System.IntPtr ptr, char val) { }
-        public static void WriteInt16(System.IntPtr ptr, short val) { }
-        public static void WriteInt16(System.IntPtr ptr, int ofs, char val) { }
-        public static void WriteInt16(System.IntPtr ptr, int ofs, short val) { }
+        public unsafe static void WriteByte(object ptr, int ofs, byte val) { }
+        public unsafe static void WriteInt16(System.IntPtr ptr, char val) { }
+        public unsafe static void WriteInt16(System.IntPtr ptr, short val) { }
+        public unsafe static void WriteInt16(System.IntPtr ptr, int ofs, char val) { }
+        public unsafe static void WriteInt16(System.IntPtr ptr, int ofs, short val) { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("WriteInt16(Object, Int32, Char) may be unavailable in future releases.")]
-        public static void WriteInt16(object ptr, int ofs, char val) { }
+        public unsafe static void WriteInt16(object ptr, int ofs, char val) { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("WriteInt16(Object, Int32, Int16) may be unavailable in future releases.")]
-        public static void WriteInt16(object ptr, int ofs, short val) { }
-        public static void WriteInt32(System.IntPtr ptr, int val) { }
-        public static void WriteInt32(System.IntPtr ptr, int ofs, int val) { }
+        public unsafe static void WriteInt16(object ptr, int ofs, short val) { }
+        public unsafe static void WriteInt32(System.IntPtr ptr, int val) { }
+        public unsafe static void WriteInt32(System.IntPtr ptr, int ofs, int val) { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("WriteInt32(Object, Int32, Int32) may be unavailable in future releases.")]
-        public static void WriteInt32(object ptr, int ofs, int val) { }
-        public static void WriteInt64(System.IntPtr ptr, int ofs, long val) { }
-        public static void WriteInt64(System.IntPtr ptr, long val) { }
+        public unsafe static void WriteInt32(object ptr, int ofs, int val) { }
+        public unsafe static void WriteInt64(System.IntPtr ptr, int ofs, long val) { }
+        public unsafe static void WriteInt64(System.IntPtr ptr, long val) { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("WriteInt64(Object, Int32, Int64) may be unavailable in future releases.")]
-        public static void WriteInt64(object ptr, int ofs, long val) { }
-        public static void WriteIntPtr(System.IntPtr ptr, int ofs, System.IntPtr val) { }
-        public static void WriteIntPtr(System.IntPtr ptr, System.IntPtr val) { }
+        public unsafe static void WriteInt64(object ptr, int ofs, long val) { }
+        public unsafe static void WriteIntPtr(System.IntPtr ptr, int ofs, System.IntPtr val) { }
+        public unsafe static void WriteIntPtr(System.IntPtr ptr, System.IntPtr val) { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("WriteIntPtr(Object, Int32, IntPtr) may be unavailable in future releases.")]
-        public static void WriteIntPtr(object ptr, int ofs, System.IntPtr val) { }
-        public static void ZeroFreeBSTR(System.IntPtr s) { }
-        public static void ZeroFreeCoTaskMemAnsi(System.IntPtr s) { }
-        public static void ZeroFreeCoTaskMemUnicode(System.IntPtr s) { }
-        public static void ZeroFreeCoTaskMemUTF8(System.IntPtr s) { }
-        public static void ZeroFreeGlobalAllocAnsi(System.IntPtr s) { }
-        public static void ZeroFreeGlobalAllocUnicode(System.IntPtr s) { }
+        public unsafe static void WriteIntPtr(object ptr, int ofs, System.IntPtr val) { }
+        public unsafe static void ZeroFreeBSTR(System.IntPtr s) { }
+        public unsafe static void ZeroFreeCoTaskMemAnsi(System.IntPtr s) { }
+        public unsafe static void ZeroFreeCoTaskMemUnicode(System.IntPtr s) { }
+        public unsafe static void ZeroFreeCoTaskMemUTF8(System.IntPtr s) { }
+        public unsafe static void ZeroFreeGlobalAllocAnsi(System.IntPtr s) { }
+        public unsafe static void ZeroFreeGlobalAllocUnicode(System.IntPtr s) { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue, Inherited=false)]
     public sealed partial class MarshalAsAttribute : System.Attribute
@@ -1292,7 +1292,7 @@ namespace System.Runtime.InteropServices
         public static bool TryLoad(string libraryPath, out System.IntPtr handle) { throw null; }
         public static bool TryLoad(string libraryName, System.Reflection.Assembly assembly, System.Runtime.InteropServices.DllImportSearchPath? searchPath, out System.IntPtr handle) { throw null; }
     }
-    public static unsafe partial class NativeMemory
+    public static partial class NativeMemory
     {
         [System.CLSCompliantAttribute(false)]
         public static void* AlignedAlloc(nuint byteCount, nuint alignment) { throw null; }
@@ -1800,11 +1800,11 @@ namespace System.Runtime.InteropServices.ComTypes
     public partial struct BINDPTR
     {
         [System.Runtime.InteropServices.FieldOffsetAttribute(0)]
-        public System.IntPtr lpfuncdesc;
+        public safe System.IntPtr lpfuncdesc;
         [System.Runtime.InteropServices.FieldOffsetAttribute(0)]
-        public System.IntPtr lptcomp;
+        public safe System.IntPtr lptcomp;
         [System.Runtime.InteropServices.FieldOffsetAttribute(0)]
-        public System.IntPtr lpvardesc;
+        public safe System.IntPtr lpvardesc;
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
@@ -1865,9 +1865,9 @@ namespace System.Runtime.InteropServices.ComTypes
         public partial struct DESCUNION
         {
             [System.Runtime.InteropServices.FieldOffsetAttribute(0)]
-            public System.Runtime.InteropServices.ComTypes.IDLDESC idldesc;
+            public safe System.Runtime.InteropServices.ComTypes.IDLDESC idldesc;
             [System.Runtime.InteropServices.FieldOffsetAttribute(0)]
-            public System.Runtime.InteropServices.ComTypes.PARAMDESC paramdesc;
+            public safe System.Runtime.InteropServices.ComTypes.PARAMDESC paramdesc;
         }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -1989,7 +1989,7 @@ namespace System.Runtime.InteropServices.ComTypes
     public partial interface IEnumConnectionPoints
     {
         void Clone(out System.Runtime.InteropServices.ComTypes.IEnumConnectionPoints ppenum);
-        int Next(int celt, System.Runtime.InteropServices.ComTypes.IConnectionPoint[] rgelt, System.IntPtr pceltFetched);
+        unsafe int Next(int celt, System.Runtime.InteropServices.ComTypes.IConnectionPoint[] rgelt, System.IntPtr pceltFetched);
         void Reset();
         int Skip(int celt);
     }
@@ -1998,7 +1998,7 @@ namespace System.Runtime.InteropServices.ComTypes
     public partial interface IEnumConnections
     {
         void Clone(out System.Runtime.InteropServices.ComTypes.IEnumConnections ppenum);
-        int Next(int celt, System.Runtime.InteropServices.ComTypes.CONNECTDATA[] rgelt, System.IntPtr pceltFetched);
+        unsafe int Next(int celt, System.Runtime.InteropServices.ComTypes.CONNECTDATA[] rgelt, System.IntPtr pceltFetched);
         void Reset();
         int Skip(int celt);
     }
@@ -2007,7 +2007,7 @@ namespace System.Runtime.InteropServices.ComTypes
     public partial interface IEnumMoniker
     {
         void Clone(out System.Runtime.InteropServices.ComTypes.IEnumMoniker ppenum);
-        int Next(int celt, System.Runtime.InteropServices.ComTypes.IMoniker[] rgelt, System.IntPtr pceltFetched);
+        unsafe int Next(int celt, System.Runtime.InteropServices.ComTypes.IMoniker[] rgelt, System.IntPtr pceltFetched);
         void Reset();
         int Skip(int celt);
     }
@@ -2016,7 +2016,7 @@ namespace System.Runtime.InteropServices.ComTypes
     public partial interface IEnumString
     {
         void Clone(out System.Runtime.InteropServices.ComTypes.IEnumString ppenum);
-        int Next(int celt, string[] rgelt, System.IntPtr pceltFetched);
+        unsafe int Next(int celt, string[] rgelt, System.IntPtr pceltFetched);
         void Reset();
         int Skip(int celt);
     }
@@ -2025,7 +2025,7 @@ namespace System.Runtime.InteropServices.ComTypes
     public partial interface IEnumVARIANT
     {
         System.Runtime.InteropServices.ComTypes.IEnumVARIANT Clone();
-        int Next(int celt, object?[] rgVar, System.IntPtr pceltFetched);
+        unsafe int Next(int celt, object?[] rgVar, System.IntPtr pceltFetched);
         int Reset();
         int Skip(int celt);
     }
@@ -2101,15 +2101,15 @@ namespace System.Runtime.InteropServices.ComTypes
     {
         void Clone(out System.Runtime.InteropServices.ComTypes.IStream ppstm);
         void Commit(int grfCommitFlags);
-        void CopyTo(System.Runtime.InteropServices.ComTypes.IStream pstm, long cb, System.IntPtr pcbRead, System.IntPtr pcbWritten);
+        unsafe void CopyTo(System.Runtime.InteropServices.ComTypes.IStream pstm, long cb, System.IntPtr pcbRead, System.IntPtr pcbWritten);
         void LockRegion(long libOffset, long cb, int dwLockType);
-        void Read(byte[] pv, int cb, System.IntPtr pcbRead);
+        unsafe void Read(byte[] pv, int cb, System.IntPtr pcbRead);
         void Revert();
-        void Seek(long dlibMove, int dwOrigin, System.IntPtr plibNewPosition);
+        unsafe void Seek(long dlibMove, int dwOrigin, System.IntPtr plibNewPosition);
         void SetSize(long libNewSize);
         void Stat(out System.Runtime.InteropServices.ComTypes.STATSTG pstatstg, int grfStatFlag);
         void UnlockRegion(long libOffset, long cb, int dwLockType);
-        void Write(byte[] pv, int cb, System.IntPtr pcbWritten);
+        unsafe void Write(byte[] pv, int cb, System.IntPtr pcbWritten);
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
@@ -2125,7 +2125,7 @@ namespace System.Runtime.InteropServices.ComTypes
         void AddressOfMember(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, out System.IntPtr ppv);
         void CreateInstance(object? pUnkOuter, ref System.Guid riid, out object ppvObj);
         void GetContainingTypeLib(out System.Runtime.InteropServices.ComTypes.ITypeLib ppTLB, out int pIndex);
-        void GetDllEntry(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, System.IntPtr pBstrDllName, System.IntPtr pBstrName, System.IntPtr pwOrdinal);
+        unsafe void GetDllEntry(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, System.IntPtr pBstrDllName, System.IntPtr pBstrName, System.IntPtr pwOrdinal);
         void GetDocumentation(int index, out string strName, out string strDocString, out int dwHelpContext, out string strHelpFile);
         void GetFuncDesc(int index, out System.IntPtr ppFuncDesc);
         void GetIDsOfNames(string[] rgszNames, int cNames, int[] pMemId);
@@ -2137,10 +2137,10 @@ namespace System.Runtime.InteropServices.ComTypes
         void GetTypeAttr(out System.IntPtr ppTypeAttr);
         void GetTypeComp(out System.Runtime.InteropServices.ComTypes.ITypeComp ppTComp);
         void GetVarDesc(int index, out System.IntPtr ppVarDesc);
-        void Invoke(object pvInstance, int memid, short wFlags, ref System.Runtime.InteropServices.ComTypes.DISPPARAMS pDispParams, System.IntPtr pVarResult, System.IntPtr pExcepInfo, out int puArgErr);
-        void ReleaseFuncDesc(System.IntPtr pFuncDesc);
-        void ReleaseTypeAttr(System.IntPtr pTypeAttr);
-        void ReleaseVarDesc(System.IntPtr pVarDesc);
+        unsafe void Invoke(object pvInstance, int memid, short wFlags, ref System.Runtime.InteropServices.ComTypes.DISPPARAMS pDispParams, System.IntPtr pVarResult, System.IntPtr pExcepInfo, out int puArgErr);
+        unsafe void ReleaseFuncDesc(System.IntPtr pFuncDesc);
+        unsafe void ReleaseTypeAttr(System.IntPtr pTypeAttr);
+        unsafe void ReleaseVarDesc(System.IntPtr pVarDesc);
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
@@ -2148,11 +2148,11 @@ namespace System.Runtime.InteropServices.ComTypes
     {
         new void AddressOfMember(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, out System.IntPtr ppv);
         new void CreateInstance(object? pUnkOuter, ref System.Guid riid, out object ppvObj);
-        void GetAllCustData(System.IntPtr pCustData);
-        void GetAllFuncCustData(int index, System.IntPtr pCustData);
-        void GetAllImplTypeCustData(int index, System.IntPtr pCustData);
-        void GetAllParamCustData(int indexFunc, int indexParam, System.IntPtr pCustData);
-        void GetAllVarCustData(int index, System.IntPtr pCustData);
+        unsafe void GetAllCustData(System.IntPtr pCustData);
+        unsafe void GetAllFuncCustData(int index, System.IntPtr pCustData);
+        unsafe void GetAllImplTypeCustData(int index, System.IntPtr pCustData);
+        unsafe void GetAllParamCustData(int indexFunc, int indexParam, System.IntPtr pCustData);
+        unsafe void GetAllVarCustData(int index, System.IntPtr pCustData);
         new void GetContainingTypeLib(out System.Runtime.InteropServices.ComTypes.ITypeLib ppTLB, out int pIndex);
         void GetCustData(ref System.Guid guid, out object pVarVal);
         new void GetDllEntry(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, System.IntPtr pBstrDllName, System.IntPtr pBstrName, System.IntPtr pwOrdinal);
@@ -2194,26 +2194,26 @@ namespace System.Runtime.InteropServices.ComTypes
         void GetTypeInfoOfGuid(ref System.Guid guid, out System.Runtime.InteropServices.ComTypes.ITypeInfo ppTInfo);
         void GetTypeInfoType(int index, out System.Runtime.InteropServices.ComTypes.TYPEKIND pTKind);
         bool IsName(string szNameBuf, int lHashVal);
-        void ReleaseTLibAttr(System.IntPtr pTLibAttr);
+        unsafe void ReleaseTLibAttr(System.IntPtr pTLibAttr);
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface ITypeLib2 : System.Runtime.InteropServices.ComTypes.ITypeLib
     {
         new void FindName(string szNameBuf, int lHashVal, System.Runtime.InteropServices.ComTypes.ITypeInfo[] ppTInfo, int[] rgMemId, ref short pcFound);
-        void GetAllCustData(System.IntPtr pCustData);
+        unsafe void GetAllCustData(System.IntPtr pCustData);
         void GetCustData(ref System.Guid guid, out object pVarVal);
         new void GetDocumentation(int index, out string strName, out string strDocString, out int dwHelpContext, out string strHelpFile);
         void GetDocumentation2(int index, out string pbstrHelpString, out int pdwHelpStringContext, out string pbstrHelpStringDll);
         new void GetLibAttr(out System.IntPtr ppTLibAttr);
-        void GetLibStatistics(System.IntPtr pcUniqueNames, out int pcchUniqueNames);
+        unsafe void GetLibStatistics(System.IntPtr pcUniqueNames, out int pcchUniqueNames);
         new void GetTypeComp(out System.Runtime.InteropServices.ComTypes.ITypeComp ppTComp);
         new void GetTypeInfo(int index, out System.Runtime.InteropServices.ComTypes.ITypeInfo ppTI);
         new int GetTypeInfoCount();
         new void GetTypeInfoOfGuid(ref System.Guid guid, out System.Runtime.InteropServices.ComTypes.ITypeInfo ppTInfo);
         new void GetTypeInfoType(int index, out System.Runtime.InteropServices.ComTypes.TYPEKIND pTKind);
         new bool IsName(string szNameBuf, int lHashVal);
-        new void ReleaseTLibAttr(System.IntPtr pTLibAttr);
+        unsafe new void ReleaseTLibAttr(System.IntPtr pTLibAttr);
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.FlagsAttribute]
@@ -2357,9 +2357,9 @@ namespace System.Runtime.InteropServices.ComTypes
         public partial struct DESCUNION
         {
             [System.Runtime.InteropServices.FieldOffsetAttribute(0)]
-            public System.IntPtr lpvarValue;
+            public safe System.IntPtr lpvarValue;
             [System.Runtime.InteropServices.FieldOffsetAttribute(0)]
-            public int oInst;
+            public safe int oInst;
         }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -2402,7 +2402,7 @@ namespace System.Runtime.InteropServices.Java
     [System.CLSCompliantAttribute(false)]
     public static class JavaMarshal
     {
-        public static unsafe void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences) => throw null;
+        public static void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences) => throw null;
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context) => throw null;
         public static unsafe void* GetContext(GCHandle obj) => throw null;
         public static unsafe void FinishCrossReferenceProcessing(
@@ -2411,7 +2411,7 @@ namespace System.Runtime.InteropServices.Java
     }
     [System.Runtime.Versioning.SupportedOSPlatform("android")]
     [System.CLSCompliantAttribute(false)]
-    public unsafe struct StronglyConnectedComponent
+    public struct StronglyConnectedComponent
     {
         public nuint Count;
         public void** Contexts;
@@ -2419,7 +2419,7 @@ namespace System.Runtime.InteropServices.Java
 
     [System.Runtime.Versioning.SupportedOSPlatform("android")]
     [System.CLSCompliantAttribute(false)]
-    public unsafe struct MarkCrossReferencesArgs
+    public struct MarkCrossReferencesArgs
     {
         public nuint ComponentCount;
         public StronglyConnectedComponent* Components;
@@ -2440,7 +2440,7 @@ namespace System.Runtime.InteropServices.ObjectiveC
     [System.CLSCompliantAttribute(false)]
     public static class ObjectiveCMarshal
     {
-        public unsafe delegate delegate* unmanaged<System.IntPtr, void> UnhandledExceptionPropagationHandler(
+        public delegate delegate* unmanaged<System.IntPtr, void> UnhandledExceptionPropagationHandler(
             System.Exception exception,
             System.RuntimeMethodHandle lastMethod,
             out System.IntPtr context);
@@ -2461,7 +2461,7 @@ namespace System.Runtime.InteropServices.ObjectiveC
             MsgSendSuper,
             MsgSendSuperStret,
         }
-        public static void SetMessageSendCallback(MessageSendFunction msgSendFunction, System.IntPtr func) => throw null;
+        public unsafe static void SetMessageSendCallback(MessageSendFunction msgSendFunction, System.IntPtr func) => throw null;
         public static void SetMessageSendPendingException(Exception? exception) => throw null;
     }
 }
@@ -2474,7 +2474,7 @@ namespace System.Runtime.InteropServices.Marshalling
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(string),
         System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedIn,
         typeof(System.Runtime.InteropServices.Marshalling.AnsiStringMarshaller.ManagedToUnmanagedIn))]
-    public static unsafe class AnsiStringMarshaller
+    public static class AnsiStringMarshaller
     {
         public static byte* ConvertToUnmanaged(string? managed) { throw null; }
         public static string? ConvertToManaged(byte* unmanaged) { throw null; }
@@ -2497,7 +2497,7 @@ namespace System.Runtime.InteropServices.Marshalling
         System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedIn,
         typeof(System.Runtime.InteropServices.Marshalling.ArrayMarshaller<,>.ManagedToUnmanagedIn))]
     [System.Runtime.InteropServices.Marshalling.ContiguousCollectionMarshaller]
-    public static unsafe class ArrayMarshaller<T, TUnmanagedElement>
+    public static class ArrayMarshaller<T, TUnmanagedElement>
         where TUnmanagedElement : unmanaged
     {
         public static TUnmanagedElement* AllocateContainerForUnmanagedElements(T[]? managed, out int numElements) { throw null; }
@@ -2508,7 +2508,7 @@ namespace System.Runtime.InteropServices.Marshalling
         public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements) { throw null; }
         public static void Free(TUnmanagedElement* unmanaged) { }
 
-        public unsafe ref struct ManagedToUnmanagedIn
+        public ref struct ManagedToUnmanagedIn
         {
             private object _dummy;
             private int _dummyPrimitive;
@@ -2529,7 +2529,7 @@ namespace System.Runtime.InteropServices.Marshalling
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(string),
         System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedIn,
         typeof(System.Runtime.InteropServices.Marshalling.BStrStringMarshaller.ManagedToUnmanagedIn))]
-    public static unsafe class BStrStringMarshaller
+    public static class BStrStringMarshaller
     {
         public static ushort* ConvertToUnmanaged(string? managed) { throw null; }
         public static string? ConvertToManaged(ushort* unmanaged) { throw null; }
@@ -2562,7 +2562,7 @@ namespace System.Runtime.InteropServices.Marshalling
         System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedIn,
         typeof(System.Runtime.InteropServices.Marshalling.PointerArrayMarshaller<,>.ManagedToUnmanagedIn))]
     [System.Runtime.InteropServices.Marshalling.ContiguousCollectionMarshaller]
-    public static unsafe class PointerArrayMarshaller<T, TUnmanagedElement>
+    public static class PointerArrayMarshaller<T, TUnmanagedElement>
         where T : unmanaged
         where TUnmanagedElement : unmanaged
     {
@@ -2574,7 +2574,7 @@ namespace System.Runtime.InteropServices.Marshalling
         public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements) { throw null; }
         public static void Free(TUnmanagedElement* unmanaged) { }
 
-        public unsafe ref struct ManagedToUnmanagedIn
+        public ref struct ManagedToUnmanagedIn
         {
             private object _dummy;
             private int _dummyPrimitive;
@@ -2595,7 +2595,7 @@ namespace System.Runtime.InteropServices.Marshalling
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(string),
         System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedIn,
         typeof(System.Runtime.InteropServices.Marshalling.Utf8StringMarshaller.ManagedToUnmanagedIn))]
-    public static unsafe class Utf8StringMarshaller
+    public static class Utf8StringMarshaller
     {
         public static byte* ConvertToUnmanaged(string? managed) { throw null; }
         public static string? ConvertToManaged(byte* unmanaged) { throw null; }
@@ -2613,7 +2613,7 @@ namespace System.Runtime.InteropServices.Marshalling
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(string),
         System.Runtime.InteropServices.Marshalling.MarshalMode.Default,
         typeof(System.Runtime.InteropServices.Marshalling.Utf16StringMarshaller))]
-    public static unsafe class Utf16StringMarshaller
+    public static class Utf16StringMarshaller
     {
         public static ushort* ConvertToUnmanaged(string? managed) { throw null; }
         public static string? ConvertToManaged(ushort* unmanaged) { throw null; }
@@ -2626,12 +2626,12 @@ namespace System.Runtime.InteropServices.Marshalling
 
         public void Dispose() { }
         public static System.Runtime.InteropServices.Marshalling.ComVariant Create<T>([System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T value) { throw null; }
-        public static System.Runtime.InteropServices.Marshalling.ComVariant CreateRaw<T>(System.Runtime.InteropServices.VarEnum vt, T rawValue) where T : unmanaged { throw null; }
+        public unsafe static System.Runtime.InteropServices.Marshalling.ComVariant CreateRaw<T>(System.Runtime.InteropServices.VarEnum vt, T rawValue) where T : unmanaged { throw null; }
         public static System.Runtime.InteropServices.Marshalling.ComVariant Null { get { throw null; } }
         public readonly T? As<T>() { throw null; }
         public readonly System.Runtime.InteropServices.VarEnum VarType { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.UnscopedRefAttribute]
-        public ref T GetRawDataRef<T>() where T : unmanaged { throw null; }
+        public unsafe ref T GetRawDataRef<T>() where T : unmanaged { throw null; }
     }
 }
 namespace System.Security

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
@@ -8,6 +8,7 @@
     <NoWarn>$(NoWarn);CS9368</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.InteropServices.cs" />

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -45,8 +45,8 @@ namespace System.Runtime.Intrinsics
         public static System.Runtime.Intrinsics.Vector128<float> AsVector128(this System.Numerics.Vector2 value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> AsVector128(this System.Numerics.Vector3 value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> AsVector128(this System.Numerics.Vector4 value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<float> AsVector128Unsafe(this System.Numerics.Vector2 value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<float> AsVector128Unsafe(this System.Numerics.Vector3 value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> AsVector128Unsafe(this System.Numerics.Vector2 value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> AsVector128Unsafe(this System.Numerics.Vector3 value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> AsVector128<T>(this System.Numerics.Vector<T> value) { throw null; }
         public static System.Numerics.Vector2 AsVector2(this System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
         public static System.Numerics.Vector3 AsVector3(this System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
@@ -152,24 +152,24 @@ namespace System.Runtime.Intrinsics
         [System.CLSCompliantAttribute(false)]
         public static System.Runtime.Intrinsics.Vector128<ulong> CreateScalar(ulong value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> CreateScalar<T>(T value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<byte> CreateScalarUnsafe(byte value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<double> CreateScalarUnsafe(double value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<short> CreateScalarUnsafe(short value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<int> CreateScalarUnsafe(int value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<long> CreateScalarUnsafe(long value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<nint> CreateScalarUnsafe(nint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<byte> CreateScalarUnsafe(byte value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<double> CreateScalarUnsafe(double value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<short> CreateScalarUnsafe(short value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<int> CreateScalarUnsafe(int value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<long> CreateScalarUnsafe(long value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<nint> CreateScalarUnsafe(nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector128<nuint> CreateScalarUnsafe(nuint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<nuint> CreateScalarUnsafe(nuint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector128<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<float> CreateScalarUnsafe(float value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<float> CreateScalarUnsafe(float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector128<ushort> CreateScalarUnsafe(ushort value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ushort> CreateScalarUnsafe(ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector128<uint> CreateScalarUnsafe(uint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<uint> CreateScalarUnsafe(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector128<ulong> CreateScalarUnsafe(ulong value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<T> CreateScalarUnsafe<T>(T value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<ulong> CreateScalarUnsafe(ulong value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<T> CreateScalarUnsafe<T>(T value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> CreateSequence<T>(T start, T step) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> CreateGeometricSequence<T>(T initial, [System.Diagnostics.CodeAnalysis.ConstantExpected] T multiplier) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> CreateAlternatingSequence<T>(T even, T odd) { throw null; }
@@ -249,9 +249,9 @@ namespace System.Runtime.Intrinsics
         public static unsafe System.Runtime.Intrinsics.Vector128<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector128<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector128<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> Log(System.Runtime.Intrinsics.Vector128<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> Log(System.Runtime.Intrinsics.Vector128<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> Log2(System.Runtime.Intrinsics.Vector128<double> vector) { throw null; }
@@ -384,14 +384,14 @@ namespace System.Runtime.Intrinsics
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector128<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector128<T> source, T* destination) { throw null; }
-        public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector128<T> source, ref T destination) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector128<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector128<T> source, ref T destination, nuint elementOffset) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector128<T> source, ref T destination, nuint elementOffset) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> Subtract<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> SubtractSaturate<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) { throw null; }
         public static T Sum<T>(System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         public static T ToScalar<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<T> ToVector256Unsafe<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<T> ToVector256Unsafe<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> ToVector256<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> Truncate(System.Runtime.Intrinsics.Vector128<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> Truncate(System.Runtime.Intrinsics.Vector128<float> vector) { throw null; }
@@ -618,24 +618,24 @@ namespace System.Runtime.Intrinsics
         [System.CLSCompliantAttribute(false)]
         public static System.Runtime.Intrinsics.Vector256<ulong> CreateScalar(ulong value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> CreateScalar<T>(T value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<byte> CreateScalarUnsafe(byte value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<double> CreateScalarUnsafe(double value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<short> CreateScalarUnsafe(short value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<int> CreateScalarUnsafe(int value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<long> CreateScalarUnsafe(long value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<nint> CreateScalarUnsafe(nint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<byte> CreateScalarUnsafe(byte value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<double> CreateScalarUnsafe(double value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<short> CreateScalarUnsafe(short value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<int> CreateScalarUnsafe(int value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<long> CreateScalarUnsafe(long value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<nint> CreateScalarUnsafe(nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector256<nuint> CreateScalarUnsafe(nuint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<nuint> CreateScalarUnsafe(nuint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector256<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<float> CreateScalarUnsafe(float value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<float> CreateScalarUnsafe(float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector256<ushort> CreateScalarUnsafe(ushort value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ushort> CreateScalarUnsafe(ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector256<uint> CreateScalarUnsafe(uint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<uint> CreateScalarUnsafe(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector256<ulong> CreateScalarUnsafe(ulong value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<T> CreateScalarUnsafe<T>(T value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<ulong> CreateScalarUnsafe(ulong value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<T> CreateScalarUnsafe<T>(T value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> CreateSequence<T>(T start, T step) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> CreateGeometricSequence<T>(T initial, [System.Diagnostics.CodeAnalysis.ConstantExpected] T multiplier) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> CreateAlternatingSequence<T>(T even, T odd) { throw null; }
@@ -716,9 +716,9 @@ namespace System.Runtime.Intrinsics
         public static unsafe System.Runtime.Intrinsics.Vector256<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector256<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-        public static System.Runtime.Intrinsics.Vector256<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector256<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector256<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> Log(System.Runtime.Intrinsics.Vector256<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<float> Log(System.Runtime.Intrinsics.Vector256<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> Log2(System.Runtime.Intrinsics.Vector256<double> vector) { throw null; }
@@ -851,14 +851,14 @@ namespace System.Runtime.Intrinsics
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector256<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector256<T> source, T* destination) { throw null; }
-        public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector256<T> source, ref T destination) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector256<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector256<T> source, ref T destination, nuint elementOffset) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector256<T> source, ref T destination, nuint elementOffset) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> Subtract<T>(System.Runtime.Intrinsics.Vector256<T> left, System.Runtime.Intrinsics.Vector256<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> SubtractSaturate<T>(System.Runtime.Intrinsics.Vector256<T> left, System.Runtime.Intrinsics.Vector256<T> right) { throw null; }
         public static T Sum<T>(System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         public static T ToScalar<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<T> ToVector512Unsafe<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<T> ToVector512Unsafe<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> ToVector512<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> Truncate(System.Runtime.Intrinsics.Vector256<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<float> Truncate(System.Runtime.Intrinsics.Vector256<float> vector) { throw null; }
@@ -1085,24 +1085,24 @@ namespace System.Runtime.Intrinsics
         [System.CLSCompliantAttribute(false)]
         public static System.Runtime.Intrinsics.Vector512<ulong> CreateScalar(ulong value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> CreateScalar<T>(T value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<byte> CreateScalarUnsafe(byte value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<double> CreateScalarUnsafe(double value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<short> CreateScalarUnsafe(short value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<int> CreateScalarUnsafe(int value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<long> CreateScalarUnsafe(long value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<nint> CreateScalarUnsafe(nint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<byte> CreateScalarUnsafe(byte value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<double> CreateScalarUnsafe(double value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<short> CreateScalarUnsafe(short value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<int> CreateScalarUnsafe(int value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<long> CreateScalarUnsafe(long value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<nint> CreateScalarUnsafe(nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector512<nuint> CreateScalarUnsafe(nuint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<nuint> CreateScalarUnsafe(nuint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector512<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<float> CreateScalarUnsafe(float value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<float> CreateScalarUnsafe(float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector512<ushort> CreateScalarUnsafe(ushort value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<ushort> CreateScalarUnsafe(ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector512<uint> CreateScalarUnsafe(uint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<uint> CreateScalarUnsafe(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector512<ulong> CreateScalarUnsafe(ulong value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<T> CreateScalarUnsafe<T>(T value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<ulong> CreateScalarUnsafe(ulong value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<T> CreateScalarUnsafe<T>(T value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> CreateSequence<T>(T start, T step) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> CreateGeometricSequence<T>(T initial, [System.Diagnostics.CodeAnalysis.ConstantExpected] T multiplier) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> CreateAlternatingSequence<T>(T even, T odd) { throw null; }
@@ -1184,9 +1184,9 @@ namespace System.Runtime.Intrinsics
         public static unsafe System.Runtime.Intrinsics.Vector512<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector512<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-        public static System.Runtime.Intrinsics.Vector512<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector512<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector512<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<double> Log(System.Runtime.Intrinsics.Vector512<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<float> Log(System.Runtime.Intrinsics.Vector512<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<double> Log2(System.Runtime.Intrinsics.Vector512<double> vector) { throw null; }
@@ -1319,9 +1319,9 @@ namespace System.Runtime.Intrinsics
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector512<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector512<T> source, T* destination) { throw null; }
-        public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector512<T> source, ref T destination) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector512<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector512<T> source, ref T destination, nuint elementOffset) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector512<T> source, ref T destination, nuint elementOffset) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> Subtract<T>(System.Runtime.Intrinsics.Vector512<T> left, System.Runtime.Intrinsics.Vector512<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> SubtractSaturate<T>(System.Runtime.Intrinsics.Vector512<T> left, System.Runtime.Intrinsics.Vector512<T> right) { throw null; }
         public static T Sum<T>(System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
@@ -1528,24 +1528,24 @@ namespace System.Runtime.Intrinsics
         [System.CLSCompliantAttribute(false)]
         public static System.Runtime.Intrinsics.Vector64<ulong> CreateScalar(ulong value) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> CreateScalar<T>(T value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector64<byte> CreateScalarUnsafe(byte value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector64<double> CreateScalarUnsafe(double value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector64<short> CreateScalarUnsafe(short value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector64<int> CreateScalarUnsafe(int value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector64<long> CreateScalarUnsafe(long value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector64<nint> CreateScalarUnsafe(nint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<byte> CreateScalarUnsafe(byte value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<double> CreateScalarUnsafe(double value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<short> CreateScalarUnsafe(short value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<int> CreateScalarUnsafe(int value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<long> CreateScalarUnsafe(long value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<nint> CreateScalarUnsafe(nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector64<nuint> CreateScalarUnsafe(nuint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<nuint> CreateScalarUnsafe(nuint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector64<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector64<float> CreateScalarUnsafe(float value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<sbyte> CreateScalarUnsafe(sbyte value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<float> CreateScalarUnsafe(float value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector64<ushort> CreateScalarUnsafe(ushort value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<ushort> CreateScalarUnsafe(ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector64<uint> CreateScalarUnsafe(uint value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<uint> CreateScalarUnsafe(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector64<ulong> CreateScalarUnsafe(ulong value) { throw null; }
-        public static System.Runtime.Intrinsics.Vector64<T> CreateScalarUnsafe<T>(T value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<ulong> CreateScalarUnsafe(ulong value) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<T> CreateScalarUnsafe<T>(T value) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> CreateSequence<T>(T start, T step) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> CreateGeometricSequence<T>(T initial, [System.Diagnostics.CodeAnalysis.ConstantExpected] T multiplier) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> CreateAlternatingSequence<T>(T even, T odd) { throw null; }
@@ -1621,9 +1621,9 @@ namespace System.Runtime.Intrinsics
         public static unsafe System.Runtime.Intrinsics.Vector64<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe System.Runtime.Intrinsics.Vector64<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
-        public static System.Runtime.Intrinsics.Vector64<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static System.Runtime.Intrinsics.Vector64<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector64<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<double> Log(System.Runtime.Intrinsics.Vector64<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<float> Log(System.Runtime.Intrinsics.Vector64<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<double> Log2(System.Runtime.Intrinsics.Vector64<double> vector) { throw null; }
@@ -1748,14 +1748,14 @@ namespace System.Runtime.Intrinsics
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector64<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector64<T> source, T* destination) { throw null; }
-        public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector64<T> source, ref T destination) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector64<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector64<T> source, ref T destination, nuint elementOffset) { throw null; }
+        public unsafe static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector64<T> source, ref T destination, nuint elementOffset) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> Subtract<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> SubtractSaturate<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) { throw null; }
         public static T Sum<T>(System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         public static T ToScalar<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
-        public static System.Runtime.Intrinsics.Vector128<T> ToVector128Unsafe<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
+        public unsafe static System.Runtime.Intrinsics.Vector128<T> ToVector128Unsafe<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> ToVector128<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<double> Truncate(System.Runtime.Intrinsics.Vector64<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<float> Truncate(System.Runtime.Intrinsics.Vector64<float> vector) { throw null; }

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.csproj
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.csproj
@@ -4,6 +4,7 @@
     <!-- https://github.com/dotnet/dotnet/issues/5640 -->
     <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.Intrinsics.cs" />

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -3087,7 +3087,7 @@ namespace System
         public static int MaxGeneration { get { throw null; } }
         public static void AddMemoryPressure(long bytesAllocated) { }
         public static T[] AllocateArray<T>(int length, bool pinned = false) { throw null; }
-        public static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) { throw null; }
+        public unsafe static T[] AllocateUninitializedArray<T>(int length, bool pinned = false) { throw null; }
         public static void CancelFullGCNotification() { }
         public static void Collect() { }
         public static void Collect(int generation) { }
@@ -5199,7 +5199,7 @@ namespace System
         public System.IntPtr Value { get { throw null; } }
         public override bool Equals(object? obj) { throw null; }
         public bool Equals(System.RuntimeFieldHandle handle) { throw null; }
-        public static System.RuntimeFieldHandle FromIntPtr(System.IntPtr value) { throw null; }
+        public unsafe static System.RuntimeFieldHandle FromIntPtr(System.IntPtr value) { throw null; }
         public override int GetHashCode() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
@@ -5215,7 +5215,7 @@ namespace System
         public System.IntPtr Value { get { throw null; } }
         public override bool Equals(object? obj) { throw null; }
         public bool Equals(System.RuntimeMethodHandle handle) { throw null; }
-        public static System.RuntimeMethodHandle FromIntPtr(System.IntPtr value) { throw null; }
+        public unsafe static System.RuntimeMethodHandle FromIntPtr(System.IntPtr value) { throw null; }
         public System.IntPtr GetFunctionPointer() { throw null; }
         public override int GetHashCode() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -5232,7 +5232,7 @@ namespace System
         public System.IntPtr Value { get { throw null; } }
         public override bool Equals(object? obj) { throw null; }
         public bool Equals(System.RuntimeTypeHandle handle) { throw null; }
-        public static System.RuntimeTypeHandle FromIntPtr(System.IntPtr value) { throw null; }
+        public unsafe static System.RuntimeTypeHandle FromIntPtr(System.IntPtr value) { throw null; }
         public override int GetHashCode() { throw null; }
         public System.ModuleHandle GetModuleHandle() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -15136,7 +15136,7 @@ namespace System.Runtime.CompilerServices
         public static int OffsetToStringData { get { throw null; } }
         public static System.IntPtr AllocateTypeAssociatedMemory(System.Type type, int size) { throw null; }
         public static System.IntPtr AllocateTypeAssociatedMemory(System.Type type, int size, int alignment) { throw null; }
-        public static object? Box(ref byte target, System.RuntimeTypeHandle type) { throw null; }
+        public unsafe static object? Box(ref byte target, System.RuntimeTypeHandle type) { throw null; }
         public static System.ReadOnlySpan<T> CreateSpan<T>(System.RuntimeFieldHandle fldHandle) { throw null; }
         public static void EnsureSufficientExecutionStack() { }
         public static new bool Equals(object? o1, object? o2) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -459,7 +459,7 @@ namespace System
         public ArgumentNullException(string? paramName, string? message) { }
         public static void ThrowIfNull([System.Diagnostics.CodeAnalysis.NotNullAttribute] object? argument, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("argument")] string? paramName = null) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public unsafe static void ThrowIfNull([System.Diagnostics.CodeAnalysis.NotNullAttribute] void* argument, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("argument")] string? paramName = null) { throw null; }
+        public static void ThrowIfNull([System.Diagnostics.CodeAnalysis.NotNullAttribute] void* argument, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("argument")] string? paramName = null) { throw null; }
     }
     public partial class ArgumentOutOfRangeException : System.ArgumentException
     {
@@ -4227,7 +4227,7 @@ namespace System
         public IntPtr(int value) { throw null; }
         public IntPtr(long value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public unsafe IntPtr(void* value) { throw null; }
+        public IntPtr(void* value) { throw null; }
         public static nint MaxValue { get { throw null; } }
         public static nint MinValue { get { throw null; } }
         public static int Size { get { throw null; } }
@@ -4273,9 +4273,9 @@ namespace System
         public static explicit operator int (nint value) { throw null; }
         public static explicit operator long (nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public unsafe static explicit operator void* (nint value) { throw null; }
+        public static explicit operator void* (nint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public unsafe static explicit operator nint (void* value) { throw null; }
+        public static explicit operator nint (void* value) { throw null; }
         public static bool operator !=(nint value1, nint value2) { throw null; }
         public static nint operator -(nint pointer, int offset) { throw null; }
         public static nint Parse(System.ReadOnlySpan<byte> utf8Text, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
@@ -4351,7 +4351,7 @@ namespace System
         public int ToInt32() { throw null; }
         public long ToInt64() { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public unsafe void* ToPointer() { throw null; }
+        public void* ToPointer() { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
@@ -7550,7 +7550,7 @@ namespace System
         public static readonly nuint Zero;
         public UIntPtr(uint value) { throw null; }
         public UIntPtr(ulong value) { throw null; }
-        public unsafe UIntPtr(void* value) { throw null; }
+        public UIntPtr(void* value) { throw null; }
         public static nuint MaxValue { get { throw null; } }
         public static nuint MinValue { get { throw null; } }
         public static int Size { get { throw null; } }
@@ -7588,8 +7588,8 @@ namespace System
         public static explicit operator nuint (ulong value) { throw null; }
         public static explicit operator uint (nuint value) { throw null; }
         public static explicit operator ulong (nuint value) { throw null; }
-        public unsafe static explicit operator void* (nuint value) { throw null; }
-        public unsafe static explicit operator nuint (void* value) { throw null; }
+        public static explicit operator void* (nuint value) { throw null; }
+        public static explicit operator nuint (void* value) { throw null; }
         public static bool operator !=(nuint value1, nuint value2) { throw null; }
         public static nuint operator -(nuint pointer, int offset) { throw null; }
         public static nuint Parse(System.ReadOnlySpan<byte> utf8Text, System.Globalization.NumberStyles style = System.Globalization.NumberStyles.Integer, System.IFormatProvider? provider = null) { throw null; }
@@ -7668,7 +7668,7 @@ namespace System
         static nuint System.Numerics.IUnaryNegationOperators<nuint, nuint>.operator -(nuint value) { throw null; }
         static nuint System.Numerics.IUnaryPlusOperators<nuint, nuint>.operator +(nuint value) { throw null; }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public unsafe void* ToPointer() { throw null; }
+        public void* ToPointer() { throw null; }
         public override string ToString() { throw null; }
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("NumericFormat")] string? format) { throw null; }
@@ -15285,32 +15285,32 @@ namespace System.Runtime.CompilerServices
     }
     public static partial class Unsafe
     {
-        public static ref T AddByteOffset<T>(ref T source, System.IntPtr byteOffset) where T : allows ref struct { throw null; }
+        public unsafe static ref T AddByteOffset<T>(ref T source, System.IntPtr byteOffset) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static ref T AddByteOffset<T>(ref T source, nuint byteOffset) where T : allows ref struct { throw null; }
+        public unsafe static ref T AddByteOffset<T>(ref T source, nuint byteOffset) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static void* Add<T>(void* source, int elementOffset) where T : allows ref struct { throw null; }
-        public static ref T Add<T>(ref T source, int elementOffset) where T : allows ref struct { throw null; }
-        public static ref T Add<T>(ref T source, System.IntPtr elementOffset) where T : allows ref struct { throw null; }
+        public unsafe static ref T Add<T>(ref T source, int elementOffset) where T : allows ref struct { throw null; }
+        public unsafe static ref T Add<T>(ref T source, System.IntPtr elementOffset) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static ref T Add<T>(ref T source, nuint elementOffset) where T : allows ref struct { throw null; }
+        public unsafe static ref T Add<T>(ref T source, nuint elementOffset) where T : allows ref struct { throw null; }
         public static bool AreSame<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T left, [System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T right) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static void* AsPointer<T>(ref readonly T value) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static ref T AsRef<T>(void* source) where T : allows ref struct { throw null; }
-        public static ref T AsRef<T>(scoped ref readonly T source) where T : allows ref struct { throw null; }
+        public unsafe static ref T AsRef<T>(scoped ref readonly T source) where T : allows ref struct { throw null; }
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("o")]
-        public static T? As<T>(object? o) where T : class? { throw null; }
-        public static ref TTo As<TFrom, TTo>(ref TFrom source) where TFrom : allows ref struct where TTo : allows ref struct { throw null; }
-        public static TTo BitCast<TFrom, TTo>(TFrom source) where TFrom : allows ref struct where TTo : allows ref struct { throw null; }
+        public unsafe static T? As<T>(object? o) where T : class? { throw null; }
+        public unsafe static ref TTo As<TFrom, TTo>(ref TFrom source) where TFrom : allows ref struct where TTo : allows ref struct { throw null; }
+        public unsafe static TTo BitCast<TFrom, TTo>(TFrom source) where TFrom : allows ref struct where TTo : allows ref struct { throw null; }
         public static System.IntPtr ByteOffset<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T origin, [System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T target) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static void CopyBlock(ref byte destination, ref readonly byte source, uint byteCount) { }
+        public unsafe static void CopyBlock(ref byte destination, ref readonly byte source, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
         public unsafe static void CopyBlock(void* destination, void* source, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
-        public static void CopyBlockUnaligned(ref byte destination, ref readonly byte source, uint byteCount) { }
+        public unsafe static void CopyBlockUnaligned(ref byte destination, ref readonly byte source, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
         public unsafe static void CopyBlockUnaligned(void* destination, void* source, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
@@ -15318,11 +15318,11 @@ namespace System.Runtime.CompilerServices
         [System.CLSCompliantAttribute(false)]
         public unsafe static void Copy<T>(ref T destination, void* source) where T : allows ref struct { }
         [System.CLSCompliantAttribute(false)]
-        public static void InitBlock(ref byte startAddress, byte value, uint byteCount) { }
+        public unsafe static void InitBlock(ref byte startAddress, byte value, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
         public unsafe static void InitBlock(void* startAddress, byte value, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
-        public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount) { }
+        public unsafe static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
         public unsafe static void InitBlockUnaligned(void* startAddress, byte value, uint byteCount) { }
         public static bool IsAddressGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T left, [System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T right) where T : allows ref struct { throw null; }
@@ -15331,24 +15331,24 @@ namespace System.Runtime.CompilerServices
         public static bool IsAddressLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T left, [System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T right) where T : allows ref struct { throw null; }
         public static bool IsNullRef<T>(ref readonly T source) where T : allows ref struct { throw null; }
         public static ref T NullRef<T>() where T : allows ref struct { throw null; }
-        public static T ReadUnaligned<T>(scoped ref readonly byte source) where T : allows ref struct { throw null; }
+        public unsafe static T ReadUnaligned<T>(scoped ref readonly byte source) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static T ReadUnaligned<T>(void* source) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static T Read<T>(void* source) where T : allows ref struct { throw null; }
         public static int SizeOf<T>() where T : allows ref struct { throw null; }
-        public static void SkipInit<T>(out T value) where T : allows ref struct { throw null; }
-        public static ref T SubtractByteOffset<T>(ref T source, System.IntPtr byteOffset) where T : allows ref struct { throw null; }
+        public unsafe static void SkipInit<T>(out T value) where T : allows ref struct { throw null; }
+        public unsafe static ref T SubtractByteOffset<T>(ref T source, System.IntPtr byteOffset) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static ref T SubtractByteOffset<T>(ref T source, nuint byteOffset) where T : allows ref struct { throw null; }
+        public unsafe static ref T SubtractByteOffset<T>(ref T source, nuint byteOffset) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static void* Subtract<T>(void* source, int elementOffset) where T : allows ref struct { throw null; }
-        public static ref T Subtract<T>(ref T source, int elementOffset) where T : allows ref struct { throw null; }
-        public static ref T Subtract<T>(ref T source, System.IntPtr elementOffset) where T : allows ref struct { throw null; }
+        public unsafe static ref T Subtract<T>(ref T source, int elementOffset) where T : allows ref struct { throw null; }
+        public unsafe static ref T Subtract<T>(ref T source, System.IntPtr elementOffset) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
-        public static ref T Subtract<T>(ref T source, nuint elementOffset) where T : allows ref struct { throw null; }
-        public static ref T Unbox<T>(object box) where T : struct { throw null; }
-        public static void WriteUnaligned<T>(ref byte destination, T value) where T : allows ref struct { }
+        public unsafe static ref T Subtract<T>(ref T source, nuint elementOffset) where T : allows ref struct { throw null; }
+        public unsafe static ref T Unbox<T>(object box) where T : struct { throw null; }
+        public unsafe static void WriteUnaligned<T>(ref byte destination, T value) where T : allows ref struct { }
         [System.CLSCompliantAttribute(false)]
         public unsafe static void WriteUnaligned<T>(void* destination, T value) where T : allows ref struct { }
         [System.CLSCompliantAttribute(false)]
@@ -15564,11 +15564,11 @@ namespace System.Runtime.InteropServices
         public static System.Runtime.InteropServices.GCHandle Alloc(object? value, System.Runtime.InteropServices.GCHandleType type) { throw null; }
         public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? o) { throw null; }
         public readonly bool Equals(System.Runtime.InteropServices.GCHandle other) { throw null; }
-        public void Free() { }
-        public static System.Runtime.InteropServices.GCHandle FromIntPtr(System.IntPtr value) { throw null; }
+        public unsafe void Free() { }
+        public unsafe static System.Runtime.InteropServices.GCHandle FromIntPtr(System.IntPtr value) { throw null; }
         public override readonly int GetHashCode() { throw null; }
         public static bool operator ==(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
-        public static explicit operator System.Runtime.InteropServices.GCHandle (System.IntPtr value) { throw null; }
+        public unsafe static explicit operator System.Runtime.InteropServices.GCHandle (System.IntPtr value) { throw null; }
         public static explicit operator System.IntPtr (System.Runtime.InteropServices.GCHandle value) { throw null; }
         public static bool operator !=(System.Runtime.InteropServices.GCHandle a, System.Runtime.InteropServices.GCHandle b) { throw null; }
         public static System.IntPtr ToIntPtr(System.Runtime.InteropServices.GCHandle value) { throw null; }
@@ -15579,9 +15579,9 @@ namespace System.Runtime.InteropServices
         public void Dispose() { }
         public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public readonly bool Equals(System.Runtime.InteropServices.GCHandle<T> other) { throw null; }
-        public static System.Runtime.InteropServices.GCHandle<T> FromIntPtr(System.IntPtr value) { throw null; }
+        public unsafe static System.Runtime.InteropServices.GCHandle<T> FromIntPtr(System.IntPtr value) { throw null; }
         public override readonly int GetHashCode() { throw null; }
-        public GCHandle(T target) { }
+        public unsafe GCHandle(T target) { }
         public readonly bool IsAllocated { get { throw null; } }
         public readonly T Target { get { throw null; } set { } }
         public static System.IntPtr ToIntPtr(System.Runtime.InteropServices.GCHandle<T> value) { throw null; }
@@ -15623,36 +15623,36 @@ namespace System.Runtime.InteropServices
     }
     public static partial class MemoryMarshal
     {
-        public static System.ReadOnlySpan<byte> AsBytes<T>(System.ReadOnlySpan<T> span) where T : struct { throw null; }
+        public unsafe static System.ReadOnlySpan<byte> AsBytes<T>(System.ReadOnlySpan<T> span) where T : struct { throw null; }
         [System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute(1)]
-        public static System.Span<byte> AsBytes<T>(System.Span<T> span) where T : struct { throw null; }
-        public static System.Memory<T> AsMemory<T>(System.ReadOnlyMemory<T> memory) { throw null; }
-        public static ref readonly T AsRef<T>(System.ReadOnlySpan<byte> span) where T : struct { throw null; }
+        public unsafe static System.Span<byte> AsBytes<T>(System.Span<T> span) where T : struct { throw null; }
+        public unsafe static System.Memory<T> AsMemory<T>(System.ReadOnlyMemory<T> memory) { throw null; }
+        public unsafe static ref readonly T AsRef<T>(System.ReadOnlySpan<byte> span) where T : struct { throw null; }
         [System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute(1)]
-        public static ref T AsRef<T>(System.Span<byte> span) where T : struct { throw null; }
-        public static System.ReadOnlySpan<TTo> Cast<TFrom, TTo>(System.ReadOnlySpan<TFrom> span) where TFrom : struct where TTo : struct { throw null; }
+        public unsafe static ref T AsRef<T>(System.Span<byte> span) where T : struct { throw null; }
+        public unsafe static System.ReadOnlySpan<TTo> Cast<TFrom, TTo>(System.ReadOnlySpan<TFrom> span) where TFrom : struct where TTo : struct { throw null; }
         [System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute(1)]
-        public static System.Span<TTo> Cast<TFrom, TTo>(System.Span<TFrom> span) where TFrom : struct where TTo : struct { throw null; }
-        public static System.Memory<T> CreateFromPinnedArray<T>(T[]? array, int start, int length) { throw null; }
+        public unsafe static System.Span<TTo> Cast<TFrom, TTo>(System.Span<TFrom> span) where TFrom : struct where TTo : struct { throw null; }
+        public unsafe static System.Memory<T> CreateFromPinnedArray<T>(T[]? array, int start, int length) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static System.ReadOnlySpan<byte> CreateReadOnlySpanFromNullTerminated(byte* value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static System.ReadOnlySpan<char> CreateReadOnlySpanFromNullTerminated(char* value) { throw null; }
-        public static System.ReadOnlySpan<T> CreateReadOnlySpan<T>(scoped ref readonly T reference, int length) { throw null; }
-        public static System.Span<T> CreateSpan<T>(scoped ref T reference, int length) { throw null; }
-        public static ref byte GetArrayDataReference(System.Array array) { throw null; }
-        public static ref T GetArrayDataReference<T>(T[] array) { throw null; }
-        public static ref T GetReference<T>(System.ReadOnlySpan<T> span) { throw null; }
-        public static ref T GetReference<T>(System.Span<T> span) { throw null; }
-        public static T Read<T>(System.ReadOnlySpan<byte> source) where T : struct { throw null; }
+        public unsafe static System.ReadOnlySpan<T> CreateReadOnlySpan<T>(scoped ref readonly T reference, int length) { throw null; }
+        public unsafe static System.Span<T> CreateSpan<T>(scoped ref T reference, int length) { throw null; }
+        public unsafe static ref byte GetArrayDataReference(System.Array array) { throw null; }
+        public unsafe static ref T GetArrayDataReference<T>(T[] array) { throw null; }
+        public unsafe static ref T GetReference<T>(System.ReadOnlySpan<T> span) { throw null; }
+        public unsafe static ref T GetReference<T>(System.Span<T> span) { throw null; }
+        public unsafe static T Read<T>(System.ReadOnlySpan<byte> source) where T : struct { throw null; }
         public static System.Collections.Generic.IEnumerable<T> ToEnumerable<T>(System.ReadOnlyMemory<T> memory) { throw null; }
-        public static bool TryGetArray<T>(System.ReadOnlyMemory<T> memory, out System.ArraySegment<T> segment) { throw null; }
-        public static bool TryGetMemoryManager<T, TManager>(System.ReadOnlyMemory<T> memory, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TManager? manager) where TManager : System.Buffers.MemoryManager<T> { throw null; }
-        public static bool TryGetMemoryManager<T, TManager>(System.ReadOnlyMemory<T> memory, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TManager? manager, out int start, out int length) where TManager : System.Buffers.MemoryManager<T> { throw null; }
+        public unsafe static bool TryGetArray<T>(System.ReadOnlyMemory<T> memory, out System.ArraySegment<T> segment) { throw null; }
+        public unsafe static bool TryGetMemoryManager<T, TManager>(System.ReadOnlyMemory<T> memory, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TManager? manager) where TManager : System.Buffers.MemoryManager<T> { throw null; }
+        public unsafe static bool TryGetMemoryManager<T, TManager>(System.ReadOnlyMemory<T> memory, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TManager? manager, out int start, out int length) where TManager : System.Buffers.MemoryManager<T> { throw null; }
         public static bool TryGetString(System.ReadOnlyMemory<char> memory, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out string? text, out int start, out int length) { throw null; }
-        public static bool TryRead<T>(System.ReadOnlySpan<byte> source, out T value) where T : struct { throw null; }
-        public static bool TryWrite<T>(System.Span<byte> destination, in T value) where T : struct { throw null; }
-        public static void Write<T>(System.Span<byte> destination, in T value) where T : struct { }
+        public unsafe static bool TryRead<T>(System.ReadOnlySpan<byte> source, out T value) where T : struct { throw null; }
+        public unsafe static bool TryWrite<T>(System.Span<byte> destination, in T value) where T : struct { throw null; }
+        public unsafe static void Write<T>(System.Span<byte> destination, in T value) where T : struct { }
     }
     public readonly partial struct OSPlatform : System.IEquatable<System.Runtime.InteropServices.OSPlatform>
     {
@@ -15681,13 +15681,13 @@ namespace System.Runtime.InteropServices
         public void Dispose() { }
         public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public readonly bool Equals(System.Runtime.InteropServices.PinnedGCHandle<T> other) { throw null; }
-        public static System.Runtime.InteropServices.PinnedGCHandle<T> FromIntPtr(System.IntPtr value) { throw null; }
+        public unsafe static System.Runtime.InteropServices.PinnedGCHandle<T> FromIntPtr(System.IntPtr value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public readonly unsafe void* GetAddressOfObjectData() { throw null; }
         public override readonly int GetHashCode() { throw null; }
         public readonly bool IsAllocated { get { throw null; } }
-        public PinnedGCHandle(T target) { }
-        public T Target { readonly get { throw null; } set { } }
+        public unsafe PinnedGCHandle(T target) { }
+        public unsafe T Target { readonly get { throw null; } set { } }
         public static System.IntPtr ToIntPtr(System.Runtime.InteropServices.PinnedGCHandle<T> value) { throw null; }
     }
     public static partial class RuntimeInformation
@@ -15713,18 +15713,18 @@ namespace System.Runtime.InteropServices
         [System.CLSCompliantAttribute(false)]
         public void Initialize<T>(uint numElements) where T : struct { }
         [System.CLSCompliantAttribute(false)]
-        public void ReadArray<T>(ulong byteOffset, T[] array, int index, int count) where T : struct { }
+        public unsafe void ReadArray<T>(ulong byteOffset, T[] array, int index, int count) where T : struct { }
         [System.CLSCompliantAttribute(false)]
-        public void ReadSpan<T>(ulong byteOffset, System.Span<T> buffer) where T : struct { }
+        public unsafe void ReadSpan<T>(ulong byteOffset, System.Span<T> buffer) where T : struct { }
         [System.CLSCompliantAttribute(false)]
-        public T Read<T>(ulong byteOffset) where T : struct { throw null; }
+        public unsafe T Read<T>(ulong byteOffset) where T : struct { throw null; }
         public void ReleasePointer() { }
         [System.CLSCompliantAttribute(false)]
-        public void WriteArray<T>(ulong byteOffset, T[] array, int index, int count) where T : struct { }
+        public unsafe void WriteArray<T>(ulong byteOffset, T[] array, int index, int count) where T : struct { }
         [System.CLSCompliantAttribute(false)]
-        public void WriteSpan<T>(ulong byteOffset, System.ReadOnlySpan<T> data) where T : struct { }
+        public unsafe void WriteSpan<T>(ulong byteOffset, System.ReadOnlySpan<T> data) where T : struct { }
         [System.CLSCompliantAttribute(false)]
-        public void Write<T>(ulong byteOffset, T value) where T : struct { }
+        public unsafe void Write<T>(ulong byteOffset, T value) where T : struct { }
     }
     public abstract partial class SafeHandle : System.Runtime.ConstrainedExecution.CriticalFinalizerObject, System.IDisposable
     {
@@ -15818,13 +15818,13 @@ namespace System.Runtime.InteropServices
         public void Dispose() { }
         public override readonly bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public readonly bool Equals(System.Runtime.InteropServices.WeakGCHandle<T> other) { throw null; }
-        public static System.Runtime.InteropServices.WeakGCHandle<T> FromIntPtr(System.IntPtr value) { throw null; }
+        public unsafe static System.Runtime.InteropServices.WeakGCHandle<T> FromIntPtr(System.IntPtr value) { throw null; }
         public override readonly int GetHashCode() { throw null; }
         public readonly bool IsAllocated { get { throw null; } }
-        public readonly void SetTarget(T target) { }
+        public unsafe readonly void SetTarget(T target) { }
         public static System.IntPtr ToIntPtr(System.Runtime.InteropServices.WeakGCHandle<T> value) { throw null; }
         public readonly bool TryGetTarget([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T? target) { throw null; }
-        public WeakGCHandle(T target, bool trackResurrection = false) { }
+        public unsafe WeakGCHandle(T target, bool trackResurrection = false) { }
     }
 }
 namespace System.Runtime.InteropServices.Marshalling
@@ -15869,7 +15869,7 @@ namespace System.Runtime.InteropServices.Marshalling
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(System.ReadOnlySpan<>), System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedIn, typeof(System.Runtime.InteropServices.Marshalling.ReadOnlySpanMarshaller<,>.ManagedToUnmanagedIn))]
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(System.ReadOnlySpan<>), System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedOut, typeof(System.Runtime.InteropServices.Marshalling.ReadOnlySpanMarshaller<,>.ManagedToUnmanagedOut))]
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(System.ReadOnlySpan<>), System.Runtime.InteropServices.Marshalling.MarshalMode.UnmanagedToManagedOut, typeof(System.Runtime.InteropServices.Marshalling.ReadOnlySpanMarshaller<,>.UnmanagedToManagedOut))]
-    public static unsafe partial class ReadOnlySpanMarshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
+    public static partial class ReadOnlySpanMarshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
     {
         public ref partial struct ManagedToUnmanagedIn
         {

--- a/src/libraries/System.Runtime/ref/System.Runtime.csproj
+++ b/src/libraries/System.Runtime/ref/System.Runtime.csproj
@@ -8,6 +8,7 @@
     <NoWarn>$(NoWarn);0809;0618;CS3015</NoWarn>
     <!-- https://github.com/dotnet/dotnet/issues/5640 -->
     <NoWarn>$(NoWarn);CS9368</NoWarn>
+    <Features>$(Features);updated-memory-safety-rules</Features>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -989,7 +989,7 @@ namespace System.Security.Cryptography
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
-        public DSAOpenSsl(System.IntPtr handle) { }
+        public unsafe DSAOpenSsl(System.IntPtr handle) { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("android")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
@@ -1229,7 +1229,7 @@ namespace System.Security.Cryptography
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
-        public ECDiffieHellmanOpenSsl(System.IntPtr handle) { }
+        public unsafe ECDiffieHellmanOpenSsl(System.IntPtr handle) { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("android")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
@@ -1387,7 +1387,7 @@ namespace System.Security.Cryptography
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
-        public ECDsaOpenSsl(System.IntPtr handle) { }
+        public unsafe ECDsaOpenSsl(System.IntPtr handle) { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("android")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
@@ -2754,7 +2754,7 @@ namespace System.Security.Cryptography
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
-        public RSAOpenSsl(System.IntPtr handle) { }
+        public unsafe RSAOpenSsl(System.IntPtr handle) { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("android")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
@@ -3842,7 +3842,7 @@ namespace System.Security.Cryptography.X509Certificates
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public X509Certificate(byte[] rawData, string? password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public X509Certificate(System.IntPtr handle) { }
+        public unsafe X509Certificate(System.IntPtr handle) { }
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public X509Certificate(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
@@ -3951,7 +3951,7 @@ namespace System.Security.Cryptography.X509Certificates
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public X509Certificate2(byte[] rawData, string? password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
-        public X509Certificate2(System.IntPtr handle) { }
+        public unsafe X509Certificate2(System.IntPtr handle) { }
         [System.ObsoleteAttribute("Loading certificate data through the constructor or Import is obsolete. Use X509CertificateLoader instead to load certificates.", DiagnosticId="SYSLIB0057", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public X509Certificate2(System.ReadOnlySpan<byte> rawData) { }
@@ -4171,7 +4171,7 @@ namespace System.Security.Cryptography.X509Certificates
         public X509Chain() { }
         public X509Chain(bool useMachineContext) { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
-        public X509Chain(System.IntPtr chainContext) { }
+        public unsafe X509Chain(System.IntPtr chainContext) { }
         public System.IntPtr ChainContext { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509ChainElementCollection ChainElements { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509ChainPolicy ChainPolicy { get { throw null; } set { } }
@@ -4440,7 +4440,7 @@ namespace System.Security.Cryptography.X509Certificates
     public sealed partial class X509Store : System.IDisposable
     {
         public X509Store() { }
-        public X509Store(System.IntPtr storeHandle) { }
+        public unsafe X509Store(System.IntPtr storeHandle) { }
         public X509Store(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) { }
         public X509Store(System.Security.Cryptography.X509Certificates.StoreName storeName) { }
         public X509Store(System.Security.Cryptography.X509Certificates.StoreName storeName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) { }

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.csproj
@@ -5,6 +5,8 @@
     <NoWarn>$(NoWarn);SYSLIB0026</NoWarn>
     <!-- PasswordDeriveBytes.GetBytes is obsolete but DeriveBytes.GetBytes intentionally isn't. -->
     <NoWarn>$(NoWarn);CS0809</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
+++ b/src/libraries/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.cs
@@ -74,7 +74,7 @@ namespace System.Security.Principal
         public static readonly int MaxBinaryLength;
         public static readonly int MinBinaryLength;
         public SecurityIdentifier(byte[] binaryForm, int offset) { }
-        public SecurityIdentifier(System.IntPtr binaryForm) { }
+        public unsafe SecurityIdentifier(System.IntPtr binaryForm) { }
         public SecurityIdentifier(System.Security.Principal.WellKnownSidType sidType, System.Security.Principal.SecurityIdentifier? domainSid) { }
         public SecurityIdentifier(string sddlForm) { }
         public System.Security.Principal.SecurityIdentifier? AccountDomainSid { get { throw null; } }

--- a/src/libraries/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.csproj
+++ b/src/libraries/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Principal.Windows.cs" />

--- a/src/libraries/System.Transactions.Local/ref/System.Transactions.Local.cs
+++ b/src/libraries/System.Transactions.Local/ref/System.Transactions.Local.cs
@@ -53,9 +53,9 @@ namespace System.Transactions
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface IDtcTransaction
     {
-        void Abort(System.IntPtr reason, int retaining, int async);
+        unsafe void Abort(System.IntPtr reason, int retaining, int async);
         void Commit(int retaining, int commitType, int reserved);
-        void GetTransactionInfo(System.IntPtr transactionInformation);
+        unsafe void GetTransactionInfo(System.IntPtr transactionInformation);
     }
     public partial interface IEnlistmentNotification
     {

--- a/src/libraries/System.Transactions.Local/ref/System.Transactions.Local.csproj
+++ b/src/libraries/System.Transactions.Local/ref/System.Transactions.Local.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Transactions.Local.cs" />


### PR DESCRIPTION
Annotate APIs as caller-unsafe based on the approved API proposals:

- https://github.com/dotnet/runtime/issues/126956
- https://github.com/dotnet/runtime/issues/127098
- https://github.com/dotnet/runtime/issues/128075
- https://github.com/dotnet/runtime/issues/129750
- https://github.com/dotnet/runtime/issues/129751
    - Didn't include all SafeHandles and ArrayPool/MemoryPool, they need to be re-considered.

Doing this properly requires full migration to the new rules in sources (a huge change) + changes in GenAPI tool in arcade (BTW, it looks like we mosly modify `/ref/` by hands). A simpler manual change for .NET 11.0.