### PR TITLE
[Android][Testing] Run tests on supported Android API levels

### DIFF
--- a/eng/pipelines/coreclr/hardware-intrinsics.yml
+++ b/eng/pipelines/coreclr/hardware-intrinsics.yml
@@ -1,17 +1,7 @@
 trigger: none
-pr:
-  branches:
-    include:
-    - '*'
-    exclude:
-    - release/*
-    - internal/release/*
-  paths:
-    include:
-    - eng/pipelines/**
-    - src/coreclr/jit/**
-    - src/tests/Common/GenerateHWIntrinsicTests/**
-    - src/tests/JIT/HardwareIntrinsics/**
+
+# Disabled for the Android API-level validation PR.
+pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -63,7 +63,19 @@ jobs:
     # Android x64
     - ${{ if in(parameters.platform, 'android_x64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - Ubuntu.2204.Amd64.Android.24.Open
+        - Ubuntu.2204.Amd64.Android.25.Open
+        - Ubuntu.2204.Amd64.Android.26.Open
+        - Ubuntu.2204.Amd64.Android.27.Open
+        - Ubuntu.2204.Amd64.Android.28.Open
         - Ubuntu.2204.Amd64.Android.29.Open
+        - Ubuntu.2204.Amd64.Android.30.Open
+        - Ubuntu.2204.Amd64.Android.31.Open
+        - Ubuntu.2204.Amd64.Android.32.Open
+        - Ubuntu.2204.Amd64.Android.33.Open
+        - Ubuntu.2204.Amd64.Android.34.Open
+        - Ubuntu.2204.Amd64.Android.35.Open
+        - Ubuntu.2204.Amd64.Android.36.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Ubuntu.2204.Amd64.Android.29
 

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -38,7 +38,7 @@ jobs:
       testGroup: innerloop
       nameSuffix: AllSubsets_NativeAOT_RuntimeTests
       buildArgs: -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
+      timeoutInMinutes: 1800
       # extra steps, run tests
       postBuildSteps:
         - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -75,7 +75,7 @@ jobs:
       testGroup: innerloop
       nameSuffix: AllSubsets_CoreCLR_RuntimeTests
       buildArgs: -s clr+libs -c $(_BuildConfig)
-      timeoutInMinutes: 360
+      timeoutInMinutes: 1800
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
           parameters:
@@ -109,7 +109,7 @@ jobs:
       nameSuffix: AllSubsets_CoreCLR
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       buildArgs: -s clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg)
-      timeoutInMinutes: 240
+      timeoutInMinutes: 1800
       # extra steps, run tests
       postBuildSteps:
         - template: /eng/pipelines/libraries/helix.yml
@@ -142,7 +142,7 @@ jobs:
       nameSuffix: NativeAOT
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       buildArgs: -s clr.aot+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:UseNativeAOTRuntime=true /p:RuntimeFlavor=coreclr /p:TestNativeAOT=true
-      timeoutInMinutes: 240
+      timeoutInMinutes: 1800
       # extra steps, run tests
       postBuildSteps:
         - template: /eng/pipelines/libraries/helix.yml

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -4,24 +4,8 @@
 
 trigger: none
 
-pr:
-  branches:
-    include:
-    - '*'
-  paths:
-    include:
-    - '*'
-    - eng/pipelines/global-build.yml
-    exclude:
-    - '**.md'
-    - .devcontainer/*
-    - .github/*
-    - docs/*
-    - eng/pipelines/coreclr/*.*
-    - eng/pipelines/libraries/*.*
-    - eng/pipelines/installer/*.*
-    - PATENTS.TXT
-    - THIRD-PARTY-NOTICES.TXT
+# Disabled for the Android API-level validation PR.
+pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -90,8 +90,22 @@ jobs:
     # Android
     # Use the Ubuntu-based Android queue for x86/x64/bionic_x64 on all projects,
     # and also for arm/arm64/bionic_arm/bionic_arm64 on non-public projects (no internal Windows Android queue).
-    - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
+    - ${{ if in(parameters.platform, 'android_x86', 'linux_bionic_x64') }}:
       - Ubuntu.2204.Amd64.Android.29.Open
+    - ${{ if eq(parameters.platform, 'android_x64') }}:
+      - Ubuntu.2204.Amd64.Android.24.Open
+      - Ubuntu.2204.Amd64.Android.25.Open
+      - Ubuntu.2204.Amd64.Android.26.Open
+      - Ubuntu.2204.Amd64.Android.27.Open
+      - Ubuntu.2204.Amd64.Android.28.Open
+      - Ubuntu.2204.Amd64.Android.29.Open
+      - Ubuntu.2204.Amd64.Android.30.Open
+      - Ubuntu.2204.Amd64.Android.31.Open
+      - Ubuntu.2204.Amd64.Android.32.Open
+      - Ubuntu.2204.Amd64.Android.33.Open
+      - Ubuntu.2204.Amd64.Android.34.Open
+      - Ubuntu.2204.Amd64.Android.35.Open
+      - Ubuntu.2204.Amd64.Android.36.Open
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Ubuntu.2204.Amd64.Android.29.Open
     - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'linux_bionic_arm')) }}:

--- a/eng/pipelines/runtime-androidemulator.yml
+++ b/eng/pipelines/runtime-androidemulator.yml
@@ -3,7 +3,22 @@
 # point the pipeline in azdo UI to this, and thus avoid any scheduled
 # triggers
 
-trigger: none
+trigger:
+  branches:
+    include:
+    - release/*.*
+  paths:
+    include:
+    - '*'
+
+pr:
+  branches:
+    include:
+    - main
+    - release/*.*
+  paths:
+    include:
+    - '*'
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -96,19 +96,8 @@ schedules:
     - main
   always: true
 
-pr:
-  branches:
-    include:
-    - '*'
-    exclude:
-    - release/*
-    - internal/release/*
-  paths:
-    include:
-    - eng/pipelines/**
-    - src/native/managed/cdac/**
-    - src/coreclr/debug/runtimeinfo/**
-    - src/coreclr/vm/cdacstress.cpp
+# Disabled for the Android API-level validation PR.
+pr: none
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -29,22 +29,8 @@ schedules:
       - main
     always: false # run only if there were changes since the last successful scheduled run.
 
-pr:
-  branches:
-    include:
-    - '*'
-  paths:
-    include:
-    - '*'
-    exclude:
-    - '**.md'
-    - eng/Version.Details.xml
-    - .devcontainer/*
-    - .github/*
-    - docs/*
-    - LICENSE.TXT
-    - PATENTS.TXT
-    - THIRD-PARTY-NOTICES.TXT
+# Disabled for the Android API-level validation PR.
+pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -30,22 +30,8 @@ schedules:
       - main
     always: false # run only if there were changes since the last successful scheduled run.
 
-pr:
-  branches:
-    include:
-    - '*'
-  paths:
-    include:
-    - '*'
-    exclude:
-    - '**.md'
-    - eng/Version.Details.xml
-    - .devcontainer/*
-    - .github/*
-    - docs/*
-    - LICENSE.TXT
-    - PATENTS.TXT
-    - THIRD-PARTY-NOTICES.TXT
+# Disabled for the Android API-level validation PR.
+pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml


### PR DESCRIPTION
Run Android x64 runtime and library tests on API levels 24 through 36, following the approach used in #120093 and the minimum API-level update in #126838.

- Fan out CoreCLR, NativeAOT, and library tests across the API-specific Helix queues.
- Increase emulator pipeline timeouts for the expanded matrix.
- Enable the `runtime-androidemulator` PR pipeline.
- Disable the regular `runtime`, `runtime-coreclr hardware-intrinsics`, `runtime-diagnostics`, `runtime-dev-innerloop`, and `dotnet-linker-tests` PR pipelines to avoid overloading CI.

This is a test-only PR and must not be merged.

**Summary is posted as a last comment**

> [!NOTE]
> This pull request was created with GitHub Copilot.