### PR TITLE
Restore stress guards on process-isolated IL tests

### DIFF
--- a/src/tests/JIT/Methodical/Arrays/misc/arrres_il_r.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/misc/arrres_il_r.ilproj
@@ -10,6 +10,19 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
+    <!--
+      The whole test body lives in a single Main, so unoptimized codegen (tier-0, minopts, JIT
+      stress) keeps the Test objects alive in untracked stack slots for the duration of Main. They
+      are then never finalized and never resurrected, and the test fails. Only fully optimized code
+      reports the precise lifetimes this test depends on.
+
+      The [SkipOnCoreClr] attribute on the IL entry point cannot express this on its own. Because
+      this test requires process isolation, the merged runner emits an OutOfProcessTest that just
+      launches the generated run script, and the IL assembly has a hand-written .entrypoint rather
+      than a generated wrapper, so nothing ever reads the attribute. The MSBuild property is what
+      puts the guard into the run script, so it must be kept.
+    -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arrres.il" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b143840/b143840.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b143840/b143840.ilproj
@@ -1,7 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for UnloadabilityIncompatible -->
+    <!-- Needed for GCStressIncompatible, UnloadabilityIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!--
+      The [SkipOnCoreClr] attribute on the IL entry point cannot express this on its own. Because
+      this test requires process isolation, the merged runner emits an OutOfProcessTest that just
+      launches the generated run script, and the IL assembly has a hand-written .entrypoint rather
+      than a generated wrapper, so nothing ever reads the attribute. The MSBuild property is what
+      puts the guard into the run script, so it must be kept.
+    -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This test leaves threads running at exit -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #131447.

## Root cause

Not a JIT bug. #126108 replaced the `<JitOptimizationSensitive>` and `<GCStressIncompatible>` MSBuild properties with `[SkipOnCoreClr(...)]` attributes on test entry points. That works for C# tests and for in-process IL tests, but silently drops the guard for **IL tests that also set `<RequiresProcessIsolation>`**:

| Test kind | What evaluates the skip | Result |
| --- | --- | --- |
| C#, any isolation | `GenerateStandaloneSimpleTestRunner` compiles the check into `__GeneratedMainWrapper.Main` | ✅ honored |
| IL, in-process | merged runner reads the attribute from metadata via `ExternallyReferencedTestMethodsVisitor` | ✅ honored |
| **IL + process isolation** | merged runner emits an `OutOfProcessTest` that only calls `RunOutOfProcessTest(...)` on the generated run script, and `ReferenceXUnitWrapperGenerator` is gated on `'$(Language)' == 'C#'` so the IL assembly's hand-written `.entrypoint` never gets a wrapper either | ❌ **nothing reads the attribute** |

In that last case only the MSBuild property puts the guard into the generated `.cmd`/`.sh`.

`arrres_il_r` keeps its whole body in a single `Main`, so unoptimized codegen (tier-0, minopts, JIT stress) keeps the `Test` objects alive in untracked stack slots for the duration of `Main`. They are then never finalized and never resurrected, and the test throws. It fails on every default (tiered) run, which is why it lit up across outerloop, jitstress and pgo on all platforms at once.

## Fix

Restore the MSBuild property on the two affected tests (option 1 from https://github.com/dotnet/runtime/pull/126108#issuecomment-5171017315):

- `arrres_il_r.ilproj` → `<JitOptimizationSensitive>`
- `b143840.ilproj` → `<GCStressIncompatible>` (same bug, unguarded on gcstress legs; it kept `<RequiresProcessIsolation>` for `<UnloadabilityIncompatible>`)

The `[SkipOnCoreClr]` attributes are intentionally left in place, so the guard keeps working if either test ever stops requiring process isolation. Each project gets a comment explaining why the property cannot be dropped in favour of the attribute.

## Fallout audit

I enumerated all 16 IL tests carrying `[SkipOnCoreClr]` and evaluated each owning project's *effective* `RequiresProcessIsolation` with `msbuild -getProperty` (so inherited `Directory.Build.props`/`.targets` values are accounted for). These two are the only process-isolated ones — the other 14 are in-process and unaffected.

I also confirmed empirically, rather than by inspection alone, that both of the "honored" rows above really do emit the guard, by disassembling the built assemblies:

- `Directed_3.dll` (merged runner, in-process IL) contains `IsJitStress` / `IsJitStressRegs` / `IsJitMinOpts` / `IsTailCallStress` / `IsTieredCompilation` checks guarding the call to `[AttributeConflict]P::Main()`.
- `ObjectStackAllocationTests.dll` (process-isolated C#) contains the same checks inside `__GeneratedMainWrapper`.

No C# test is affected by this class of bug.

## Validation

Built and ran the generated run scripts on windows-x64 checked:

```
arrres_il_r  default (tiered)     SKIP
             TieredCompilation=0  PASS  (Test passed., 100)
             TC=0 + JITMinOpts=1  SKIP
             TC=0 + JitStress=2   SKIP
b143840      default              PASS
             GCStress=0xC         SKIP
```

Before the change, `arrres_il_r` reproduced the exact CI signature under the default environment: unhandled `System.Exception` in `GCTest_arrres_il.Test.Main`, exit `-532462766`.

cc @jkoritzinsky @jakobbotsch @JulieLeeMSFT
