### PR TITLE
[Mono]: Fix InvalidCastException for enum nested in a generic type on Mono

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ArrayTests.cs
@@ -1110,6 +1110,16 @@ namespace System.Tests
 
             yield return new object[] { new int[1] { 2 }, 0, new Int32Enum[1], 0, 1, new Int32Enum[] { (Int32Enum)2 } };
 
+            // Enum nested in a generic type conversions
+            yield return new object[] { new int[] { 1, 2, 3 }, 0, new GenericClassWithNestedEnum<object>.NestedEnum[3], 0, 3, new GenericClassWithNestedEnum<object>.NestedEnum[] { (GenericClassWithNestedEnum<object>.NestedEnum)1, (GenericClassWithNestedEnum<object>.NestedEnum)2, (GenericClassWithNestedEnum<object>.NestedEnum)3 } };
+            yield return new object[] { new uint[] { 1, 2, 3 }, 0, new GenericClassWithNestedEnum<object>.NestedEnum[3], 0, 3, new GenericClassWithNestedEnum<object>.NestedEnum[] { (GenericClassWithNestedEnum<object>.NestedEnum)1, (GenericClassWithNestedEnum<object>.NestedEnum)2, (GenericClassWithNestedEnum<object>.NestedEnum)3 } };
+            yield return new object[] { new GenericClassWithNestedEnum<object>.NestedEnum[] { (GenericClassWithNestedEnum<object>.NestedEnum)1, (GenericClassWithNestedEnum<object>.NestedEnum)2, (GenericClassWithNestedEnum<object>.NestedEnum)3 }, 0, new int[3], 0, 3, new int[] { 1, 2, 3 } };
+            yield return new object[] { new GenericClassWithNestedEnum<object>.NestedEnum[] { (GenericClassWithNestedEnum<object>.NestedEnum)1, (GenericClassWithNestedEnum<object>.NestedEnum)2, (GenericClassWithNestedEnum<object>.NestedEnum)3 }, 0, new uint[3], 0, 3, new uint[] { 1, 2, 3 } };
+
+            // Same, but with a value-type generic argument (produces a distinct, unshared instantiation)
+            yield return new object[] { new int[] { 1, 2, 3 }, 0, new GenericClassWithNestedEnum<int>.NestedEnum[3], 0, 3, new GenericClassWithNestedEnum<int>.NestedEnum[] { (GenericClassWithNestedEnum<int>.NestedEnum)1, (GenericClassWithNestedEnum<int>.NestedEnum)2, (GenericClassWithNestedEnum<int>.NestedEnum)3 } };
+            yield return new object[] { new GenericClassWithNestedEnum<int>.NestedEnum[] { (GenericClassWithNestedEnum<int>.NestedEnum)1, (GenericClassWithNestedEnum<int>.NestedEnum)2, (GenericClassWithNestedEnum<int>.NestedEnum)3 }, 0, new int[3], 0, 3, new int[] { 1, 2, 3 } };
+
             // Signed/Unsigned conversions
             yield return new object[] { new byte[] { unchecked((byte)-2) }, 0, new sbyte[1], 0, 1, new sbyte[] { -2 } };
             yield return new object[] { new sbyte[] { -3 }, 0, new byte[1], 0, 1, new byte[] { unchecked((byte)-3) } };
@@ -1225,6 +1235,9 @@ namespace System.Tests
             // SByteEnum[] -> primitive[]
             yield return new object[] { new SByteEnum[] { (SByteEnum)1, (SByteEnum)2, (SByteEnum)3 }, 0, new int[3], 0, 3, new int[] { 1, 2, 3 } };
             yield return new object[] { new SByteEnum[] { (SByteEnum)1, (SByteEnum)2, (SByteEnum)3 }, 0, new Int32Enum[3], 0, 3, new Int32Enum[] { (Int32Enum)1, (Int32Enum)2, (Int32Enum)3 } };
+
+            // Enum nested in a generic type -> wider primitive[]
+            yield return new object[] { new GenericClassWithNestedEnum<object>.NestedEnum[] { (GenericClassWithNestedEnum<object>.NestedEnum)1, (GenericClassWithNestedEnum<object>.NestedEnum)2, (GenericClassWithNestedEnum<object>.NestedEnum)3 }, 0, new long[3], 0, 3, new long[] { 1, 2, 3 } };
         }
 
         public static IEnumerable<object[]> Copy_SZArray_UnreliableConversion_CanPerform_TestData()
@@ -1367,6 +1380,36 @@ namespace System.Tests
             Array destinationArrayClone4 = overlaps ? sourceArrayClone4 : (Array)destinationArray.Clone();
             Array.Copy(sourceArrayClone4, (long)sourceIndex, destinationArrayClone4, destinationIndex, length);
             Assert.Equal(expected, destinationArrayClone4);
+        }
+
+        [Fact]
+        public static void Copy_EnumNestedInGenericType()
+        {
+            // Exercise both a reference-type and a value-type generic argument: the two produce
+            // distinct instantiations of the nested enum (a value-type argument is not shared).
+            VerifyEnumNestedInGenericType<GenericClassWithNestedEnum<object>.NestedEnum>();
+            VerifyEnumNestedInGenericType<GenericClassWithNestedEnum<int>.NestedEnum>();
+        }
+
+        private static void VerifyEnumNestedInGenericType<TEnum>() where TEnum : struct, Enum
+        {
+            // Enum.GetValues<T> internally copies from the underlying integer array to a T[].
+            TEnum[] values = Enum.GetValues<TEnum>();
+            Assert.Equal(
+                new[]
+                {
+                    (TEnum)Enum.ToObject(typeof(TEnum), 0),
+                    (TEnum)Enum.ToObject(typeof(TEnum), 1),
+                    (TEnum)Enum.ToObject(typeof(TEnum), 2),
+                    (TEnum)Enum.ToObject(typeof(TEnum), 3),
+                },
+                values);
+
+            // Array.SetValue with the boxed enum value (exact-type path).
+            TEnum value = (TEnum)Enum.ToObject(typeof(TEnum), 2);
+            var dst = new TEnum[1];
+            dst.SetValue(value, 0);
+            Assert.Equal(value, dst[0]);
         }
 
         [Theory]
@@ -4904,6 +4947,12 @@ namespace System.Tests
         }
 
         public enum Int64Enum : long { }
+
+        // Enum nested in a generic type, used as a regression case for Array.Copy/SetValue.
+        public class GenericClassWithNestedEnum<T>
+        {
+            public enum NestedEnum { Value0, Value1, Value2, Value3 }
+        }
     }
 
     [Collection(nameof(DisableParallelization))]

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -483,9 +483,11 @@ array_set_value_impl (MonoArray *arr, MonoObjectHandle value_handle, guint32 pos
 
 	vsize = mono_class_value_size (vc, NULL);
 
-	// et/vt = m_class_get_byval_arg (ec/vc)->type so get_klass_unchecked is safe here
-	et_isenum = et == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (m_class_get_byval_arg (ec)));
-	vt_isenum = vt == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_type_data_get_klass_unchecked (m_class_get_byval_arg (vc)));
+	// An enum nested in a generic type is an inflated type whose byval_arg->type
+	// is MONO_TYPE_GENERICINST rather than MONO_TYPE_VALUETYPE, so check the class
+	// directly instead of relying solely on the MonoTypeEnum tag.
+	et_isenum = (et == MONO_TYPE_VALUETYPE || et == MONO_TYPE_GENERICINST) && m_class_is_enumtype (ec);
+	vt_isenum = (vt == MONO_TYPE_VALUETYPE || vt == MONO_TYPE_GENERICINST) && m_class_is_enumtype (vc);
 
 	if (strict_enums && et_isenum && !vt_isenum) {
 		INVALID_CAST;
@@ -493,10 +495,10 @@ array_set_value_impl (MonoArray *arr, MonoObjectHandle value_handle, guint32 pos
 	}
 
 	if (et_isenum)
-		et = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (m_class_get_byval_arg (ec)))->type;
+		et = mono_class_enum_basetype_internal (ec)->type;
 
 	if (vt_isenum)
-		vt = mono_class_enum_basetype_internal (m_type_data_get_klass_unchecked (m_class_get_byval_arg (vc)))->type;
+		vt = mono_class_enum_basetype_internal (vc)->type;
 
 	// Treat MONO_TYPE_U/I as MONO_TYPE_U8/I8/U4/I4
 #if SIZEOF_VOID_P == 8


### PR DESCRIPTION
An enum nested in a generic type (e.g. GenericClass<T>.NestedEnum) is an inflated class whose byval_arg->type is MONO_TYPE_GENERICINST rather than MONO_TYPE_VALUETYPE. In array_set_value_impl the enum detection was gated solely on the MONO_TYPE_VALUETYPE tag, so such enums were never recognized and the type switch fell through to INVALID_CAST. This broke Array.Copy, Array.SetValue, and Enum.GetValues<T>() for those enums.

Detect enum-ness from the class flags (m_class_is_enumtype) and resolve the underlying type via mono_class_enum_basetype_internal on the class directly, widening the tag gate to also accept MONO_TYPE_GENERICINST. Reading the class directly (instead of round-tripping through m_type_data_get_klass_unchecked on the byval_arg) is required, since for a GENERICINST type that union member holds a MonoGenericClass, not a MonoClass.

Add regression tests covering both copy directions, primitive widening, Enum.GetValues<T>, and Array.SetValue, for both reference-type and value-type generic arguments.

Fixes #116462