### PR TITLE
Change VOLATILE_MEMORY_BARRIER for x64 Unix

### DIFF
--- a/src/coreclr/gc/env/volatile.h
+++ b/src/coreclr/gc/env/volatile.h
@@ -90,7 +90,7 @@
 // Please do not use this macro outside of this file.  It is subject to change or removal without
 // notice.
 //
-#define VOLATILE_MEMORY_BARRIER() asm volatile ("" : : : "memory")
+#define VOLATILE_MEMORY_BARRIER() __atomic_signal_fence(__ATOMIC_SEQ_CST)
 #endif // HOST_ARM || HOST_ARM64
 #elif (defined(HOST_ARM) || defined(HOST_ARM64)) && _ISO_VOLATILE
 // ARM & ARM64 have a very weak memory model and very few tools to control that model. We're forced to perform a full

--- a/src/coreclr/inc/volatile.h
+++ b/src/coreclr/inc/volatile.h
@@ -100,7 +100,7 @@
 // Please do not use this macro outside of this file.  It is subject to change or removal without
 // notice.
 //
-#define VOLATILE_MEMORY_BARRIER() asm volatile ("" : : : "memory")
+#define VOLATILE_MEMORY_BARRIER() __atomic_signal_fence(__ATOMIC_SEQ_CST)
 #endif // HOST_ARM || HOST_ARM64
 
 #elif (defined(HOST_ARM) || defined(HOST_ARM64)) && _ISO_VOLATILE


### PR DESCRIPTION
Currently the macro is defined as asm volatile ("" : : : "memory"). That caused a recent regression in HndWriteBarrier due to an added VolatileStore where clang adds an extra dummy jmp instruction to the very next location after a call to HndWriteBarrierWorker. This happens due to LLVM internal handling of the asm volatile ("" : : : "memory").

This change fixes it by replacing the barrier definition for x64 Unix by __atomic_signal_fence(__ATOMIC_SEQ_CST)

This is a pure compiler only barrier and it doesn't introduce the side effect like the asm volatile ("" : : : "memory").

Close #130698