### PR TITLE
JIT: Handle op1 struct-values in commas in physical promotion

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9473,12 +9473,15 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     {
                         JITDUMP("\nHave extra IL stack entry after tail await\n");
                         GenTree* val = impPopStack().val;
-                        if (varTypeIsStruct(val))
+                        if ((val->gtFlags & GTF_SIDE_EFFECT) != 0)
                         {
-                            val = impNormStructVal(val, CHECK_SPILL_ALL);
-                        }
+                            if (varTypeIsStruct(val))
+                            {
+                                val = impNormStructVal(val, CHECK_SPILL_ALL);
+                            }
 
-                        impAppendTree(gtUnusedValNode(val), CHECK_SPILL_ALL, impCurStmtDI);
+                            impAppendTree(gtUnusedValNode(val), CHECK_SPILL_ALL, impCurStmtDI);
+                        }
                     }
 
                     prefixFlags &= ~PREFIX_TAILCALL;

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -3000,7 +3000,7 @@ bool Promotion::IsCandidateForPhysicalPromotion(LclVarDsc* dsc)
 //   Find the effective user given an ancestor stack.
 //
 // Returns:
-//   The user, or null if all users are commas.
+//   The user of the value or null if nothing uses the value.
 //
 GenTree* Promotion::EffectiveUser(Compiler::GenTreeStack& ancestors)
 {
@@ -3010,9 +3010,14 @@ GenTree* Promotion::EffectiveUser(Compiler::GenTreeStack& ancestors)
         GenTree* ancestor = ancestors.Top(userIndex);
         GenTree* child    = ancestors.Top(userIndex - 1);
 
-        if (!ancestor->OperIs(GT_COMMA) || (ancestor->gtGetOp2() != child))
+        if (!ancestor->OperIs(GT_COMMA))
         {
             return ancestor;
+        }
+
+        if (ancestor->gtGetOp1() == child)
+        {
+            return nullptr;
         }
 
         userIndex++;


### PR DESCRIPTION
Two changes:
- In physical promotion, if a struct local is the op1 of a comma, then it does not have an effective user and we do not need to do anything. This would assert before.
- In the importer avoid creating an unnecessary `gtUnusedValNode` when the operand has no side effects.

Fix #131664