### PR TITLE
Fix incorrect checks for CreateThread failure

### DIFF
--- a/src/coreclr/pal/tests/palsuite/threading/CreateThread/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/CreateThread/test1/test1.cpp
@@ -56,7 +56,7 @@ BOOL CreateThreadTest()
                             &dwThreadId );
 
     /* Ensure that the HANDLE is not invalid! */
-    if (hThread != INVALID_HANDLE_VALUE)
+    if (hThread != NULL)
     {
         dwRet = WaitForSingleObject(hThread,INFINITE);
 

--- a/src/coreclr/pal/tests/palsuite/threading/ExitThread/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/ExitThread/test1/test1.cpp
@@ -62,7 +62,7 @@ BOOL ExitThreadTest()
                             dwStackSize, lpStartAddress, lpParameter,
                             dwCreationFlags, &dwThreadId );
 
-    if (hThread != INVALID_HANDLE_VALUE)
+    if (hThread != NULL)
     {
         dwRet = WaitForSingleObject(hThread,INFINITE);
 

--- a/src/coreclr/pal/tests/palsuite/threading/ResumeThread/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/ResumeThread/test1/test1.cpp
@@ -51,7 +51,7 @@ BOOL ResumeThreadTest()
                             dwStackSize, lpStartAddress, lpParameter, 
                             dwCreationFlags, &dwThreadId ); 
     
-    if (hThread != INVALID_HANDLE_VALUE)
+    if (hThread != NULL)
     {
         /* Wait for one second.  This should return WAIT_TIMEOUT */
         dwRet = WaitForSingleObject(hThread,1000);

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -761,7 +761,7 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
         DisplayStackOverflowException();
 
         HandleHolder stackDumpThreadHandle{ Thread::CreateUtilityThread(Thread::StackSize_Small, LogStackOverflowStackTraceThread, GetThreadNULLOk(), W(".NET SO Tracer")) };
-        if (stackDumpThreadHandle != INVALID_HANDLE_VALUE)
+        if (stackDumpThreadHandle != NULL)
         {
             // Wait for the stack trace logging completion
             DWORD res = WaitForSingleObject(stackDumpThreadHandle, INFINITE);

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -3406,7 +3406,7 @@ CreateCrashDumpIfEnabled(bool stackoverflow)
         if (stackoverflow)
         {
             HandleHolder createDumpThreadHandle{ Thread::CreateUtilityThread(Thread::StackSize_Small, (LPTHREAD_START_ROUTINE)LaunchCreateDump, (void*)createDumpCommandLine, W(".NET SO Dumper")) };
-            if (createDumpThreadHandle != INVALID_HANDLE_VALUE)
+            if (createDumpThreadHandle != NULL)
             {
                 // Wait for the dump to be generated
                 DWORD res = WaitForSingleObject(createDumpThreadHandle, INFINITE);

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1619,7 +1619,7 @@ namespace
         };
 
         args.Thread = Thread::CreateUtilityThread(Thread::StackSize_Medium, threadStub, &args, name);
-        if (args.Thread == INVALID_HANDLE_VALUE)
+        if (args.Thread == NULL)
         {
             args.ThreadStartedEvent.CloseEvent();
             return false;

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1586,7 +1586,7 @@ namespace
         ThreadStubArguments args;
         args.Argument = argument;
         args.ThreadStart = threadStart;
-        args.Thread = INVALID_HANDLE_VALUE;
+        args.Thread = NULL;
 #ifdef __APPLE__
         args.name = name;
 #endif //__APPLE__

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1878,7 +1878,7 @@ HANDLE Thread::CreateUtilityThread(Thread::StackSizeBucket stackSizeBucket, LPTH
     DWORD threadId;
     HANDLE hThread = CreateThread(NULL, stackSize, start, args, flags, &threadId);
 
-    if (hThread != INVALID_HANDLE_VALUE)
+    if (hThread != NULL)
     {
         SetThreadName(hThread, pName);
 


### PR DESCRIPTION
At multiple places in the code base, the return value of the CreateThread Windows API is compared to INVALID_HANDLE_VALUE to detect failure to create the thread. That's incorrect though, since the CreateThread is documented to return NULL in case it fails.

I've discovered this while debugging an issue with the OutOfMemoryException test by running the test in a job object with limited amount of memory assigned.