### PR TITLE
 [APX] Add Jmpabs support.

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -9072,6 +9072,7 @@ void CodeGen::genAmd64EmitterUnitTestsApx()
     theEmitter->emitIns_S_I(INS_imul_19, EA_4BYTE, 0, 20, 30);
     theEmitter->emitIns_S_I(INS_imul_09, EA_4BYTE, 0, 20, 30);
     theEmitter->emitIns_R_AR(INS_crc32_apx, EA_4BYTE, REG_R17, REG_EAX, 0x14);
+    theEmitter->emitIns_I(INS_jmpabs, EA_8BYTE, 1234345234ULL); // jump to absolute address in imm64
 }
 
 void CodeGen::genAmd64EmitterUnitTestsAvx10v2()

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -9072,7 +9072,6 @@ void CodeGen::genAmd64EmitterUnitTestsApx()
     theEmitter->emitIns_S_I(INS_imul_19, EA_4BYTE, 0, 20, 30);
     theEmitter->emitIns_S_I(INS_imul_09, EA_4BYTE, 0, 20, 30);
     theEmitter->emitIns_R_AR(INS_crc32_apx, EA_4BYTE, REG_R17, REG_EAX, 0x14);
-    theEmitter->emitIns_I(INS_jmpabs, EA_8BYTE, 1234345234ULL); // jump to absolute address in imm64
 }
 
 void CodeGen::genAmd64EmitterUnitTestsAvx10v2()

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2205,16 +2205,15 @@ bool emitter::TakesRex2Prefix(const instrDesc* id) const
         return true;
     }
 
-    if (id->idIsApxPpxContextSet())
+    if (ins >= INS_imul_16 && ins <= INS_imul_31)
     {
-        // The instruction uses PPX hint, and it requires REX2.
+        // The instructions have implicit use of EGPRs.
         return true;
     }
 
-    if ((ins >= INS_imul_16 && ins <= INS_imul_31) || (ins == INS_jmpabs))
+    if (id->idIsApxPpxContextSet())
     {
-        // These instructions either have implicit use of EGPRs or in case on jmpabs,
-        // it is a special case that requires REX2 encoding.
+        // The instruction uses PPX hint, and it requires REX2.
         return true;
     }
 
@@ -7393,12 +7392,6 @@ void emitter::emitIns_I(instruction ins, emitAttr attr, cnsval_ssize_t val)
         case INS_push:
             sz = valInByte ? 2 : 5;
             break;
-
-#ifdef TARGET_AMD64
-        case INS_jmpabs:
-            sz = 9;
-            break;
-#endif // TARGET_AMD64
 
         default:
             NO_WAY("unexpected instruction");
@@ -17268,6 +17261,7 @@ BYTE* emitter::emitOutputIV(BYTE* dst, instrDesc* id)
     emitAttr    size      = id->idOpSize();
     ssize_t     val       = emitGetInsSC(id);
     bool        valInByte = ((signed char)val == (target_ssize_t)val);
+
     // We would to update GC info correctly
     assert(!IsSSEInstruction(ins));
     assert(!IsSimdVexOrEvexEncodableInstruction(ins));
@@ -17343,19 +17337,6 @@ BYTE* emitter::emitOutputIV(BYTE* dst, instrDesc* id)
                 }
             }
             break;
-
-#ifdef TARGET_AMD64
-        case INS_jmpabs:
-        {
-            assert(TakesRex2Prefix(id));
-            code = insCodeMI(ins);
-            code = AddRex2Prefix(ins, code);
-            dst += emitOutputRexOrSimdPrefixIfNeeded(ins, dst, code);
-            dst += emitOutputByte(dst, code);
-            dst += emitOutputSizeT(dst, val);
-        }
-        break;
-#endif // TARGET_AMD64
 
         default:
             assert(!"unexpected instruction");

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -7368,9 +7368,9 @@ void emitter::emitIns_I(instruction ins, emitAttr attr, cnsval_ssize_t val)
     bool           valInByte = ((signed char)val == (target_ssize_t)val);
 
 #ifdef TARGET_AMD64
-    // mov reg, imm64 and jmpabs are the only opcodes which take a full 8 byte immediate
+    // mov reg, imm64 is the only opcode which takes a full 8 byte immediate
     // all other opcodes take a sign-extended 4-byte immediate
-    noway_assert(EA_SIZE(attr) < EA_8BYTE || !EA_IS_CNS_RELOC(attr) || ins == INS_jmpabs);
+    noway_assert(EA_SIZE(attr) < EA_8BYTE || !EA_IS_CNS_RELOC(attr));
 #endif
 
     if (EA_IS_CNS_RELOC(attr))
@@ -17353,10 +17353,6 @@ BYTE* emitter::emitOutputIV(BYTE* dst, instrDesc* id)
             dst += emitOutputRexOrSimdPrefixIfNeeded(ins, dst, code);
             dst += emitOutputByte(dst, code);
             dst += emitOutputSizeT(dst, val);
-            if (id->idIsCnsReloc())
-            {
-                emitRecordRelocation((void*)(dst - sizeof(size_t)), (void*)(size_t)val, CorInfoReloc::DIRECT);
-            }
         }
         break;
 #endif // TARGET_AMD64

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -7368,9 +7368,9 @@ void emitter::emitIns_I(instruction ins, emitAttr attr, cnsval_ssize_t val)
     bool           valInByte = ((signed char)val == (target_ssize_t)val);
 
 #ifdef TARGET_AMD64
-    // mov reg, imm64 is the only opcode which takes a full 8 byte immediate
+    // mov reg, imm64 and jmpabs are the only opcodes which take a full 8 byte immediate
     // all other opcodes take a sign-extended 4-byte immediate
-    noway_assert(EA_SIZE(attr) < EA_8BYTE || !EA_IS_CNS_RELOC(attr));
+    noway_assert(EA_SIZE(attr) < EA_8BYTE || !EA_IS_CNS_RELOC(attr) || ins == INS_jmpabs);
 #endif
 
     if (EA_IS_CNS_RELOC(attr))
@@ -17353,6 +17353,10 @@ BYTE* emitter::emitOutputIV(BYTE* dst, instrDesc* id)
             dst += emitOutputRexOrSimdPrefixIfNeeded(ins, dst, code);
             dst += emitOutputByte(dst, code);
             dst += emitOutputSizeT(dst, val);
+            if (id->idIsCnsReloc())
+            {
+                emitRecordRelocation((void*)(dst - sizeof(size_t)), (void*)(size_t)val, CorInfoReloc::DIRECT);
+            }
         }
         break;
 #endif // TARGET_AMD64

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2205,15 +2205,16 @@ bool emitter::TakesRex2Prefix(const instrDesc* id) const
         return true;
     }
 
-    if (ins >= INS_imul_16 && ins <= INS_imul_31)
-    {
-        // The instructions have implicit use of EGPRs.
-        return true;
-    }
-
     if (id->idIsApxPpxContextSet())
     {
         // The instruction uses PPX hint, and it requires REX2.
+        return true;
+    }
+
+    if ((ins >= INS_imul_16 && ins <= INS_imul_31) || (ins == INS_jmpabs))
+    {
+        // These instructions either have implicit use of EGPRs or in case on jmpabs,
+        // it is a special case that requires REX2 encoding.
         return true;
     }
 
@@ -7392,6 +7393,12 @@ void emitter::emitIns_I(instruction ins, emitAttr attr, cnsval_ssize_t val)
         case INS_push:
             sz = valInByte ? 2 : 5;
             break;
+
+#ifdef TARGET_AMD64
+        case INS_jmpabs:
+            sz = 9;
+            break;
+#endif // TARGET_AMD64
 
         default:
             NO_WAY("unexpected instruction");
@@ -17261,7 +17268,6 @@ BYTE* emitter::emitOutputIV(BYTE* dst, instrDesc* id)
     emitAttr    size      = id->idOpSize();
     ssize_t     val       = emitGetInsSC(id);
     bool        valInByte = ((signed char)val == (target_ssize_t)val);
-
     // We would to update GC info correctly
     assert(!IsSSEInstruction(ins));
     assert(!IsSimdVexOrEvexEncodableInstruction(ins));
@@ -17337,6 +17343,19 @@ BYTE* emitter::emitOutputIV(BYTE* dst, instrDesc* id)
                 }
             }
             break;
+
+#ifdef TARGET_AMD64
+        case INS_jmpabs:
+        {
+            assert(TakesRex2Prefix(id));
+            code = insCodeMI(ins);
+            code = AddRex2Prefix(ins, code);
+            dst += emitOutputRexOrSimdPrefixIfNeeded(ins, dst, code);
+            dst += emitOutputByte(dst, code);
+            dst += emitOutputSizeT(dst, val);
+        }
+        break;
+#endif // TARGET_AMD64
 
         default:
             assert(!"unexpected instruction");

--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -1222,7 +1222,8 @@ INST3(setl_apx,         "setzul",           IUM_WR, SSEDBLMAP(4, 0x4C),  BAD_COD
 INST3(setge_apx,        "setzuge",          IUM_WR, SSEDBLMAP(4, 0x4D),  BAD_CODE, BAD_CODE,                             1C,                2X,         INS_TT_NONE,    Reads_OF | Reads_SF | Encoding_EVEX_APX_ONLY)
 INST3(setle_apx,        "setzule",          IUM_WR, SSEDBLMAP(4, 0x4E),  BAD_CODE, BAD_CODE,                             1C,                2X,         INS_TT_NONE,    Reads_OF | Reads_SF | Reads_ZF | Encoding_EVEX_APX_ONLY)
 INST3(setg_apx,         "setzug",           IUM_WR, SSEDBLMAP(4, 0x4F),  BAD_CODE, BAD_CODE,                             1C,                2X,         INS_TT_NONE,    Reads_OF | Reads_SF | Reads_ZF | Encoding_EVEX_APX_ONLY)
-#define LAST_APX_INSTRUCTION INS_setg_apx
+INST3(jmpabs,           "jmpabs",           IUM_WR, BAD_CODE          ,  0xA1,     BAD_CODE,                             BRANCH_DIRECT,     2C,         INS_TT_NONE,    Encoding_REX2 | REX_W0)
+#define LAST_APX_INSTRUCTION INS_jmpabs
 #endif // TARGET_AMD64
 
 // Scalar instructions in SSE4.2

--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -1222,8 +1222,7 @@ INST3(setl_apx,         "setzul",           IUM_WR, SSEDBLMAP(4, 0x4C),  BAD_COD
 INST3(setge_apx,        "setzuge",          IUM_WR, SSEDBLMAP(4, 0x4D),  BAD_CODE, BAD_CODE,                             1C,                2X,         INS_TT_NONE,    Reads_OF | Reads_SF | Encoding_EVEX_APX_ONLY)
 INST3(setle_apx,        "setzule",          IUM_WR, SSEDBLMAP(4, 0x4E),  BAD_CODE, BAD_CODE,                             1C,                2X,         INS_TT_NONE,    Reads_OF | Reads_SF | Reads_ZF | Encoding_EVEX_APX_ONLY)
 INST3(setg_apx,         "setzug",           IUM_WR, SSEDBLMAP(4, 0x4F),  BAD_CODE, BAD_CODE,                             1C,                2X,         INS_TT_NONE,    Reads_OF | Reads_SF | Reads_ZF | Encoding_EVEX_APX_ONLY)
-INST3(jmpabs,           "jmpabs",           IUM_WR, BAD_CODE          ,  0xA1,     BAD_CODE,                             BRANCH_DIRECT,     2C,         INS_TT_NONE,    Encoding_REX2 | REX_W0)
-#define LAST_APX_INSTRUCTION INS_jmpabs
+#define LAST_APX_INSTRUCTION INS_setg_apx
 #endif // TARGET_AMD64
 
 // Scalar instructions in SSE4.2

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -394,40 +394,6 @@ BOOL GetAnyThunkTarget (CONTEXT *pctx, TADDR *pTarget, TADDR *pTargetMethodDesc)
 
 #ifndef DACCESS_COMPILE
 
-void EncodeLoadAndJumpThunk (LPBYTE pBuffer, LPVOID pv, LPVOID pTarget)
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_NOTRIGGER;
-        MODE_ANY;
-
-        PRECONDITION(CheckPointer(pBuffer));
-    }
-    CONTRACTL_END;
-
-    // mov r10, pv                      49 ba xx xx xx xx xx xx xx xx
-
-    pBuffer[0]  = 0x49;
-    pBuffer[1]  = 0xBA;
-
-    SET_UNALIGNED_64(&pBuffer[2], pv);
-
-    // mov rax, pTarget                 48 b8 xx xx xx xx xx xx xx xx
-
-    pBuffer[10] = 0x48;
-    pBuffer[11] = 0xB8;
-
-    SET_UNALIGNED_64(&pBuffer[12], pTarget);
-
-    // jmp rax                          ff e0
-
-    pBuffer[20] = 0xFF;
-    pBuffer[21] = 0xE0;
-
-    _ASSERTE(DbgIsExecutable(pBuffer, 22));
-}
-
 void emitBackToBackJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target)
 {
     CONTRACTL

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -394,6 +394,18 @@ BOOL GetAnyThunkTarget (CONTEXT *pctx, TADDR *pTarget, TADDR *pTargetMethodDesc)
 
 #ifndef DACCESS_COMPILE
 
+bool IsJmpAbsAvailable()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    // Cache the result in a static local - initialized once on first call
+    static const bool s_isJmpAbsAvailable =
+        ExecutionManager::GetEEJitManager()->GetCPUCompileFlags()
+            .GetInstructionSetFlags().HasInstructionSet(InstructionSet_APX);
+
+    return s_isJmpAbsAvailable;
+}
+
 void emitBackToBackJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target)
 {
     CONTRACTL
@@ -406,7 +418,7 @@ void emitBackToBackJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target)
     }
     CONTRACTL_END;
 
-    if (g_IsJmpAbsAvailable)
+    if (IsJmpAbsAvailable())
     {
         // JMPABS (11 bytes) + NOP padding = 12 bytes
         emitJmpAbsJump(pBufferRX, pBufferRW, target);
@@ -436,7 +448,7 @@ void emitJmpAbsJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target)
         MODE_ANY;
 
         PRECONDITION(CheckPointer(pBufferRX));
-        PRECONDITION(g_IsJmpAbsAvailable);  // Caller must check APX availability
+        PRECONDITION(IsJmpAbsAvailable());  // Caller must check APX availability
     }
     CONTRACTL_END;
 

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -420,6 +420,29 @@ void emitBackToBackJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target)
     _ASSERTE(DbgIsExecutable(pBufferRX, 12));
 }
 
+void emitJmpAbsJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        MODE_ANY;
+
+        PRECONDITION(CheckPointer(pBufferRX));
+        PRECONDITION(g_IsJmpAbsAvailable);  // Caller must check APX availability
+    }
+    CONTRACTL_END;
+
+    // JMPABS instruction (APX):    D5 00 A1 xx xx xx xx xx xx xx xx
+    pBufferRW[0]  = 0xD5;  // APX prefix
+    pBufferRW[1]  = 0x00;  // Map select
+    pBufferRW[2]  = 0xA1;  // JMPABS opcode
+
+    SET_UNALIGNED_64(&pBufferRW[3], target);  // 64-bit absolute address
+
+    _ASSERTE(DbgIsExecutable(pBufferRX, 11));
+}
+
 INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMethod,
     LoaderAllocator *pLoaderAllocator /* = NULL */, bool throwOnOutOfMemoryWithinRange /*= true*/)
 {

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -354,6 +354,16 @@ bool isBackToBackJump(PCODE pCode)
     LIMITED_METHOD_CONTRACT;
     PTR_BYTE pbCode = PTR_BYTE(pCode);
 
+    // Check for JMPABS encoding (APX): D5 00 A1 [8 bytes] 90
+    if (0xD5 == pbCode[0] &&
+        0x00 == pbCode[1] &&
+        0xA1 == pbCode[2] &&
+        0x90 == pbCode[11])
+    {
+        return true;
+    }
+
+    // Check for legacy encoding: 48 B8 [8 bytes] FF E0
     return 0x48 == pbCode[0]  &&
            0xB8 == pbCode[1]  &&
            0xFF == pbCode[10] &&
@@ -364,11 +374,18 @@ PCODE decodeBackToBackJump(PCODE pBuffer)
 {
     LIMITED_METHOD_CONTRACT;
 
-    // mov rax, xxx
-    // jmp rax
     _ASSERTE(isBackToBackJump(pBuffer));
 
-    return *PTR_UINT64(pBuffer+2);
+    PTR_BYTE pbCode = PTR_BYTE(pBuffer);
+
+    // JMPABS encoding (APX): D5 00 A1 [8 bytes at offset 3-10] 90
+    if (0xD5 == pbCode[0])
+    {
+        return *PTR_UINT64(pBuffer + 3);
+    }
+
+    // Legacy encoding: 48 B8 [8 bytes at offset 2-9] FF E0
+    return *PTR_UINT64(pBuffer + 2);
 }
 
 #ifdef DACCESS_COMPILE

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -406,16 +406,23 @@ void emitBackToBackJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target)
     }
     CONTRACTL_END;
 
-    // mov rax, 123456789abcdef0h       48 b8 xx xx xx xx xx xx xx xx
-    // jmp rax                          ff e0
+    if (g_IsJmpAbsAvailable)
+    {
+        // JMPABS (11 bytes) + NOP padding = 12 bytes
+        emitJmpAbsJump(pBufferRX, pBufferRW, target);
+        pBufferRW[11] = 0x90;  // NOP padding
+    }
+    else
+    {
+        // Fallback: mov rax, imm64; jmp rax (12 bytes)
+        pBufferRW[0]  = 0x48;
+        pBufferRW[1]  = 0xB8;
 
-    pBufferRW[0]  = 0x48;
-    pBufferRW[1]  = 0xB8;
+        SET_UNALIGNED_64(&pBufferRW[2], target);
 
-    SET_UNALIGNED_64(&pBufferRW[2], target);
-
-    pBufferRW[10] = 0xFF;
-    pBufferRW[11] = 0xE0;
+        pBufferRW[10] = 0xFF;
+        pBufferRW[11] = 0xE0;
+    }
 
     _ASSERTE(DbgIsExecutable(pBufferRX, 12));
 }

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -487,12 +487,6 @@ inline TADDR GetSecondArgReg(CONTEXT *context)
 extern "C" void* GetCurrentSP();
 
 // Emits:
-//  mov r10, pv1
-//  mov rax, pTarget
-//  jmp rax
-void EncodeLoadAndJumpThunk (LPBYTE pBuffer, LPVOID pv, LPVOID pTarget);
-
-
 // Get Rel32 destination, emit jumpStub if necessary
 INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMethod,
     LoaderAllocator *pLoaderAllocator = NULL, bool throwOnOutOfMemoryWithinRange = true);

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -500,7 +500,7 @@ INT32 rel32UsingPreallocatedJumpStub(INT32 UNALIGNED * pRel32, PCODE target, PCO
 void emitBackToBackJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target);
 
 // Emits raw 11-byte JMPABS instruction (D5 00 A1 + 8-byte immediate)
-// Requires g_IsJmpAbsAvailable == true.
+// Caller must ensure IsJmpAbsAvailable() == true.
 void emitJmpAbsJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target);
 
 bool isBackToBackJump(PCODE pCode);

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -38,10 +38,6 @@ class ComCallMethodDesc;
 #define SIZEOF_LOAD_AND_JUMP_THUNK              22   // # bytes to mov r10, X; jmp Z
 #define SIZEOF_LOAD2_AND_JUMP_THUNK             32   // # bytes to mov r10, X; mov r11, Y; jmp Z
 
-// JMPABS instruction sizes (APX)
-#define JMPABS_INSTRUCTION_SIZE                 11   // # bytes for JMPABS (D5 00 A1 + 8-byte immediate)
-#define JMPABS_WITH_PADDING_SIZE                12   // # bytes for JMPABS + 1-byte NOP for alignment
-
 #define HAS_PINVOKE_IMPORT_PRECODE              1
 #define HAS_FIXUP_PRECODE                       1
 
@@ -490,8 +486,8 @@ inline TADDR GetSecondArgReg(CONTEXT *context)
 
 extern "C" void* GetCurrentSP();
 
-// Global flag indicating JMPABS instruction availability (set when APX is detected)
-extern bool g_IsJmpAbsAvailable;
+// Check if JMPABS instruction is available (queries cached APX instruction set flag)
+bool IsJmpAbsAvailable();
 
 // Emits:
 // Get Rel32 destination, emit jumpStub if necessary

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -38,6 +38,10 @@ class ComCallMethodDesc;
 #define SIZEOF_LOAD_AND_JUMP_THUNK              22   // # bytes to mov r10, X; jmp Z
 #define SIZEOF_LOAD2_AND_JUMP_THUNK             32   // # bytes to mov r10, X; mov r11, Y; jmp Z
 
+// JMPABS instruction sizes (APX)
+#define JMPABS_INSTRUCTION_SIZE                 11   // # bytes for JMPABS (D5 00 A1 + 8-byte immediate)
+#define JMPABS_WITH_PADDING_SIZE                12   // # bytes for JMPABS + 1-byte NOP for alignment
+
 #define HAS_PINVOKE_IMPORT_PRECODE              1
 #define HAS_FIXUP_PRECODE                       1
 
@@ -486,6 +490,9 @@ inline TADDR GetSecondArgReg(CONTEXT *context)
 
 extern "C" void* GetCurrentSP();
 
+// Global flag indicating JMPABS instruction availability (set when APX is detected)
+extern bool g_IsJmpAbsAvailable;
+
 // Emits:
 // Get Rel32 destination, emit jumpStub if necessary
 INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMethod,
@@ -495,6 +502,10 @@ INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMe
 INT32 rel32UsingPreallocatedJumpStub(INT32 UNALIGNED * pRel32, PCODE target, PCODE jumpStubAddr, PCODE jumpStubAddrRW, bool emitJump);
 
 void emitBackToBackJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target);
+
+// Emits raw 11-byte JMPABS instruction (D5 00 A1 + 8-byte immediate)
+// Requires g_IsJmpAbsAvailable == true.
+void emitJmpAbsJump(LPBYTE pBufferRX, LPBYTE pBufferRW, LPVOID target);
 
 bool isBackToBackJump(PCODE pCode);
 PCODE decodeBackToBackJump(PCODE pCode);

--- a/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
@@ -131,15 +131,61 @@ struct DispatchStubShort
     friend struct DispatchStub;
 
     static BOOL isShortStub(LPCBYTE pCode);
-    inline PCODE implTarget() const { LIMITED_METHOD_CONTRACT;  return (PCODE) _implTarget; }
+
+    inline BOOL isJmpAbsEncoding() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        // JMPABS encoding starts with 0x0F 0x85 (jne near)
+        // Legacy encoding starts with 0x48 0xB8 (mov rax, imm64)
+        return part1[0] == 0x0F;
+    }
+
+    inline PCODE implTarget() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        if (isJmpAbsEncoding())
+        {
+            // JMPABS encoding: address at offset 10-17 (after jne + nop + D5 00 A1)
+            const BYTE* pThis = reinterpret_cast<const BYTE*>(this);
+            return *reinterpret_cast<const PCODE*>(pThis + 10);
+        }
+        else
+        {
+            // Legacy encoding: address at offset 2-9
+            return (PCODE)_implTarget;
+        }
+    }
 
     inline TADDR implTargetSlot() const
     {
         LIMITED_METHOD_CONTRACT;
-        return (TADDR)&_implTarget;
+        const BYTE* pThis = reinterpret_cast<const BYTE*>(this);
+        if (isJmpAbsEncoding())
+        {
+            return (TADDR)(pThis + 10);  // JMPABS address location
+        }
+        else
+        {
+            return (TADDR)&_implTarget;  // Legacy address location
+        }
     }
 
-    inline PCODE failTarget() const { LIMITED_METHOD_CONTRACT;  return (PCODE) &_failDispl + sizeof(DISPL) + _failDispl; }
+    inline PCODE failTarget() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        const BYTE* pThis = reinterpret_cast<const BYTE*>(this);
+        if (isJmpAbsEncoding())
+        {
+            // JMPABS encoding: jne near at bytes 0-5, displacement at bytes 2-5
+            DISPL displacement = *reinterpret_cast<const DISPL*>(pThis + 2);
+            return (PCODE)(pThis + 6) + displacement;
+        }
+        else
+        {
+            // Legacy encoding: jne at bytes 10-15, displacement at bytes 12-15
+            return (PCODE)&_failDispl + sizeof(DISPL) + _failDispl;
+        }
+    }
 
 private:
     BYTE    part1 [2];            // 48 B8                    mov    rax,
@@ -154,7 +200,12 @@ private:
 inline BOOL DispatchStubShort::isShortStub(LPCBYTE pCode)
 {
     LIMITED_METHOD_CONTRACT;
-    return reinterpret_cast<DispatchStubShort const *>(pCode)->part2[0] == 0x0f;
+    // JMPABS encoding: starts with 0x0F 0x85 (jne near) at byte 0
+    if (pCode[0] == 0x0F && pCode[1] == 0x85)
+        return TRUE;
+
+    // Legacy encoding: starts with 0x48 0xB8 (mov rax), byte 10 is 0x0F (jne near)
+    return pCode[0] == 0x48 && reinterpret_cast<DispatchStubShort const *>(pCode)->part2[0] == 0x0f;
 }
 
 
@@ -676,12 +727,42 @@ void  DispatchHolder::Initialize(DispatchHolder* pDispatchHolderRX, PCODE implTa
         // initialize the static data
         *shortStubRW = dispatchShortInit;
 
-        // fill in the dynamic data
-        size_t displ = (failTarget - ((PCODE) &shortStubRX->_failDispl + sizeof(DISPL)));
-        CONSISTENCY_CHECK(FitsInI4(displ));
-        shortStubRW->_failDispl   = (DISPL) displ;
-        shortStubRW->_implTarget  = (size_t) implTarget;
-        CONSISTENCY_CHECK((PCODE)&shortStubRX->_failDispl + sizeof(DISPL) + shortStubRX->_failDispl == failTarget);
+#if defined(TARGET_AMD64)
+        if (g_IsJmpAbsAvailable)
+        {
+            // JMPABS encoding (18 bytes):
+            // 0-5:   jne near failTarget (0F 85 + 4-byte displacement)
+            // 6:     nop (90)
+            // 7-17:  jmpabs implTarget (D5 00 A1 + 8-byte address)
+
+            BYTE* pStubRW = reinterpret_cast<BYTE*>(shortStubRW);
+            BYTE* pStubRX = reinterpret_cast<BYTE*>(shortStubRX);
+
+            // Encode jne near failTarget
+            pStubRW[0] = 0x0F;
+            pStubRW[1] = 0x85;
+
+            // Calculate displacement from offset 6 (after jne instruction)
+            size_t displ = failTarget - ((PCODE)(pStubRX + 6));
+            CONSISTENCY_CHECK(FitsInI4(displ));
+            *reinterpret_cast<DISPL*>(pStubRW + 2) = (DISPL)displ;
+
+            // NOP padding
+            pStubRW[6] = 0x90;
+
+            // JMPABS to implTarget
+            emitJmpAbsJump(pStubRX + 7, pStubRW + 7, (LPVOID)implTarget);
+        }
+        else
+#endif
+        {
+            // Legacy encoding: fill in the dynamic data
+            size_t displ = (failTarget - ((PCODE) &shortStubRX->_failDispl + sizeof(DISPL)));
+            CONSISTENCY_CHECK(FitsInI4(displ));
+            shortStubRW->_failDispl   = (DISPL) displ;
+            shortStubRW->_implTarget  = (size_t) implTarget;
+            CONSISTENCY_CHECK((PCODE)&shortStubRX->_failDispl + sizeof(DISPL) + shortStubRW->_failDispl == failTarget);
+        }
     }
     else
     {

--- a/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
@@ -631,11 +631,11 @@ void LookupHolder::InitializeStatic()
     lookupInit._entryPoint [1]     = 0x48;
     lookupInit._entryPoint [2]     = 0xB8;
     lookupInit._token              = 0xcccccccccccccccc;
-    lookupInit.part2 [0]           = 0x50;  // push rax
-    lookupInit.part2 [1]           = 0x48;  // mov rax, (fallback encoding, overwritten if APX available)
+    lookupInit.part2 [0]           = 0x50;
+    lookupInit.part2 [1]           = 0x48;
     lookupInit.part2 [2]           = 0xB8;
     lookupInit._resolveWorkerAddr  = 0xcccccccccccccccc;
-    lookupInit.part3 [0]           = 0xFF;  // jmp rax (fallback encoding, overwritten if APX available)
+    lookupInit.part3 [0]           = 0xFF;
     lookupInit.part3 [1]           = 0xE0;
 }
 
@@ -644,25 +644,8 @@ void  LookupHolder::Initialize(LookupHolder* pLookupHolderRX, PCODE resolveWorke
     _stub = lookupInit;
 
     //fill in the stub specific fields
-    _stub._token = dispatchToken;
-
-#if defined(TARGET_AMD64)
-    if (IsJmpAbsAvailable())
-    {
-        // Use JMPABS at offset 12-22 (11 bytes) + NOP padding at 23
-        BYTE* pStubRW = reinterpret_cast<BYTE*>(&_stub);
-        BYTE* pStubRX = reinterpret_cast<BYTE*>(&pLookupHolderRX->_stub);
-
-        pStubRW[11] = 0x50;  // push rax
-        emitJmpAbsJump(pStubRX + 12, pStubRW + 12, (LPVOID)resolveWorkerTarget);
-        pStubRW[23] = 0x90;  // NOP padding to maintain 12-byte jump size
-    }
-    else
-#endif
-    {
-        // Fallback: mov rax, imm64; jmp rax
-        _stub._resolveWorkerAddr = (size_t)resolveWorkerTarget;
-    }
+    _stub._token              = dispatchToken;
+    _stub._resolveWorkerAddr  = (size_t) resolveWorkerTarget;
 }
 
 /* Template used to generate the stub.  We generate a stub by allocating a block of

--- a/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
@@ -124,7 +124,7 @@ a DispatchStubLong which is bigger but is a full 64-bit jump. */
 
 /*DispatchStubShort*********************************************************************************
 This is the logical continuation of DispatchStub for the case when the failure target is within
-a rel32 jump (DISPL). */
+a rel32 jump (DISPL). Uses a union to handle both legacy and APX encodings. */
 struct DispatchStubShort
 {
     friend struct DispatchHolder;
@@ -137,65 +137,65 @@ struct DispatchStubShort
         LIMITED_METHOD_CONTRACT;
         // JMPABS encoding starts with 0x0F 0x85 (jne near)
         // Legacy encoding starts with 0x48 0xB8 (mov rax, imm64)
-        return part1[0] == 0x0F;
+        return _bytes[0] == 0x0F;
     }
 
     inline PCODE implTarget() const
     {
         LIMITED_METHOD_CONTRACT;
-        if (isJmpAbsEncoding())
-        {
-            // JMPABS encoding: address at offset 10-17 (after jne + nop + D5 00 A1)
-            const BYTE* pThis = reinterpret_cast<const BYTE*>(this);
-            return *reinterpret_cast<const PCODE*>(pThis + 10);
-        }
-        else
-        {
-            // Legacy encoding: address at offset 2-9
-            return (PCODE)_implTarget;
-        }
+        return isJmpAbsEncoding() ? (PCODE)_apx._implTarget : (PCODE)_legacy._implTarget;
     }
 
     inline TADDR implTargetSlot() const
     {
         LIMITED_METHOD_CONTRACT;
-        const BYTE* pThis = reinterpret_cast<const BYTE*>(this);
-        if (isJmpAbsEncoding())
-        {
-            return (TADDR)(pThis + 10);  // JMPABS address location
-        }
-        else
-        {
-            return (TADDR)&_implTarget;  // Legacy address location
-        }
+        return isJmpAbsEncoding() ? (TADDR)&_apx._implTarget : (TADDR)&_legacy._implTarget;
     }
 
     inline PCODE failTarget() const
     {
         LIMITED_METHOD_CONTRACT;
-        const BYTE* pThis = reinterpret_cast<const BYTE*>(this);
         if (isJmpAbsEncoding())
         {
-            // JMPABS encoding: jne near at bytes 0-5, displacement at bytes 2-5
-            DISPL displacement = *reinterpret_cast<const DISPL*>(pThis + 2);
-            return (PCODE)(pThis + 6) + displacement;
+            // APX: displacement base is after the jne near instruction
+            return (PCODE)&_apx.nop + _apx._failDispl;
         }
         else
         {
-            // Legacy encoding: jne at bytes 10-15, displacement at bytes 12-15
-            return (PCODE)&_failDispl + sizeof(DISPL) + _failDispl;
+            // Legacy: displacement base after the jne instruction
+            return (PCODE)&_legacy._failDispl + sizeof(DISPL) + _legacy._failDispl;
         }
     }
 
 private:
-    BYTE    part1 [2];            // 48 B8                    mov    rax,
-    size_t  _implTarget;          // xx xx xx xx xx xx xx xx              64-bit address
-    BYTE    part2[2];             // 0f 85                    jne
-    DISPL   _failDispl;           // xx xx xx xx                     failEntry         ;must be forward jmp for perf reasons
-    BYTE    part3 [2];            // FF E0                    jmp    rax
+    union
+    {
+        // Legacy encoding (18 bytes): mov rax, imm64; jne; jmp rax
+        struct
+        {
+            BYTE    part1[2];         // 48 B8                    mov    rax,
+            size_t  _implTarget;      // xx xx xx xx xx xx xx xx              64-bit address
+            BYTE    part2[2];         // 0f 85                    jne
+            DISPL   _failDispl;       // xx xx xx xx                     failEntry
+            BYTE    part3[2];         // FF E0                    jmp    rax
+        } _legacy;
+
+        // APX encoding (18 bytes): jne near; nop; jmpabs
+        struct
+        {
+            BYTE    part1[2];         // 0F 85                    jne near
+            DISPL   _failDispl;       // xx xx xx xx                     4-byte displacement
+            BYTE    nop;              // 90                       nop
+            BYTE    jmpabsPrefix[3];  // D5 00 A1                 JMPABS prefix
+            size_t  _implTarget;      // xx xx xx xx xx xx xx xx              64-bit address at offset 10
+        } _apx;
+
+        // Raw bytes for detection and access
+        BYTE _bytes[18];
+    };
 };
 
-#define DispatchStubShort_offsetof_failDisplBase (offsetof(DispatchStubLong, _failDispl) + sizeof(DISPL))
+#define DispatchStubShort_offsetof_failDisplBase (offsetof(DispatchStubShort, _legacy._failDispl) + sizeof(DISPL))
 
 inline BOOL DispatchStubShort::isShortStub(LPCBYTE pCode)
 {
@@ -204,8 +204,8 @@ inline BOOL DispatchStubShort::isShortStub(LPCBYTE pCode)
     if (pCode[0] == 0x0F && pCode[1] == 0x85)
         return TRUE;
 
-    // Legacy encoding: starts with 0x48 0xB8 (mov rax), byte 10 is 0x0F (jne near)
-    return pCode[0] == 0x48 && reinterpret_cast<DispatchStubShort const *>(pCode)->part2[0] == 0x0f;
+    // Legacy encoding: check for jne near instruction at expected offset
+    return reinterpret_cast<DispatchStubShort const *>(pCode)->_legacy.part2[0] == 0x0F;
 }
 
 
@@ -375,9 +375,24 @@ struct DispatchHolder
     static BOOL CanShortJumpDispatchStubReachFailTarget(PCODE failTarget, LPCBYTE stubMemory)
     {
         STATIC_CONTRACT_WRAPPER;
-        LPCBYTE pFrom = stubMemory + sizeof(DispatchStub) + DispatchStubShort_offsetof_failDisplBase;
-        size_t cbRelJump = failTarget - (PCODE)pFrom;
-        return FitsInI4(cbRelJump);
+
+        // Both encodings use a rel32 jump for the fail target.
+        // For legacy: failDispl base is after the jne instruction
+        // For APX: displacement base is at byte 6 (the nop byte)
+        if (IsJmpAbsAvailable())
+        {
+            // APX: jne near at bytes 0-5, displacement base at byte 6 (nop)
+            LPCBYTE pFrom = stubMemory + sizeof(DispatchStub) + offsetof(DispatchStubShort, _apx.nop);
+            size_t cbRelJump = failTarget - (PCODE)pFrom;
+            return FitsInI4(cbRelJump);
+        }
+        else
+        {
+            // Legacy encoding
+            LPCBYTE pFrom = stubMemory + sizeof(DispatchStub) + DispatchStubShort_offsetof_failDisplBase;
+            size_t cbRelJump = failTarget - (PCODE)pFrom;
+            return FitsInI4(cbRelJump);
+        }
     }
 
     DispatchStub* stub()      { LIMITED_METHOD_CONTRACT;  return reinterpret_cast<DispatchStub *>(this); }
@@ -658,7 +673,7 @@ void  LookupHolder::Initialize(LookupHolder* pLookupHolderRX, PCODE resolveWorke
 void DispatchHolder::InitializeStatic()
 {
     // Check that _implTarget is aligned in the DispatchStub for backpatching
-    static_assert(((sizeof(DispatchStub) + offsetof(DispatchStubShort, _implTarget)) % sizeof(void *)) == 0);
+    static_assert(((sizeof(DispatchStub) + offsetof(DispatchStubShort, _legacy._implTarget)) % sizeof(void *)) == 0);
     static_assert(((sizeof(DispatchStub) + offsetof(DispatchStubLong, _implTarget)) % sizeof(void *)) == 0);
 
     static_assert(((sizeof(DispatchStub) + sizeof(DispatchStubShort)) % sizeof(void*)) == 0);
@@ -674,15 +689,15 @@ void DispatchHolder::InitializeStatic()
     dispatchInit.part1 [2]            = (X64_INSTR_CMP_IND_THIS_REG_RAX >> 16) & 0xff;
     dispatchInit.nopOp                = 0x90;
 
-    // Short dispatch stub initialization
-    dispatchShortInit.part1 [0]       = 0x48;
-    dispatchShortInit.part1 [1]       = 0xb8;
-    dispatchShortInit._implTarget     = 0xcccccccccccccccc;
-    dispatchShortInit.part2 [0]       = 0x0F;
-    dispatchShortInit.part2 [1]       = 0x85;
-    dispatchShortInit._failDispl      = 0xcccccccc;
-    dispatchShortInit.part3 [0]       = 0xFF;
-    dispatchShortInit.part3 [1]       = 0xE0;
+    // Short dispatch stub initialization (legacy encoding)
+    dispatchShortInit._legacy.part1 [0]       = 0x48;
+    dispatchShortInit._legacy.part1 [1]       = 0xb8;
+    dispatchShortInit._legacy._implTarget     = 0xcccccccccccccccc;
+    dispatchShortInit._legacy.part2 [0]       = 0x0F;
+    dispatchShortInit._legacy.part2 [1]       = 0x85;
+    dispatchShortInit._legacy._failDispl      = 0xcccccccc;
+    dispatchShortInit._legacy.part3 [0]       = 0xFF;
+    dispatchShortInit._legacy.part3 [1]       = 0xE0;
 
     // Long dispatch stub initialization
     dispatchLongInit.part1 [0]        = 0x48;
@@ -727,38 +742,37 @@ void  DispatchHolder::Initialize(DispatchHolder* pDispatchHolderRX, PCODE implTa
 #if defined(TARGET_AMD64)
         if (IsJmpAbsAvailable())
         {
-            // JMPABS encoding (18 bytes):
-            // 0-5:   jne near failTarget (0F 85 + 4-byte displacement)
-            // 6:     nop (90)
-            // 7-17:  jmpabs implTarget (D5 00 A1 + 8-byte address)
-
-            BYTE* pStubRW = reinterpret_cast<BYTE*>(shortStubRW);
-            BYTE* pStubRX = reinterpret_cast<BYTE*>(shortStubRX);
+            // JMPABS encoding (18 bytes): jne near; nop; jmpabs
+            // 0-1:   0x0F 0x85 (jne near)
+            // 2-5:   4-byte displacement
+            // 6:     nop (0x90)
+            // 7-9:   JMPABS prefix (D5 00 A1)
+            // 10-17: 8-byte implTarget address
 
             // Encode jne near failTarget
-            pStubRW[0] = 0x0F;
-            pStubRW[1] = 0x85;
+            shortStubRW->_apx.part1[0] = 0x0F;
+            shortStubRW->_apx.part1[1] = 0x85;
 
-            // Calculate displacement from offset 6 (after jne instruction)
-            size_t displ = failTarget - ((PCODE)(pStubRX + 6));
+            // Calculate displacement from offset 6 (the nop byte, which is the instruction after jne)
+            size_t displ = failTarget - ((PCODE)&shortStubRX->_apx.nop);
             CONSISTENCY_CHECK(FitsInI4(displ));
-            *reinterpret_cast<DISPL*>(pStubRW + 2) = (DISPL)displ;
+            shortStubRW->_apx._failDispl = (DISPL)displ;
 
             // NOP padding
-            pStubRW[6] = 0x90;
+            shortStubRW->_apx.nop = 0x90;
 
             // JMPABS to implTarget
-            emitJmpAbsJump(pStubRX + 7, pStubRW + 7, (LPVOID)implTarget);
+            emitJmpAbsJump((LPBYTE)&shortStubRX->_apx.jmpabsPrefix, (LPBYTE)&shortStubRW->_apx.jmpabsPrefix, (LPVOID)implTarget);
         }
         else
 #endif
         {
             // Legacy encoding: fill in the dynamic data
-            size_t displ = (failTarget - ((PCODE) &shortStubRX->_failDispl + sizeof(DISPL)));
+            size_t displ = (failTarget - ((PCODE)&shortStubRX->_legacy._failDispl + sizeof(DISPL)));
             CONSISTENCY_CHECK(FitsInI4(displ));
-            shortStubRW->_failDispl   = (DISPL) displ;
-            shortStubRW->_implTarget  = (size_t) implTarget;
-            CONSISTENCY_CHECK((PCODE)&shortStubRX->_failDispl + sizeof(DISPL) + shortStubRW->_failDispl == failTarget);
+            shortStubRW->_legacy._failDispl   = (DISPL)displ;
+            shortStubRW->_legacy._implTarget  = (size_t)implTarget;
+            CONSISTENCY_CHECK((PCODE)&shortStubRX->_legacy._failDispl + sizeof(DISPL) + shortStubRW->_legacy._failDispl == failTarget);
         }
     }
     else

--- a/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
@@ -590,9 +590,6 @@ ResolveStub       resolveInit;
 
 #ifndef DACCESS_COMPILE
 
-// Global flag indicating JMPABS availability (defined in codeman.cpp)
-extern bool g_IsJmpAbsAvailable;
-
 #include "asmconstants.h"
 
 #ifdef STUB_LOGGING
@@ -635,7 +632,7 @@ void  LookupHolder::Initialize(LookupHolder* pLookupHolderRX, PCODE resolveWorke
     _stub._token = dispatchToken;
 
 #if defined(TARGET_AMD64)
-    if (g_IsJmpAbsAvailable)
+    if (IsJmpAbsAvailable())
     {
         // Use JMPABS at offset 12-22 (11 bytes) + NOP padding at 23
         BYTE* pStubRW = reinterpret_cast<BYTE*>(&_stub);
@@ -728,7 +725,7 @@ void  DispatchHolder::Initialize(DispatchHolder* pDispatchHolderRX, PCODE implTa
         *shortStubRW = dispatchShortInit;
 
 #if defined(TARGET_AMD64)
-        if (g_IsJmpAbsAvailable)
+        if (IsJmpAbsAvailable())
         {
             // JMPABS encoding (18 bytes):
             // 0-5:   jne near failTarget (0F 85 + 4-byte displacement)

--- a/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
@@ -137,7 +137,7 @@ struct DispatchStubShort
         LIMITED_METHOD_CONTRACT;
         // JMPABS encoding starts with 0x0F 0x85 (jne near)
         // Legacy encoding starts with 0x48 0xB8 (mov rax, imm64)
-        return _bytes[0] == 0x0F;
+        return _bytes[0] == 0x0F && _bytes[1] == 0x85;
     }
 
     inline PCODE implTarget() const
@@ -674,6 +674,7 @@ void DispatchHolder::InitializeStatic()
 {
     // Check that _implTarget is aligned in the DispatchStub for backpatching
     static_assert(((sizeof(DispatchStub) + offsetof(DispatchStubShort, _legacy._implTarget)) % sizeof(void *)) == 0);
+    static_assert(((sizeof(DispatchStub) + offsetof(DispatchStubShort, _apx._implTarget)) % sizeof(void *)) == 0);
     static_assert(((sizeof(DispatchStub) + offsetof(DispatchStubLong, _implTarget)) % sizeof(void *)) == 0);
 
     static_assert(((sizeof(DispatchStub) + sizeof(DispatchStubShort)) % sizeof(void*)) == 0);

--- a/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
@@ -539,6 +539,9 @@ ResolveStub       resolveInit;
 
 #ifndef DACCESS_COMPILE
 
+// Global flag indicating JMPABS availability (defined in codeman.cpp)
+extern bool g_IsJmpAbsAvailable;
+
 #include "asmconstants.h"
 
 #ifdef STUB_LOGGING
@@ -565,11 +568,11 @@ void LookupHolder::InitializeStatic()
     lookupInit._entryPoint [1]     = 0x48;
     lookupInit._entryPoint [2]     = 0xB8;
     lookupInit._token              = 0xcccccccccccccccc;
-    lookupInit.part2 [0]           = 0x50;
-    lookupInit.part2 [1]           = 0x48;
+    lookupInit.part2 [0]           = 0x50;  // push rax
+    lookupInit.part2 [1]           = 0x48;  // mov rax, (fallback encoding, overwritten if APX available)
     lookupInit.part2 [2]           = 0xB8;
     lookupInit._resolveWorkerAddr  = 0xcccccccccccccccc;
-    lookupInit.part3 [0]           = 0xFF;
+    lookupInit.part3 [0]           = 0xFF;  // jmp rax (fallback encoding, overwritten if APX available)
     lookupInit.part3 [1]           = 0xE0;
 }
 
@@ -578,8 +581,25 @@ void  LookupHolder::Initialize(LookupHolder* pLookupHolderRX, PCODE resolveWorke
     _stub = lookupInit;
 
     //fill in the stub specific fields
-    _stub._token              = dispatchToken;
-    _stub._resolveWorkerAddr  = (size_t) resolveWorkerTarget;
+    _stub._token = dispatchToken;
+
+#if defined(TARGET_AMD64)
+    if (g_IsJmpAbsAvailable)
+    {
+        // Use JMPABS at offset 12-22 (11 bytes) + NOP padding at 23
+        BYTE* pStubRW = reinterpret_cast<BYTE*>(&_stub);
+        BYTE* pStubRX = reinterpret_cast<BYTE*>(&pLookupHolderRX->_stub);
+
+        pStubRW[11] = 0x50;  // push rax
+        emitJmpAbsJump(pStubRX + 12, pStubRW + 12, (LPVOID)resolveWorkerTarget);
+        pStubRW[23] = 0x90;  // NOP padding to maintain 12-byte jump size
+    }
+    else
+#endif
+    {
+        // Fallback: mov rax, imm64; jmp rax
+        _stub._resolveWorkerAddr = (size_t)resolveWorkerTarget;
+    }
 }
 
 /* Template used to generate the stub.  We generate a stub by allocating a block of

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -74,9 +74,6 @@ static TADDR s_nextVirtualIP = 0x80000001;
 
 #ifndef DACCESS_COMPILE
 
-// Global flag set when APX instruction set is available (enables JMPABS)
-bool g_IsJmpAbsAvailable = false;
-
 CrstStatic ExecutionManager::m_JumpStubCrst;
 
 unsigned   ExecutionManager::m_normal_JumpStubLookup;
@@ -1516,7 +1513,6 @@ void EEJitManager::SetCpuInfo()
     if (((cpuFeatures & XArchIntrinsicConstants_Apx) != 0) && CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_EnableAPX))
     {
         CPUCompileFlags.Set(InstructionSet_APX);
-        g_IsJmpAbsAvailable = true;
     }
 #endif  // TARGET_AMD64
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -74,6 +74,9 @@ static TADDR s_nextVirtualIP = 0x80000001;
 
 #ifndef DACCESS_COMPILE
 
+// Global flag set when APX instruction set is available (enables JMPABS)
+bool g_IsJmpAbsAvailable = false;
+
 CrstStatic ExecutionManager::m_JumpStubCrst;
 
 unsigned   ExecutionManager::m_normal_JumpStubLookup;
@@ -1513,6 +1516,7 @@ void EEJitManager::SetCpuInfo()
     if (((cpuFeatures & XArchIntrinsicConstants_Apx) != 0) && CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_EnableAPX))
     {
         CPUCompileFlags.Set(InstructionSet_APX);
+        g_IsJmpAbsAvailable = true;
     }
 #endif  // TARGET_AMD64
 


### PR DESCRIPTION



# Add JMPABS (APX) Support for Virtual Call Stubs on AMD64

## Summary

This PR adds support for the JMPABS instruction (part of Intel's APX - Advanced Performance Extensions) to virtual call stubs on AMD64, reducing stub size and improving instruction fetch efficiency.

## Background

APX introduces the JMPABS instruction (`D5 00 A1` + 8-byte address), which performs a 64-bit absolute jump. JMPABS provides performance benefits over the traditional `mov rax, imm64; jmp rax` sequence:



Virtual call stubs are small code sequences generated at runtime for dispatching interface and virtual method calls. Currently, these stubs use a two-instruction sequence (`mov rax, target; jmp rax`) to perform 64-bit absolute jumps.

## Changes



### Virtual Call Stub Infrastructure

**Stub Generation Helpers** ([src/coreclr/vm/amd64/cgenamd64.cpp](src/coreclr/vm/amd64/cgenamd64.cpp), [cgencpu.h](src/coreclr/vm/amd64/cgencpu.h))
- Added `emitJmpAbsJump()` helper function to emit raw JMPABS instructions (11 bytes)
- Modified `emitBackToBackJump()` to use JMPABS encoding when available, with fallback to legacy encoding
- Extend AMD64 virtual call short dispatch stubs to support an APX encoding path (jne rel32; nop; jmpabs imm64) and use it when APX is available.
- Added `IsJmpAbsAvailable()` CPU capability detection function
- Removed dead code: `EncodeLoadAndJumpThunk()` (obsolete thunk generation helper)
- Fixed `DispatchStubShort_offsetof_failDisplBase` macro referencing wrong struct type (`DispatchStubLong` → `DispatchStubShort`)


## Testing

1. **JIT Emitter Unit Tests**: Ran unit tests to verify JMPABS instruction encoding in the JIT emitter
2. **Library Tests**: Ran library tests with APX enabled/disabled to verify stub changes cause no failures on non-APX hardware
3. **Runtime Tests**: Ran `src/tests` with and without APX to validate stub changes on non-APX hardware


## Issue
Fixes #131817


### JIT Emitter

**[src/coreclr/jit/emitxarch.cpp](src/coreclr/jit/emitxarch.cpp)**
- Added JMPABS instruction encoding support in the emitter
- Added unit test for JMPABS encoding
- Note: JMPABS is not currently used anywhere in the JIT itself


Edit - the emitter changes have been reveretd based on feedback from @jkotas 


### Opens

### 1. Static Stub Size with NOP Padding
Current approach: To maintain consistent stub size and simplify stub management, this PR uses NOP padding in the APX encoding path:

emitBackToBackJump (used in jump stubs): Both encodings are 12 bytes

Legacy: `mov rax, imm64; jmp rax` (12 bytes)
APX: `jmpabs imm64 (11 bytes) + nop (1 byte)` = 12 bytes
`DispatchStubShort` (used in dispatch stubs): Both encodings are 18 bytes

Legacy: `jne rel32 (6 bytes) + mov rax, imm64; jmp rax (12 bytes)` = 18 bytes
APX: `jne rel32 (6 bytes) + nop (1 byte) + jmpabs imm64 (11 bytes)` = 18 bytes

### 2. APX Availability Detection
JMPABS availability is determined at runtime via` IsJmpAbsAvailable(`), which checks `HasInstructionSet(InstructionSet_APX)` from the JIT's CPU capability flags. Is runtime-only detection sufficient, or do we need additional compile-time or toolchain checks for crossgen/ReadyToRun scenarios?

### 3. DispatchStubLong JMPABS Support
`DispatchStubLong` could benefit from JMPABS encoding, but the instruction's 3-byte prefix shifts the 64-bit immediate from offset +2 (legacy` mov rax, imm64`) to offset +3 (JMPABS). This offset change may break the 8-byte alignment requirement.Should we defer this optimization?