### PR TITLE
Use inline arrays in `GCMemoryInfoData`.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
@@ -367,19 +367,14 @@ public:
     uint32_t pauseTimePercent;
     uint8_t isCompaction;
     uint8_t isConcurrent;
-    RH_GC_GENERATION_INFO generationInfo0;
-    RH_GC_GENERATION_INFO generationInfo1;
-    RH_GC_GENERATION_INFO generationInfo2;
-    RH_GC_GENERATION_INFO generationInfo3;
-    RH_GC_GENERATION_INFO generationInfo4;
-    uint64_t pauseDuration0;
-    uint64_t pauseDuration1;
+    RH_GC_GENERATION_INFO generationInfo[5];
+    uint64_t pauseDurations[2];
 };
 
 FCIMPL2(void, RhGetMemoryInfo, RH_GH_MEMORY_INFO* pData, int kind)
 {
-    uint64_t* genInfoRaw = (uint64_t*)&(pData->generationInfo0);
-    uint64_t* pauseInfoRaw = (uint64_t*)&(pData->pauseDuration0);
+    uint64_t* genInfoRaw = (uint64_t*)&(pData->generationInfo[0]);
+    uint64_t* pauseInfoRaw = (uint64_t*)&(pData->pauseDurations[0]);
 
     return GCHeapUtilities::GetGCHeap()->GetMemoryInfo(
         &(pData->highMemLoadThresholdBytes),

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -502,8 +502,8 @@ FCIMPL2(void, GCInterface::GetMemoryInfo, Object* objUNSAFE, int kind)
 
     GCMEMORYINFODATAREF objGCMemoryInfo = (GCMEMORYINFODATAREF)(ObjectToOBJECTREF (objUNSAFE));
 
-    UINT64* genInfoRaw = (UINT64*)&(objGCMemoryInfo->generationInfo0);
-    UINT64* pauseInfoRaw = (UINT64*)&(objGCMemoryInfo->pauseDuration0);
+    UINT64* genInfoRaw = (UINT64*)&(objGCMemoryInfo->generationInfo[0]);
+    UINT64* pauseInfoRaw = (UINT64*)&(objGCMemoryInfo->pauseDurations[0]);
 
     return GCHeapUtilities::GetGCHeap()->GetMemoryInfo(
         &(objGCMemoryInfo->highMemLoadThresholdBytes),

--- a/src/coreclr/vm/comutilnative.h
+++ b/src/coreclr/vm/comutilnative.h
@@ -113,13 +113,8 @@ public:
 #ifndef UNIX_X86_ABI
     UINT8 padding[6];
 #endif
-    GCGenerationInfo generationInfo0;
-    GCGenerationInfo generationInfo1;
-    GCGenerationInfo generationInfo2;
-    GCGenerationInfo generationInfo3;
-    GCGenerationInfo generationInfo4;
-    UINT64 pauseDuration0;
-    UINT64 pauseDuration1;
+    GCGenerationInfo generationInfo[5];
+    UINT64 pauseDurations[2];
 };
 #include "poppack.h"
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -1442,13 +1442,8 @@ DEFINE_FIELD_U(_generation, GCMemoryInfoData, generation)
 DEFINE_FIELD_U(_pauseTimePercentage, GCMemoryInfoData, pauseTimePercent)
 DEFINE_FIELD_U(_compacted, GCMemoryInfoData, isCompaction)
 DEFINE_FIELD_U(_concurrent, GCMemoryInfoData, isConcurrent)
-DEFINE_FIELD_U(_pauseDuration0, GCMemoryInfoData, pauseDuration0)
-DEFINE_FIELD_U(_pauseDuration1, GCMemoryInfoData, pauseDuration1)
-DEFINE_FIELD_U(_generationInfo0, GCMemoryInfoData, generationInfo0)
-DEFINE_FIELD_U(_generationInfo1, GCMemoryInfoData, generationInfo1)
-DEFINE_FIELD_U(_generationInfo2, GCMemoryInfoData, generationInfo2)
-DEFINE_FIELD_U(_generationInfo3, GCMemoryInfoData, generationInfo3)
-DEFINE_FIELD_U(_generationInfo4, GCMemoryInfoData, generationInfo4)
+DEFINE_FIELD_U(_pauseDurations, GCMemoryInfoData, pauseDurations)
+DEFINE_FIELD_U(_generationInfo, GCMemoryInfoData, generationInfo)
 
 #undef DEFINE_CLASS
 #undef DEFINE_METHOD

--- a/src/libraries/System.Private.CoreLib/src/System/GCMemoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/GCMemoryInfo.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace System
@@ -70,19 +71,8 @@ namespace System
         internal int _pauseTimePercentage;
         internal byte _compacted;
         internal byte _concurrent;
-
-        private GCGenerationInfo _generationInfo0;
-        private GCGenerationInfo _generationInfo1;
-        private GCGenerationInfo _generationInfo2;
-        private GCGenerationInfo _generationInfo3;
-        private GCGenerationInfo _generationInfo4;
-
-        internal ReadOnlySpan<GCGenerationInfo> GenerationInfoAsSpan => MemoryMarshal.CreateReadOnlySpan(ref _generationInfo0, 5);
-
-        private TimeSpan _pauseDuration0;
-        private TimeSpan _pauseDuration1;
-
-        internal ReadOnlySpan<TimeSpan> PauseDurationsAsSpan => MemoryMarshal.CreateReadOnlySpan(ref _pauseDuration0, 2);
+        internal InlineArray5<GCGenerationInfo> _generationInfo;
+        internal InlineArray2<TimeSpan> _pauseDurations;
     }
 
     /// <summary>Provides a set of APIs that can be used to retrieve garbage collection information.</summary>
@@ -188,7 +178,7 @@ namespace System
         /// <summary>
         /// Pause durations. For blocking GCs there's only 1 pause; for BGC there are 2.
         /// </summary>
-        public ReadOnlySpan<TimeSpan> PauseDurations => _data.PauseDurationsAsSpan;
+        public ReadOnlySpan<TimeSpan> PauseDurations => _data._pauseDurations;
 
         /// <summary>
         /// This is the % pause time in GC so far. If it's 1.2%, this number is 1.2.
@@ -198,6 +188,6 @@ namespace System
         /// <summary>
         /// Generation info for all generations.
         /// </summary>
-        public ReadOnlySpan<GCGenerationInfo> GenerationInfo => _data.GenerationInfoAsSpan;
+        public ReadOnlySpan<GCGenerationInfo> GenerationInfo => _data._generationInfo;
     }
 }


### PR DESCRIPTION
Removes two uses of `MemoryMarshal.CreateReadOnlySpan`.