### PR TITLE
[clr-interp] Fix DAC access to interpreter frame data

### DIFF
--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2464,7 +2464,7 @@ public:
 
     void GcScanRoots_Impl(promote_func *fn, ScanContext* sc)
     {
-        fn(dac_cast<PTR_PTR_Object>(dac_cast<TADDR>(&m_continuation)), sc, 0);
+        fn(GetContinuationPtr(), sc, 0);
     }
 
     void SetContinuation(OBJECTREF continuation)
@@ -2482,7 +2482,7 @@ public:
     PTR_PTR_Object GetContinuationPtr()
     {
         LIMITED_METHOD_CONTRACT;
-        return dac_cast<PTR_PTR_Object>(dac_cast<TADDR>(&m_continuation));
+        return dac_cast<PTR_PTR_Object>(PTR_HOST_MEMBER_TADDR(InterpreterFrame, this, m_continuation));
     }
 private:
     // The last known topmost interpreter frame in the InterpExecMethod belonging to

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -2152,9 +2152,9 @@ template <> OBJECTREF* TGcInfoDecoder<InterpreterGcInfoEncoding>::GetStackSlot(
         _ASSERTE(fp);
         pObjRef = (OBJECTREF*)(fp + spOffset);
     }
-    InterpMethodContextFrame* pFrame = (InterpMethodContextFrame*)GetSP(pRD->pCurrentContext);
+    PTR_InterpMethodContextFrame pFrame = dac_cast<PTR_InterpMethodContextFrame>(GetSP(pRD->pCurrentContext));
     _ASSERTE(pFrame->pStack == (int8_t *)GetFP(pRD->pCurrentContext));
-    InterpMethodContextFrame* pFrameCallee = pFrame->pNext;
+    PTR_InterpMethodContextFrame pFrameCallee = pFrame->pNext;
 
     // If the stack slot is in a callee's frame, then we do not actually need to report it. This should ONLY happen if the
     // stack slot is in the argument area of the caller. As a double check, we validate in the caller of this function that


### PR DESCRIPTION
## Summary

Fix two DAC pointer-marshalling errors reached while enumerating GC references for interpreter frames:

- Translate `InterpreterFrame::m_continuation` from its marshalled host instance with `PTR_HOST_MEMBER_TADDR` instead of converting an interior host pointer as an exact DAC instance.
- Access `InterpMethodContextFrame` target memory through `PTR_InterpMethodContextFrame` instead of dereferencing a target stack address as a raw host pointer.

## Validation

`Inspection.MemoryDiagnostics` passed on macOS arm64 and x64 with no `DAC coding error`, `dacfn.cpp:850`, `SIGSEGV`, or segmentation-fault signatures.

> [!NOTE]
> This pull request description was generated by GitHub Copilot.