### PR TITLE
JIT: Avoid unnecessary argument spills in indirect call transformer

### DIFF
--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -221,9 +221,12 @@ private:
                 for (GenTree** use : m_origCall->UseEdges())
                 {
                     GenTree* node = *use;
-                    if (((node->gtFlags & GTF_ALL_EFFECT) != 0) || m_compiler->gtHasLocalsWithAddrOp(node))
+                    if (!node->IsInvariant())
                     {
-                        SpillUseToTemp(block, use);
+                        if (((node->gtFlags & GTF_ALL_EFFECT) != 0) || m_compiler->gtHasLocalsWithAddrOp(node))
+                        {
+                            SpillUseToTemp(block, use);
+                        }
                     }
 
                     if (use == lastSideEffectUse)

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -221,12 +221,10 @@ private:
                 for (GenTree** use : m_origCall->UseEdges())
                 {
                     GenTree* node = *use;
-                    if (!node->IsInvariant())
+                    if (((node->gtFlags & GTF_ALL_EFFECT) != 0) ||
+                        (!m_compiler->impIsInvariant(node) && m_compiler->gtHasLocalsWithAddrOp(node)))
                     {
-                        if (((node->gtFlags & GTF_ALL_EFFECT) != 0) || m_compiler->gtHasLocalsWithAddrOp(node))
-                        {
-                            SpillUseToTemp(block, use);
-                        }
+                        SpillUseToTemp(block, use);
                     }
 
                     if (use == lastSideEffectUse)


### PR DESCRIPTION
Fix #131665