### PR TITLE
Improve watchdog child exit status check

### DIFF
--- a/src/native/watchdog/watchdog.cpp
+++ b/src/native/watchdog/watchdog.cpp
@@ -120,10 +120,16 @@ int run_timed_process(const long timeout_ms, const int proc_argc, const char *pr
 
             if (wait_code == -1)
             {
-                printf("waitpid failed: errno=%d (%s)\n", errno, strerror(errno));
-                return EINVAL;
-            }
+                int err = errno;
+                if (err != EINTR)
+                {
+                    printf("waitpid failed: errno=%d (%s)\n", err, strerror(err));
+                    return err;
+                }
 
+                // Retry on interrupt.
+                wait_code = 0;
+            }
             std::this_thread::sleep_for(std::chrono::milliseconds(check_interval_ms));
 
             if (wait_code)

--- a/src/native/watchdog/watchdog.cpp
+++ b/src/native/watchdog/watchdog.cpp
@@ -119,7 +119,10 @@ int run_timed_process(const long timeout_ms, const int proc_argc, const char *pr
             wait_code = waitpid(child_pid, &child_status, WNOHANG);
 
             if (wait_code == -1)
+            {
+                printf("waitpid failed: errno=%d (%s)\n", errno, strerror(errno));
                 return EINVAL;
+            }
 
             std::this_thread::sleep_for(std::chrono::milliseconds(check_interval_ms));
 
@@ -127,6 +130,13 @@ int run_timed_process(const long timeout_ms, const int proc_argc, const char *pr
             {
                 if (WIFEXITED(child_status))
                     return WEXITSTATUS(child_status);
+
+                if (WIFSIGNALED(child_status))
+                {
+                    int sig = WTERMSIG(child_status);
+                    printf("Child killed by signal %d\n", sig);
+                    return 128 + sig;  // Convention: 128 + signal number
+                }
             }
             check_count++;
 

--- a/src/native/watchdog/watchdog.cpp
+++ b/src/native/watchdog/watchdog.cpp
@@ -147,7 +147,7 @@ int run_timed_process(const long timeout_ms, const int proc_argc, const char *pr
                 }
             }
 
-            const std::chrono::steady_clock::time_point next_check_time =
+            std::chrono::steady_clock::time_point next_check_time =
                 std::chrono::steady_clock::now() + std::chrono::milliseconds(check_interval_ms);
             if (next_check_time > timeout_time)
             {

--- a/src/native/watchdog/watchdog.cpp
+++ b/src/native/watchdog/watchdog.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <errno.h>
 #include <signal.h>
 
@@ -85,7 +86,6 @@ int run_timed_process(const long timeout_ms, const int proc_argc, const char *pr
 #else // !TARGET_WINDOWS
 
     const int check_interval_ms = 25;
-    int check_count = 0;
     std::vector<const char*> args;
 
     pid_t child_pid;
@@ -113,6 +113,9 @@ int run_timed_process(const long timeout_ms, const int proc_argc, const char *pr
     }
     else
     {
+        const std::chrono::steady_clock::time_point timeout_time =
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+
         do
         {
             // Instructions for the parent process!
@@ -123,14 +126,13 @@ int run_timed_process(const long timeout_ms, const int proc_argc, const char *pr
                 int err = errno;
                 if (err != EINTR)
                 {
-                    printf("waitpid failed: errno=%d (%s)\n", err, strerror(err));
+                    printf("waitpid failed: errno=%d (%s)\n", err, std::strerror(err));
                     return err;
                 }
 
                 // Retry on interrupt.
                 wait_code = 0;
             }
-            std::this_thread::sleep_for(std::chrono::milliseconds(check_interval_ms));
 
             if (wait_code)
             {
@@ -144,9 +146,16 @@ int run_timed_process(const long timeout_ms, const int proc_argc, const char *pr
                     return 128 + sig;  // Convention: 128 + signal number
                 }
             }
-            check_count++;
 
-        } while (check_count < (timeout_ms / check_interval_ms));
+            const std::chrono::steady_clock::time_point next_check_time =
+                std::chrono::steady_clock::now() + std::chrono::milliseconds(check_interval_ms);
+            if (next_check_time > timeout_time)
+            {
+                next_check_time = timeout_time;
+            }
+            std::this_thread::sleep_until(next_check_time);
+
+        } while (std::chrono::steady_clock::now() < timeout_time);
     }
 
     printf("Child process took too long. Timed out... Exiting...\n");
@@ -155,4 +164,3 @@ int run_timed_process(const long timeout_ms, const int proc_argc, const char *pr
 #endif // TARGET_WINDOWS
     return ETIMEDOUT;
 }
-


### PR DESCRIPTION
The watchdog only checks for WIFEXITED(child_status). When the child was killed by a signal, most likely the SIGKILL, it doesn't report that and ends up timing out instead.

The change fixes that and also adds reporting errno when the waitpid fails.