### PR TITLE
Fix interpreter step-in stub-manager assertion

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -7973,7 +7973,10 @@ void DebuggerStepper::TriggerMethodEnter(Thread * thread,
 #if defined(TARGET_ARM64) && defined(__APPLE__)
     LOG((LF_CORDB, LL_INFO10000, "DebuggerStepper::TriggerMethodEnter: Consistency_check_MSGF not needed because we skip setting breakpoints in certain patches on arm64-macOS\n"));
 #else
-    if ((m_StepInStartMethod != pDesc) &&
+    // Interpreter step-in intentionally relies on MethodEnter instead of stub managers.
+    EECodeInfo codeInfo((PCODE)dji->m_addrOfCode);
+    if (!codeInfo.IsInterpretedCode() &&
+        (m_StepInStartMethod != pDesc) &&
         (!m_StepInStartMethod->IsLCGMethod()))
     {
         // Since normal step-in should stop us at the prolog, and TME is after the prolog,

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -7974,8 +7974,13 @@ void DebuggerStepper::TriggerMethodEnter(Thread * thread,
     LOG((LF_CORDB, LL_INFO10000, "DebuggerStepper::TriggerMethodEnter: Consistency_check_MSGF not needed because we skip setting breakpoints in certain patches on arm64-macOS\n"));
 #else
     // Interpreter step-in intentionally relies on MethodEnter instead of stub managers.
+#ifdef FEATURE_INTERPRETER
     EECodeInfo codeInfo((PCODE)dji->m_addrOfCode);
-    if (!codeInfo.IsInterpretedCode() &&
+    const bool isInterpretedCode = codeInfo.IsInterpretedCode();
+#else
+    const bool isInterpretedCode = false;
+#endif // FEATURE_INTERPRETER
+    if (!isInterpretedCode &&
         (m_StepInStartMethod != pDesc) &&
         (!m_StepInStartMethod->IsLCGMethod()))
     {


### PR DESCRIPTION
## Summary

- Exclude interpreted code from the JIT/R2R stub-manager consistency check in `DebuggerStepper::TriggerMethodEnter`.
- Interpreter step-in intentionally uses MethodEnter as its primary call-entry mechanism, so reaching this path does not indicate a missing stub manager.
- Preserve the existing consistency check for JIT and R2R code.

