### PR TITLE
Fix Uri equality contract violation in PackUriHelper.ValidatedPartUri

### DIFF
--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -601,7 +602,9 @@ namespace System.IO.Packaging
         /// to reduce the parsing and number of allocations for Strings and Uris
         /// we cache the results after parsing.
         /// </summary>
+#pragma warning disable CA1067 // Override Equals because it implements IEquatable<T>; not overriding to avoid possible regressions in code that's working
         internal sealed class ValidatedPartUri : Uri, IComparable<ValidatedPartUri>, IEquatable<ValidatedPartUri>
+#pragma warning restore CA1067
         {
             //------------------------------------------------------
             //
@@ -650,22 +653,6 @@ namespace System.IO.Packaging
             }
 
             #endregion IEquatable Methods
-
-            #region Overrides
-
-            public override bool Equals(object? obj)
-            {
-                if (obj is ValidatedPartUri other)
-                    return Compare(other) == 0;
-                return false;
-            }
-
-            public override int GetHashCode()
-            {
-                return StringComparer.OrdinalIgnoreCase.GetHashCode(NormalizedPartUriString);
-            }
-
-            #endregion Overrides
 
             #region Internal Properties
 
@@ -891,6 +878,38 @@ namespace System.IO.Packaging
             #endregion Private Methods
 
             //------------------------------------------------------
+        }
+
+        /// <summary>
+        /// Compares <see cref="ValidatedPartUri"/> instances for equality using the same
+        /// case-insensitive, normalized comparison as <see cref="ValidatedPartUri.Compare"/>
+        /// via <see cref="IEquatable{ValidatedPartUri}"/>.
+        /// This is used explicitly by internal collections that need case-insensitive part-name
+        /// semantics (e.g. <see cref="ZipPackage"/>'s content-type override dictionary), without
+        /// relying on <see cref="ValidatedPartUri"/> overriding <see cref="object.Equals(object?)"/>
+        /// or <see cref="object.GetHashCode"/>, which would break the equality contract inherited
+        /// from <see cref="Uri"/> when a <see cref="ValidatedPartUri"/> is compared against, or
+        /// co-located in a hash collection with, a plain <see cref="Uri"/> of the same value.
+        /// </summary>
+        internal sealed class ValidatedPartUriEqualityComparer : IEqualityComparer<ValidatedPartUri>
+        {
+            internal static readonly ValidatedPartUriEqualityComparer Instance = new();
+
+            private ValidatedPartUriEqualityComparer() { }
+
+            public bool Equals(ValidatedPartUri? x, ValidatedPartUri? y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (x is null || y is null)
+                    return false;
+
+                return ((IEquatable<ValidatedPartUri>)x).Equals(y);
+            }
+
+            public int GetHashCode(ValidatedPartUri obj)
+                => StringComparer.OrdinalIgnoreCase.GetHashCode(obj.NormalizedPartUriString);
         }
 
         #endregion Private Class

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -947,7 +947,9 @@ namespace System.IO.Packaging
             {
                 // The part Uris are stored in the Override Dictionary in their original form , but they are compared
                 // in a normalized manner using the PartUriComparer
-                _overrideDictionary ??= new Dictionary<PackUriHelper.ValidatedPartUri, ContentType>(OverrideDictionaryInitialSize);
+                _overrideDictionary ??= new Dictionary<PackUriHelper.ValidatedPartUri, ContentType>(
+                    OverrideDictionaryInitialSize,
+                    PackUriHelper.ValidatedPartUriEqualityComparer.Instance);
             }
 
             private void ParseContentTypesFile(System.Collections.ObjectModel.ReadOnlyCollection<ZipArchiveEntry> zipFiles)

--- a/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/PartPieceTests.cs
@@ -362,6 +362,70 @@ namespace System.IO.Packaging.Tests
         }
 
         [Fact]
+        public void PartUriHonorsSystemUriEqualityContract()
+        {
+            // PackUriHelper.CreatePartUri returns an internal Uri subclass (ValidatedPartUri) that must
+            // preserve System.Uri's object.Equals/GetHashCode contract so it can be safely mixed with
+            // plain System.Uri instances in hash-based collections such as HashSet<Uri>/Dictionary<Uri,_>.
+            Uri plain = new Uri("/foo.xml", UriKind.Relative);
+            Uri validated = PackUriHelper.CreatePartUri(plain);
+
+            object a = validated;
+            object b = plain;
+
+            // object.Equals must be symmetric.
+            Assert.Equal(a.Equals(b), b.Equals(a));
+
+            // GetHashCode must be consistent with a value-equal plain System.Uri so both types can
+            // coexist as keys in the same hash-based collection.
+            Assert.Equal(plain.GetHashCode(), validated.GetHashCode());
+
+            var set = new HashSet<Uri> { plain };
+            Assert.Contains(validated, set);
+
+            var set2 = new HashSet<Uri> { validated };
+            Assert.Contains(plain, set2);
+        }
+
+        [Fact]
+        public void ContentTypeOverrideLookupIsCaseInsensitive()
+        {
+            // Regression test: a package whose [Content_Types].xml Override PartName differs only
+            // by case from the actual zip entry name must still resolve the part's content type.
+            // This exercises ZipPackage's internal ValidatedPartUri-keyed override dictionary, which
+            // must remain case-insensitive independent of whether ValidatedPartUri overrides
+            // object.Equals/GetHashCode.
+            using var ms = new MemoryStream();
+            using (var zipArchive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                var contentTypesEntry = zipArchive.CreateEntry("[Content_Types].xml");
+                using (var writer = new StreamWriter(contentTypesEntry.Open()))
+                {
+                    writer.Write(
+                        """
+                        <?xml version="1.0" encoding="utf-8"?>
+                        <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+                            <Override PartName="/Test.xml" ContentType="application/foo" />
+                        </Types>
+                        """);
+                }
+
+                var partEntry = zipArchive.CreateEntry("test.xml");
+                using (var writer = new StreamWriter(partEntry.Open()))
+                {
+                    writer.Write("<root/>");
+                }
+            }
+
+            ms.Position = 0;
+            using var package = Package.Open(ms, FileMode.Open, FileAccess.Read);
+            PackagePart[] parts = package.GetParts().ToArray();
+
+            Assert.Single(parts);
+            Assert.Equal("application/foo", parts[0].ContentType);
+        }
+
+        [Fact]
         public void CanCreateAtomicPart()
         {
             using var ms = new MemoryStream();


### PR DESCRIPTION
Fixes #129927
PR #118574 added object.Equals/GetHashCode overrides to ValidatedPartUri (which derives from System.Uri) to support case-insensitive part-name matching. This broke the inherited Uri equality contract: Equals became asymmetric against a plain System.Uri of the same value, and GetHashCode became inconsistent with System.Uri.GetHashCode(). Consumers mixing ValidatedPartUri with plain System.Uri in HashSet<Uri>/Dictionary<Uri,_> (e.g. the Open XML SDK) got incorrect lookup results.

- Revert the Equals(object?)/GetHashCode() overrides, restoring the original CA1067 suppression. ValidatedPartUri once again inherits Uri's value-equality, matching plain System.Uri semantics.
- Keep the case-insensitive Compare()/IComparable<ValidatedPartUri>/ IEquatable<ValidatedPartUri> logic, which is what makes Package.cs's SortedList<ValidatedPartUri, PackagePart> lookups case-insensitive (fixing #112783 for that path) and is unaffected by this change.
- Add PackUriHelper.ValidatedPartUriEqualityComparer, an internal IEqualityComparer<ValidatedPartUri> providing case-insensitive equality/hashing, and use it explicitly in ZipPackage's content-type override dictionary. Without this, removing GetHashCode() would leave that Dictionary<ValidatedPartUri,_> with a hash/equals mismatch (case-insensitive Equals via IEquatable<T>, case-sensitive hash via inherited Uri.GetHashCode()), silently dropping parts whose zip entry name casing differs from their [Content_Types].xml Override PartName.
- Add regression tests covering the Uri equality contract and the content-type override case-insensitivity behavior.