### PR TITLE
Use released TFM for cDAC projects where supported

### DIFF
--- a/src/native/managed/cdac/Directory.Build.props
+++ b/src/native/managed/cdac/Directory.Build.props
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
       <!-- Source build and platforms absent from the released ILCompiler pack must use the in-repo NativeAOT toolchain. -->
-      <CDacTfm Condition="'$(CDacTfm)' == '' and ('$(DotNetBuildSourceOnly)' == 'true' or '$(TargetOS)' == 'haiku' or '$(TargetOS)' == 'illumos' or '$(TargetOS)' == 'openbsd' or '$(TargetOS)' == 'solaris')">$(NetCoreAppToolCurrent)</CDacTfm>
+      <CDacTfm Condition="'$(CDacTfm)' == '' and ('$(DotNetBuildSourceOnly)' == 'true' or '$(TargetOS)' == 'haiku' or '$(TargetOS)' == 'illumos' or '$(TargetOS)' == 'openbsd' or '$(TargetOS)' == 'netbsd' or '$(TargetOS)' == 'solaris')">$(NetCoreAppToolCurrent)</CDacTfm>
       <CDacTfm Condition="'$(CDacTfm)' == ''">$(NetCoreAppMinimum)</CDacTfm>
     </PropertyGroup>
 

--- a/src/native/managed/cdac/Directory.Build.props
+++ b/src/native/managed/cdac/Directory.Build.props
@@ -2,8 +2,18 @@
     <Import Project="..\Directory.Build.props" />
 
     <PropertyGroup>
-      <!-- Source build and platforms absent from the released ILCompiler pack must use the in-repo NativeAOT toolchain. -->
-      <CDacTfm Condition="'$(CDacTfm)' == '' and ('$(DotNetBuildSourceOnly)' == 'true' or '$(TargetOS)' == 'haiku' or '$(TargetOS)' == 'illumos' or '$(TargetOS)' == 'openbsd' or '$(TargetOS)' == 'netbsd' or '$(TargetOS)' == 'solaris')">$(NetCoreAppToolCurrent)</CDacTfm>
+      <!-- Source-build and bootstrap NativeAOT publishing on community platforms require toolchain assets that are not in the released SDK. -->
+      <CDacTfm Condition="
+        '$(CDacTfm)' == '' and
+        ('$(DotNetBuildSourceOnly)' == 'true' or
+         ('$(UseBootstrapLayout)' == 'true' and
+          '$(TargetOS)' != 'windows' and
+          '$(TargetOS)' != 'osx' and
+          !('$(TargetOS)' == 'linux' and
+            ('$(TargetArchitecture)' == 'x64' or
+             '$(TargetArchitecture)' == 'x86' or
+             '$(TargetArchitecture)' == 'arm' or
+             '$(TargetArchitecture)' == 'arm64'))))">$(NetCoreAppToolCurrent)</CDacTfm>
       <CDacTfm Condition="'$(CDacTfm)' == ''">$(NetCoreAppMinimum)</CDacTfm>
     </PropertyGroup>
 

--- a/src/native/managed/cdac/Directory.Build.props
+++ b/src/native/managed/cdac/Directory.Build.props
@@ -11,7 +11,6 @@
           '$(TargetOS)' != 'osx' and
           !('$(TargetOS)' == 'linux' and
             ('$(TargetArchitecture)' == 'x64' or
-             '$(TargetArchitecture)' == 'x86' or
              '$(TargetArchitecture)' == 'arm' or
              '$(TargetArchitecture)' == 'arm64'))))">$(NetCoreAppToolCurrent)</CDacTfm>
       <CDacTfm Condition="'$(CDacTfm)' == ''">$(NetCoreAppMinimum)</CDacTfm>

--- a/src/native/managed/cdac/Directory.Build.props
+++ b/src/native/managed/cdac/Directory.Build.props
@@ -2,6 +2,12 @@
     <Import Project="..\Directory.Build.props" />
 
     <PropertyGroup>
+      <!-- Source build and platforms absent from the released ILCompiler pack must use the in-repo NativeAOT toolchain. -->
+      <CDacTfm Condition="'$(CDacTfm)' == '' and ('$(DotNetBuildSourceOnly)' == 'true' or '$(TargetOS)' == 'haiku' or '$(TargetOS)' == 'illumos' or '$(TargetOS)' == 'openbsd' or '$(TargetOS)' == 'solaris')">$(NetCoreAppToolCurrent)</CDacTfm>
+      <CDacTfm Condition="'$(CDacTfm)' == ''">$(NetCoreAppMinimum)</CDacTfm>
+    </PropertyGroup>
+
+    <PropertyGroup>
       <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
       <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
       <AppendTargetFrameworkToOutputPath Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</AppendTargetFrameworkToOutputPath>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Microsoft.Diagnostics.DataContractReader.Legacy.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Microsoft.Diagnostics.DataContractReader.Legacy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader.Legacy</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Microsoft.Diagnostics.DataContractReader.Legacy.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Microsoft.Diagnostics.DataContractReader.Legacy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader.Legacy</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/mscordaccore_universal/mscordaccore_universal.csproj
+++ b/src/native/managed/cdac/mscordaccore_universal/mscordaccore_universal.csproj
@@ -10,7 +10,7 @@
          which doesn't set NativeBinaryPrefix. Disable UseNativeLibPrefix to prevent
          double-prefix when building with local NativeAOT targets (bootstrap). -->
     <UseNativeLibPrefix>false</UseNativeLibPrefix>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/mscordaccore_universal/mscordaccore_universal.csproj
+++ b/src/native/managed/cdac/mscordaccore_universal/mscordaccore_universal.csproj
@@ -10,7 +10,7 @@
          which doesn't set NativeBinaryPrefix. Disable UseNativeLibPrefix to prevent
          double-prefix when building with local NativeAOT targets (bootstrap). -->
     <UseNativeLibPrefix>false</UseNativeLibPrefix>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/scripts/cdac-dump-inspect.csproj
+++ b/src/native/managed/cdac/scripts/cdac-dump-inspect.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/scripts/cdac-dump-inspect.csproj
+++ b/src/native/managed/cdac/scripts/cdac-dump-inspect.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
+    <RollForward Condition="'$(CDacTfm)' != '$(NetCoreAppToolCurrent)'">LatestMajor</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/tests/DataGenerator/Microsoft.Diagnostics.DataContractReader.DataGenerator.Tests.csproj
+++ b/src/native/managed/cdac/tests/DataGenerator/Microsoft.Diagnostics.DataContractReader.DataGenerator.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>

--- a/src/native/managed/cdac/tests/DataGenerator/Microsoft.Diagnostics.DataContractReader.DataGenerator.Tests.csproj
+++ b/src/native/managed/cdac/tests/DataGenerator/Microsoft.Diagnostics.DataContractReader.DataGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
+    <RollForward Condition="'$(CDacTfm)' != '$(NetCoreAppToolCurrent)'">LatestMajor</RollForward>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>

--- a/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>

--- a/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
+    <RollForward Condition="'$(CDacTfm)' != '$(NetCoreAppToolCurrent)'">LatestMajor</RollForward>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>

--- a/src/native/managed/cdac/tests/StressTests/Microsoft.Diagnostics.DataContractReader.StressTests.csproj
+++ b/src/native/managed/cdac/tests/StressTests/Microsoft.Diagnostics.DataContractReader.StressTests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/native/managed/cdac/tests/StressTests/Microsoft.Diagnostics.DataContractReader.StressTests.csproj
+++ b/src/native/managed/cdac/tests/StressTests/Microsoft.Diagnostics.DataContractReader.StressTests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
+    <RollForward Condition="'$(CDacTfm)' != '$(NetCoreAppToolCurrent)'">LatestMajor</RollForward>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/native/managed/cdac/tests/TestInfrastructure/Microsoft.Diagnostics.DataContractReader.TestInfrastructure.csproj
+++ b/src/native/managed/cdac/tests/TestInfrastructure/Microsoft.Diagnostics.DataContractReader.TestInfrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/tests/TestInfrastructure/Microsoft.Diagnostics.DataContractReader.TestInfrastructure.csproj
+++ b/src/native/managed/cdac/tests/TestInfrastructure/Microsoft.Diagnostics.DataContractReader.TestInfrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/tests/UnitTests/Microsoft.Diagnostics.DataContractReader.Tests.csproj
+++ b/src/native/managed/cdac/tests/UnitTests/Microsoft.Diagnostics.DataContractReader.Tests.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 

--- a/src/native/managed/cdac/tests/UnitTests/Microsoft.Diagnostics.DataContractReader.Tests.csproj
+++ b/src/native/managed/cdac/tests/UnitTests/Microsoft.Diagnostics.DataContractReader.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>$(NetCoreAppMinimum)</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <TargetFramework>$(CDacTfm)</TargetFramework>
+    <RollForward Condition="'$(CDacTfm)' != '$(NetCoreAppToolCurrent)'">LatestMajor</RollForward>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 


### PR DESCRIPTION
## What

Defines `CDacTfm` for cDAC product, tooling, and test projects. It defaults to `$(NetCoreAppMinimum)` and uses `$(NetCoreAppToolCurrent)` for source-build and platforms unsupported by the released NativeAOT toolchain.

Runnable net10 outputs use `RollForward=LatestMajor` so they can run in repo environments containing only the current runtime.

## Why

The cDAC stack is source-shared with tools that can only build using released SDKs. Targeting a released TFM where supported lets the stack build in those environments without regressing source-build or unsupported platforms.

> [!NOTE]
> This PR was created with the assistance of GitHub Copilot.