### PR TITLE
[s390x] add in-process crash reporter for s390x

### DIFF
--- a/src/coreclr/debug/crashreport/inproccrashreporter.cpp
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.cpp
@@ -60,6 +60,8 @@ static const char CRASHREPORT_ARCHITECTURE_NAME[] =
     "loongarch64";
 #elif defined(TARGET_S390X)
     "s390x";
+#elif defined(TARGET_POWERPC64)
+    "ppc64le";
 #else
 #error "Unsupported arch"
 #endif
@@ -1247,6 +1249,11 @@ CrashReportHelpers::WriteRegistersToJson(
     #define CRASH_MCREG_PC(uc) (static_cast<uint64_t>((uc)->uc_mcontext.psw.addr))
     #define CRASH_MCREG_SP(uc) (static_cast<uint64_t>((uc)->uc_mcontext.gregs[15]))
     #define CRASH_MCREG_FP(uc) (static_cast<uint64_t>((uc)->uc_mcontext.gregs[11]))
+
+#elif defined(TARGET_POWERPC64)
+    #define CRASH_MCREG_PC(uc) (static_cast<uint64_t>((uc)->uc_mcontext.gp_regs[32]))
+    #define CRASH_MCREG_SP(uc) (static_cast<uint64_t>((uc)->uc_mcontext.gp_regs[1]))
+    #define CRASH_MCREG_FP(uc) (static_cast<uint64_t>((uc)->uc_mcontext.gp_regs[31]))
 #else
     #error "Unsupported arch"
 #endif

--- a/src/coreclr/debug/crashreport/inproccrashreporter.cpp
+++ b/src/coreclr/debug/crashreport/inproccrashreporter.cpp
@@ -58,6 +58,8 @@ static const char CRASHREPORT_ARCHITECTURE_NAME[] =
     "riscv64";
 #elif defined(TARGET_LOONGARCH64)
     "loongarch64";
+#elif defined(TARGET_S390X)
+    "s390x";
 #else
 #error "Unsupported arch"
 #endif
@@ -1241,6 +1243,10 @@ CrashReportHelpers::WriteRegistersToJson(
     #define CRASH_MCREG_SP(uc) (static_cast<uint64_t>((uc)->uc_mcontext.__gregs[2]))
     #define CRASH_MCREG_FP(uc) (static_cast<uint64_t>((uc)->uc_mcontext.__gregs[8]))
 
+#elif defined(TARGET_S390X)
+    #define CRASH_MCREG_PC(uc) (static_cast<uint64_t>((uc)->uc_mcontext.psw.addr))
+    #define CRASH_MCREG_SP(uc) (static_cast<uint64_t>((uc)->uc_mcontext.gregs[15]))
+    #define CRASH_MCREG_FP(uc) (static_cast<uint64_t>((uc)->uc_mcontext.gregs[11]))
 #else
     #error "Unsupported arch"
 #endif


### PR DESCRIPTION
Fixes #131535 for linux-s390x, #131604 introduced a build error

```
  /home/sanjam/runtime/src/coreclr/debug/crashreport/inproccrashreporter.cpp:62:2: error: "Unsupported arch"
     62 | #error "Unsupported arch"
        |  ^
  /home/sanjam/runtime/src/coreclr/debug/crashreport/inproccrashreporter.cpp:89:1: error: expected expression
     89 | struct StackOverflowTraceFrame
        | ^
  /home/sanjam/runtime/src/coreclr/debug/crashreport/inproccrashreporter.cpp:102:5: error: unknown type name 'StackOverflowTraceFrame'; did you mean 'StackOverflowTraceSnapshot'?
    102 |     StackOverflowTraceFrame frames[CRASHREPORT_STACK_OVERFLOW_MAX_TRACE_FRAMES];
        |     ^~~~~~~~~~~~~~~~~~~~~~~
        |     StackOverflowTraceSnapshot


....

  /home/sanjam/runtime/src/coreclr/debug/crashreport/inproccrashreporter.cpp:1245:6: error: "Unsupported arch"
   1245 |     #error "Unsupported arch"
        |      ^
  /home/sanjam/runtime/src/coreclr/debug/crashreport/inproccrashreporter.cpp:1258:12: error: use of undeclared identifier 'CRASH_MCREG_PC'
   1258 |     return CRASH_MCREG_PC(ucontext);
        |            ^
  /home/sanjam/runtime/src/coreclr/debug/crashreport/inproccrashreporter.cpp:1271:12: error: use of undeclared identifier 'CRASH_MCREG_SP'
   1271 |     return CRASH_MCREG_SP(ucontext);
        |            ^
  /home/sanjam/runtime/src/coreclr/debug/crashreport/inproccrashreporter.cpp:1284:12: error: use of undeclared identifier 'CRASH_MCREG_FP'
   1284 |     return CRASH_MCREG_FP(ucontext);
```