### PR TITLE
Make custom IData initializers lazy

### DIFF
--- a/docs/design/datacontracts/EcmaMetadata.md
+++ b/docs/design/datacontracts/EcmaMetadata.md
@@ -55,6 +55,7 @@ Types from other contracts:
 | `StgPoolSeg` | `DataSize` | `uint32` | Live byte count of this extension segment |
 | `StgPoolSeg` | `NextSegment` | `pointer` | Pointer to the next pool segment, or null |
 | `StgPoolSeg` | `SegData` | `pointer` | Pointer to this extension segment's data |
+| `TableRW` | *(type size)* | `uint32` | Size in bytes of each TableRW entry in the CMiniMdRW tables array |
 
 ### Global variables used
 

--- a/docs/design/datacontracts/ExecutionManager.md
+++ b/docs/design/datacontracts/ExecutionManager.md
@@ -218,6 +218,8 @@ Within a range section fragment, a [nibble map](#nibblemap) structure is used to
 | `RangeSectionFragment` | `RangeEndOpen` | `pointer` | End address of the fragment |
 | `RangeSectionFragment` | `RangeSection` | `pointer` | Pointer to the corresponding `RangeSection` |
 | `RangeSectionMap` | `TopLevelData` | `pointer` | Pointer to the outermost RangeSection |
+| `ReadyToRunCoreHeader` | *(type size)* | `uint32` | Size of the ReadyToRun core header in bytes |
+| `ReadyToRunCoreHeader` | `NumberOfSections` | `uint32` | Number of sections following the header |
 | `ReadyToRunCoreInfo` | `Header` | `pointer` | Pointer to the `READYTORUN_CORE_HEADER` |
 | `ReadyToRunHeader` | `MajorVersion` | `uint16` | ReadyToRun major version |
 | `ReadyToRunInfo` | `Composite` | `pointer` | Pointer to the `ReadyToRunCoreInfo` used for section lookup |
@@ -226,13 +228,12 @@ Within a range section fragment, a [nibble map](#nibblemap) structure is used to
 | `ReadyToRunInfo` | `DelayLoadMethodCallThunks` | `pointer` | Pointer to an `ImageDataDirectory` for the delay load method call thunks |
 | `ReadyToRunInfo` | `EntryPointToMethodDescMap` | `HashMap` | `HashMap` of entry point addresses to `MethodDesc` pointers |
 | `ReadyToRunInfo` | `HotColdMap` | `pointer` | Pointer to an array of 32-bit integers - [see R2R format](../coreclr/botr/readytorun-format.md#readytorunsectiontypehotcoldmap-v80) |
-| `ReadyToRunInfo` | `ImportSections` | `pointer` | Pointer to the array of ReadyToRun import sections |
 | `ReadyToRunInfo` | `LoadedImageBase` | `pointer` | Base address of the loaded R2R image |
 | `ReadyToRunInfo` | `NumHotColdMap` | `uint32` | Number of entries in the `HotColdMap` |
-| `ReadyToRunInfo` | `NumImportSections` | `uint32` | Number of ReadyToRun import sections |
 | `ReadyToRunInfo` | `NumRuntimeFunctions` | `uint32` | Number of `RuntimeFunctions` |
 | `ReadyToRunInfo` | `ReadyToRunHeader` | `pointer` | Pointer to the ReadyToRunHeader |
 | `ReadyToRunInfo` | `RuntimeFunctions` | `pointer` | Pointer to an array of `RuntimeFunctions` - [see R2R format](../coreclr/botr/readytorun-format.md#readytorunsectiontyperuntimefunctions) |
+| `ReadyToRunSection` | *(type size)* | `uint32` | Size of a ReadyToRun section entry in bytes |
 | `ReadyToRunSection` | `Section` | `ImageDataDirectory` | `IMAGE_DATA_DIRECTORY` for the section data |
 | `ReadyToRunSection` | `Type` | `uint32` | Section type (`ReadyToRunSectionType`) |
 | `RealCodeHeader` | `DebugInfo` | `pointer` | Pointer to the DebugInfo |

--- a/docs/design/datacontracts/Object.md
+++ b/docs/design/datacontracts/Object.md
@@ -77,10 +77,7 @@ ulong GetSize(TargetPointer address);
 | `ObjectHeader` | `SyncBlockValue` | `uint32` | Sync block value from the object header |
 | `String` | `m_FirstChar` | `pointer` | Address of the first UTF-16 character in the string |
 | `String` | `m_StringLength` | `uint32` | Length of the string in UTF-16 characters |
-| `SyncBlock` | `EnCInfo` | `pointer` | Pointer to Edit-and-Continue added-field information for the object; optional when Edit and Continue is not configured |
 | `SyncBlock` | `HashCode` | `uint32` | Hash code stored in the sync block |
-| `SyncBlock` | `InteropInfo` | `pointer` | Pointer to optional COM interop data associated with the sync block |
-| `SyncBlock` | `Lock` | `ObjectHandle` | Object handle referring to the System.Threading.Lock used for the object's monitor |
 
 ### Global variables used
 

--- a/docs/design/datacontracts/RuntimeMutableTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeMutableTypeSystem.md
@@ -35,8 +35,6 @@ TargetPointer GetEnCInstanceFieldAddress(TargetPointer objectAddress, TargetPoin
 | `Module` | `EnCClassList` | `pointer` | Pointer to the list of classes added through Edit and Continue |
 | `Object` | *(type size)* | `uint32` | Size in bytes of the fixed Object portion through its MethodTable pointer |
 | `SyncBlock` | `EnCInfo` | `pointer` | Pointer to Edit-and-Continue added-field information for the object; optional when Edit and Continue is not configured |
-| `SyncBlock` | `InteropInfo` | `pointer` | Pointer to optional COM interop data associated with the sync block |
-| `SyncBlock` | `Lock` | `ObjectHandle` | Object handle referring to the System.Threading.Lock used for the object's monitor |
 | `System.Diagnostics.EditAndContinueHelper` | `_objectReference` | `pointer` | Holds the per-field storage for an EnC-added instance field. |
 | `UnorderedArrayBase` | `Count` | `uint32` | Number of valid entries currently stored in the array. |
 | `UnorderedArrayBase` | `Table` | `pointer` | Pointer to the backing storage holding the array's entries. |

--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -183,15 +183,9 @@ Unwinding call frames on the stack usually requires an OS specific implementatio
 | `Module` | `ReadyToRunInfo` | `pointer` | Pointer to the module's ReadyToRun information |
 | `Object` | `m_pMethTab` | `pointer` | Method table for the object |
 | `PInvokeCalliFrame` | `VASigCookiePtr` | `pointer` | Pointer to the varargs signature cookie for the unmanaged call |
-| `ReadyToRunInfo` | `CompositeInfo` | `pointer` | Pointer to composite R2R info - or itself for non-composite |
-| `ReadyToRunInfo` | `EntryPointToMethodDescMap` | `HashMap` | `HashMap` of entry point addresses to `MethodDesc` pointers |
-| `ReadyToRunInfo` | `HotColdMap` | `pointer` | Pointer to an array of 32-bit integers - [see R2R format](../coreclr/botr/readytorun-format.md#readytorunsectiontypehotcoldmap-v80) |
 | `ReadyToRunInfo` | `ImportSections` | `pointer` | Pointer to the array of ReadyToRun import sections |
 | `ReadyToRunInfo` | `LoadedImageBase` | `pointer` | Base address of the loaded R2R image |
-| `ReadyToRunInfo` | `NumHotColdMap` | `uint32` | Number of entries in the `HotColdMap` |
 | `ReadyToRunInfo` | `NumImportSections` | `uint32` | Number of ReadyToRun import sections |
-| `ReadyToRunInfo` | `NumRuntimeFunctions` | `uint32` | Number of `RuntimeFunctions` |
-| `ReadyToRunInfo` | `RuntimeFunctions` | `pointer` | Pointer to an array of `RuntimeFunctions` - [see R2R format](../coreclr/botr/readytorun-format.md#readytorunsectiontyperuntimefunctions) |
 | `ResumableFrame` | `TargetContextPtr` | `pointer` | Pointer to the Frame's Target Context |
 | `SoftwareExceptionFrame` | `ReturnAddress` | `CodePointer` | Return address saved in Frame |
 | `SoftwareExceptionFrame` | `TargetContext` | `pointer` | Context object saved in Frame |
@@ -204,8 +198,6 @@ Unwinding call frames on the stack usually requires an OS specific implementatio
 | `TailCallFrame` | `CalleeSavedRegisters` | `pointer` | Address of the embedded nonvolatile-register values saved in the tailcall frame |
 | `TailCallFrame` | `ReturnAddress` | `CodePointer` | Return address saved in the tailcall frame |
 | `Thread` | `ExceptionTracker` | `pointer` | Pointer to exception tracking information |
-| `Thread` | `RuntimeThreadLocals` | `pointer` | Pointer to some thread-local storage |
-| `Thread` | `ThreadHandle` | `pointer` | OS thread handle (optional, Windows only; readers should expect `TargetPointer.Null` on non-Windows targets) |
 | `TransitionBlock` | *(type size)* | `uint32` | Size in bytes of the transition block, used to restore the caller's stack pointer |
 | `TransitionBlock` | `ArgumentRegisters` | `pointer` | Byte offset of the argument registers area within the TransitionBlock |
 | `TransitionBlock` | `CalleeSavedRegisters` | `pointer` | Platform specific CalleeSavedRegisters struct associated with the TransitionBlock |

--- a/docs/design/datacontracts/SyncBlock.md
+++ b/docs/design/datacontracts/SyncBlock.md
@@ -26,7 +26,6 @@ bool GetBuiltInComData(TargetPointer syncBlock, out TargetPointer rcw, out Targe
 | `InteropSyncBlockInfo` | `CCF` | `pointer` | COM class factory pointer; sentinel value 0x1 means previously had a CCF (treat as null) |
 | `InteropSyncBlockInfo` | `CCW` | `pointer` | CCW pointer; sentinel value 0x1 means previously had a CCW (treat as null) |
 | `InteropSyncBlockInfo` | `RCW` | `pointer` | RCW pointer; bit 0 is a lock bit and must be masked off |
-| `SyncBlock` | `EnCInfo` | `pointer` | Pointer to Edit-and-Continue added-field information for the object; optional when Edit and Continue is not configured |
 | `SyncBlock` | `InteropInfo` | `pointer` | Pointer to optional COM interop data associated with the sync block |
 | `SyncBlock` | `LinkNext` | `pointer` | Head pointer for cleanup list link |
 | `SyncBlock` | `Lock` | `ObjectHandle` | Object handle referring to the System.Threading.Lock used for the object's monitor |

--- a/docs/design/datacontracts/WindowsErrorReporting.md
+++ b/docs/design/datacontracts/WindowsErrorReporting.md
@@ -21,8 +21,6 @@ byte[] GetWatsonBuckets(TargetPointer threadPointer);
 | `ExceptionInfo` | `ExceptionWatsonBucketTrackerBuckets` | `pointer` | Pointer to Watson unhandled buckets on non-Unix |
 | `ExceptionInfo` | `ThrownObject` | `pointer` | Handle to the thrown exception object |
 | `Thread` | `ExceptionTracker` | `pointer` | Pointer to exception tracking information |
-| `Thread` | `RuntimeThreadLocals` | `pointer` | Pointer to some thread-local storage |
-| `Thread` | `ThreadHandle` | `pointer` | OS thread handle (optional, Windows only; readers should expect `TargetPointer.Null` on non-Windows targets) |
 | `Thread` | `UEWatsonBucketTrackerBuckets` | `pointer` | Pointer to thread Watson buckets data (optional, Windows only) |
 
 ### Global variables used

--- a/docs/design/datacontracts/data-descriptor-meanings.json
+++ b/docs/design/datacontracts/data-descriptor-meanings.json
@@ -620,6 +620,7 @@
     "SystemVEightByteRegistersInfo.EightByteSize0": "Byte size of the first eightbyte",
     "SystemVEightByteRegistersInfo.EightByteSize1": "Byte size of the second eightbyte",
     "SystemVEightByteRegistersInfo.NumEightBytes": "Number of eightbyte slots used to pass the value type in registers (0 if not passed in registers)",
+    "TableRW.Size": "Size in bytes of each TableRW entry in the CMiniMdRW tables array",
     "TableSegment.NextSegment": "Pointer to the next segment",
     "TableSegment.RgAllocation": "Circular block-list links per block",
     "TableSegment.RgTail": "Tail block index per handle type",

--- a/src/native/managed/cdac/IData.md
+++ b/src/native/managed/cdac/IData.md
@@ -33,15 +33,18 @@ listed in order of preference:
    `Address` property. Use this for all new types unless the declarative
    surface cannot express the required logic.
 
-2. **Source-generated with `OnInit`** -- when the declarative attributes
-   cover most of the type but a few fields need custom logic (e.g.
-   stripping a tag bit from a pointer, reading from a second descriptor,
-   variable-count loops, raw byte buffers, or multiple
-   `Target.TypeInfo` lookups), add a
-   `partial void OnInit(Target target, TargetPointer address)`
-   implementation. The generator calls it at the end of the constructor
-   after all `[Field]` reads are complete. This covers all scenarios
-   that the declarative surface cannot express.
+2. **Source-generated with `[CustomInit]`** -- when the declarative
+   attributes cover most of the type but a few properties need custom
+   logic (e.g. stripping a tag bit from a pointer, reading from a second
+   descriptor, variable-count loops, raw byte buffers, or multiple
+   `Target.TypeInfo` lookups), mark those properties
+   `[CustomInit(nameof(MethodName))]` and implement the named per-property
+   `private partial T MethodName(Target target, TargetPointer address)`
+   initializer. The generator calls each initializer **lazily** on first
+   access to its property -- exactly like a `[Field]` property -- so the
+   custom-logic properties keep the same lazy, versioning-friendly
+   behavior as the declarative ones. This covers all scenarios that the
+   declarative surface cannot express.
 
 This document describes the source-generated path.
 
@@ -56,11 +59,12 @@ analyzer. It scans for classes carrying `[CdacType]` and emits a
 * A `public TargetPointer Address { get; }` property (always emitted --
   the instance remembers the address it was constructed from).
 * A `public {Name}(Target target, TargetPointer address)` constructor
-  that records the address and calls `OnInit`. It performs **no** field
+  that records the address. It performs **no** field
   reads -- fields are read lazily (see
   [Lazy field reads and versioning](#lazy-field-reads-and-versioning)).
 * A lazily-read `partial` property implementation for each `[Field]` /
-  `[FieldAddress]` / `[InstanceDataStart]` / `[RawOffset]` declaration.
+  `[FieldAddress]` / `[InstanceDataStart]` / `[CustomInit]` /
+  `[RawOffset]` declaration.
   Each getter resolves the type name against native descriptors and
   managed metadata through the `LayoutSet` cascade on first access,
   reads the field, and memoizes the value. A required field missing from
@@ -84,11 +88,13 @@ analyzer. It scans for classes carrying `[CdacType]` and emits a
 * For each `[StaticAddress]` / `[StaticReference]` partial method
   declaration: a corresponding implementation that tries native globals
   first (`TypeName.fieldName`), then falls back to `ManagedTypeSource`.
-* A `partial void OnInit(Target target, TargetPointer address);`
-  declaration plus a call to it at the end of the constructor.
+* For each `[CustomInit]` property: a
+  `private partial T MethodName(Target target, TargetPointer address);`
+  declaration for the method named by the attribute. The author writes its
+  implementation and the property's lazy getter calls it on first access.
 
-The user provides the property declarations and (optionally) the
-`OnInit` implementation. Everything else is emitted.
+The user provides the property declarations and (for `[CustomInit]`
+properties) the named initializer implementations. Everything else is emitted.
 
 ### User-side conventions
 
@@ -96,25 +102,27 @@ The user provides the property declarations and (optionally) the
 * Implement `IData<T>` on the class declaration.
 * Declare data properties as `public partial T Prop { get; }`. The
   property **must** be `partial`: the generator owns the getter body
-  (a lazy read). Add a setter -- `{ get; private set; }` (or
-  `{ get; set; }`) -- when the generated `Write{Name}` method or
-  hand-written code needs to assign it; the generated setter stores the
-  value in the property's memoized backing field. For non-nullable
-  reference-typed properties that are populated only inside `OnInit`
-  (i.e. **not** decorated with a cdac attribute), keep a plain
-  `{ get; private set; }` auto-property and prefer annotating `OnInit`
-  with `[MemberNotNull(nameof(X), ...)]` over `required` or
-  `= null!;` -- it lets the compiler verify the property is assigned
-  along every path through `OnInit` without forcing callers to use
-  object-initializer syntax or accepting a deliberately-lying null.
+  (a lazy read). A `[Field(Writable = true)]` property must declare
+  `{ get; private set; }`; the generated `Write{Name}` method uses that setter
+  to update the memoized value. Other generated properties are get-only. A
+  non-private setter produces a partial-property accessor mismatch that fails
+  to compile. For a property that needs custom read logic (i.e. one the
+  declarative attributes can't express), mark it
+  `[CustomInit(nameof(MethodName))]` and supply a
+  `private partial T MethodName(Target target, TargetPointer address)`
+  initializer -- the generator wires up the same lazy getter that calls your
+  initializer on first access, so no `[MemberNotNull]` or `= null!;` workaround
+  is needed. Put any `[DataDescriptorDependency]` or
+  `[UsesDataDescriptorTypeSize]` annotations on the initializer method.
 
 ## Lazy field reads and versioning
 
-Fields are read **lazily**. The constructor records the address and runs
-`OnInit`; it performs no descriptor field reads. Each `[Field]` /
-`[FieldAddress]` / `[InstanceDataStart]` / `[RawOffset]` property is a
-generated `partial` property whose getter, on first access, resolves the
-layout, reads the field from the target, and memoizes the value.
+Fields are read **lazily**. The constructor only records the address; it
+performs no descriptor field reads. Each `[Field]` /
+`[FieldAddress]` / `[InstanceDataStart]` / `[CustomInit]` / `[RawOffset]`
+property is a generated `partial` property whose getter, on first access,
+resolves the layout, reads the field from the target, and memoizes the
+value.
 
 The laziness is **invisible**: a getter throws exactly what the old eager
 constructor would have thrown for that field, just deferred to first
@@ -136,9 +144,12 @@ access instead of construction. This has two consequences:
   performs the real read. Optional (`T?`) fields instead yield `null`
   when absent (see the [`[Field]`](#property-level-field) table).
 
-`OnInit` still runs eagerly at construction, so reads performed directly
-in `OnInit` (rather than through generated properties) happen when the
-instance is created, not lazily.
+A `[CustomInit]` property behaves exactly like a `[Field]` property in
+this respect: its named initializer runs lazily on first access,
+not at construction, and whatever it throws (an
+`InvalidOperationException` from a layout lookup, a `VirtualReadException`
+from a failed read, or nothing for an optional value) surfaces at first
+access.
 
 ### Forcing a full read: `IReadableData`
 
@@ -190,7 +201,7 @@ managed metadata. The first match wins.
 [CdacType("Lock", "System.Threading.Lock")]
 [CdacType(nameof(DataType.Exception), "System.Exception")]
 
-// Parameterless -- no descriptor lookup. Use with [RawOffset] or OnInit only.
+// Parameterless -- no descriptor lookup. Use with [RawOffset] or [CustomInit] only.
 [CdacType]
 
 // HasTypeHandle -- emits a TypeHandle(Target) accessor.
@@ -299,6 +310,32 @@ public partial TargetPointer Data { get; }
 // generates: Data = address + type.Size!.Value;
 ```
 
+### Property-level: `[CustomInit]`
+
+Marks a property whose value is produced by a hand-written initializer
+rather than a declarative read. The generator emits a `partial` method
+declaration you implement, plus the usual lazy getter that calls it on
+first access:
+
+```csharp
+[CustomInit(nameof(InitNext))] public partial TargetPointer Next { get; }
+
+// You implement:
+[DataDescriptorDependency(nameof(Next), "pointer")]
+private partial TargetPointer InitNext(Target target, TargetPointer address)
+{
+    Target.TypeInfo type = target.GetTypeInfo(DataType.RangeSectionFragment);
+    return target.ReadPointerField(address, type, nameof(Next)) & ~1ul;
+}
+```
+
+The initializer name is supplied to `[CustomInit]`, takes `(Target target,
+TargetPointer address)`, and returns the property's type. It runs lazily (on
+first property access) and its result is memoized. Descriptor dependency
+attributes belong on this method. See
+[The `[CustomInit]` escape hatch](#the-custominit-escape-hatch) for the
+patterns it covers.
+
 ### Method-level (`static partial`): static-field accessors
 
 These attributes target `static partial` method declarations. The
@@ -331,16 +368,23 @@ internal sealed partial class ComWrappers : IData<ComWrappers>
 }
 ```
 
-## The `OnInit` escape hatch
+## The `[CustomInit]` escape hatch
 
-Every generator-emitted constructor ends with a call to
-`partial void OnInit(Target target, TargetPointer address)`. If the user
-provides no implementation, the C# compiler elides both the call and
-the signature. When the user *does* provide an implementation, it runs
-after all the declarative `[Field]` / `[FieldAddress]` / etc.
-assignments and can perform any custom reads.
+Mark a property `[CustomInit(nameof(MethodName))]` to supply your own read logic
+for it. The generator emits a `partial` declaration
 
-Use `OnInit` for any pattern the declarative surface can't express:
+```csharp
+private partial T MethodName(Target target, TargetPointer address);
+```
+
+that you implement, plus the same lazy getter it emits for a `[Field]`
+property -- except the getter calls your named method on first access
+instead of reading a descriptor field. `target` is the `Target` the
+instance was constructed from and `address` is its `Address`. The
+initializer can read from other (already-lazy) properties on the same
+instance; doing so triggers their own lazy reads.
+
+Use `[CustomInit]` for any pattern the declarative surface can't express:
 
 * Variable-count loops over arrays whose length is a global or another
   field. (`Bucket`, `RCW`, `ComCallWrapper`, ...)
@@ -355,26 +399,37 @@ Use `OnInit` for any pattern the declarative surface can't express:
   class is anchored on. (TypeDesc subclasses reading the base
   `TypeAndFlags` from `DataType.TypeDesc`.)
 
-For properties populated only inside `OnInit`, declare them as
-`{ get; private set; }` and annotate `OnInit` with
-`[MemberNotNull(nameof(X), ...)]` so the compiler is satisfied without
-the `= null!;` workaround:
+Put `[DataDescriptorDependency]` and `[UsesDataDescriptorTypeSize]` on the
+initializer method rather than the property. The usage analyzer records that
+metadata and still walks the initializer body to capture global reads, helper
+calls, and dependencies on other lazy properties.
+
+Because each initializer feeds the property's own lazy getter, a
+`[CustomInit]` property needs no `[MemberNotNull]` or `= null!;`
+workaround -- the generator owns the backing field and only calls the
+initializer when the property is first read:
 
 ```csharp
 [CdacType(nameof(DataType.Bucket))]
 internal sealed partial class Bucket : IData<Bucket>
 {
-    public TargetPointer[] Keys { get; private set; }
-    public TargetPointer[] Values { get; private set; }
+    [CustomInit(nameof(InitKeys))] public partial TargetPointer[] Keys { get; }
+    [CustomInit(nameof(InitValues))] public partial TargetPointer[] Values { get; }
 
-    [MemberNotNull(nameof(Keys), nameof(Values))]
-    partial void OnInit(Target target, TargetPointer address)
+    [DataDescriptorDependency(nameof(Keys), "pointer")]
+    private partial TargetPointer[] InitKeys(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.Bucket);
         uint numSlots = target.ReadGlobal<uint>(Constants.Globals.HashMapSlotsPerBucket);
-        Keys = new TargetPointer[numSlots];
-        Values = new TargetPointer[numSlots];
+        var keys = new TargetPointer[numSlots];
         // ... populate
+        return keys;
+    }
+
+    [DataDescriptorDependency(nameof(Values), "pointer")]
+    private partial TargetPointer[] InitValues(Target target, TargetPointer address)
+    {
+        // ... same shape, returns the values array
     }
 }
 ```
@@ -395,8 +450,7 @@ internal sealed partial class Module : IData<Module>
 // Generated (the class captures _target for any type with instance members):
 public void WriteFlags(uint value)
 {
-    LayoutSet layouts = EnsureLayouts();
-    layouts.Select(Address, out var t, out var b, out var n, "Flags");
+    _layouts.Select(Address, out var t, out var b, out var n, "Flags");
     _target.WriteField<uint>(b, t, n, value);
     Flags = value;
 }
@@ -659,7 +713,7 @@ Data.Module module = target.ProcessedData.GetOrAdd<Data.Module>(addr);
 module.WriteFlags(newFlags);
 ```
 
-### Source-generated with `OnInit` custom logic
+### Source-generated with `[CustomInit]` custom logic
 
 ```csharp
 [CdacType(nameof(DataType.RangeSectionFragment))]
@@ -670,12 +724,13 @@ internal sealed partial class RangeSectionFragment : IData<RangeSectionFragment>
     [Field] public partial TargetPointer RangeSection { get; }
 
     // The Next pointer uses the low bit as a collectible flag; strip it.
-    public TargetPointer Next { get; private set; }
+    [CustomInit(nameof(InitNext))] public partial TargetPointer Next { get; }
 
-    partial void OnInit(Target target, TargetPointer address)
+    [DataDescriptorDependency(nameof(Next), "pointer")]
+    private partial TargetPointer InitNext(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.RangeSectionFragment);
-        Next = target.ReadPointerField(address, type, nameof(Next)) & ~1ul;
+        return target.ReadPointerField(address, type, nameof(Next)) & ~1ul;
     }
 }
 ```
@@ -695,39 +750,42 @@ IData properties should not expose mutable collections or types that
 allow external callers to change the snapshot. The only legitimate
 mutation path is through `Write{Name}` methods for write-back fields.
 
-For collection-typed properties populated in `OnInit`, expose them as
-`IReadOnlyList<T>` (or another read-only interface) with
-`{ get; private set; }` and assign a `List<T>` built inside `OnInit`.
-This prevents callers from accidentally mutating the cached snapshot.
+For collection-typed properties that need custom read logic, expose them
+as `IReadOnlyList<T>` (or another read-only interface) with `[CustomInit]`
+and build a `List<T>` inside the initializer. This prevents callers from
+accidentally mutating the cached snapshot.
 
 Bad:
 
 ```csharp
-public List<TargetPointer> Elements { get; } = [];
+[CustomInit(nameof(InitElements))] public partial List<TargetPointer> Elements { get; }
 
-partial void OnInit(Target target, TargetPointer address)
+private partial List<TargetPointer> InitElements(Target target, TargetPointer address)
 {
-    Elements.Add(...);
+    // Exposes a mutable List<T> that callers can change.
+    List<TargetPointer> elements = [];
+    elements.Add(...);
+    return elements;
 }
 ```
 
 Good:
 
 ```csharp
-public IReadOnlyList<TargetPointer> Elements { get; private set; } = [];
+[CustomInit(nameof(InitElements))] public partial IReadOnlyList<TargetPointer> Elements { get; }
 
-[MemberNotNull(nameof(Elements))]
-partial void OnInit(Target target, TargetPointer address)
+private partial IReadOnlyList<TargetPointer> InitElements(Target target, TargetPointer address)
 {
     List<TargetPointer> elements = [];
     elements.Add(...);
-    Elements = elements;
+    return elements;
 }
 ```
 
 ### Avoid algorithm logic in IData classes
 
-The constructor (and `OnInit`) should be limited to reads from the
+The initializers (whether declarative or `[CustomInit]`) should be
+limited to reads from the
 target -- enough to populate the declared properties. Derived
 computations, interpretation, and any contract algorithms belong in
 the consuming contract implementation (`Contracts\*.cs`), not in the
@@ -880,9 +938,9 @@ internal sealed partial class LoaderAllocator : IData<LoaderAllocator>
 Don't read fields from a different `Target.TypeInfo` than the one the
 class is anchored on. If a type's layout genuinely spans two
 descriptors (e.g. `ParamTypeDesc` inheriting `TypeAndFlags` from the
-base `TypeDesc` descriptor), use `OnInit` to do the cross-descriptor
-read explicitly -- don't try to express it through `[CdacType]`
-alone.
+base `TypeDesc` descriptor), use a `[CustomInit]` initializer to do the
+cross-descriptor read explicitly -- don't try to express it through
+`[CdacType]` alone.
 
 ## Migrating types between sources
 
@@ -934,4 +992,3 @@ thread statics are not currently supported.
 > **TODO:** A type forwarding system for native-to-managed migration is
 > planned but not yet implemented. This section will be updated when the
 > forwarding mechanism is available.
-

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/CdacAttributes.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/CdacAttributes.cs
@@ -239,6 +239,33 @@ public sealed class InstanceDataStartAttribute : Attribute
 }
 
 /// <summary>
+/// Marks a property whose value is computed by an author-provided initializer
+/// rather than a declarative descriptor read. The generator emits a lazy getter
+/// (computed once on first access, then memoized) that calls the named partial
+/// method, which the author must implement with the signature
+/// <c>T MethodName(Target target, TargetPointer address)</c>. Use for reads the
+/// declarative attributes can't express: conditional reads, bitmask cleanup,
+/// cross-descriptor reads, variable-count loops, etc. The property must be
+/// declared <c>partial</c> and get-only; the computation stays lazy (deferred to
+/// first access).
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+public sealed class CustomInitAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomInitAttribute"/> class.
+    /// </summary>
+    /// <param name="methodName">The name of the initializer method.</param>
+    public CustomInitAttribute(string methodName)
+    {
+        MethodName = methodName;
+    }
+
+    /// <summary>Gets the name of the initializer method.</summary>
+    public string MethodName { get; }
+}
+
+/// <summary>
 /// Marks a static partial method as a static-field-address accessor. Method
 /// must return <c>TargetPointer</c> and take a <c>Target</c> parameter.
 /// </summary>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ArrayListBase.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ArrayListBase.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
@@ -17,11 +16,10 @@ internal sealed partial class ArrayListBase : IData<ArrayListBase>
     [FieldAddress]
     public partial TargetPointer FirstBlock { get; }
 
-    public IReadOnlyList<ArrayListBlock> Blocks { get; private set; } = [];
-    public IReadOnlyList<TargetPointer> Elements { get; private set; } = [];
+    [CustomInit(nameof(InitBlocks))] public partial IReadOnlyList<ArrayListBlock> Blocks { get; }
+    [CustomInit(nameof(InitElements))] public partial IReadOnlyList<TargetPointer> Elements { get; }
 
-    [MemberNotNull(nameof(Blocks), nameof(Elements))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial IReadOnlyList<ArrayListBlock> InitBlocks(Target target, TargetPointer address)
     {
         List<ArrayListBlock> blocks = [];
         TargetPointer next = FirstBlock;
@@ -32,9 +30,14 @@ internal sealed partial class ArrayListBase : IData<ArrayListBase>
             next = block.Next;
         }
 
+        return blocks;
+    }
+
+    private partial IReadOnlyList<TargetPointer> InitElements(Target target, TargetPointer address)
+    {
         List<TargetPointer> elements = [];
         uint elementsFound = 0;
-        foreach (ArrayListBlock block in blocks)
+        foreach (ArrayListBlock block in Blocks)
         {
             foreach (TargetPointer element in block.Elements)
             {
@@ -48,8 +51,7 @@ internal sealed partial class ArrayListBase : IData<ArrayListBase>
             }
         }
 
-        Blocks = blocks;
-        Elements = elements;
+        return elements;
     }
 }
 
@@ -62,10 +64,9 @@ internal sealed partial class ArrayListBlock : IData<ArrayListBlock>
     [FieldAddress]
     public partial TargetPointer ArrayStart { get; }
 
-    public IReadOnlyList<TargetPointer> Elements { get; private set; } = [];
+    [CustomInit(nameof(InitElements))] public partial IReadOnlyList<TargetPointer> Elements { get; }
 
-    [MemberNotNull(nameof(Elements))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial IReadOnlyList<TargetPointer> InitElements(Target target, TargetPointer address)
     {
         List<TargetPointer> elements = new((int)Size);
         for (ulong i = 0; i < Size; i++)
@@ -73,6 +74,6 @@ internal sealed partial class ArrayListBlock : IData<ArrayListBlock>
             elements.Add(target.ReadPointer(ArrayStart + (i * (ulong)target.PointerSize)));
         }
 
-        Elements = elements;
+        return elements;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Bucket.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Bucket.cs
@@ -1,33 +1,41 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
 [CdacType(nameof(DataType.Bucket))]
 internal sealed partial class Bucket : IData<Bucket>
 {
+    [CustomInit(nameof(InitKeys))] public partial TargetPointer[] Keys { get; }
+    [CustomInit(nameof(InitValues))] public partial TargetPointer[] Values { get; }
+
     [DataDescriptorDependency(nameof(Keys), "pointer")]
-    public TargetPointer[] Keys { get; private set; }
-
-    [DataDescriptorDependency(nameof(Values), "pointer")]
-    public TargetPointer[] Values { get; private set; }
-
-    [MemberNotNull(nameof(Keys), nameof(Values))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial TargetPointer[] InitKeys(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.Bucket);
         ulong keysStart = address + (ulong)type.Fields[nameof(Keys)].Offset;
-        ulong valuesStart = address + (ulong)type.Fields[nameof(Values)].Offset;
-
         uint numSlots = target.ReadGlobal<uint>(Constants.Globals.HashMapSlotsPerBucket);
-        Keys = new TargetPointer[numSlots];
-        Values = new TargetPointer[numSlots];
+        TargetPointer[] keys = new TargetPointer[numSlots];
         for (int i = 0; i < numSlots; i++)
         {
-            Keys[i] = target.ReadPointer(keysStart + (ulong)(i * target.PointerSize));
-            Values[i] = target.ReadPointer(valuesStart + (ulong)(i * target.PointerSize));
+            keys[i] = target.ReadPointer(keysStart + (ulong)(i * target.PointerSize));
         }
+
+        return keys;
+    }
+
+    [DataDescriptorDependency(nameof(Values), "pointer")]
+    private partial TargetPointer[] InitValues(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.Bucket);
+        ulong valuesStart = address + (ulong)type.Fields[nameof(Values)].Offset;
+        uint numSlots = target.ReadGlobal<uint>(Constants.Globals.HashMapSlotsPerBucket);
+        TargetPointer[] values = new TargetPointer[numSlots];
+        for (int i = 0; i < numSlots; i++)
+        {
+            values[i] = target.ReadPointer(valuesStart + (ulong)(i * target.PointerSize));
+        }
+
+        return values;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/CMiniMdRW.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/CMiniMdRW.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
@@ -18,20 +16,18 @@ internal sealed partial class CMiniMdRW : IData<CMiniMdRW>
     [FieldAddress] public partial TargetPointer BlobHeap { get; }
     [FieldAddress] public partial TargetPointer UserStringHeap { get; }
     [FieldAddress] public partial TargetPointer GuidHeap { get; }
-    public ImmutableArray<TargetPointer> TableSegments { get; private set; }
+    [CustomInit(nameof(InitTableSegments))] public partial ImmutableArray<TargetPointer> TableSegments { get; }
 
-    [MemberNotNull(nameof(TableSegments))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial ImmutableArray<TargetPointer> InitTableSegments(Target target, TargetPointer address)
     {
         int tableCount = checked((int)TableCount);
-        uint tableStride = target.GetTypeInfo(DataType.TableRW).Size
-            ?? throw new InvalidOperationException("TableRW size is required to index the tables array.");
+        uint tableStride = TableRW.GetSize(target);
 
         var tableSegments = new TargetPointer[tableCount];
         for (int i = 0; i < tableCount; i++)
         {
             tableSegments[i] = Tables + (ulong)i * tableStride;
         }
-        TableSegments = ImmutableArray.Create(tableSegments);
+        return ImmutableArray.Create(tableSegments);
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ComCallWrapper.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ComCallWrapper.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
 [CdacType(nameof(DataType.ComCallWrapper))]
@@ -15,16 +13,17 @@ internal sealed partial class ComCallWrapper : IData<ComCallWrapper>
     [FieldAddress]
     public partial TargetPointer IPtr { get; }
 
-    public TargetPointer[] IPtrs { get; private set; }
+    [CustomInit(nameof(InitIPtrs))] public partial TargetPointer[] IPtrs { get; }
 
-    [MemberNotNull(nameof(IPtrs))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial TargetPointer[] InitIPtrs(Target target, TargetPointer address)
     {
         int numInterfaces = (int)target.ReadGlobal<uint>(Constants.Globals.CCWNumInterfaces);
-        IPtrs = new TargetPointer[numInterfaces];
+        TargetPointer[] iptrs = new TargetPointer[numInterfaces];
         for (int i = 0; i < numInterfaces; i++)
         {
-            IPtrs[i] = target.ReadPointer(IPtr + (ulong)(i * target.PointerSize));
+            iptrs[i] = target.ReadPointer(IPtr + (ulong)(i * target.PointerSize));
         }
+
+        return iptrs;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ComInterfaceEntry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ComInterfaceEntry.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 [CdacType(nameof(DataType.ComInterfaceEntry))]
 internal sealed partial class ComInterfaceEntry : IData<ComInterfaceEntry>
 {
-    [DataDescriptorDependency(nameof(IID), "nuint")]
-    public Guid IID { get; private set; }
+    [CustomInit(nameof(InitIID))] public partial Guid IID { get; }
 
-    partial void OnInit(Target target, TargetPointer address)
+    [DataDescriptorDependency(nameof(IID), "nuint")]
+    private partial Guid InitIID(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.ComInterfaceEntry);
         // IID is a 16-byte GUID
         byte[] iidBytes = new byte[16];
         target.ReadBuffer(address + (ulong)type.Fields[nameof(IID)].Offset, iidBytes);
-        IID = new Guid(iidBytes);
+        return new Guid(iidBytes);
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ComWrappersVtablePtrs.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ComWrappersVtablePtrs.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
 [CdacType(nameof(DataType.ComWrappersVtablePtrs))]
 internal sealed partial class ComWrappersVtablePtrs : IData<ComWrappersVtablePtrs>
 {
-    public IReadOnlyList<TargetCodePointer> ComWrappersInterfacePointers { get; private set; } = [];
+    [CustomInit(nameof(InitComWrappersInterfacePointers))] public partial IReadOnlyList<TargetCodePointer> ComWrappersInterfacePointers { get; }
 
-    [MemberNotNull(nameof(ComWrappersInterfacePointers))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial IReadOnlyList<TargetCodePointer> InitComWrappersInterfacePointers(Target target, TargetPointer address)
     {
         int count = (int)(GetSize(target) / (uint)target.PointerSize);
         List<TargetCodePointer> pointers = new(count);
@@ -21,6 +19,6 @@ internal sealed partial class ComWrappersVtablePtrs : IData<ComWrappersVtablePtr
             pointers.Add(target.ReadCodePointer(address + (ulong)(i * target.PointerSize)));
         }
 
-        ComWrappersInterfacePointers = pointers;
+        return pointers;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DynamicStaticsInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/DynamicStaticsInfo.cs
@@ -6,17 +6,22 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 [CdacType(nameof(DataType.DynamicStaticsInfo))]
 internal sealed partial class DynamicStaticsInfo : IData<DynamicStaticsInfo>
 {
+    [CustomInit(nameof(InitGCStatics))] public partial TargetPointer GCStatics { get; }
+    [CustomInit(nameof(InitNonGCStatics))] public partial TargetPointer NonGCStatics { get; }
+
     [DataDescriptorDependency(nameof(GCStatics), "pointer")]
-    public TargetPointer GCStatics { get; private set; }
-
-    [DataDescriptorDependency(nameof(NonGCStatics), "pointer")]
-    public TargetPointer NonGCStatics { get; private set; }
-
-    partial void OnInit(Target target, TargetPointer address)
+    private partial TargetPointer InitGCStatics(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.DynamicStaticsInfo);
         TargetPointer mask = target.ReadGlobalPointer(Constants.Globals.StaticsPointerMask);
-        GCStatics = target.ReadPointerField(address, type, nameof(GCStatics)) & mask;
-        NonGCStatics = target.ReadPointerField(address, type, nameof(NonGCStatics)) & mask;
+        return target.ReadPointerField(address, type, nameof(GCStatics)) & mask;
+    }
+
+    [DataDescriptorDependency(nameof(NonGCStatics), "pointer")]
+    private partial TargetPointer InitNonGCStatics(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.DynamicStaticsInfo);
+        TargetPointer mask = target.ReadGlobalPointer(Constants.Globals.StaticsPointerMask);
+        return target.ReadPointerField(address, type, nameof(NonGCStatics)) & mask;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EETypeHashTable.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EETypeHashTable.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
@@ -10,15 +9,13 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 internal sealed partial class EETypeHashTable : IData<EETypeHashTable>
 {
     private const ulong FLAG_MASK = 0x1ul;
+    [CustomInit(nameof(InitEntries))] public partial IReadOnlyList<Entry> Entries { get; }
 
     [DataDescriptorDependency("Buckets", "pointer")]
     [DataDescriptorDependency("Count", "uint32")]
     [DataDescriptorDependency("VolatileEntryValue", "pointer")]
     [DataDescriptorDependency("VolatileEntryNextEntry", "pointer")]
-    public IReadOnlyList<Entry> Entries { get; private set; }
-
-    [MemberNotNull(nameof(Entries))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial IReadOnlyList<Entry> InitEntries(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.EETypeHashTable);
         DacEnumerableHash baseHashTable = new(target, address, type);
@@ -29,7 +26,7 @@ internal sealed partial class EETypeHashTable : IData<EETypeHashTable>
             TargetPointer typeHandle = target.ReadPointer(entry);
             entries.Add(new(typeHandle));
         }
-        Entries = entries;
+        return entries;
     }
 
     public readonly struct Entry(TargetPointer value)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/ArgumentRegisters.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/ArgumentRegisters.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
 [CdacType(nameof(DataType.ArgumentRegisters))]
 internal partial class ArgumentRegisters : IData<ArgumentRegisters>
 {
-    public IReadOnlyDictionary<string, TargetNUInt> Registers { get; private set; }
+    [CustomInit(nameof(InitRegisters))] public partial IReadOnlyDictionary<string, TargetNUInt> Registers { get; }
 
-    [MemberNotNull(nameof(Registers))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial IReadOnlyDictionary<string, TargetNUInt> InitRegisters(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.ArgumentRegisters);
         Dictionary<string, TargetNUInt> registers = new(type.Fields.Count);
@@ -21,6 +19,6 @@ internal partial class ArgumentRegisters : IData<ArgumentRegisters>
             TargetNUInt value = target.ReadNUInt(address + (ulong)field.Offset);
             registers.Add(name, value);
         }
-        Registers = registers;
+        return registers;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/CalleeSavedRegisters.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/CalleeSavedRegisters.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
 [CdacType(nameof(DataType.CalleeSavedRegisters))]
 internal partial class CalleeSavedRegisters : IData<CalleeSavedRegisters>
 {
-    public IReadOnlyDictionary<string, TargetNUInt> Registers { get; private set; }
+    [CustomInit(nameof(InitRegisters))] public partial IReadOnlyDictionary<string, TargetNUInt> Registers { get; }
 
-    [MemberNotNull(nameof(Registers))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial IReadOnlyDictionary<string, TargetNUInt> InitRegisters(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.CalleeSavedRegisters);
         Dictionary<string, TargetNUInt> registers = new(type.Fields.Count);
@@ -21,6 +19,6 @@ internal partial class CalleeSavedRegisters : IData<CalleeSavedRegisters>
             TargetNUInt value = target.ReadNUInt(address + (ulong)field.Offset);
             registers.Add(name, value);
         }
-        Registers = registers;
+        return registers;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/Frame.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/Frame.cs
@@ -7,10 +7,10 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 internal sealed partial class Frame : IData<Frame>
 {
     [Field] public partial TargetPointer Next { get; }
-    public TargetPointer Identifier { get; private set; }
+    [CustomInit(nameof(InitIdentifier))] public partial TargetPointer Identifier { get; }
 
-    partial void OnInit(Target target, TargetPointer address)
+    private partial TargetPointer InitIdentifier(Target target, TargetPointer address)
     {
-        Identifier = target.ReadPointer(address);
+        return target.ReadPointer(address);
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/HijackArgs.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Frames/HijackArgs.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
 [CdacType(nameof(DataType.HijackArgs))]
 internal partial class HijackArgs : IData<HijackArgs>
 {
-    public IReadOnlyDictionary<string, TargetNUInt> Registers { get; private set; }
+    [CustomInit(nameof(InitRegisters))] public partial IReadOnlyDictionary<string, TargetNUInt> Registers { get; }
 
-    [MemberNotNull(nameof(Registers))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial IReadOnlyDictionary<string, TargetNUInt> InitRegisters(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.HijackArgs);
         Dictionary<string, TargetNUInt> registers = new(type.Fields.Count);
@@ -21,6 +19,6 @@ internal partial class HijackArgs : IData<HijackArgs>
             TargetNUInt value = target.ReadNUInt(address + (ulong)field.Offset);
             registers.Add(name, value);
         }
-        Registers = registers;
+        return registers;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/HandleTableMap.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/HandleTableMap.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
@@ -10,11 +9,10 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 internal sealed partial class HandleTableMap : IData<HandleTableMap>
 {
     [Field] public partial TargetPointer Next { get; }
-    [DataDescriptorDependency(nameof(BucketsPtr), "pointer")]
-    public IReadOnlyList<TargetPointer> BucketsPtr { get; private set; } = [];
+    [CustomInit(nameof(InitBucketsPtr))] public partial IReadOnlyList<TargetPointer> BucketsPtr { get; }
 
-    [MemberNotNull(nameof(BucketsPtr))]
-    partial void OnInit(Target target, TargetPointer address)
+    [DataDescriptorDependency(nameof(BucketsPtr), "pointer")]
+    private partial IReadOnlyList<TargetPointer> InitBucketsPtr(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.HandleTableMap);
         TargetPointer bucketsPtr = target.ReadPointerField(address, type, nameof(BucketsPtr));
@@ -26,6 +24,6 @@ internal sealed partial class HandleTableMap : IData<HandleTableMap>
             buckets.Add(bucketPtr);
         }
 
-        BucketsPtr = buckets;
+        return buckets;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/InstMethodHashTable.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/InstMethodHashTable.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
@@ -10,15 +9,13 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 internal sealed partial class InstMethodHashTable : IData<InstMethodHashTable>
 {
     private const ulong FLAG_MASK = 0x3ul;
+    [CustomInit(nameof(InitEntries))] public partial IReadOnlyList<Entry> Entries { get; }
 
     [DataDescriptorDependency("Buckets", "pointer")]
     [DataDescriptorDependency("Count", "uint32")]
     [DataDescriptorDependency("VolatileEntryValue", "pointer")]
     [DataDescriptorDependency("VolatileEntryNextEntry", "pointer")]
-    public IReadOnlyList<Entry> Entries { get; private set; }
-
-    [MemberNotNull(nameof(Entries))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial IReadOnlyList<Entry> InitEntries(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.InstMethodHashTable);
         DacEnumerableHash baseHashTable = new(target, address, type);
@@ -29,7 +26,7 @@ internal sealed partial class InstMethodHashTable : IData<InstMethodHashTable>
             TargetPointer methodDescPtr = target.ReadPointer(entry);
             entries.Add(new(methodDescPtr));
         }
-        Entries = entries;
+        return entries;
     }
 
     public readonly struct Entry(TargetPointer value)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/InterpreterRealCodeHeader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/InterpreterRealCodeHeader.cs
@@ -9,15 +9,15 @@ internal sealed partial class InterpreterRealCodeHeader : IData<InterpreterRealC
     [Field] public partial TargetPointer MethodDesc { get; }
     [Field] public partial TargetPointer DebugInfo { get; }
     [Field] public partial TargetPointer GCInfo { get; }
+    [CustomInit(nameof(InitJitEHInfo))] public partial EEILException? JitEHInfo { get; }
 
     [DataDescriptorDependency(nameof(JitEHInfo), "pointer")]
-    public EEILException? JitEHInfo { get; private set; }
-
-    partial void OnInit(Target target, TargetPointer address)
+    private partial EEILException? InitJitEHInfo(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.InterpreterRealCodeHeader);
         TargetPointer jitEHInfoAddr = target.ReadPointerField(address, type, nameof(JitEHInfo));
-        if (jitEHInfoAddr != TargetPointer.Null)
-            JitEHInfo = target.ProcessedData.GetOrAdd<EEILException>(jitEHInfoAddr);
+        return jitEHInfoAddr != TargetPointer.Null
+            ? target.ProcessedData.GetOrAdd<EEILException>(jitEHInfoAddr)
+            : null;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ObjectHandle.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ObjectHandle.cs
@@ -6,16 +6,18 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 [CdacType]
 internal sealed partial class ObjectHandle : IData<ObjectHandle>
 {
-    public TargetPointer Handle { get; private set; } = TargetPointer.Null;
-    public TargetPointer Object { get; private set; } = TargetPointer.Null;
+    [CustomInit(nameof(InitHandle))] public partial TargetPointer Handle { get; }
+    [CustomInit(nameof(InitObject))] public partial TargetPointer Object { get; }
 
-    partial void OnInit(Target target, TargetPointer address)
+    private partial TargetPointer InitHandle(Target target, TargetPointer address)
     {
-        if (address != TargetPointer.Null)
-        {
-            Handle = target.ReadPointer(address);
-            if (Handle != TargetPointer.Null && target.TryReadPointer(Handle, out TargetPointer obj))
-                Object = obj;
-        }
+        return address != TargetPointer.Null ? target.ReadPointer(address) : TargetPointer.Null;
+    }
+
+    private partial TargetPointer InitObject(Target target, TargetPointer address)
+    {
+        return Handle != TargetPointer.Null && target.TryReadPointer(Handle, out TargetPointer obj)
+            ? obj
+            : TargetPointer.Null;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/PrecodeMachineDescriptor.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/PrecodeMachineDescriptor.cs
@@ -9,94 +9,102 @@ internal sealed partial class PrecodeMachineDescriptor : IData<PrecodeMachineDes
     [Field] public partial byte InvalidPrecodeType { get; }
     [Field] public partial byte StubPrecodeType { get; }
     [Field] public partial uint StubCodePageSize { get; }
+    [CustomInit(nameof(InitOffsetOfPrecodeType))] public partial byte? OffsetOfPrecodeType { get; } // Not present for version 3 and above
+    [CustomInit(nameof(InitReadWidthOfPrecodeType))] public partial byte? ReadWidthOfPrecodeType { get; } // Not present for version 3 and above
+    [CustomInit(nameof(InitShiftOfPrecodeType))] public partial byte? ShiftOfPrecodeType { get; } // Not present for version 3 and above
+    [CustomInit(nameof(InitPInvokeImportPrecodeType))] public partial byte? PInvokeImportPrecodeType { get; }
+    [CustomInit(nameof(InitFixupPrecodeType))] public partial byte? FixupPrecodeType { get; }
+    [CustomInit(nameof(InitThisPointerRetBufPrecodeType))] public partial byte? ThisPointerRetBufPrecodeType { get; }
+    [CustomInit(nameof(InitInterpreterPrecodeType))] public partial byte? InterpreterPrecodeType { get; } // May be present for version 3 and above
+    [CustomInit(nameof(InitUMEntryPrecodeType))] public partial byte? UMEntryPrecodeType { get; } // May be present for version 3 and above
+    [CustomInit(nameof(InitDynamicHelperPrecodeType))] public partial byte? DynamicHelperPrecodeType { get; } // May be present for version 3 and above
+    [CustomInit(nameof(InitFixupStubPrecodeSize))] public partial byte? FixupStubPrecodeSize { get; } // Present for version 3 and above
+    [CustomInit(nameof(InitFixupBytes))] public partial byte[]? FixupBytes { get; } // Present for version 3 and above
+    [CustomInit(nameof(InitFixupIgnoredBytes))] public partial byte[]? FixupIgnoredBytes { get; } // Present for version 3 and above
+    [CustomInit(nameof(InitStubPrecodeSize))] public partial byte? StubPrecodeSize { get; } // Present for version 3 and above
+    [CustomInit(nameof(InitStubBytes))] public partial byte[]? StubBytes { get; } // Present for version 3 and above
+    [CustomInit(nameof(InitStubIgnoredBytes))] public partial byte[]? StubIgnoredBytes { get; } // Present for version 3 and above
 
     [DataDescriptorDependency(nameof(OffsetOfPrecodeType), "uint8")]
-    public byte? OffsetOfPrecodeType { get; private set; } // Not present for version 3 and above
+    private partial byte? InitOffsetOfPrecodeType(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(OffsetOfPrecodeType));
 
     [DataDescriptorDependency(nameof(ReadWidthOfPrecodeType), "uint8")]
-    public byte? ReadWidthOfPrecodeType { get; private set; } // Not present for version 3 and above
+    private partial byte? InitReadWidthOfPrecodeType(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(ReadWidthOfPrecodeType));
 
     [DataDescriptorDependency(nameof(ShiftOfPrecodeType), "uint8")]
-    public byte? ShiftOfPrecodeType { get; private set; } // Not present for version 3 and above
+    private partial byte? InitShiftOfPrecodeType(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(ShiftOfPrecodeType));
 
     [DataDescriptorDependency(nameof(PInvokeImportPrecodeType), "uint8")]
-    public byte? PInvokeImportPrecodeType { get; private set; }
+    private partial byte? InitPInvokeImportPrecodeType(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(PInvokeImportPrecodeType));
 
     [DataDescriptorDependency(nameof(FixupPrecodeType), "uint8")]
-    public byte? FixupPrecodeType { get; private set; }
+    private partial byte? InitFixupPrecodeType(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(FixupPrecodeType));
 
     [DataDescriptorDependency(nameof(ThisPointerRetBufPrecodeType), "uint8")]
-    public byte? ThisPointerRetBufPrecodeType { get; private set; }
+    private partial byte? InitThisPointerRetBufPrecodeType(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(ThisPointerRetBufPrecodeType));
 
     [DataDescriptorDependency(nameof(InterpreterPrecodeType), "uint8")]
-    public byte? InterpreterPrecodeType { get; private set; } // May be present for version 3 and above
+    private partial byte? InitInterpreterPrecodeType(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(InterpreterPrecodeType));
 
     [DataDescriptorDependency(nameof(UMEntryPrecodeType), "uint8")]
-    public byte? UMEntryPrecodeType { get; private set; } // May be present for version 3 and above
+    private partial byte? InitUMEntryPrecodeType(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(UMEntryPrecodeType));
 
     [DataDescriptorDependency(nameof(DynamicHelperPrecodeType), "uint8")]
-    public byte? DynamicHelperPrecodeType { get; private set; } // May be present for version 3 and above
+    private partial byte? InitDynamicHelperPrecodeType(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(DynamicHelperPrecodeType));
 
     [DataDescriptorDependency(nameof(FixupStubPrecodeSize), "uint8")]
-    public byte? FixupStubPrecodeSize { get; private set; } // Present for version 3 and above
+    private partial byte? InitFixupStubPrecodeSize(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(FixupStubPrecodeSize));
 
     [DataDescriptorDependency(nameof(FixupStubPrecodeSize), "uint8")]
     [DataDescriptorDependency(nameof(FixupBytes), "uint8[]")]
-    public byte[]? FixupBytes { get; private set; } // Present for version 3 and above
+    private partial byte[]? InitFixupBytes(Target target, TargetPointer address)
+        => MaybeGetBytes(target, address, FixupStubPrecodeSize, nameof(FixupBytes));
 
     [DataDescriptorDependency(nameof(FixupStubPrecodeSize), "uint8")]
     [DataDescriptorDependency(nameof(FixupIgnoredBytes), "uint8[]")]
-    public byte[]? FixupIgnoredBytes { get; private set; } // Present for version 3 and above
+    private partial byte[]? InitFixupIgnoredBytes(Target target, TargetPointer address)
+        => MaybeGetBytes(target, address, FixupStubPrecodeSize, nameof(FixupIgnoredBytes));
 
     [DataDescriptorDependency(nameof(StubPrecodeSize), "uint8")]
-    public byte? StubPrecodeSize { get; private set; } // Present for version 3 and above
+    private partial byte? InitStubPrecodeSize(Target target, TargetPointer address)
+        => MaybeGetByte(target, address, nameof(StubPrecodeSize));
 
     [DataDescriptorDependency(nameof(StubPrecodeSize), "uint8")]
     [DataDescriptorDependency(nameof(StubBytes), "uint8[]")]
-    public byte[]? StubBytes { get; private set; } // Present for version 3 and above
+    private partial byte[]? InitStubBytes(Target target, TargetPointer address)
+        => MaybeGetBytes(target, address, StubPrecodeSize, nameof(StubBytes));
 
     [DataDescriptorDependency(nameof(StubPrecodeSize), "uint8")]
     [DataDescriptorDependency(nameof(StubIgnoredBytes), "uint8[]")]
-    public byte[]? StubIgnoredBytes { get; private set; } // Present for version 3 and above
+    private partial byte[]? InitStubIgnoredBytes(Target target, TargetPointer address)
+        => MaybeGetBytes(target, address, StubPrecodeSize, nameof(StubIgnoredBytes));
 
-    partial void OnInit(Target target, TargetPointer address)
+    private static byte? MaybeGetByte(Target target, TargetPointer address, string fieldName)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.PrecodeMachineDescriptor);
-        if (type.Fields.ContainsKey(nameof(OffsetOfPrecodeType)))
-        {
-            OffsetOfPrecodeType = target.ReadField<byte>(address, type, nameof(OffsetOfPrecodeType));
-            ReadWidthOfPrecodeType = target.ReadField<byte>(address, type, nameof(ReadWidthOfPrecodeType));
-            ShiftOfPrecodeType = target.ReadField<byte>(address, type, nameof(ShiftOfPrecodeType));
-        }
+        return type.Fields.ContainsKey(fieldName)
+            ? target.Read<byte>(address + (ulong)type.Fields[fieldName].Offset)
+            : null;
+    }
 
-        if (type.Fields.ContainsKey(nameof(FixupStubPrecodeSize)))
-        {
-            FixupStubPrecodeSize = target.ReadField<byte>(address, type, nameof(FixupStubPrecodeSize));
-            FixupBytes = new byte[FixupStubPrecodeSize.Value];
-            target.ReadBuffer(address + (ulong)type.Fields[nameof(FixupBytes)].Offset, FixupBytes);
-            FixupIgnoredBytes = new byte[FixupStubPrecodeSize.Value];
-            target.ReadBuffer(address + (ulong)type.Fields[nameof(FixupIgnoredBytes)].Offset, FixupIgnoredBytes);
-        }
+    private static byte[]? MaybeGetBytes(Target target, TargetPointer address, byte? size, string fieldName)
+    {
+        if (size is not byte length)
+            return null;
 
-        if (type.Fields.ContainsKey(nameof(StubPrecodeSize)))
-        {
-            StubPrecodeSize = target.ReadField<byte>(address, type, nameof(StubPrecodeSize));
-            StubBytes = new byte[StubPrecodeSize.Value];
-            target.ReadBuffer(address + (ulong)type.Fields[nameof(StubBytes)].Offset, StubBytes);
-            StubIgnoredBytes = new byte[StubPrecodeSize.Value];
-            target.ReadBuffer(address + (ulong)type.Fields[nameof(StubIgnoredBytes)].Offset, StubIgnoredBytes);
-        }
-
-        PInvokeImportPrecodeType = MaybeGetPrecodeType(target, address, type, nameof(PInvokeImportPrecodeType));
-        FixupPrecodeType = MaybeGetPrecodeType(target, address, type, nameof(FixupPrecodeType));
-        ThisPointerRetBufPrecodeType = MaybeGetPrecodeType(target, address, type, nameof(ThisPointerRetBufPrecodeType));
-        InterpreterPrecodeType = MaybeGetPrecodeType(target, address, type, nameof(InterpreterPrecodeType));
-        UMEntryPrecodeType = MaybeGetPrecodeType(target, address, type, nameof(UMEntryPrecodeType));
-        DynamicHelperPrecodeType = MaybeGetPrecodeType(target, address, type, nameof(DynamicHelperPrecodeType));
-
-        static byte? MaybeGetPrecodeType(Target target, TargetPointer address, Target.TypeInfo type, string fieldName)
-            => type.Fields.ContainsKey(fieldName)
-                ? target.Read<byte>(address + (ulong)type.Fields[fieldName].Offset)
-                : null;
+        Target.TypeInfo type = target.GetTypeInfo(DataType.PrecodeMachineDescriptor);
+        byte[] bytes = new byte[length];
+        target.ReadBuffer(address + (ulong)type.Fields[fieldName].Offset, bytes);
+        return bytes;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/RCW.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/RCW.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
@@ -20,11 +19,10 @@ internal sealed partial class RCW : IData<RCW>
     [Field] public partial TargetPointer CreatorThread { get; }
     [Field] public partial uint RefCount { get; }
     [Field] public partial TargetPointer UnknownPointer { get; }
-    [DataDescriptorDependency(nameof(InterfaceEntries), "pointer")]
-    public IReadOnlyList<Data.InterfaceEntry> InterfaceEntries { get; private set; } = [];
+    [CustomInit(nameof(InitInterfaceEntries))] public partial IReadOnlyList<Data.InterfaceEntry> InterfaceEntries { get; }
 
-    [MemberNotNull(nameof(InterfaceEntries))]
-    partial void OnInit(Target target, TargetPointer address)
+    [DataDescriptorDependency(nameof(InterfaceEntries), "pointer")]
+    private partial IReadOnlyList<Data.InterfaceEntry> InitInterfaceEntries(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.RCW);
         TargetPointer interfaceEntriesAddr = address + (ulong)type.Fields[nameof(InterfaceEntries)].Offset;
@@ -39,6 +37,6 @@ internal sealed partial class RCW : IData<RCW>
             entries.Add(target.ProcessedData.GetOrAdd<Data.InterfaceEntry>(entryAddress));
         }
 
-        InterfaceEntries = entries;
+        return entries;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/RangeSectionFragment.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/RangeSectionFragment.cs
@@ -13,15 +13,15 @@ internal sealed partial class RangeSectionFragment : IData<RangeSectionFragment>
     /// <summary>
     /// The Next pointer uses the low bit as a collectible flag
     /// (see <c>RangeSectionFragmentPointer</c> in codeman.h).
-    /// The OnInit handler strips it to get the actual address.
+    /// The initializer strips it to get the actual address.
     /// </summary>
-    [DataDescriptorDependency(nameof(Next), "pointer")]
-    public TargetPointer Next { get; private set; }
+    [CustomInit(nameof(InitNext))] public partial TargetPointer Next { get; }
 
-    partial void OnInit(Target target, TargetPointer address)
+    [DataDescriptorDependency(nameof(Next), "pointer")]
+    private partial TargetPointer InitNext(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.RangeSectionFragment);
-        Next = target.ReadPointerField(address, type, nameof(Next)) & ~1ul;
+        return target.ReadPointerField(address, type, nameof(Next)) & ~1ul;
     }
 
     public bool Contains(TargetCodePointer address)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ReadyToRunCoreHeader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ReadyToRunCoreHeader.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
@@ -10,10 +9,9 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 internal sealed partial class ReadyToRunCoreHeader : IData<ReadyToRunCoreHeader>
 {
     [Field] public partial uint NumberOfSections { get; }
-    public IReadOnlyList<ReadyToRunSection> Sections { get; private set; } = [];
+    [CustomInit(nameof(InitSections))] public partial IReadOnlyList<ReadyToRunSection> Sections { get; }
 
-    [MemberNotNull(nameof(Sections))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial IReadOnlyList<ReadyToRunSection> InitSections(Target target, TargetPointer address)
     {
         uint headerSize = GetSize(target);
         uint sectionSize = ReadyToRunSection.GetSize(target);
@@ -24,6 +22,6 @@ internal sealed partial class ReadyToRunCoreHeader : IData<ReadyToRunCoreHeader>
             sections.Add(target.ProcessedData.GetOrAdd<ReadyToRunSection>(sectionAddress));
         }
 
-        Sections = sections;
+        return sections;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ReadyToRunInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ReadyToRunInfo.cs
@@ -21,41 +21,48 @@ internal sealed partial class ReadyToRunInfo : IData<ReadyToRunInfo>
 
     // WASM-only: base virtual IP for this module's R2R function table (m_minVirtualIP).
     [Field] public partial TargetPointer? MinVirtualIP { get; }
+    [CustomInit(nameof(InitRuntimeFunctions))] public partial TargetPointer RuntimeFunctions { get; }
+    [CustomInit(nameof(InitHotColdMap))] public partial TargetPointer HotColdMap { get; }
+    [CustomInit(nameof(InitImportSections))] public partial TargetPointer ImportSections { get; }
+    [CustomInit(nameof(InitEntryPointToMethodDescMap))] public partial TargetPointer EntryPointToMethodDescMap { get; }
 
     [DataDescriptorDependency(nameof(NumRuntimeFunctions), "uint32")]
     [DataDescriptorDependency(nameof(RuntimeFunctions), "pointer")]
-    public TargetPointer RuntimeFunctions { get; private set; }
+    private partial TargetPointer InitRuntimeFunctions(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.ReadyToRunInfo);
+        return NumRuntimeFunctions > 0
+            ? target.ReadPointerField(address, type, nameof(RuntimeFunctions))
+            : TargetPointer.Null;
+    }
 
     [DataDescriptorDependency(nameof(NumHotColdMap), "uint32")]
     [DataDescriptorDependency(nameof(HotColdMap), "pointer")]
-    public TargetPointer HotColdMap { get; private set; }
+    private partial TargetPointer InitHotColdMap(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.ReadyToRunInfo);
+        Debug.Assert(NumHotColdMap % 2 == 0, "Hot/cold map should have an even number of entries (pairs of hot/cold runtime function indexes)");
+        return NumHotColdMap > 0
+            ? target.ReadPointerField(address, type, nameof(HotColdMap))
+            : TargetPointer.Null;
+    }
 
     [DataDescriptorDependency(nameof(NumImportSections), "uint32")]
     [DataDescriptorDependency(nameof(ImportSections), "pointer")]
-    public TargetPointer ImportSections { get; private set; }
+    private partial TargetPointer InitImportSections(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.ReadyToRunInfo);
+        return NumImportSections > 0
+            ? target.ReadPointer(address + (ulong)type.Fields[nameof(ImportSections)].Offset)
+            : TargetPointer.Null;
+    }
 
     [DataDescriptorDependency(nameof(CompositeInfo), "pointer")]
     [DataDescriptorDependency(nameof(EntryPointToMethodDescMap), "HashMap")]
-    public TargetPointer EntryPointToMethodDescMap { get; private set; }
-
-    partial void OnInit(Target target, TargetPointer address)
+    private partial TargetPointer InitEntryPointToMethodDescMap(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.ReadyToRunInfo);
-
-        RuntimeFunctions = NumRuntimeFunctions > 0
-            ? target.ReadPointerField(address, type, nameof(RuntimeFunctions))
-            : TargetPointer.Null;
-
-        Debug.Assert(NumHotColdMap % 2 == 0, "Hot/cold map should have an even number of entries (pairs of hot/cold runtime function indexes)");
-        HotColdMap = NumHotColdMap > 0
-            ? target.ReadPointerField(address, type, nameof(HotColdMap))
-            : TargetPointer.Null;
-
-        ImportSections = NumImportSections > 0
-            ? target.ReadPointer(address + (ulong)type.Fields[nameof(ImportSections)].Offset)
-            : TargetPointer.Null;
-
         // Map is from the composite info pointer (set to itself for non-multi-assembly composite images)
-        EntryPointToMethodDescMap = CompositeInfo + (ulong)type.Fields[nameof(EntryPointToMethodDescMap)].Offset;
+        return CompositeInfo + (ulong)type.Fields[nameof(EntryPointToMethodDescMap)].Offset;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SyncBlock.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SyncBlock.cs
@@ -9,32 +9,36 @@ internal sealed partial class SyncBlock : IData<SyncBlock>
     [Field] public partial uint ThinLock { get; }
     [Field] public partial TargetPointer LinkNext { get; }
     [Field] public partial uint HashCode { get; }
+    [CustomInit(nameof(InitInteropInfo))] public partial InteropSyncBlockInfo? InteropInfo { get; }
+    [CustomInit(nameof(InitLock))] public partial ObjectHandle? Lock { get; }
+    [CustomInit(nameof(InitEnCInfo))] public partial TargetPointer? EnCInfo { get; }
 
     [DataDescriptorDependency(nameof(InteropInfo), "pointer")]
-    public InteropSyncBlockInfo? InteropInfo { get; private set; }
-
-    [DataDescriptorDependency(nameof(Lock), "ObjectHandle")]
-    public ObjectHandle? Lock { get; private set; }
-
-    [DataDescriptorDependency(nameof(EnCInfo), "pointer")]
-    public TargetPointer? EnCInfo { get; private set; }
-
-    partial void OnInit(Target target, TargetPointer address)
+    private partial InteropSyncBlockInfo? InitInteropInfo(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.SyncBlock);
         TargetPointer interopInfoPointer = target.ReadPointerField(address, type, nameof(InteropInfo));
-        if (interopInfoPointer != TargetPointer.Null)
-            InteropInfo = target.ProcessedData.GetOrAdd<InteropSyncBlockInfo>(interopInfoPointer);
+        return interopInfoPointer != TargetPointer.Null
+            ? target.ProcessedData.GetOrAdd<InteropSyncBlockInfo>(interopInfoPointer)
+            : null;
+    }
 
+    [DataDescriptorDependency(nameof(Lock), "ObjectHandle")]
+    private partial ObjectHandle? InitLock(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.SyncBlock);
         ObjectHandle lockHandle = target.ReadDataField<ObjectHandle>(address, type, nameof(Lock));
-        if (lockHandle.Handle != TargetPointer.Null)
-            Lock = lockHandle;
+        return lockHandle.Handle != TargetPointer.Null ? lockHandle : null;
+    }
 
-        if (type.Fields.ContainsKey(nameof(EnCInfo)))
-        {
-            TargetPointer encInfoPointer = target.ReadPointerField(address, type, nameof(EnCInfo));
-            if (encInfoPointer != TargetPointer.Null)
-                EnCInfo = encInfoPointer;
-        }
+    [DataDescriptorDependency(nameof(EnCInfo), "pointer")]
+    private partial TargetPointer? InitEnCInfo(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.SyncBlock);
+        if (!type.Fields.ContainsKey(nameof(EnCInfo)))
+            return null;
+
+        TargetPointer encInfoPointer = target.ReadPointerField(address, type, nameof(EnCInfo));
+        return encInfoPointer != TargetPointer.Null ? encInfoPointer : null;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SyncTableEntry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SyncTableEntry.cs
@@ -6,22 +6,27 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 [CdacType(nameof(DataType.SyncTableEntry))]
 internal sealed partial class SyncTableEntry : IData<SyncTableEntry>
 {
+    [CustomInit(nameof(InitSyncBlock))] public partial SyncBlock? SyncBlock { get; }
+    [CustomInit(nameof(InitObject))] public partial Object? Object { get; }
+
     [DataDescriptorDependency(nameof(SyncBlock), "pointer")]
-    public SyncBlock? SyncBlock { get; private set; }
-
-    [DataDescriptorDependency(nameof(Object), "pointer")]
-    public Object? Object { get; private set; }
-
-    partial void OnInit(Target target, TargetPointer address)
+    private partial SyncBlock? InitSyncBlock(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.SyncTableEntry);
-
         TargetPointer syncBlockPointer = target.ReadPointerField(address, type, nameof(SyncBlock));
-        if (syncBlockPointer != TargetPointer.Null)
-            SyncBlock = target.ProcessedData.GetOrAdd<SyncBlock>(syncBlockPointer);
+        return syncBlockPointer != TargetPointer.Null
+            ? target.ProcessedData.GetOrAdd<SyncBlock>(syncBlockPointer)
+            : null;
+    }
 
+    [DataDescriptorDependency(nameof(Object), "pointer")]
+    private partial Object? InitObject(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.SyncTableEntry);
         TargetPointer objectPointer = target.ReadPointerField(address, type, nameof(Object));
-        if (objectPointer != TargetPointer.Null && (objectPointer & 1) == 0) // Defensive check: if the lowest bit is set, this is a free sync block entry and the pointer is not valid.
-            Object = target.ProcessedData.GetOrAdd<Object>(objectPointer);
+        // Defensive check: if the lowest bit is set, this is a free sync block entry and the pointer is not valid.
+        return objectPointer != TargetPointer.Null && (objectPointer & 1) == 0
+            ? target.ProcessedData.GetOrAdd<Object>(objectPointer)
+            : null;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TableRW.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TableRW.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+[CdacType(nameof(DataType.TableRW))]
+internal sealed partial class TableRW : IData<TableRW>
+{
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TableSegment.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TableSegment.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
 [CdacType(nameof(DataType.TableSegment))]
@@ -12,33 +10,40 @@ internal sealed partial class TableSegment : IData<TableSegment>
 
     [FieldAddress]
     public partial TargetPointer RgValue { get; }
+    [CustomInit(nameof(InitRgTail))] public partial byte[] RgTail { get; }
+    [CustomInit(nameof(InitRgAllocation))] public partial byte[] RgAllocation { get; }
+    [CustomInit(nameof(InitRgUserData))] public partial byte[] RgUserData { get; }
 
     [DataDescriptorDependency(nameof(RgTail), "uint8[]")]
-    public byte[] RgTail { get; private set; }
+    private partial byte[] InitRgTail(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.TableSegment);
+        uint handleMaxInternalTypes = target.ReadGlobal<uint>(Constants.Globals.HandleMaxInternalTypes);
+        TargetPointer rgTailPtr = address + (ulong)type.Fields[nameof(RgTail)].Offset;
+        byte[] rgTail = new byte[handleMaxInternalTypes];
+        target.ReadBuffer(rgTailPtr, rgTail);
+        return rgTail;
+    }
 
     [DataDescriptorDependency(nameof(RgAllocation), "uint8[]")]
-    public byte[] RgAllocation { get; private set; }
-
-    [DataDescriptorDependency(nameof(RgUserData), "uint8[]")]
-    public byte[] RgUserData { get; private set; }
-
-    [MemberNotNull(nameof(RgTail), nameof(RgAllocation), nameof(RgUserData))]
-    partial void OnInit(Target target, TargetPointer address)
+    private partial byte[] InitRgAllocation(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.TableSegment);
         uint handleBlocksPerSegment = target.ReadGlobal<uint>(Constants.Globals.HandleBlocksPerSegment);
-        uint handleMaxInternalTypes = target.ReadGlobal<uint>(Constants.Globals.HandleMaxInternalTypes);
-
-        TargetPointer rgTailPtr = address + (ulong)type.Fields[nameof(RgTail)].Offset;
-        RgTail = new byte[handleMaxInternalTypes];
-        target.ReadBuffer(rgTailPtr, RgTail);
-
         TargetPointer rgAllocationPtr = address + (ulong)type.Fields[nameof(RgAllocation)].Offset;
-        RgAllocation = new byte[handleBlocksPerSegment];
-        target.ReadBuffer(rgAllocationPtr, RgAllocation);
+        byte[] rgAllocation = new byte[handleBlocksPerSegment];
+        target.ReadBuffer(rgAllocationPtr, rgAllocation);
+        return rgAllocation;
+    }
 
+    [DataDescriptorDependency(nameof(RgUserData), "uint8[]")]
+    private partial byte[] InitRgUserData(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.TableSegment);
+        uint handleBlocksPerSegment = target.ReadGlobal<uint>(Constants.Globals.HandleBlocksPerSegment);
         TargetPointer rgUserDataPtr = address + (ulong)type.Fields[nameof(RgUserData)].Offset;
-        RgUserData = new byte[handleBlocksPerSegment];
-        target.ReadBuffer(rgUserDataPtr, RgUserData);
+        byte[] rgUserData = new byte[handleBlocksPerSegment];
+        target.ReadBuffer(rgUserDataPtr, rgUserData);
+        return rgUserData;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Thread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Thread.cs
@@ -29,22 +29,24 @@ internal sealed partial class Thread : IData<Thread>
     [Field] public partial TargetPointer DebuggerFilterContext { get; }
     [Field] public partial uint InteropDebuggingHijacked { get; }
     [Field] public partial ObjectHandle CurrentCustomDebuggerNotification { get; }
-
-    [DataDescriptorDependency(nameof(RuntimeThreadLocals), "pointer")]
-    public RuntimeThreadLocals? RuntimeThreadLocals { get; private set; }
+    [CustomInit(nameof(InitRuntimeThreadLocals))] public partial RuntimeThreadLocals? RuntimeThreadLocals { get; }
 
     // Descriptor-optional: not present on all platforms.
-    [DataDescriptorDependency(nameof(ThreadHandle), "pointer")]
-    public TargetPointer ThreadHandle { get; private set; }
+    [CustomInit(nameof(InitThreadHandle))] public partial TargetPointer ThreadHandle { get; }
 
-    partial void OnInit(Target target, TargetPointer address)
+    [DataDescriptorDependency(nameof(RuntimeThreadLocals), "pointer")]
+    private partial RuntimeThreadLocals? InitRuntimeThreadLocals(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.Thread);
-
         TargetPointer rtlPointer = target.ReadPointerField(address, type, nameof(RuntimeThreadLocals));
-        if (rtlPointer != TargetPointer.Null)
-            RuntimeThreadLocals = target.ProcessedData.GetOrAdd<RuntimeThreadLocals>(rtlPointer);
-
-        ThreadHandle = target.ReadPointerFieldOrNull(address, type, nameof(ThreadHandle));
+        return rtlPointer != TargetPointer.Null
+            ? target.ProcessedData.GetOrAdd<RuntimeThreadLocals>(rtlPointer)
+            : null;
+    }
+    [DataDescriptorDependency(nameof(ThreadHandle), "pointer")]
+    private partial TargetPointer InitThreadHandle(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.Thread);
+        return target.ReadPointerFieldOrNull(address, type, nameof(ThreadHandle));
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TypeDesc.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/TypeDesc.cs
@@ -12,33 +12,33 @@ internal sealed partial class TypeDesc : IData<TypeDesc>
 [CdacType(nameof(DataType.ParamTypeDesc))]
 internal sealed partial class ParamTypeDesc : IData<ParamTypeDesc>
 {
-    public uint TypeAndFlags { get; private set; }
+    [CustomInit(nameof(InitTypeAndFlags))] public partial uint TypeAndFlags { get; }
     [Field] public partial TargetPointer TypeArg { get; }
 
-    partial void OnInit(Target target, TargetPointer address)
+    private partial uint InitTypeAndFlags(Target target, TargetPointer address)
     {
-        TypeAndFlags = target.ProcessedData.GetOrAdd<TypeDesc>(address).TypeAndFlags;
+        return target.ProcessedData.GetOrAdd<TypeDesc>(address).TypeAndFlags;
     }
 }
 
 [CdacType(nameof(DataType.TypeVarTypeDesc))]
 internal sealed partial class TypeVarTypeDesc : IData<TypeVarTypeDesc>
 {
-    public uint TypeAndFlags { get; private set; }
+    [CustomInit(nameof(InitTypeAndFlags))] public partial uint TypeAndFlags { get; }
     [Field] public partial TargetPointer Module { get; }
     [Field] public partial uint Token { get; }
     [Field] public partial uint Index { get; }
 
-    partial void OnInit(Target target, TargetPointer address)
+    private partial uint InitTypeAndFlags(Target target, TargetPointer address)
     {
-        TypeAndFlags = target.ProcessedData.GetOrAdd<TypeDesc>(address).TypeAndFlags;
+        return target.ProcessedData.GetOrAdd<TypeDesc>(address).TypeAndFlags;
     }
 }
 
 [CdacType(nameof(DataType.FnPtrTypeDesc))]
 internal sealed partial class FnPtrTypeDesc : IData<FnPtrTypeDesc>
 {
-    public uint TypeAndFlags { get; private set; }
+    [CustomInit(nameof(InitTypeAndFlags))] public partial uint TypeAndFlags { get; }
     [Field] public partial uint NumArgs { get; }
     [Field] public partial uint CallConv { get; }
 
@@ -47,8 +47,8 @@ internal sealed partial class FnPtrTypeDesc : IData<FnPtrTypeDesc>
 
     [Field] public partial TargetPointer LoaderModule { get; }
 
-    partial void OnInit(Target target, TargetPointer address)
+    private partial uint InitTypeAndFlags(Target target, TargetPointer address)
     {
-        TypeAndFlags = target.ProcessedData.GetOrAdd<TypeDesc>(address).TypeAndFlags;
+        return target.ProcessedData.GetOrAdd<TypeDesc>(address).TypeAndFlags;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/UnwindInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/UnwindInfo.cs
@@ -6,23 +6,25 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 [CdacType(nameof(DataType.UnwindInfo))]
 internal sealed partial class UnwindInfo : IData<UnwindInfo>
 {
+    [CustomInit(nameof(InitFunctionLength))] public partial uint? FunctionLength { get; }
+    [CustomInit(nameof(InitHeader))] public partial uint? Header { get; }
+
     [DataDescriptorDependency(nameof(FunctionLength), "uint32")]
-    public uint? FunctionLength { get; private set; }
-
-    public uint? Header { get; private set; }
-
-    partial void OnInit(Target target, TargetPointer address)
+    private partial uint? InitFunctionLength(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.UnwindInfo);
-        if (type.Fields.ContainsKey(nameof(FunctionLength)))
-        {
-            // The unwind info contains the function length on some platforms (x86)
-            FunctionLength = target.ReadField<uint>(address, type, nameof(FunctionLength));
-        }
-        else
-        {
-            // Otherwise, it starts with a bitfield header
-            Header = target.Read<uint>(address);
-        }
+        // The unwind info contains the function length on some platforms (x86)
+        return type.Fields.ContainsKey(nameof(FunctionLength))
+            ? target.ReadField<uint>(address, type, nameof(FunctionLength))
+            : null;
+    }
+
+    private partial uint? InitHeader(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.UnwindInfo);
+        // When the function length is absent, the unwind info starts with a bitfield header
+        return type.Fields.ContainsKey(nameof(FunctionLength))
+            ? null
+            : target.Read<uint>(address);
     }
 }

--- a/src/native/managed/cdac/gen/Emitter.cs
+++ b/src/native/managed/cdac/gen/Emitter.cs
@@ -171,7 +171,7 @@ internal static class Emitter
     {
         foreach (MemberModel member in model.Members)
         {
-            if (member.Kind != MemberKind.Field || member.Setter != SetterKind.Writable)
+            if (member.Kind != MemberKind.Field || !member.Writable)
                 continue;
 
             if (member.ReadKind != FieldReadKind.Primitive
@@ -215,14 +215,6 @@ internal static class Emitter
 
     private static void EmitConstructor(StringBuilder sb, CdacTypeModel model, bool hasInstanceMembers, bool needsDescriptor)
     {
-        // Hook: a `partial void OnInit(Target, TargetPointer)` the user may
-        // implement to perform reads that don't fit the declarative attribute
-        // surface (e.g. variable-count loops, raw-offset reads, or values
-        // computed from other fields). If no implementation is provided the
-        // C# compiler elides both the call site and the signature.
-        sb.AppendLine($"    partial void OnInit({Target} target, {TargetPointer} address);");
-        sb.AppendLine();
-
         sb.AppendLine($"    public {model.ClassName}({Target} target, {TargetPointer} address)");
         sb.AppendLine("    {");
         sb.AppendLine("        Address = address;");
@@ -237,8 +229,6 @@ internal static class Emitter
             sb.AppendLine("        _layouts = LayoutSet.Resolve(target, _typeNames);");
         }
 
-        sb.AppendLine();
-        sb.AppendLine("        OnInit(target, address);");
         sb.AppendLine("    }");
         sb.AppendLine();
     }
@@ -268,7 +258,7 @@ internal static class Emitter
                     EmitLayoutRead(read, member, valueField,
                         ReadExpression(member, "b", "t", "n", Shorten(member.DataTypeArgumentFqn)),
                         $"default({Shorten(member.PropertyOrReturnTypeFqn)})");
-                EmitLazyProperty(sb, member, read, emitSetter: member.Setter != SetterKind.None);
+                EmitLazyProperty(sb, member, read, emitSetter: member.Writable);
                 break;
             case MemberKind.FieldAddress:
                 EmitLayoutRead(read, member, valueField, "b + (ulong)t.Fields[n].Offset", "null");
@@ -276,6 +266,18 @@ internal static class Emitter
                 break;
             case MemberKind.InstanceDataStart:
                 read.Add($"                {valueField} = Address + _layouts.InstanceSize;");
+                EmitLazyProperty(sb, member, read, emitSetter: false);
+                break;
+            case MemberKind.CustomInit:
+                string initializerName = member.CustomInitializerName!;
+                // The generator declares a partial init method the author
+                // implements; the getter calls it lazily on first access. The
+                // suppression is required because simple init methods read only
+                // from the target and never touch instance state, which would
+                // otherwise trip CA1822.
+                sb.AppendLine($"    [System.Diagnostics.CodeAnalysis.SuppressMessage(\"Performance\", \"CA1822:Mark members as static\", Justification = \"Generated lazy initializer; may read instance members.\")]");
+                sb.AppendLine($"    private partial {Shorten(member.PropertyOrReturnTypeFqn)} {initializerName}({Target} target, {TargetPointer} address);");
+                read.Add($"                {valueField} = {initializerName}(_target, Address);");
                 EmitLazyProperty(sb, member, read, emitSetter: false);
                 break;
         }
@@ -344,7 +346,12 @@ internal static class Emitter
 
     private static void EmitDataDescriptorDependencyAttribute(StringBuilder sb, MemberModel member)
     {
-        if (member.Kind == MemberKind.InstanceDataStart)
+        if (member.Kind is MemberKind.CustomInit)
+        {
+            // The attributes on the user-declared partial property are part of
+            // the combined property symbol; do not duplicate them here.
+        }
+        else if (member.Kind == MemberKind.InstanceDataStart)
         {
             sb.AppendLine("    [UsesDataDescriptorTypeSize]");
         }
@@ -363,14 +370,19 @@ internal static class Emitter
     /// </summary>
     private static void EmitEnsureAllFieldsRead(StringBuilder sb, CdacTypeModel model)
     {
-        EmitEnsureAllFieldsReadDependencyAttributes(sb, model);
+        // Descriptor attributes short-circuit body analysis in CdacUsageGraph.
+        // A custom initializer can also read globals, call helpers, and access
+        // other Data properties, so let the analyzer walk this method's body.
+        if (!model.Members.Any(member => member.Kind == MemberKind.CustomInit))
+            EmitEnsureAllFieldsReadDependencyAttributes(sb, model);
         sb.AppendLine("    void global::Microsoft.Diagnostics.DataContractReader.Data.IReadableData.EnsureAllFieldsRead()");
         sb.AppendLine("    {");
         foreach (MemberModel member in model.Members)
         {
             if (member.Kind == MemberKind.Field
                 || member.Kind == MemberKind.FieldAddress
-                || member.Kind == MemberKind.InstanceDataStart)
+                || member.Kind == MemberKind.InstanceDataStart
+                || member.Kind == MemberKind.CustomInit)
             {
                 sb.AppendLine($"        _ = {member.Name};");
             }
@@ -463,7 +475,8 @@ internal static class Emitter
         {
             if (member.Kind == MemberKind.Field
                 || member.Kind == MemberKind.FieldAddress
-                || member.Kind == MemberKind.InstanceDataStart)
+                || member.Kind == MemberKind.InstanceDataStart
+                || member.Kind == MemberKind.CustomInit)
                 return true;
         }
 

--- a/src/native/managed/cdac/gen/Model.cs
+++ b/src/native/managed/cdac/gen/Model.cs
@@ -40,23 +40,10 @@ internal enum MemberKind
     Field,
     FieldAddress,
     InstanceDataStart,
+    CustomInit,
     StaticAddress,
     StaticReference,
     ThreadStaticAddress,
-}
-
-/// <summary>
-/// The setter a generated <c>[Field]</c> property exposes. A field is either
-/// read-only, privately settable (populated internally, e.g. by <c>OnInit</c>
-/// or a hand-written constructor), or writable (a <c>Write{Name}</c> method
-/// writes the value back to the target). A <c>[Field]</c> never exposes a
-/// public setter -- mutation always goes through <c>Write{Name}</c>.
-/// </summary>
-internal enum SetterKind
-{
-    None,
-    Private,
-    Writable,
 }
 
 /// <summary>
@@ -75,9 +62,10 @@ internal sealed record MemberModel(
     bool IsNullable,
     int? RawOffset,
     bool LittleEndian,
-    SetterKind Setter,
+    bool Writable,
     string? BoolUnderlyingType,
-    EquatableArray<string> Names) : IEquatable<MemberModel>;
+    EquatableArray<string> Names,
+    string? CustomInitializerName = null) : IEquatable<MemberModel>;
 
 /// <summary>
 /// A <c>[CdacType]</c>-annotated class to be emitted.

--- a/src/native/managed/cdac/gen/Parser.cs
+++ b/src/native/managed/cdac/gen/Parser.cs
@@ -16,6 +16,7 @@ internal static class Parser
     public const string RawOffsetAttributeFqn = AttrNs + ".RawOffsetAttribute";
     public const string FieldAddressAttributeFqn = AttrNs + ".FieldAddressAttribute";
     public const string InstanceDataStartAttributeFqn = AttrNs + ".InstanceDataStartAttribute";
+    public const string CustomInitAttributeFqn = AttrNs + ".CustomInitAttribute";
     public const string StaticAddressAttributeFqn = AttrNs + ".StaticAddressAttribute";
     public const string StaticReferenceAttributeFqn = AttrNs + ".StaticReferenceAttribute";
     public const string ThreadStaticAddressAttributeFqn = AttrNs + ".ThreadStaticAddressAttribute";
@@ -181,6 +182,7 @@ internal static class Parser
         AttributeData? fieldOffsetAttr = null;
         AttributeData? addrAttr = null;
         AttributeData? startAttr = null;
+        AttributeData? customInitAttr = null;
 
         foreach (AttributeData a in prop.GetAttributes())
         {
@@ -201,11 +203,38 @@ internal static class Parser
             {
                 startAttr = a;
             }
+            else if (fqn == CustomInitAttributeFqn)
+            {
+                customInitAttr = a;
+            }
         }
 
-        if (fieldAttr is null && fieldOffsetAttr is null && addrAttr is null && startAttr is null)
+        if (fieldAttr is null && fieldOffsetAttr is null && addrAttr is null && startAttr is null && customInitAttr is null)
         {
             return false;
+        }
+
+        if (customInitAttr is not null)
+        {
+            string customInitializerName =
+                (string)customInitAttr.ConstructorArguments[0].Value!;
+            model = new MemberModel(
+                Name: prop.Name,
+                Kind: MemberKind.CustomInit,
+                DescriptorOrFieldName: prop.Name,
+                DescriptorNativeType: null,
+                PropertyOrReturnTypeFqn: prop.Type.ToDisplayString(s_propertyTypeFormat),
+                ReadKind: FieldReadKind.Primitive,
+                DataTypeArgumentFqn: null,
+                IsOptional: false,
+                IsNullable: false,
+                RawOffset: null,
+                LittleEndian: false,
+                Writable: false,
+                BoolUnderlyingType: null,
+                Names: EquatableArray<string>.FromEnumerable(new[] { prop.Name }),
+                CustomInitializerName: customInitializerName);
+            return true;
         }
 
         if (fieldOffsetAttr is not null)
@@ -227,7 +256,7 @@ internal static class Parser
                 IsNullable: isNullable,
                 RawOffset: offset,
                 LittleEndian: littleEndian,
-                Setter: SetterKind.None,
+                Writable: false,
                 BoolUnderlyingType: null,
                 Names: EquatableArray<string>.FromEnumerable(new[] { prop.Name }));
             return true;
@@ -247,15 +276,9 @@ internal static class Parser
             (FieldReadKind readKind, string? dataTypeArg, bool isNullable) = ClassifyFieldRead(prop, isPointer);
             string fqnType = prop.Type.ToDisplayString(s_propertyTypeFormat);
 
-            // A [Field] property is read-only, privately settable, or writable.
-            // It never exposes a public setter -- mutation goes through the
-            // generated Write{Name} method. The generated setter is always
-            // private, so a public setter in the declaration is a compile error
-            // (accessibility mismatch on the partial property).
+            // A writable [Field] exposes a private setter used by the generated
+            // Write{Name} method to update the memoized value.
             bool writable = GetNamedBool(fieldAttr, "Writable");
-            SetterKind setter = writable
-                ? SetterKind.Writable
-                : prop.SetMethod is not null ? SetterKind.Private : SetterKind.None;
 
             // DescriptorOrFieldName is retained for static-accessor emit paths.
             // For [Field] codegen, only the Names array is used.
@@ -273,7 +296,7 @@ internal static class Parser
                 IsNullable: isNullable,
                 RawOffset: null,
                 LittleEndian: false,
-                Setter: setter,
+                Writable: writable,
                 BoolUnderlyingType: boolUnderlyingType,
                 Names: ComputeFieldNames(prop.Name, rawNames, usePropertyName));
             return true;
@@ -302,7 +325,7 @@ internal static class Parser
                 IsNullable: isNullable,
                 RawOffset: null,
                 LittleEndian: false,
-                Setter: SetterKind.None,
+                Writable: false,
                 BoolUnderlyingType: null,
                 Names: ComputeFieldNames(prop.Name, rawNames, usePropertyName));
             return true;
@@ -322,7 +345,7 @@ internal static class Parser
                 IsNullable: false,
                 RawOffset: null,
                 LittleEndian: false,
-                Setter: SetterKind.None,
+                Writable: false,
                 BoolUnderlyingType: null,
                 Names: EquatableArray<string>.FromEnumerable(new[] { prop.Name }));
             return true;
@@ -366,7 +389,7 @@ internal static class Parser
             IsNullable: false,
             RawOffset: null,
             LittleEndian: false,
-            Setter: SetterKind.None,
+            Writable: false,
             BoolUnderlyingType: null,
             Names: EquatableArray<string>.FromEnumerable(new[] { fieldName }));
         return true;

--- a/src/native/managed/cdac/tests/DataGenerator/DataGeneratorTests.cs
+++ b/src/native/managed/cdac/tests/DataGenerator/DataGeneratorTests.cs
@@ -103,6 +103,34 @@ public class DataGeneratorTests
         Assert.False(UsesTypeSize(ensureAllFieldsRead));
     }
 
+    [Fact]
+    public void EnsureAllFieldsReadWithCustomInitHasNoShortCircuitingDependencies()
+    {
+        InterfaceMapping map = typeof(TestCustomInit).GetInterfaceMap(typeof(IReadableData));
+        int index = Array.IndexOf(map.InterfaceMethods, typeof(IReadableData).GetMethod(nameof(IReadableData.EnsureAllFieldsRead))!);
+        MethodInfo ensureAllFieldsRead = map.TargetMethods[index];
+
+        Assert.Empty(Dependencies(ensureAllFieldsRead));
+        Assert.False(UsesTypeSize(ensureAllFieldsRead));
+    }
+
+    [Fact]
+    public void CustomInitNamesInitializerWithDependencyMetadata()
+    {
+        PropertyInfo property = typeof(TestCustomInit).GetProperty(nameof(TestCustomInit.Doubled))!;
+        CustomInitAttribute customInit = property.GetCustomAttribute<CustomInitAttribute>()!;
+        Assert.Equal("InitDoubled", customInit.MethodName);
+
+        MethodInfo initializer = typeof(TestCustomInit).GetMethod(
+            "InitDoubled",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Assert.Equal(
+            [(FieldName: "CustomValue", NativeType: "uint32", TypeName: "CustomDescriptor")],
+            Dependencies(initializer)
+                .Select(attribute => (attribute.FieldName, attribute.NativeType, attribute.TypeName)));
+        Assert.True(UsesTypeSize(initializer));
+    }
+
     // ================================================================
     // Single-source baselines
     // ================================================================
@@ -110,7 +138,7 @@ public class DataGeneratorTests
     [Fact]
     public void Native_Baseline_Reads()
     {
-        var target = new TestTarget()
+        TestTarget target = new TestTarget()
             .AddNativeType("TestNative", size: 16,
                 ("A", 0),
                 ("B", 8))
@@ -422,6 +450,31 @@ public class DataGeneratorTests
 
         Assert.Equal(5u, t.Required);
         Assert.Null(t.Optional);
+    }
+
+    // ================================================================
+    // CustomInit -- author-provided lazy initializer
+    // ================================================================
+
+    [Fact]
+    public void CustomInit_ComputesLazilyAndMemoizes()
+    {
+        TestTarget target = new TestTarget()
+            .AddNativeType("TestCustomInit", size: 4, ("Raw", 0))
+            .Allocate(InstanceAddr, 4, (0, U32(21u)));
+
+        TestCustomInit.InitDoubledCallCount = 0;
+        TestCustomInit t = Materialize<TestCustomInit>(target, InstanceAddr);
+
+        // Constructing does not run the initializer (it is lazy).
+        Assert.Equal(0, TestCustomInit.InitDoubledCallCount);
+
+        Assert.Equal(42u, t.Doubled);
+        Assert.Equal(1, TestCustomInit.InitDoubledCallCount);
+
+        // Second access is memoized -- the initializer does not run again.
+        Assert.Equal(42u, t.Doubled);
+        Assert.Equal(1, TestCustomInit.InitDoubledCallCount);
     }
 
     // ================================================================

--- a/src/native/managed/cdac/tests/DataGenerator/TestTypes.cs
+++ b/src/native/managed/cdac/tests/DataGenerator/TestTypes.cs
@@ -173,3 +173,23 @@ internal sealed partial class TestRawOffset : IData<TestRawOffset>
     [RawOffset(4)]
     public partial uint Value { get; }
 }
+
+// 19. CustomInit -- author-provided lazy initializer. The generator emits a
+//     lazy getter that calls the partial InitXxx method on first access.
+[CdacType("TestCustomInit")]
+internal sealed partial class TestCustomInit : IData<TestCustomInit>
+{
+    [Field] public partial uint Raw { get; }
+
+    // Computed lazily from Raw (declarative field) + custom descriptor data.
+    [CustomInit(nameof(InitDoubled))] public partial uint Doubled { get; }
+
+    public static int InitDoubledCallCount;
+    [DataDescriptorDependency("CustomValue", "uint32", "CustomDescriptor")]
+    [UsesDataDescriptorTypeSize("CustomDescriptor")]
+    private partial uint InitDoubled(Target target, TargetPointer address)
+    {
+        InitDoubledCallCount++;
+        return Raw * 2;
+    }
+}

--- a/src/native/managed/cdac/tools/CdacUsageGraph/src/CdacUsageGraph/Analysis/UsageWalker.cs
+++ b/src/native/managed/cdac/tools/CdacUsageGraph/src/CdacUsageGraph/Analysis/UsageWalker.cs
@@ -168,7 +168,7 @@ internal sealed class UsageWalker
             return false;
 
         _collector.RecordDependencies(label, dataType, dependencies);
-        return true;
+        return !_attributes.IsCustomInitializer(method);
     }
 
     private bool TryHandleStaticReference(

--- a/src/native/managed/cdac/tools/CdacUsageGraph/src/CdacUsageGraph/CdacSymbols.cs
+++ b/src/native/managed/cdac/tools/CdacUsageGraph/src/CdacUsageGraph/CdacSymbols.cs
@@ -29,6 +29,8 @@ internal static class CdacSymbols
         "Microsoft.Diagnostics.DataContractReader.CdacTypeAttribute";
     public const string DataDescriptorDependencyAttributeMetadataName =
         "Microsoft.Diagnostics.DataContractReader.DataDescriptorDependencyAttribute";
+    public const string CustomInitAttributeMetadataName =
+        "Microsoft.Diagnostics.DataContractReader.CustomInitAttribute";
     public const string UsesDataDescriptorTypeSizeAttributeMetadataName =
         "Microsoft.Diagnostics.DataContractReader.UsesDataDescriptorTypeSizeAttribute";
     public const string StaticReferenceAttributeMetadataName =

--- a/src/native/managed/cdac/tools/CdacUsageGraph/src/CdacUsageGraph/Semantic/CdacAttributeMatcher.cs
+++ b/src/native/managed/cdac/tools/CdacUsageGraph/src/CdacUsageGraph/Semantic/CdacAttributeMatcher.cs
@@ -13,6 +13,7 @@ internal sealed class CdacAttributeMatcher
     private readonly INamedTypeSymbol? _cdacType;
     private readonly INamedTypeSymbol? _dataDescriptorDependency;
     private readonly INamedTypeSymbol? _usesDataDescriptorTypeSize;
+    private readonly INamedTypeSymbol? _customInit;
     private readonly INamedTypeSymbol? _staticReference;
 
     public CdacAttributeMatcher(CSharpCompilation compilation)
@@ -23,6 +24,8 @@ internal sealed class CdacAttributeMatcher
             CdacSymbols.DataDescriptorDependencyAttributeMetadataName);
         _usesDataDescriptorTypeSize = compilation.GetTypeByMetadataName(
             CdacSymbols.UsesDataDescriptorTypeSizeAttributeMetadataName);
+        _customInit = compilation.GetTypeByMetadataName(
+            CdacSymbols.CustomInitAttributeMetadataName);
         _staticReference = compilation.GetTypeByMetadataName(
             CdacSymbols.StaticReferenceAttributeMetadataName);
     }
@@ -95,6 +98,24 @@ internal sealed class CdacAttributeMatcher
         }
 
         fieldName = null!;
+        return false;
+    }
+
+    public bool IsCustomInitializer(IMethodSymbol method)
+    {
+        foreach (IPropertySymbol property in method.ContainingType.GetMembers().OfType<IPropertySymbol>())
+        {
+            foreach (AttributeData attribute in GetAttributes(property))
+            {
+                if (Matches(attribute, _customInit)
+                    && attribute.ConstructorArguments is [{ Value: string methodName }]
+                    && methodName == method.Name)
+                {
+                    return true;
+                }
+            }
+        }
+
         return false;
     }
 

--- a/src/native/managed/cdac/tools/CdacUsageGraph/tests/CdacUsageGraph.Tests/DataTypeIndexTests.cs
+++ b/src/native/managed/cdac/tools/CdacUsageGraph/tests/CdacUsageGraph.Tests/DataTypeIndexTests.cs
@@ -477,7 +477,7 @@ public sealed class DataTypeIndexTests
     }
 
     [Fact]
-    public void DependencyAttributesReplaceOnInitInference()
+    public void DependencyAttributesOnPartialPropertiesReplaceInitializerInference()
     {
         const string source = """
             namespace Microsoft.Diagnostics.DataContractReader
@@ -507,21 +507,16 @@ public sealed class DataTypeIndexTests
                     public int Raw { get; }
 
                     [Microsoft.Diagnostics.DataContractReader.DataDescriptorDependency("Raw", "int32")]
-                    public int Derived { get; private set; }
+                    public partial int Derived { get; }
 
                     [Microsoft.Diagnostics.DataContractReader.DataDescriptorDependency("Raw", "int32")]
-                    public int CompoundDerived { get; private set; }
-
-                    partial void OnInit();
+                    public partial int CompoundDerived { get; }
                 }
 
                 public sealed partial class Widget
                 {
-                    partial void OnInit()
-                    {
-                        Derived = Raw;
-                        CompoundDerived += Raw;
-                    }
+                    public partial int Derived => Raw;
+                    public partial int CompoundDerived => Raw + Raw;
                 }
             }
             namespace Microsoft.Diagnostics.DataContractReader.Contracts
@@ -539,7 +534,7 @@ public sealed class DataTypeIndexTests
             }
             """;
         CSharpCompilation compilation = CSharpCompilation.Create(
-            "OnInitPropertyTest",
+            "PartialPropertyDependencyTest",
             [CSharpSyntaxTree.ParseText(source)],
             RuntimeReferences(),
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
@@ -558,6 +553,93 @@ public sealed class DataTypeIndexTests
         Assert.Contains("Raw", fields.Select(field => field.Name));
         Assert.DoesNotContain("Derived", fields.Select(field => field.Name));
         Assert.DoesNotContain("CompoundDerived", fields.Select(field => field.Name));
+    }
+
+    [Fact]
+    public void CustomInitDependenciesAreCombinedWithInitializerInference()
+    {
+        const string source = """
+            namespace Microsoft.Diagnostics.DataContractReader
+            {
+                public sealed class CdacTypeAttribute : System.Attribute
+                {
+                    public CdacTypeAttribute(params string[] names) { }
+                }
+                public sealed class FieldAttribute : System.Attribute { }
+                public sealed class CustomInitAttribute : System.Attribute
+                {
+                    public CustomInitAttribute(string methodName) { }
+                }
+                [System.AttributeUsage(
+                    System.AttributeTargets.Property | System.AttributeTargets.Method,
+                    AllowMultiple = true)]
+                public sealed class DataDescriptorDependencyAttribute : System.Attribute
+                {
+                    public DataDescriptorDependencyAttribute(string fieldName, string nativeType) { }
+                }
+            }
+            namespace Microsoft.Diagnostics.DataContractReader.Data
+            {
+                public interface IData<T> { }
+
+                [Microsoft.Diagnostics.DataContractReader.CdacType("Widget")]
+                public sealed partial class Widget : IData<Widget>
+                {
+                    [Microsoft.Diagnostics.DataContractReader.Field]
+                    [Microsoft.Diagnostics.DataContractReader.DataDescriptorDependency("Raw", "int32")]
+                    public int Raw { get; }
+
+                    [Microsoft.Diagnostics.DataContractReader.Field]
+                    [Microsoft.Diagnostics.DataContractReader.DataDescriptorDependency("Nested", "int32")]
+                    public int Nested { get; }
+
+                    [Microsoft.Diagnostics.DataContractReader.CustomInit(nameof(InitDerived))]
+                    public partial int Derived { get; }
+
+                    [Microsoft.Diagnostics.DataContractReader.DataDescriptorDependency("Raw", "int32")]
+                    private partial int InitDerived() => Raw + Nested;
+                }
+
+                public sealed partial class Widget
+                {
+                    public partial int Derived => InitDerived();
+                    private partial int InitDerived();
+                }
+            }
+            namespace Microsoft.Diagnostics.DataContractReader.Contracts
+            {
+                public interface ITest
+                {
+                    int Read(Microsoft.Diagnostics.DataContractReader.Data.Widget widget);
+                }
+
+                public sealed class TestContract : ITest
+                {
+                    public int Read(Microsoft.Diagnostics.DataContractReader.Data.Widget widget)
+                        => widget.Derived;
+                }
+            }
+            """;
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "CustomInitPropertyDependencyTest",
+            [CSharpSyntaxTree.ParseText(source)],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        INamedTypeSymbol impl = compilation.GetTypeByMetadataName(
+            "Microsoft.Diagnostics.DataContractReader.Contracts.TestContract")!;
+        DataTypeIndex index = DataTypeDiscovery.BuildIndex(compilation);
+        UsageGraph graph = new UsageWalker(compilation, index).Walk(
+            [Registration(
+                new ContractVersion(new ContractInterface("ITest"), "c1"),
+                impl)], "");
+        IReadOnlyCollection<FieldUsage> fields = DataType(
+            graph,
+            new ContractVersion(new ContractInterface("ITest"), "c1"),
+            "Data.Widget").Fields;
+
+        Assert.Equal(
+            ["Nested", "Raw"],
+            fields.Select(field => field.Name).OrderBy(name => name, StringComparer.Ordinal));
     }
 
     [Fact]

--- a/src/native/managed/cdac/tools/CdacUsageGraph/tests/CdacUsageGraph.Tests/UsageWalkerIntegrationTests.cs
+++ b/src/native/managed/cdac/tools/CdacUsageGraph/tests/CdacUsageGraph.Tests/UsageWalkerIntegrationTests.cs
@@ -69,11 +69,11 @@ public sealed class UsageWalkerIntegrationTests
 
         INamedTypeSymbol thread = compilation.GetTypeByMetadataName(
             "Microsoft.Diagnostics.DataContractReader.Data.Thread")!;
-        IPropertySymbol threadHandle = thread.GetMembers("ThreadHandle")
-            .OfType<IPropertySymbol>()
+        IMethodSymbol initThreadHandle = thread.GetMembers("InitThreadHandle")
+            .OfType<IMethodSymbol>()
             .Single();
         Assert.True(new CdacAttributeMatcher(compilation).TryGetDescriptorDependencies(
-            threadHandle,
+            initThreadHandle,
             out _));
     }
 
@@ -384,7 +384,7 @@ public sealed class UsageWalkerIntegrationTests
 
         DataTypeUsage syncBlock = DataType(graph, label, "Data.SyncBlock");
         Assert.Equal(
-            ["EnCInfo", "InteropInfo", "LinkNext", "Lock", "ThinLock"],
+            ["InteropInfo", "LinkNext", "Lock", "ThinLock"],
             syncBlock.Fields.Select(field => field.Name).Order().ToArray());
         Assert.DoesNotContain(syncBlock.Fields, field => field.Name == "Address");
 


### PR DESCRIPTION
## Summary

This changes custom IData initialization from one eager `OnInit` hook to named, per-property lazy initializer methods.

### IData generation

- Add `[CustomInit(nameof(Method))]` for properties requiring custom read logic.
- Generate lazy property getters that invoke and memoize the named initializer on first access.
- Keep generated writable fields limited to `[Field(Writable = true)]` properties.
- Add a descriptor-only `TableRW` IData type so its generated `GetSize` method is used when indexing metadata tables.

### Usage analysis

- Put `DataDescriptorDependency` and `UsesDataDescriptorTypeSize` annotations on custom initializer methods.
- Record declared initializer dependencies while continuing to analyze the initializer body for globals, helper calls, and nested IData property reads.
- Avoid treating `EnsureAllFieldsRead` as a complete dependency summary for types with custom initializers.

### IData implementations

- Convert existing `OnInit` implementations to named per-property initializer methods.
- Preserve optional-field behavior and defer custom reads until the corresponding property is accessed.

### Documentation and tests

- Document named custom initializers and method-level dependency annotations.
- Regenerate contract usage documentation to reflect property-level lazy reads.
- Add generator and usage-analysis coverage for lazy initialization, memoization, named methods, and combined declared/inferred dependencies.

## Testing

- Microsoft.Diagnostics.DataContractReader.Contracts build
- DataGenerator.Tests: 46 passed
- CdacUsageGraph.Tests: 86 passed
- Usage.Tests: 4 passed
- Microsoft.Diagnostics.DataContractReader.Tests: 3207 passed, 16 skipped
- CdacUsageGraph `docs --check`

> [!NOTE]
> This pull request description was generated with GitHub Copilot.