### PR TITLE
Always match the union payload with a property pattern in the STJ source generator

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -782,23 +782,14 @@ namespace System.Text.Json.SourceGeneration
                             continue;
                         }
 
-                        string patternTypeFQN = caseSpec.PatternType.FullyQualifiedName;
-
-                        if (patternTypeFQN == typeMetadata.TypeRef.FullyQualifiedName)
-                        {
-                            // Recursive case: the case type is the union type itself. A type pattern `T`
-                            // applied to a union is equivalent to `T or { Value: T }`, so a bare type
-                            // pattern here is also satisfied by the union instance itself. That both binds
-                            // the union rather than its payload -- making the converter recurse on the same
-                            // value forever -- and renders any later arm unreachable. Match the payload
-                            // explicitly so that only the unwrapped value is bound.
-                            writer.WriteLine($"{{ Value: {patternTypeFQN} caseValue{deconArmIndex} }} => (typeof({caseSpec.CaseType.FullyQualifiedName}), (object?)caseValue{deconArmIndex}),");
-                        }
-                        else
-                        {
-                            writer.WriteLine($"{patternTypeFQN} caseValue{deconArmIndex} => (typeof({caseSpec.CaseType.FullyQualifiedName}), (object?)caseValue{deconArmIndex}),");
-                        }
-
+                        // Match the payload through a property pattern rather than applying a type
+                        // pattern to the union itself. A type pattern `T` applied to a union is
+                        // equivalent to `T or { Value: T }`, so for a case whose type is the union
+                        // type itself the union instance also matches: that would bind the union
+                        // rather than its payload -- making the converter recurse on the same value
+                        // forever -- and would render every later arm unreachable. The explicit form
+                        // binds only the unwrapped value and behaves the same for all other cases.
+                        writer.WriteLine($"{{ Value: {caseSpec.PatternType.FullyQualifiedName} caseValue{deconArmIndex} }} => (typeof({caseSpec.CaseType.FullyQualifiedName}), (object?)caseValue{deconArmIndex}),");
                         deconArmIndex++;
                     }
 


### PR DESCRIPTION
Follow-up to the review feedback on #131569.

That PR fixed infinite recursion in the generated union deconstructor for recursive union types by matching the payload with a `{ Value: T x }` property pattern, but only for the case whose type is the union type itself; every other case kept a bare type pattern.

Per [@AlekseyTs's suggestion](https://github.com/dotnet/runtime/pull/131569#discussion_r3704512418), this generates all cases that way unconditionally, which removes the special case from the emitter and is more robust:

- It does not rely on the compiler's union-unwrapping rule for type patterns. Per the [unions proposal](https://github.com/dotnet/csharplang/blob/main/proposals/unions.md#type-pattern), a type pattern `T` applied to a union is equivalent to `T or { Value: T }`, so a bare type pattern happens to work for cases that are not the union type itself only because the union instance can never match them.
- It always verifies the payload rather than the union instance, so no arm can become a trivially-matching catch-all that shadows the arms after it.

Generated code before:

```csharp
return value switch
{
    null => ((Type?)null, (object?)null),
    bool caseValue0 => (typeof(bool), (object?)caseValue0),
    { Value: RecursiveNat caseValue1 } => (typeof(RecursiveNat), (object?)caseValue1),
};
```

After:

```csharp
return value switch
{
    null => ((Type?)null, (object?)null),
    { Value: bool caseValue0 } => (typeof(bool), (object?)caseValue0),
    { Value: RecursiveNat caseValue1 } => (typeof(RecursiveNat), (object?)caseValue1),
};
```

No behavior change is expected, so no new tests are added; #131569 already added recursive-union coverage in both case-declaration orders.

## Testing

- `System.Text.Json.SourceGeneration.Roslyn4.4.Tests` — 10932 passed, 0 failed
- `System.Text.Json.SourceGeneration.Roslyn3.11.Tests` — 475 passed, 0 failed
- `System.Text.Json.SourceGeneration.Roslyn4.4.Unit.Tests` — 282 passed, 0 failed

cc @eiriktsarpalis @AlekseyTs

> [!NOTE]
> This PR was created with the assistance of GitHub Copilot.
