### PR TITLE
Fix interpreter SetIP breakpoint handling

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1072,8 +1072,12 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
         if (ilOffset < (uint32_t)m_ILCodeSizeFromILHeader)
         {
             uint32_t nativeOffset = ConvertOffset(ins->nativeOffset);
+            bool isEmptyILStack = (ins->flags & INTERP_INST_FLAG_EMPTY_IL_STACK) != 0;
+            bool isFilterOrCatchEntry = m_pCBB->isFilterOrCatchFuncletEntry && (ilOffset == (uint32_t)m_pCBB->ilOffset);
+
             // Only emit mapping entries at IL offsets where the evaluation stack is empty
-            if ((ins->flags & INTERP_INST_FLAG_EMPTY_IL_STACK) &&
+            // or at filter and catch entries, where the exception object is on the stack.
+            if ((isEmptyILStack || isFilterOrCatchEntry) &&
                 ((m_ILToNativeMapSize == 0) || (m_pILToNativeMap[m_ILToNativeMapSize - 1].ilOffset != ilOffset)))
             {
                 // This code assumes that instructions for the same IL offset are emitted in a single run without
@@ -1096,7 +1100,9 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
 
                 m_pILToNativeMap[m_ILToNativeMapSize].ilOffset = ilOffset;
                 m_pILToNativeMap[m_ILToNativeMapSize].nativeOffset = nativeOffset;
-                m_pILToNativeMap[m_ILToNativeMapSize].source = ICorDebugInfo::STACK_EMPTY;
+                m_pILToNativeMap[m_ILToNativeMapSize].source = isEmptyILStack
+                    ? ICorDebugInfo::STACK_EMPTY
+                    : ICorDebugInfo::SOURCE_TYPE_INVALID;
                 m_ILToNativeMapSize++;
             }
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -845,11 +845,16 @@ static void InterpBreakpoint(const int32_t *ip, const InterpMethodContextFrame *
             EX_END_CATCH
             pThread->SetFilterContext(NULL);
 
-            // The debugger may have moved execution via SetIP. If so, drop the bypass
-            // (it was set up for the original IP) and resume at the new context via
-            // ResumeAfterCatchException.
+            // The debugger may have moved execution via SetIP. Preserve a bypass
+            // created for the destination before resuming at the new context.
             if ((GetIP(&ctx) != (PCODE)ip) || (GetSP(&ctx) != (DWORD64)pFrame))
             {
+                if (GetIP(&ctx) == (PCODE)savedBypassAddress)
+                {
+                    pThreadContext->m_bypassAddress = savedBypassAddress;
+                    pThreadContext->m_bypassOpcode = savedBypassOpcode;
+                }
+
                 ThrowResumeAfterCatchException(GetSP(&ctx), GetIP(&ctx));
             }
 
@@ -1500,10 +1505,17 @@ SWITCH_OPCODE:
                 INTOP_CASE(INTOP_BREAKPOINT)
                 {
                     pFrame->ip = ip;
-                    LOG((LF_CORDB, LL_INFO10000, "InterpExecMethod: Hit breakpoint at IP %p\n", ip));
-                    InterpBreakpoint(ip, pFrame, stack, pInterpreterFrame);
 
                     int32_t bypassOpcode = 0;
+                    if (pThreadContext->HasBypass(ip, &bypassOpcode))
+                    {
+                        LOG((LF_CORDB, LL_INFO10000, "InterpExecMethod: Pre-callback bypass at IP %p with opcode 0x%x\n", ip, bypassOpcode));
+                        pThreadContext->ClearBypass();
+                        INTOP_DISPATCH(bypassOpcode);
+                    }
+
+                    LOG((LF_CORDB, LL_INFO10000, "InterpExecMethod: Hit breakpoint at IP %p\n", ip));
+                    InterpBreakpoint(ip, pFrame, stack, pInterpreterFrame);
 
                     // After debugger callback, check if bypass was set on the thread context
                     if (pThreadContext->HasBypass(ip, &bypassOpcode))


### PR DESCRIPTION
## Summary

- Preserve the destination breakpoint bypass across SetIP context mutation and consume the matching bypass before debugger notification, allowing the saved opcode to execute exactly once.
- Emit interpreter IL/native mappings for catch and filter entries whose exception object makes the IL stack non-empty, using an invalid source type rather than omitting the entry.

## Validation
- macOS arm64 directly fixed `Stepping.SetIPTest` and `Stepping.SetIPTestwithUnvaildPos` (2/2).

> [!NOTE]
> This pull request description was generated by GitHub Copilot.