### PR TITLE
Accept moving write buffers for socket-bound TLS sessions

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -124,6 +124,9 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetFd")]
         internal static partial int SslSetFd(SafeSslHandle ssl, SafeSocketHandle socket);
 
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetAcceptMovingWriteBuffer")]
+        internal static partial void SslSetAcceptMovingWriteBuffer(SafeSslHandle ssl);
+
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslDoHandshake")]
         internal static partial int SslDoHandshake(SafeSslHandle ssl, out SslErrorCode error);
 
@@ -582,6 +585,15 @@ namespace Microsoft.Win32.SafeHandles
             // CertVerifyCallback needs the SafeSslHandle to stash a
             // CertificateValidationException; expose it via the options.
             options.SafeSslHandle = handle;
+
+            if (useFd)
+            {
+                // Socket-bound sessions can see SSL_write flush only part of a record and
+                // report WANT_WRITE. The retry hands OpenSSL a span over the same managed
+                // buffer, but the GC may have relocated it in the meantime; without this
+                // mode OpenSSL rejects the changed address with SSL_R_BAD_WRITE_RETRY.
+                Interop.Ssl.SslSetAcceptMovingWriteBuffer(handle);
+            }
 
             if (useFd && !useReplayBio)
             {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
@@ -3029,7 +3029,7 @@ namespace System.Net.Security.Tests
             int port = ((IPEndPoint)listener.LocalEndPoint!).Port;
 
             using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            // Shrink the client's receive window so that, once the client stops reading, the server's
+            // Reduce the client's receive buffer so that, once the client stops reading, the server's
             // socket send buffer fills quickly and drives SSL_write into WANT_WRITE.
             clientUnderlying.ReceiveBufferSize = 512;
             Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -3005,6 +3006,155 @@ namespace System.Net.Security.Tests
             }
             catch
             {
+            }
+        }
+
+        // Regression coverage for the socket-bound write-retry contract. When the socket send
+        // buffer fills, SSL_write reports WANT_WRITE (surfaced as DestinationTooSmall) and OpenSSL
+        // remembers the address of the plaintext buffer it was handed. Managed callers retry with a
+        // span over GC-tracked memory that the collector may have relocated in the meantime, so the
+        // session enables SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER: a retry must make progress rather
+        // than fail with SSL_R_BAD_WRITE_RETRY.
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsOpenSslSupported))]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SocketBoundSession_WriteRetryWithRelocatedBuffer_Succeeds(bool forceGarbageCollection)
+        {
+            using X509Certificate2 serverCert = TestCertificates.GetServerCertificate();
+            string serverName = serverCert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+            int port = ((IPEndPoint)listener.LocalEndPoint!).Port;
+
+            using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            // Shrink the client's receive window so that, once the client stops reading, the server's
+            // socket send buffer fills quickly and drives SSL_write into WANT_WRITE.
+            clientUnderlying.ReceiveBufferSize = 512;
+            Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
+            Socket serverSocket = await listener.AcceptAsync();
+            await connect;
+
+            serverSocket.Blocking = false;
+            serverSocket.SendBufferSize = 512;
+            SafeSocketHandle serverHandle = serverSocket.SafeHandle;
+
+            using TlsContext ctx = TlsContext.CreateServer(new SslServerAuthenticationOptions
+            {
+                ServerCertificate = serverCert,
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                ClientCertificateRequired = false,
+            });
+            using TlsSocketSession session = NewSocketSession(ctx, serverHandle);
+
+            using SslStream clientSsl = new SslStream(new NetworkStream(clientUnderlying, ownsSocket: false), leaveInnerStreamOpen: false, TestHelper.AllowAnyServerCertificate);
+            Task clientHandshake = clientSsl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+            {
+                TargetHost = serverName,
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                RemoteCertificateValidationCallback = TestHelper.AllowAnyServerCertificate,
+            });
+
+            Task serverHandshake = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    TlsOperationStatus s = session.Handshake();
+                    if (s == TlsOperationStatus.Complete)
+                    {
+                        return;
+                    }
+                    if (s == TlsOperationStatus.NeedsCertificateValidation)
+                    {
+                        session.AcceptWithDefaultValidation();
+                        continue;
+                    }
+                    if (s == TlsOperationStatus.NeedMoreData || s == TlsOperationStatus.DestinationTooSmall)
+                    {
+                        await Task.Delay(5);
+                        continue;
+                    }
+                    throw new InvalidOperationException($"Unexpected handshake status: {s}");
+                }
+            });
+
+            await Task.WhenAll(clientHandshake, serverHandshake).WaitAsync(TimeSpan.FromSeconds(30));
+            Assert.True(session.IsHandshakeComplete);
+
+            // The client deliberately stops reading now. Encrypt-and-send a chunk repeatedly until the
+            // socket send buffer is full and SSL_write reports WANT_WRITE (DestinationTooSmall). At that
+            // point OpenSSL has stashed the address of 'chunk' as its pending write buffer. The chunk is
+            // small enough to live on the SOH so that a compacting collection can relocate it.
+            byte[] chunk = new byte[4096];
+            new Random(42).NextBytes(chunk);
+
+            TlsOperationStatus status;
+            int guard = 0;
+            while ((status = session.Write(chunk, out _)) == TlsOperationStatus.Complete)
+            {
+                Assert.True(++guard < 20000, "Socket send buffer never filled; could not induce WANT_WRITE.");
+            }
+            Assert.Equal(TlsOperationStatus.DestinationTooSmall, status);
+
+            byte[] retryBuffer;
+            if (forceGarbageCollection)
+            {
+                // Let the GC relocate the very array the pending write was issued from - the situation a
+                // correct caller cannot avoid, since it has no way to keep a span's memory pinned across
+                // two separate calls.
+                retryBuffer = chunk;
+                for (int i = 0; i < 3; i++)
+                {
+                    for (int j = 0; j < 200; j++)
+                    {
+                        GC.KeepAlive(new byte[4096]);
+                    }
+                    GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+                    GC.WaitForPendingFinalizers();
+                }
+            }
+            else
+            {
+                // Deterministically different address, same content.
+                retryBuffer = (byte[])chunk.Clone();
+                Assert.NotSame(chunk, retryBuffer);
+            }
+
+            // Drain on the client so the server's send buffer empties and the retried write can complete.
+            using CancellationTokenSource drainCts = new CancellationTokenSource();
+            Task drain = Task.Run(async () =>
+            {
+                byte[] sink = new byte[16 * 1024];
+                try
+                {
+                    while (await clientSsl.ReadAsync(sink, drainCts.Token) > 0)
+                    {
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (IOException)
+                {
+                }
+            });
+
+            try
+            {
+                Stopwatch sw = Stopwatch.StartNew();
+                while ((status = session.Write(retryBuffer, out _)) == TlsOperationStatus.DestinationTooSmall)
+                {
+                    Assert.True(sw.Elapsed < TimeSpan.FromSeconds(30), "Retried write never completed.");
+                    await Task.Delay(10);
+                }
+
+                Assert.Equal(TlsOperationStatus.Complete, status);
+            }
+            finally
+            {
+                drainCts.Cancel();
+                await drain;
             }
         }
     }

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -416,6 +416,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_SslSetBio)
     DllImportEntry(CryptoNative_SslDoHandshake)
     DllImportEntry(CryptoNative_SslSetFd)
+    DllImportEntry(CryptoNative_SslSetAcceptMovingWriteBuffer)
     DllImportEntry(CryptoNative_SslSetRetryVerify)
     DllImportEntry(CryptoNative_SslSetClientCertCallback)
     DllImportEntry(CryptoNative_SslSetPostHandshakeAuth)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -498,6 +498,12 @@ int32_t CryptoNative_SslSetFd(SSL* ssl, intptr_t fd)
     return SSL_set_fd(ssl, (int)fd);
 }
 
+void CryptoNative_SslSetAcceptMovingWriteBuffer(SSL* ssl)
+{
+    // void shim functions don't lead to exceptions, so skip the unconditional error clearing.
+    SSL_set_mode(ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+}
+
 int32_t CryptoNative_SslDoHandshake(SSL* ssl, int32_t* errorCode)
 {
     ERR_clear_error();

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
@@ -323,6 +323,17 @@ Returns 1 on success, 0 on failure.
 PALEXPORT int32_t CryptoNative_SslSetFd(SSL* ssl, intptr_t fd);
 
 /*
+Sets SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER on the SSL object.
+
+By default OpenSSL remembers the address of the plaintext buffer handed to a
+SSL_write which could not be fully flushed, and fails a subsequent retry that
+supplies a different address with SSL_R_BAD_WRITE_RETRY. Managed callers hand
+over spans of GC-tracked memory which the collector may relocate between the
+WANT_WRITE and the retry, so the address comparison is meaningless for us.
+*/
+PALEXPORT void CryptoNative_SslSetAcceptMovingWriteBuffer(SSL* ssl);
+
+/*
 Raw SSL_do_handshake wrapper for fd-bound SSL objects (SSL_set_fd path).
 Returns the SSL_do_handshake return value; errorCode receives SSL_get_error.
 */


### PR DESCRIPTION
## Problem

A socket-bound `TlsSocketSession` can fail a perfectly valid write retry with:

```
System.Security.Authentication.AuthenticationException : Authentication failed, see inner exception.
---- Interop+OpenSsl+SslException : Encrypt failed with OpenSSL error - bad write retry.
   at System.Net.Security.TlsSession.MapSslError(SslErrorCode error, String sslErrorTemplate)
```

In fd-mode, `TryFastWrite` passes `ref MemoryMarshal.GetReference(buffer)` — a GC-heap address that is pinned only for the duration of the P/Invoke. When the socket send buffer is full, `SSL_write` reports `WANT_WRITE` (surfaced as `DestinationTooSmall`) and OpenSSL stores that address in `wpend_buf`. Before the caller retries, the GC can relocate the array, so `ssl3_write_bytes` sees a different pointer and fails with `SSL_R_BAD_WRITE_RETRY`.

This is not something the caller can work around: a `ReadOnlySpan<byte>` cannot be kept pinned across two separate calls, so retrying with the exact same `byte[]` is already the correct thing to do — and it still fails intermittently, depending on GC timing.

Not reachable through `SslStream`: its managed-span BIO grows on demand and never reports `WANT_WRITE`.

## Fix

Enable `SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER` — the mode OpenSSL provides precisely for relocating heaps — on socket-bound `SSL` objects only (`useFd` in `SafeSslHandle.Create`). This skips the address comparison. The `wpend_tot > len` check still enforces the real contract, and the pending record is flushed from OpenSSL's internal write buffer, so the retry buffer's contents are never re-read. `SslStream`'s BIO path is untouched.

* `pal_ssl.h` / `pal_ssl.c` / `entrypoints.c`: new `CryptoNative_SslSetAcceptMovingWriteBuffer` shim.
* `Interop.Ssl.cs`: `LibraryImport` and the call site in `SafeSslHandle.Create`.

## Testing

New `TlsSessionTests.SocketBoundSession_WriteRetryWithRelocatedBuffer_Succeeds` theory fills the socket send buffer to induce `WANT_WRITE`, then retries and drives the write to `Complete` while a client drains. Two cases:

* a cloned buffer (deterministically different address);
* the **same** array after a forced compacting GC — the actual customer scenario.

Verified locally on Linux/x64:

* Both cases **fail** with the fix reverted (`bad write retry` in each).
* Both **pass** with the fix.
* `TlsSessionTests`: 47/47 passed.
* Full `System.Net.Security.Tests`: 5034 passed, 0 failed, 8 skipped.

> [!NOTE]
> This pull request description was generated with the assistance of GitHub Copilot.
