### PR TITLE
Share crashing thread id gate between in-proc crash report and createdump.

### DIFF
--- a/src/coreclr/debug/crashreport/inproccrashreporter.cpp
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.cpp
@@ -368,10 +368,11 @@ public:
     void InitializeServices(const InProcCrashReporterServicesSettings& settings);
 
     // Signal-path report generation, invoked by the PAL fatal-signal dispatcher.
+    // Concurrent and recurrent crash diagnostics are serialized by the PAL's
+    // shared crash-dump gate before this is invoked.
     bool CreateReport(
         int signal,
-        void* context,
-        bool serialize);
+        void* context);
 
     // On-demand report generation. Runs the same emit core as the signal path
     // but without the watchdog or lifecycle/file management, routing the selected
@@ -591,37 +592,18 @@ public:
 bool
 InProcCrashReporter::CreateReport(
     int signal,
-    void* context,
-    bool serialize)
+    void* context)
 {
-    if (!serialize)
-    {
-        minipal_log_write_fatal("The in-proc crash reporter does not support recurrent invocations, so it is disabled for paths that may continue execution after signal handling, such as SIGTERM.\n");
-        return false;
-    }
-
+    // Concurrent and recurrent crash diagnostics are serialized by the PAL's
+    // shared crash-dump gate before this callback is invoked, so a signal-path
+    // report is only ever started once. This CAS additionally guards against
+    // overlap with the on-demand report path (which shares
+    // m_reportInFlightThreadId); on contention we bail out rather than block,
+    // since the PAL gate already owns waiting.
     LONGLONG currentThreadId = static_cast<LONGLONG>(minipal_get_current_thread_id());
-    LONGLONG previousThreadId = InterlockedCompareExchange64(&m_reportInFlightThreadId, currentThreadId, 0);
-    if (previousThreadId != 0)
+    if (InterlockedCompareExchange64(&m_reportInFlightThreadId, currentThreadId, 0) != 0)
     {
-        if (previousThreadId == currentThreadId)
-        {
-            return false;
-        }
-
-#if HAVE_POLL
-        // INFTIM is not defined when including pal.h; -1 is the equivalent poll() "wait forever" timeout.
-        const int PollWaitForever = -1;
-#endif
-        while (true)
-        {
-#if HAVE_POLL
-            poll(nullptr, 0, PollWaitForever);
-#else
-            // fakepoll uses select() and is not suitable for this signal-handler path.
-            pause();
-#endif
-        }
+        return false;
     }
 
     CrashReportWatchdogScope watchdogScope;
@@ -921,7 +903,7 @@ InProcCrashReporter::EndStackOverflowTrace()
 }
 
 void
-InProcCrashReportSignalDispatcher(int signal, void* siginfo, void* context, bool serialize)
+InProcCrashReportSignalDispatcher(int signal, void* siginfo, void* context)
 {
     (void)siginfo;
 
@@ -933,7 +915,7 @@ InProcCrashReportSignalDispatcher(int signal, void* siginfo, void* context, bool
 
     // Preserve the interrupted context's errno before the crash reporter uses syscalls.
     int savedErrno = errno;
-    reporter->CreateReport(signal, context, serialize);
+    reporter->CreateReport(signal, context);
     errno = savedErrno;
 }
 

--- a/src/coreclr/debug/crashreport/inproccrashreporter.cpp
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.cpp
@@ -18,9 +18,6 @@
 
 #include <fcntl.h>
 #include <errno.h>
-#if HAVE_POLL
-#include <poll.h>
-#endif
 #include <stdlib.h>
 #include <new>
 #include <unistd.h>

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -266,17 +266,18 @@ PAL_SetLogManagedCallstackForSignalCallback(
 /// Callback invoked from the fatal-signal path to write an in-proc crash
 /// report. The callback runs inside the signal handler and must therefore
 /// be async-signal-safe. siginfo is opaque (siginfo_t*) and context is the
-/// raw ucontext_t pointer received by the PAL signal handler. serialize
-/// mirrors createdump behavior: when true, callback implementations may
-/// serialize concurrent reporters because the caller expects process teardown;
-/// when false, callbacks should not block other threads indefinitely.
+/// raw ucontext_t pointer received by the PAL signal handler.
+///
+/// The PAL serializes concurrent crash diagnostics (this callback and the
+/// out-of-proc createdump path) through a shared gate before invoking the
+/// callback, so implementations do not need to serialize themselves.
 ///
 /// Registration is opt-in: if no callback is installed the PAL falls back
 /// to its default crash-dump path (createdump where available). The PAL
 /// itself has no source-level dependency on the in-proc reporter library;
 /// it only knows about this callback ABI.
 /// </summary>
-typedef VOID (*PINPROCCRASHREPORT_CALLBACK)(int signal, void* siginfo, void* context, bool serialize);
+typedef VOID (*PINPROCCRASHREPORT_CALLBACK)(int signal, void* siginfo, void* context);
 
 PALIMPORT
 VOID

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -453,7 +453,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
             PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
             PROCLogManagedCallstackForSignal(code);
-            PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerializeMode_WaitInfinite);
+            PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerialize_WaitInfinite);
 
             // Restore the original and restart h/w exception.
             restore_signal(code, action);
@@ -475,7 +475,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
         PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
         PROCLogManagedCallstackForSignal(code);
-        PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerializeMode_WaitInfinite);
+        PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerialize_WaitInfinite);
     }
 
     if (IsSaSigInfo(action))
@@ -496,7 +496,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
         PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
         PROCLogManagedCallstackForSignal(code);
-        PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerializeMode_WaitInfinite);
+        PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerialize_WaitInfinite);
     }
 }
 
@@ -887,7 +887,7 @@ static void sigterm_handler(int code, siginfo_t *siginfo, void *context)
         if (enableDumpOnSigTerm.IsSet() && enableDumpOnSigTerm.TryAsInteger(10, val) && val == 1)
         {
             PROCLogManagedCallstackForSignal(code);
-            PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerializeMode_None);
+            PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerialize_None);
         }
     }
 

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -453,7 +453,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
             PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
             PROCLogManagedCallstackForSignal(code);
-            PROCCreateCrashDumpIfEnabled(code, siginfo, context, /* serialize */ true);
+            PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerializeMode_WaitInfinite);
 
             // Restore the original and restart h/w exception.
             restore_signal(code, action);
@@ -475,7 +475,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
         PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
         PROCLogManagedCallstackForSignal(code);
-        PROCCreateCrashDumpIfEnabled(code, siginfo, context, /* serialize */ true);
+        PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerializeMode_WaitInfinite);
     }
 
     if (IsSaSigInfo(action))
@@ -496,7 +496,7 @@ static void invoke_previous_action(struct sigaction* action, int code, siginfo_t
         PROCNotifyProcessShutdown(IsRunningOnAlternateStack(context));
 
         PROCLogManagedCallstackForSignal(code);
-        PROCCreateCrashDumpIfEnabled(code, siginfo, context, /* serialize */ true);
+        PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerializeMode_WaitInfinite);
     }
 }
 
@@ -887,7 +887,7 @@ static void sigterm_handler(int code, siginfo_t *siginfo, void *context)
         if (enableDumpOnSigTerm.IsSet() && enableDumpOnSigTerm.TryAsInteger(10, val) && val == 1)
         {
             PROCLogManagedCallstackForSignal(code);
-            PROCCreateCrashDumpIfEnabled(code, siginfo, context, /* serialize */ false);
+            PROCCreateCrashDumpIfEnabled(code, siginfo, context, CrashDumpSerializeMode_None);
         }
     }
 

--- a/src/coreclr/pal/src/include/pal/process.h
+++ b/src/coreclr/pal/src/include/pal/process.h
@@ -122,25 +122,25 @@ VOID PROCNotifyProcessShutdown(bool isExecutingOnAltStack = false);
 
 // Controls how concurrent crash diagnostics -- both the out-of-proc
 // crash dump and the in-proc crash report -- are serialized across threads.
-// Except for CrashDumpSerializeMode_None, only one thread (the "winner") ever
+// Except for CrashDumpSerialize_None, only one thread (the "winner") ever
 // generates diagnostics at a time; the mode names the action a contending
 // thread takes when it finds the gate already held.
 enum CrashDumpSerializeMode
 {
     // Don't serialize at all: no gate, every thread generates crash diagnostics
     // concurrently.
-    CrashDumpSerializeMode_None,
+    CrashDumpSerialize_None,
 
     // On contention, don't wait: if another thread is already generating crash
     // diagnostics, return immediately without generating a (duplicate) dump or
     // report. Otherwise generate it and continue. The gate is re-armed
     // afterwards so a later crash can generate diagnostics again.
-    CrashDumpSerializeMode_NoWait,
+    CrashDumpSerialize_NoWait,
 
     // On contention, wait indefinitely: the winner generates the crash dump or
     // report and then expects to terminate the process; a contending thread waits
     // indefinitely until that happens.
-    CrashDumpSerializeMode_WaitInfinite
+    CrashDumpSerialize_WaitInfinite
 };
 
 /*++

--- a/src/coreclr/pal/src/include/pal/process.h
+++ b/src/coreclr/pal/src/include/pal/process.h
@@ -120,6 +120,29 @@ Function:
 --*/
 VOID PROCNotifyProcessShutdown(bool isExecutingOnAltStack = false);
 
+// Controls how concurrent crash diagnostics -- both the out-of-proc
+// crash dump and the in-proc crash report -- are serialized across threads.
+// Except for CrashDumpSerializeMode_None, only one thread (the "winner") ever
+// generates diagnostics at a time; the mode names the action a contending
+// thread takes when it finds the gate already held.
+enum CrashDumpSerializeMode
+{
+    // Don't serialize at all: no gate, every thread generates crash diagnostics
+    // concurrently.
+    CrashDumpSerializeMode_None,
+
+    // On contention, don't wait: if another thread is already generating crash
+    // diagnostics, return immediately without generating a (duplicate) dump or
+    // report. Otherwise generate it and continue. The gate is re-armed
+    // afterwards so a later crash can generate diagnostics again.
+    CrashDumpSerializeMode_NoWait,
+
+    // On contention, wait indefinitely: the winner generates the crash dump or
+    // report and then expects to terminate the process; a contending thread waits
+    // indefinitely until that happens.
+    CrashDumpSerializeMode_WaitInfinite
+};
+
 /*++
 Function:
   PROCCreateCrashDumpIfEnabled
@@ -131,11 +154,11 @@ Parameters:
   signal - POSIX signal number
   siginfo - POSIX signal info or nullptr
   context - signal context or nullptr
-  serialize - allow only one thread to generate core dump
+  serializeMode - how to serialize concurrent crash diagnostics
 
 (no return value)
 --*/
-VOID PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, void* context, bool serialize);
+VOID PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, void* context, CrashDumpSerializeMode serializeMode);
 
 /*++
 Function:

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -125,7 +125,7 @@ using namespace CorUnix;
 Volatile<LONG> terminator = 0;
 
 // Id of thread generating a core dump
-Volatile<LONGLONG> g_crashingThreadId = 0;
+volatile LONGLONG g_crashingThreadId = 0;
 
 // Process ID of this process.
 DWORD gPID = (DWORD) -1;

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -228,6 +228,10 @@ CreateSemaphoreName(
 
 static BOOL PROCEndProcess(UINT uExitCode, BOOL bTerminateUnconditionally);
 
+static bool TryEnterCrashDumpGate(CrashDumpSerializeMode serializeMode);
+
+static void ExitCrashDumpGate(CrashDumpSerializeMode serializeMode);
+
 /*++
 Function:
   GetCurrentProcessId
@@ -1435,47 +1439,25 @@ PROCBuildCreateDumpCommandLine(
 
 /*++
 Function:
-  PROCCreateCrashDump
+  PROCLaunchCreateDump
 
-  Creates crash dump of the process. Can be called from the unhandled
-  native exception handler. Allows only one thread to generate the core
-  dump if serialize is true.
+  Launches the out-of-proc createdump utility for the process. Does not
+  serialize; callers that need serialization should go through PROCCreateCrashDump.
 
 Return:
   TRUE - succeeds, FALSE - fails
 --*/
-BOOL
-PROCCreateCrashDump(
+static BOOL
+PROCLaunchCreateDump(
     const char* argv[],
     LPSTR errorMessageBuffer,
-    INT cbErrorMessageBuffer,
-    bool serialize)
+    INT cbErrorMessageBuffer)
 {
 #if defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_WASM)
     return FALSE;
 #else
     _ASSERTE(argv[0] != nullptr);
     _ASSERTE(errorMessageBuffer == nullptr || cbErrorMessageBuffer > 0);
-
-    if (serialize)
-    {
-        size_t currentThreadId = THREADSilentGetCurrentThreadId();
-        size_t previousThreadId = InterlockedCompareExchange(&g_crashingThreadId, currentThreadId, 0);
-        if (previousThreadId != 0)
-        {
-            // Return error if reenter this code
-            if (previousThreadId == currentThreadId)
-            {
-                return false;
-            }
-
-            // The first thread generates the crash info and any other threads are blocked
-            while (true)
-            {
-                poll(NULL, 0, INFTIM);
-            }
-        }
-    }
 
     int pipe_descs[4];
     if (pipe(pipe_descs) == -1 || pipe(pipe_descs + 2) == -1)
@@ -1632,6 +1614,35 @@ PROCCreateCrashDump(
 }
 
 /*++
+Function:
+  PROCCreateCrashDump
+
+  Creates a crash dump of the process via the out-of-proc createdump utility,
+  serializing concurrent crash diagnostics per serializeMode. Can be
+  called from the unhandled native exception handler.
+
+Return:
+  TRUE - succeeds, FALSE - fails or another thread owns the gate
+--*/
+static BOOL
+PROCCreateCrashDump(
+    const char* argv[],
+    LPSTR errorMessageBuffer,
+    INT cbErrorMessageBuffer,
+    CrashDumpSerializeMode serializeMode)
+{
+    if (!TryEnterCrashDumpGate(serializeMode))
+    {
+        return FALSE;
+    }
+
+    BOOL result = PROCLaunchCreateDump(argv, errorMessageBuffer, cbErrorMessageBuffer);
+
+    ExitCrashDumpGate(serializeMode);
+    return result;
+}
+
+/*++
 Function
   PROCAbortInitialize()
 
@@ -1750,7 +1761,7 @@ PAL_GenerateCoreDump(
     BOOL result = PROCBuildCreateDumpCommandLine(argvCreateDump, &program, &pidarg, dumpName, nullptr, dumpType, flags);
     if (result)
     {
-        result = PROCCreateCrashDump(argvCreateDump, errorMessageBuffer, cbErrorMessageBuffer, false);
+        result = PROCCreateCrashDump(argvCreateDump, errorMessageBuffer, cbErrorMessageBuffer, CrashDumpSerializeMode_None);
     }
     free(program);
     free(pidarg);
@@ -1805,6 +1816,108 @@ PROCLogManagedCallstackForSignal(int signal)
 
 /*++
 Function:
+  TryEnterCrashDumpGate
+
+  Serializes so that one thread generates a crash dump or in-proc crash report at a time.
+  The first thread to arrive wins the gate; concurrent threads wait (or not) depending on the
+  mode. See CrashDumpSerializeMode.
+
+Return:
+  TRUE  - the calling thread owns the gate.
+  FALSE - the calling thread does not own the gate.
+--*/
+static bool
+TryEnterCrashDumpGate(CrashDumpSerializeMode serializeMode)
+{
+    if (serializeMode == CrashDumpSerializeMode_None)
+    {
+        // No serialization requested.
+        return true;
+    }
+
+    size_t currentThreadId = THREADSilentGetCurrentThreadId();
+    size_t previousThreadId = InterlockedCompareExchange(&g_crashingThreadId, currentThreadId, 0);
+    if (previousThreadId == 0)
+    {
+        // Won the gate.
+        return true;
+    }
+
+    // Lost the gate, or this is a reentrant call on the owning thread. A
+    // WaitInfinite contender (other than the owner) waits indefinitely; the owner
+    // and CrashDumpSerializeMode_NoWait fall through and return immediately.
+    if (previousThreadId != currentThreadId && serializeMode == CrashDumpSerializeMode_WaitInfinite)
+    {
+        // The winner generates diagnostics and should terminate the process.
+        // Wait here until that happens.
+        while (true)
+        {
+            poll(NULL, 0, INFTIM);
+        }
+    }
+
+    return false;
+}
+
+/*++
+Function:
+  ExitCrashDumpGate
+
+  Releases the gate acquired by TryEnterCrashDumpGate. Only the owning thread
+  releases the gate; a call from any other thread is a no-op.
+--*/
+static void
+ExitCrashDumpGate(CrashDumpSerializeMode serializeMode)
+{
+    // CrashDumpSerializeMode_None never acquired the gate, and
+    // CrashDumpSerializeMode_WaitInfinite intentionally leaves it held.
+    if (serializeMode == CrashDumpSerializeMode_None || serializeMode == CrashDumpSerializeMode_WaitInfinite)
+    {
+        return;
+    }
+
+    // Re-arm the gate so a later crash can generate diagnostics again, but only
+    // if this thread still owns it.
+    size_t currentThreadId = THREADSilentGetCurrentThreadId();
+    InterlockedCompareExchange(&g_crashingThreadId, 0, currentThreadId);
+}
+
+/*++
+Function:
+  PROCCreateInProcCrashReport
+
+  Invokes the host-registered in-proc crash report callback, serializing
+  concurrent crash diagnostics per serializeMode through the shared gate.
+  Can be called from the unhandled native exception handler.
+
+Parameters:
+  signal - POSIX signal number
+  siginfo - POSIX signal info or nullptr
+  context - signal context or nullptr
+  serializeMode - how to serialize concurrent crash diagnostics
+
+(no return value)
+--*/
+static VOID
+PROCCreateInProcCrashReport(int signal, siginfo_t* siginfo, void* context, CrashDumpSerializeMode serializeMode)
+{
+    if (!TryEnterCrashDumpGate(serializeMode))
+    {
+        return;
+    }
+
+    // The host emits its report from this signal frame.
+    PINPROCCRASHREPORT_CALLBACK callback = g_inProcCrashReportCallback;
+    if (callback != nullptr)
+    {
+        callback(signal, siginfo, context);
+    }
+
+    ExitCrashDumpGate(serializeMode);
+}
+
+/*++
+Function:
   PROCCreateCrashDumpIfEnabled
 
   Creates crash dump of the process (if enabled). Can be
@@ -1814,22 +1927,29 @@ Parameters:
   signal - POSIX signal number
   siginfo - POSIX signal info or nullptr
   context - signal context or nullptr
-  serialize - allow only one thread to generate core dump
+  serializeMode - how to serialize concurrent crash diagnostics
 
 (no return value)
 --*/
 VOID
-PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, void* context, bool serialize)
+PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, void* context, CrashDumpSerializeMode serializeMode)
 {
     // Preserve context pointer to prevent optimization
     DoNotOptimize(&context);
 
-    // If a host registered an in-proc crash report callback, prefer it: the
-    // host emits its report from this signal frame.
-    PINPROCCRASHREPORT_CALLBACK callback = g_inProcCrashReportCallback;
-    if (callback != nullptr)
+    // If a host registered an in-proc crash report callback, it owns crash
+    // reporting for this process: the host emits its report from this signal
+    // frame and createdump is not launched.
+    if (g_inProcCrashReportCallback != nullptr)
     {
-        callback(signal, siginfo, context, serialize);
+        // The in-proc crash reporter runs only on terminal crash paths. Non-terminal
+        // paths that may continue execution after signal handling (e.g. SIGTERM, which
+        // uses CrashDumpSerializeMode_None) are skipped, because the reporter does not
+        // support recurrent invocations.
+        if (serializeMode != CrashDumpSerializeMode_None)
+        {
+            PROCCreateInProcCrashReport(signal, siginfo, context, serializeMode);
+        }
         return;
     }
 
@@ -1895,7 +2015,7 @@ PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, void* context, bool
         argv[argc] = nullptr;
         _ASSERTE(argc < MAX_ARGV_ENTRIES);
 
-        PROCCreateCrashDump(argv, nullptr, 0, serialize);
+        PROCCreateCrashDump(argv, nullptr, 0, serializeMode);
 
         free(signalArg);
         free(crashThreadArg);
@@ -1927,7 +2047,7 @@ PROCAbort(int signal, siginfo_t* siginfo, void* context)
     // Do any shutdown cleanup before aborting or creating a core dump
     PROCNotifyProcessShutdown();
 
-    PROCCreateCrashDumpIfEnabled(signal, siginfo, context, true);
+    PROCCreateCrashDumpIfEnabled(signal, siginfo, context, CrashDumpSerializeMode_WaitInfinite);
 
     // Restore all signals; the SIGABORT handler to prevent recursion and
     // the others to prevent multiple core dumps from being generated.

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -1622,7 +1622,11 @@ Function:
   called from the unhandled native exception handler.
 
 Return:
-  TRUE - succeeds, FALSE - fails or another thread owns the gate
+  TRUE  - succeeds.
+  FALSE - fails, or another thread already owns the gate under
+          CrashDumpSerialize_NoWait. Under CrashDumpSerialize_WaitInfinite a
+          losing thread blocks indefinitely in TryEnterCrashDumpGate instead
+          of returning.
 --*/
 static BOOL
 PROCCreateCrashDump(
@@ -1824,7 +1828,9 @@ Function:
 
 Return:
   TRUE  - the calling thread owns the gate.
-  FALSE - the calling thread does not own the gate.
+  FALSE - the calling thread does not own the gate. Only returned for
+          CrashDumpSerialize_NoWait; a losing CrashDumpSerialize_WaitInfinite
+          thread blocks indefinitely instead and never returns.
 --*/
 static bool
 TryEnterCrashDumpGate(CrashDumpSerializeMode serializeMode)
@@ -1852,7 +1858,11 @@ TryEnterCrashDumpGate(CrashDumpSerializeMode serializeMode)
         // Wait here until that happens.
         while (true)
         {
+#if HAVE_POLL
+            poll(NULL, 0, INFTIM);
+#else
             pause();
+#endif
         }
     }
 

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -124,8 +124,25 @@ using namespace CorUnix;
 // Thread ID of thread that has started the ExitProcess process
 Volatile<LONG> terminator = 0;
 
+static SIZE_T InterlockedCompareExchangeSizeT(SIZE_T volatile* destination, SIZE_T exchange, SIZE_T comparand)
+{
+#ifdef HOST_64BIT
+    LONGLONG result = InterlockedCompareExchange64(
+        reinterpret_cast<LONGLONG volatile*>(destination),
+        *reinterpret_cast<LONGLONG*>(&exchange),
+        *reinterpret_cast<LONGLONG*>(&comparand));
+    return *reinterpret_cast<SIZE_T*>(&result);
+#else
+    LONG result = InterlockedCompareExchange(
+        reinterpret_cast<LONG volatile*>(destination),
+        *reinterpret_cast<LONG*>(&exchange),
+        *reinterpret_cast<LONG*>(&comparand));
+    return *reinterpret_cast<SIZE_T*>(&result);
+#endif
+}
+
 // Id of thread generating a core dump
-volatile LONGLONG g_crashingThreadId = 0;
+SIZE_T g_crashingThreadId = 0;
 
 // Process ID of this process.
 DWORD gPID = (DWORD) -1;
@@ -1623,10 +1640,10 @@ Function:
 
 Return:
   TRUE  - succeeds.
-  FALSE - fails, or another thread already owns the gate under
-          CrashDumpSerialize_NoWait. Under CrashDumpSerialize_WaitInfinite a
-          losing thread blocks indefinitely in TryEnterCrashDumpGate instead
-          of returning.
+  FALSE - fails, another thread already owns the gate under
+          CrashDumpSerialize_NoWait, or the owning thread re-enters the gate.
+          Under CrashDumpSerialize_WaitInfinite a losing non-owner thread blocks
+          indefinitely in TryEnterCrashDumpGate instead of returning.
 --*/
 static BOOL
 PROCCreateCrashDump(
@@ -1828,9 +1845,10 @@ Function:
 
 Return:
   TRUE  - the calling thread owns the gate.
-  FALSE - the calling thread does not own the gate. Only returned for
-          CrashDumpSerialize_NoWait; a losing CrashDumpSerialize_WaitInfinite
-          thread blocks indefinitely instead and never returns.
+  FALSE - the calling thread does not own the gate. Returned for
+          CrashDumpSerialize_NoWait and for a reentrant call by the owning
+          thread; a losing non-owner CrashDumpSerialize_WaitInfinite thread
+          blocks indefinitely instead and never returns.
 --*/
 static bool
 TryEnterCrashDumpGate(CrashDumpSerializeMode serializeMode)
@@ -1841,8 +1859,8 @@ TryEnterCrashDumpGate(CrashDumpSerializeMode serializeMode)
         return true;
     }
 
-    LONGLONG currentThreadId = static_cast<LONGLONG>(THREADSilentGetCurrentThreadId());
-    LONGLONG previousThreadId = InterlockedCompareExchange64(&g_crashingThreadId, currentThreadId, 0);
+    SIZE_T currentThreadId = THREADSilentGetCurrentThreadId();
+    SIZE_T previousThreadId = InterlockedCompareExchangeSizeT(&g_crashingThreadId, currentThreadId, 0);
     if (previousThreadId == 0)
     {
         // Won the gate.
@@ -1888,8 +1906,8 @@ ExitCrashDumpGate(CrashDumpSerializeMode serializeMode)
 
     // Re-arm the gate so a later crash can generate diagnostics again, but only
     // if this thread still owns it.
-    LONGLONG currentThreadId = static_cast<LONGLONG>(THREADSilentGetCurrentThreadId());
-    InterlockedCompareExchange64(&g_crashingThreadId, 0, currentThreadId);
+    SIZE_T currentThreadId = THREADSilentGetCurrentThreadId();
+    InterlockedCompareExchangeSizeT(&g_crashingThreadId, 0, currentThreadId);
 }
 
 /*++

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -1761,7 +1761,7 @@ PAL_GenerateCoreDump(
     BOOL result = PROCBuildCreateDumpCommandLine(argvCreateDump, &program, &pidarg, dumpName, nullptr, dumpType, flags);
     if (result)
     {
-        result = PROCCreateCrashDump(argvCreateDump, errorMessageBuffer, cbErrorMessageBuffer, CrashDumpSerializeMode_None);
+        result = PROCCreateCrashDump(argvCreateDump, errorMessageBuffer, cbErrorMessageBuffer, CrashDumpSerialize_None);
     }
     free(program);
     free(pidarg);
@@ -1829,7 +1829,7 @@ Return:
 static bool
 TryEnterCrashDumpGate(CrashDumpSerializeMode serializeMode)
 {
-    if (serializeMode == CrashDumpSerializeMode_None)
+    if (serializeMode == CrashDumpSerialize_None)
     {
         // No serialization requested.
         return true;
@@ -1845,14 +1845,14 @@ TryEnterCrashDumpGate(CrashDumpSerializeMode serializeMode)
 
     // Lost the gate, or this is a reentrant call on the owning thread. A
     // WaitInfinite contender (other than the owner) waits indefinitely; the owner
-    // and CrashDumpSerializeMode_NoWait fall through and return immediately.
-    if (previousThreadId != currentThreadId && serializeMode == CrashDumpSerializeMode_WaitInfinite)
+    // and CrashDumpSerialize_NoWait fall through and return immediately.
+    if (previousThreadId != currentThreadId && serializeMode == CrashDumpSerialize_WaitInfinite)
     {
         // The winner generates diagnostics and should terminate the process.
         // Wait here until that happens.
         while (true)
         {
-            poll(NULL, 0, INFTIM);
+            pause();
         }
     }
 
@@ -1869,9 +1869,9 @@ Function:
 static void
 ExitCrashDumpGate(CrashDumpSerializeMode serializeMode)
 {
-    // CrashDumpSerializeMode_None never acquired the gate, and
-    // CrashDumpSerializeMode_WaitInfinite intentionally leaves it held.
-    if (serializeMode == CrashDumpSerializeMode_None || serializeMode == CrashDumpSerializeMode_WaitInfinite)
+    // CrashDumpSerialize_None never acquired the gate, and
+    // CrashDumpSerialize_WaitInfinite intentionally leaves it held.
+    if (serializeMode == CrashDumpSerialize_None || serializeMode == CrashDumpSerialize_WaitInfinite)
     {
         return;
     }
@@ -1944,9 +1944,9 @@ PROCCreateCrashDumpIfEnabled(int signal, siginfo_t* siginfo, void* context, Cras
     {
         // The in-proc crash reporter runs only on terminal crash paths. Non-terminal
         // paths that may continue execution after signal handling (e.g. SIGTERM, which
-        // uses CrashDumpSerializeMode_None) are skipped, because the reporter does not
+        // uses CrashDumpSerialize_None) are skipped, because the reporter does not
         // support recurrent invocations.
-        if (serializeMode != CrashDumpSerializeMode_None)
+        if (serializeMode != CrashDumpSerialize_None)
         {
             PROCCreateInProcCrashReport(signal, siginfo, context, serializeMode);
         }
@@ -2047,7 +2047,7 @@ PROCAbort(int signal, siginfo_t* siginfo, void* context)
     // Do any shutdown cleanup before aborting or creating a core dump
     PROCNotifyProcessShutdown();
 
-    PROCCreateCrashDumpIfEnabled(signal, siginfo, context, CrashDumpSerializeMode_WaitInfinite);
+    PROCCreateCrashDumpIfEnabled(signal, siginfo, context, CrashDumpSerialize_WaitInfinite);
 
     // Restore all signals; the SIGABORT handler to prevent recursion and
     // the others to prevent multiple core dumps from being generated.

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -125,7 +125,7 @@ using namespace CorUnix;
 Volatile<LONG> terminator = 0;
 
 // Id of thread generating a core dump
-Volatile<LONG> g_crashingThreadId = 0;
+Volatile<LONGLONG> g_crashingThreadId = 0;
 
 // Process ID of this process.
 DWORD gPID = (DWORD) -1;
@@ -1841,8 +1841,8 @@ TryEnterCrashDumpGate(CrashDumpSerializeMode serializeMode)
         return true;
     }
 
-    size_t currentThreadId = THREADSilentGetCurrentThreadId();
-    size_t previousThreadId = InterlockedCompareExchange(&g_crashingThreadId, currentThreadId, 0);
+    LONGLONG currentThreadId = static_cast<LONGLONG>(THREADSilentGetCurrentThreadId());
+    LONGLONG previousThreadId = InterlockedCompareExchange64(&g_crashingThreadId, currentThreadId, 0);
     if (previousThreadId == 0)
     {
         // Won the gate.
@@ -1888,8 +1888,8 @@ ExitCrashDumpGate(CrashDumpSerializeMode serializeMode)
 
     // Re-arm the gate so a later crash can generate diagnostics again, but only
     // if this thread still owns it.
-    size_t currentThreadId = THREADSilentGetCurrentThreadId();
-    InterlockedCompareExchange(&g_crashingThreadId, 0, currentThreadId);
+    LONGLONG currentThreadId = static_cast<LONGLONG>(THREADSilentGetCurrentThreadId());
+    InterlockedCompareExchange64(&g_crashingThreadId, 0, currentThreadId);
 }
 
 /*++


### PR DESCRIPTION
Unify concurrent crash-diagnostics serialization for the out-of-proc createdump path and the in-proc crash report behind a single shared gate keyed on g_crashingThreadId, replacing the per-mechanism gates.

Introduce CrashDumpSerializeMode {None, NoWait, WaitInfinite} and route both createdump and the in-proc callback through TryEnterCrashDumpGate/ExitCrashDumpGate. The in-proc callback ABI drops its 'serialize' parameter since the PAL now owns serialization; the reporter keeps a non-blocking re-entry guard. The in-proc report still runs only on terminal crash paths (serializeMode != None), preserving the prior refusal of recurrent invocations such as SIGTERM.