### PR TITLE
Suppress union ambiguity warning when a global classified is specified at compile time

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -988,7 +988,7 @@ namespace System.Text.Json.SourceGeneration
                 List<DerivedTypeSpec>? derivedTypes = null;
                 HashSet<object>? typeDiscriminators = null;
                 bool hasExplicitDerivedTypeAttribute = false;
-                bool hasUnionTypeClassifierSpecified = false;
+                bool hasUnionTypeClassifierSpecified = options?.TypeClassifiers is { Count: > 0 };
                 bool isUnionType = IsUnionType(typeToGenerate.Type);
                 INamedTypeSymbol? namedUnionType = typeToGenerate.Type as INamedTypeSymbol;
 

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -988,6 +988,7 @@ namespace System.Text.Json.SourceGeneration
                 List<DerivedTypeSpec>? derivedTypes = null;
                 HashSet<object>? typeDiscriminators = null;
                 bool hasExplicitDerivedTypeAttribute = false;
+                // A context-level classifier can opt into classifying this union at runtime.
                 bool hasUnionTypeClassifierSpecified = options?.TypeClassifiers is { Count: > 0 };
                 bool isUnionType = IsUnionType(typeToGenerate.Type);
                 INamedTypeSymbol? namedUnionType = typeToGenerate.Type as INamedTypeSymbol;

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -988,7 +988,6 @@ namespace System.Text.Json.SourceGeneration
                 List<DerivedTypeSpec>? derivedTypes = null;
                 HashSet<object>? typeDiscriminators = null;
                 bool hasExplicitDerivedTypeAttribute = false;
-                // A context-level classifier can opt into classifying this union at runtime.
                 bool hasUnionTypeClassifierSpecified = options?.TypeClassifiers is { Count: > 0 };
                 bool isUnionType = IsUnionType(typeToGenerate.Type);
                 INamedTypeSymbol? namedUnionType = typeToGenerate.Type as INamedTypeSymbol;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
@@ -816,7 +816,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             Compilation compilation = CompilationHelper.CreateCompilation(source);
             JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, disableDiagnosticValidation: true);
 
-            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "SYSLIB1227");
+            Assert.Empty(result.Diagnostics);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
@@ -781,7 +781,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         }
 
         [Fact]
-        public void UnionWithAmbiguousCaseTypesAndOptionsClassifier_CompilesWithWarning()
+        public void UnionWithAmbiguousCaseTypesAndOptionsClassifier_CompilesWithoutWarning()
         {
             string source = """
                 using System;
@@ -815,14 +815,8 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             Compilation compilation = CompilationHelper.CreateCompilation(source);
             JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, disableDiagnosticValidation: true);
-            Location unionLocation = compilation.GetSymbolsWithName("IntOrLongUnion").First().Locations[0];
 
-            var expectedDiagnostics = new DiagnosticData[]
-            {
-                new(DiagnosticSeverity.Warning, unionLocation, "Union type 'IntOrLongUnion': case types 'int', 'long' all serialize as JSON value type 'Number'. Set JsonUnionAttribute.TypeClassifier to provide a custom classifier that can disambiguate."),
-            };
-
-            CompilationHelper.AssertEqualDiagnosticMessages(expectedDiagnostics, result.Diagnostics);
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "SYSLIB1227");
         }
 
         [Fact]


### PR DESCRIPTION
Options-level type classifiers are emitted into `JsonSerializerOptions.TypeClassifiers`, but the source generator's union ambiguity diagnostic only checked `JsonUnionAttribute.TypeClassifier`. Treat a non-empty validated `JsonSourceGenerationOptionsAttribute.TypeClassifiers` list as configured classifier support so `SYSLIB1227` isn't emitted in that case.

The existing source-generator diagnostic tests now cover both per-union and options-level classifier registration.

Validated with `build.cmd clr+libs -rc release` and all System.Text.Json test projects (130,518 executions, 0 failures; 17 existing skips).

> [!NOTE]
> This pull request description was generated by GitHub Copilot.