### PR TITLE
Exclude rundownvalidation from crossgen tests

### DIFF
--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
@@ -4,6 +4,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- MethodILToNativeMap rundown events are emitted only for JIT-compiled methods. -->
+    <CrossGenTest>false</CrossGenTest>
     <!-- The test launches a secondary process and process launch creates
     an infinite event loop in the SocketAsyncEngine on Linux. Since
     runincontext loads even framework assemblies into the unloadable


### PR DESCRIPTION
`rundownvalidation` requires a `MethodILToNativeMap` rundown event, but that event is emitted only for JIT-compiled methods. A fully composite ReadyToRun framework and test image can legitimately execute with no eligible JIT methods when tiered compilation is disabled, making this assertion depend on incidental runtime JIT fallback behavior.

Exclude this test from crossgen runs so its assembly remains IL and reliably exercises the JIT-only event, while preserving the existing assertion and process-isolated execution.

Validation:
- Reproduced the exact scheduled last-good payload passing and first-bad payload failing on Windows x64 Checked with `DOTNET_TieredCompilation=0`, `--composite`, and `--inputbubble`.
- Isolated the transition to `ILCompiler.ReadyToRun.dll` from #131282 using fixed framework inputs and reciprocal compiler DLL swaps.
- Ran the exact first-bad composite framework payload with test crossgen disabled: the test passed with `hasMethodILToNativeMap=True`, and no `IL-CG2` output was created.

Fixes #131662

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
