### PR TITLE
JIT: bail out of CEA cloning if alloc block has multiple successors

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -3986,6 +3986,20 @@ bool ObjectAllocator::CheckCanClone(CloneInfo* info)
     JITDUMP("** Seeing if we can clone to guarantee non-escape under V%02u\n", info->m_local);
     BasicBlock* const allocBlock = info->m_allocBlock;
 
+    // Cloning redirects the allocation block's sole outgoing edge to the fast path,
+    // so the allocation block must be a block kind that has a single target.
+    //
+    // If the allocation block ends in a conditional (say the def of the enumerator var
+    // is in the allocation block, and is followed by a GDV guard), we can't simply
+    // redirect, so bail out.
+    //
+    if (!allocBlock->HasTarget())
+    {
+        JITDUMP("allocation block " FMT_BB " is a %s, and so has no unique target edge\n", allocBlock->bbNum,
+                bbKindNames[allocBlock->GetKind()]);
+        return false;
+    }
+
     // The allocation site must not be in a loop (stack allocation limitation)
     //
     // Note if we can prove non-escape but can't stack allocate, we might be

--- a/src/tests/JIT/opt/ObjectStackAllocation/Runtime_131713.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/Runtime_131713.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Xml;
+using System.Xml.Serialization;
+using Xunit;
+
+public class Runtime_131713
+{
+    [Fact]
+    public static void Test()
+    {
+        for (int i = 0; i < 50; i++)
+        {
+            Serialize();
+            Thread.Sleep(100);
+        }
+    }
+
+    private static void Serialize()
+    {
+        Foo model = new()
+        {
+            Foos =
+            [
+                new Foo
+                {
+                    Bars = [new Bar()]
+                }
+            ]
+        };
+
+        XmlSerializer serializer = new(typeof(Foo));
+        using StringWriter stringWriter = new();
+        using XmlWriter xmlWriter = XmlWriter.Create(stringWriter);
+        serializer.Serialize(xmlWriter, model);
+    }
+}
+
+public class Foo
+{
+    public CustomList<Bar> Bars { get; set; } = [];
+
+    public CustomList<Foo> Foos { get; set; } = [];
+}
+
+public class Bar
+{
+}
+
+public class CustomList<T> : IEnumerable<T>
+{
+    private readonly List<T> _innerList = [];
+
+    public void Add(T item) => _innerList.Add(item);
+
+    public IEnumerator<T> GetEnumerator() => _innerList.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _innerList.GetEnumerator();
+}

--- a/src/tests/JIT/opt/ObjectStackAllocation/Runtime_131713.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/Runtime_131713.cs
@@ -8,16 +8,20 @@ using System.Threading;
 using System.Xml;
 using System.Xml.Serialization;
 using Xunit;
+using TestLibrary;
 
 public class Runtime_131713
 {
+    [ActiveIssue("needs triage", TestRuntimes.Mono)]
     [Fact]
     public static void Test()
     {
-        for (int i = 0; i < 50; i++)
+        // The bug needs the serializer's methods to reach tier-1 with PGO data, so give
+        // the background compilations time to land in between calls.
+        for (int i = 0; i < 100; i++)
         {
             Serialize();
-            Thread.Sleep(100);
+            Thread.Sleep(15);
         }
     }
 

--- a/src/tests/JIT/opt/ObjectStackAllocation/Runtime_131713.csproj
+++ b/src/tests/JIT/opt/ObjectStackAllocation/Runtime_131713.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <!-- The bug reproduces only once the serializer's methods reach tier-1 with PGO data,
+         since conditional escape analysis requires profile weights. -->
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Normally we see the allocation block as one of many alternate possibilities for a GDV-guarded enumerator creation, so it has a single successor chain that flows to a merge where the enumerator var is defined. But if the GDV is optimized early the allocation block may fuse with the definition block, and this case is not handled properly by cloning.

So, bail unless the allocation block has a unique successor.

Fixes #131713.