### PR TITLE
Invalidate metadata table lookup hashes when an EnC delta adds records

### DIFF
--- a/src/coreclr/md/enc/metamodelenc.cpp
+++ b/src/coreclr/md/enc/metamodelenc.cpp
@@ -86,6 +86,18 @@ CMiniMdRW::ApplyTableDelta(
         }
         IfNullGo(pRec);
         _ASSERTE(iRid == newRid);
+
+        // The record was appended: a lookup hash already built for this table
+        // (GenericBuildHashTable) does not cover it, and GenericFindWithHash
+        // searches only the hash - the record would be invisible to lookups
+        // (e.g. GetFieldRVA during ApplyEditAndContinue, which then fails the
+        // whole update). Invalidate the hash; the next lookup rebuilds it over
+        // the full table.
+        if (m_pLookUpHashes[ixTbl] != NULL)
+        {
+            delete m_pLookUpHashes[ixTbl];
+            m_pLookUpHashes[ixTbl] = NULL;
+        }
     }
     else
     {   // Updated record.


### PR DESCRIPTION
Fixes #131752

## Problem

`CMiniMdRW::GenericFindWithHash` builds a lazy per-table lookup hash once a table exceeds `INDEX_ROW_COUNT_THRESHOLD` (25) rows and from then on searches only the hash — there is no linear fallback. The EnC delta-apply path (`CMiniMdRW::ApplyDelta` → `ApplyTableDelta`) appends rows without maintaining or invalidating `m_pLookUpHashes`, so any row an EnC delta adds after the hash was built is invisible to metadata lookups.

Seven tables are looked up through `GenericFindWithHash` (Constant, FieldMarshal, ClassLayout, FieldLayout, ImplMap, FieldRVA, NestedClass), and all of them receive EnC-added rows through `ApplyTableDelta`. The FieldRVA lookup is on the hot apply path: `EditAndContinueModule::ApplyEditAndContinue` → `GetFieldRVA` fails with `CLDB_E_RECORD_NOTFOUND` for the row the delta itself just added, and the whole update fails with `System.InvalidOperationException: The assembly update failed.` Since Roslyn emits one FieldRVA row per generation for edited method bodies containing array initializers / u8 literals (enabled by the new-in-.NET-10 `AddFieldRva` capability, #112446), hot reload dies at edit `max(2, 25 − baseline FieldRVA rows + 1)` — after one or two edits on real apps. See the issue for a self-contained repro that fails deterministically at generation 2.

## Fix

In the added-record branch of `CMiniMdRW::ApplyTableDelta`, invalidate the table's lookup hash; the next lookup rebuilds it over the full table (`GenericFindWithHash` → `GenericBuildHashTable`). Rebuilds only happen on the EnC apply path for tables that actually grew, and the rebuild is proportional to the table size that the initial build already paid.

An alternative would be to insert the new record into the existing hash incrementally (as the emitter-side `Add*` helpers with dedicated hashes do); invalidation was chosen as the minimal, obviously-correct variant. Happy to switch if incremental maintenance is preferred.

## Validation

- On a Checked build, a previously-failing captured 4-delta chain (Uno Platform hot-reload session, baseline FieldRVA = 22 → hash built at generation 3, generation 4's row invisible) applies 4/4 with this change; the failing lookup (`FindFieldRVAHelper` returning rid=0 while the table holds 26 rows) resolves correctly.
- The self-contained repro from the issue (baseline FieldRVA = 26 → fails at generation 2 on stock .NET 10.0.10) goes from `APPLY FAILED` at gen2 to all generations applied.

I can add an `ApplyUpdate` regression test (a test assembly with 25+ FieldRVA rows plus two deltas each adding one) with some guidance on where it fits in the existing hot-reload test infrastructure.