### PR TITLE
[release/10.0] Fix flaky MalformedPacketsDuringHandshake test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -760,7 +760,7 @@ namespace System.Net.Security.Tests
         }
 
         [ConditionalFact(typeof(TestConfiguration), nameof(TestConfiguration.SupportsRenegotiation))]
-        public async Task MalformedPacketsDuringHandshake_ThrowsAuthenticationException()
+        public async Task MalformedPacketsDuringRenegotiation_ThrowsAuthenticationException()
         {
             (Stream client, Stream server) = TestHelper.GetConnectedStreams();
 
@@ -774,11 +774,16 @@ namespace System.Net.Security.Tests
                 Task t1 = clientSslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions()
                 {
                     TargetHost = serverCert.GetNameInfo(X509NameType.SimpleName, false),
-                    ClientCertificates = new X509CertificateCollection() { clientCert }
+                    ClientCertificates = new X509CertificateCollection() { clientCert },
+                    // Force TLS 1.2 so the test exercises renegotiation rather than TLS 1.3 post-handshake auth.
+                    EnabledSslProtocols = SslProtocols.Tls12,
+                    CertificateRevocationCheckMode = X509RevocationMode.NoCheck
                 }, CancellationToken.None);
                 Task t2 = serverSslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions()
                 {
-                    ServerCertificate = serverCert
+                    ServerCertificate = serverCert,
+                    EnabledSslProtocols = SslProtocols.Tls12,
+                    CertificateRevocationCheckMode = X509RevocationMode.NoCheck
                 }, CancellationToken.None);
 
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);


### PR DESCRIPTION
Fixes Issue https://github.com/dotnet/runtime/issues/130887

main PR https://github.com/dotnet/runtime/pull/130756

# Description

The test `MalformedPacketsDuringHandshake_ThrowsAuthenticationException` was added to `release/10.0` as part of the MSRC 115387 fix. It intermittently fails during the initial handshake with `System.Security.Authentication.AuthenticationException : The remote certificate is invalid because of errors in the certificate chain: PartialChain`.

This backports the test fix already merged to `main` in #130756:

- Force `SslProtocols.Tls12` on both endpoints so the test exercises TLS renegotiation rather than TLS 1.3 post-handshake authentication, and rename the test to `MalformedPacketsDuringRenegotiation_ThrowsAuthenticationException` to match.
- Set `CertificateRevocationCheckMode = X509RevocationMode.NoCheck` on both endpoints to avoid the certificate chain-building / revocation lookups that cause the `PartialChain` failure in the offline CI environment.

# Customer Impact

None. This is a test-only change that fixes a flaky/unreliable test in the CI. There is no product code change and no customer-facing impact; the underlying malformed-frame source fix (from MSRC 115387) is already present in the branch.

# Regression

No. This fixes flakiness in a newly added test; it is not a regression in shipping product behavior.

# Testing

The identical change was merged and validated in CI on `main` (#130756). Relying on this PR's CI to confirm the test passes reliably in the renegotiation (TLS 1.2) configuration.

# Risk

Low. Test-only change (`SslStreamStreamToStreamTest.cs`), no product code affected. It mirrors a fix already merged and CI-validated on `main`.

# Package authoring signed off?

N/A - test-only change, no shipping package is affected.

> [!NOTE]
> This content was generated with the assistance of GitHub Copilot.
