### PR TITLE
Disable TLS resume in SslStreamServer_RejectsClientCert_ClientObservesAlert

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
@@ -405,6 +405,13 @@ namespace System.Net.Security.Tests
         //   completes; the rejection surfaces only on the first encrypted I/O after handshake
         //   (TLS 1.3 per RFC 8446 §4.4.2.4; SChannel because the user callback fires after ASC).
         // This pins the protocol-level expectation against which TlsSession behavior is compared.
+        //
+        // AllowTlsResume is disabled on both peers because the mid-handshake rejection contract only
+        // holds for a full handshake. On an abbreviated (resumed) handshake there is no Certificate
+        // exchange, and the server sends its Finished before the user RemoteCertificateValidationCallback
+        // runs, so the client's AuthenticateAsClientAsync completes and the rejection surfaces post-hoc.
+        // Without this, a session cached by a sibling parallel test lets this client resume and the
+        // Tls12 row observes the post-hoc timing instead.
         [Theory]
         [InlineData(SslProtocols.Tls12)]
         [InlineData(SslProtocols.Tls13)]
@@ -431,12 +438,14 @@ namespace System.Net.Security.Tests
                 {
                     ServerCertificate = serverCert,
                     EnabledSslProtocols = protocol,
+                    AllowTlsResume = false,
                     ClientCertificateRequired = true,
                 });
                 Task clientAuth = clientSsl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
                 {
                     TargetHost = serverName,
                     EnabledSslProtocols = protocol,
+                    AllowTlsResume = false,
                     ClientCertificates = new X509CertificateCollection { clientCert },
                     RemoteCertificateValidationCallback = TestHelper.AllowAnyServerCertificate,
                 });


### PR DESCRIPTION
Fixes #131330

`SslStreamServer_RejectsClientCert_ClientObservesAlert(protocol: Tls12)` is flaky in CI (44 hits in the last month, `blocking-clean-ci`). The failure is always the client-side assertion:

```
Assert.Throws() Failure: No exception was thrown
    at TlsSessionTests.cs(452)
```

## Root cause

The test asserts that on OpenSSL/TLS 1.2 the server's client-certificate rejection surfaces **mid-handshake** as an `AuthenticationException` on the client. That contract only holds for a **full** handshake.

On an abbreviated (resumed) handshake there is no Certificate exchange, and the server sends its Finished before the user `RemoteCertificateValidationCallback` runs. `AuthenticateAsClientAsync` therefore completes successfully and the rejection only surfaces on the first encrypted I/O — exactly the observed symptom. This is standard protocol behavior, not a product bug.

The client-side `SSL_CTX` cache in `Interop.OpenSsl.cs` is keyed by **certificate thumbprint + protocols + isClient**, not by object identity, so a sibling test running in parallel with the same certificate and `TargetHost` can populate a session that this test then resumes. That makes the failure load- and order-dependent.

## Fix

Set `AllowTlsResume = false` on both peers to force a full handshake, and document why.

This is preferred over widening the assertion to accept both timings (as `SslStreamAlertsTest` does), because the strong mid-handshake assertion is the point of the test — relaxing it would let a genuine regression pass silently.

`AllowTlsResume = false` also forces `cacheSslContext = false`, so this test's contexts never enter or read the shared `s_sslContexts` cache and cannot perturb `SslStreamTlsResumeTests`.

## Validation

- Reproduced the exact CI failure locally in a full-assembly run (5032 tests).
- Root cause confirmed deterministically by priming the client session cache with 3 successful full handshakes before the rejecting scenario:
  - `AllowTlsResume` on &rarr; client exception `<none>`, `IsAuthenticated=True` (the CI symptom)
  - `AllowTlsResume` off &rarr; `AuthenticationException`, `IsAuthenticated=False` (documented contract)
- 16+ full-assembly runs after the fix: the test never failed.

## Similar tests

I audited the other 17 tests in the area with the same shape (`ClientCertificateRequired` + `SslStream` on both sides + strict handshake-timing assertions). All are immune, via random or absent `TargetHost`, a `LocalCertificateSelectionCallback` without a `ClientCertificateContext` (which disables client context caching), remote-executor isolation, or a `TlsContext`-owned `PreallocatedSslContext`. The closest analogue, `SslStreamAlertsTest.SslStream_NoCallback_UntrustedClientCert_ServerSendsAlert`, did not reproduce under the same priming experiment, so it is left unchanged.

> [!NOTE]
> This PR description and the code change were generated with the assistance of GitHub Copilot.
