### PR TITLE
Restore BitArray constructor performance

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
@@ -142,8 +142,15 @@ namespace System.Collections
         public BitArray(byte[] bytes)
         {
             ArgumentNullException.ThrowIfNull(bytes);
+            if (bytes.Length > int.MaxValue / BitsPerByte)
+            {
+                throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerByte), nameof(bytes));
+            }
 
-            _array = CreateArray(bytes, out _bitLength);
+            _bitLength = bytes.Length * BitsPerByte;
+            _array = AllocateByteArray(_bitLength);
+
+            Array.Copy(bytes, _array, bytes.Length);
         }
 
         /// <summary>
@@ -162,22 +169,15 @@ namespace System.Collections
         /// </remarks>
         public BitArray(ReadOnlySpan<byte> bytes)
         {
-            _array = CreateArray(bytes, out _bitLength);
-        }
-
-        private static byte[] CreateArray(ReadOnlySpan<byte> bytes, out int bitLength)
-        {
             if (bytes.Length > int.MaxValue / BitsPerByte)
             {
                 throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerByte), nameof(bytes));
             }
 
-            int length = bytes.Length * BitsPerByte;
-            byte[] array = AllocateByteArray(length);
+            _bitLength = bytes.Length * BitsPerByte;
+            _array = AllocateByteArray(_bitLength);
 
-            bytes.CopyTo(array);
-            bitLength = length;
-            return array;
+            bytes.CopyTo(_array);
         }
 
         /// <summary>
@@ -193,27 +193,8 @@ namespace System.Collections
         {
             ArgumentNullException.ThrowIfNull(values);
 
-            _array = CreateArray(values);
+            _array = AllocateByteArray(values.Length);
             _bitLength = values.Length;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BitArray"/> class that contains bit values
-        /// copied from the specified read-only span of Booleans.
-        /// </summary>
-        /// <param name="values">A read-only span of Booleans to copy.</param>
-        /// <remarks>
-        /// This constructor is an <c>O(n)</c> operation, where <c>n</c> is the number of elements in <paramref name="values"/>.
-        /// </remarks>
-        public BitArray(ReadOnlySpan<bool> values)
-        {
-            _array = CreateArray(values);
-            _bitLength = values.Length;
-        }
-
-        private static byte[] CreateArray(ReadOnlySpan<bool> values)
-        {
-            byte[] array = AllocateByteArray(values.Length);
 
             uint i = 0;
 
@@ -226,8 +207,8 @@ namespace System.Collections
             // (true for any non-zero values, false for 0) - any values between 2-255 will be interpreted as false.
             // Instead, we compare with zeroes (== false) then negate the result to ensure compatibility.
 
-            ref byte arrayRef = ref MemoryMarshal.GetArrayDataReference(array);
-            ReadOnlySpan<byte> valuesAsBytes = MemoryMarshal.AsBytes(values);
+            ref byte arrayRef = ref MemoryMarshal.GetArrayDataReference(_array);
+            ReadOnlySpan<byte> valuesAsBytes = MemoryMarshal.AsBytes(values.AsSpan());
             if (Vector512.IsHardwareAccelerated)
             {
                 while (valuesAsBytes.Length >= Vector512<byte>.Count)
@@ -277,14 +258,95 @@ namespace System.Collections
         Remainder:
             for (; i < (uint)values.Length; i++)
             {
-                if (values[(int)i])
+                if (values[i])
                 {
                     (uint byteIndex, uint bitOffset) = Math.DivRem(i, BitsPerByte);
-                    array[byteIndex] |= (byte)(1 << (int)bitOffset);
+                    _array[byteIndex] |= (byte)(1 << (int)bitOffset);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitArray"/> class that contains bit values
+        /// copied from the specified read-only span of Booleans.
+        /// </summary>
+        /// <param name="values">A read-only span of Booleans to copy.</param>
+        /// <remarks>
+        /// This constructor is an <c>O(n)</c> operation, where <c>n</c> is the number of elements in <paramref name="values"/>.
+        /// </remarks>
+        public BitArray(ReadOnlySpan<bool> values)
+        {
+            _array = AllocateByteArray(values.Length);
+            _bitLength = values.Length;
+
+            int i = 0;
+
+            if (!BitConverter.IsLittleEndian || values.Length < Vector256<byte>.Count)
+            {
+                goto Remainder;
+            }
+
+            // Comparing with 1s would get rid of the final negation, however this would not work for some CLR bools
+            // (true for any non-zero values, false for 0) - any values between 2-255 will be interpreted as false.
+            // Instead, we compare with zeroes (== false) then negate the result to ensure compatibility.
+
+            ref byte arrayRef = ref MemoryMarshal.GetArrayDataReference(_array);
+            ReadOnlySpan<byte> valuesAsBytes = MemoryMarshal.AsBytes(values);
+            if (Vector512.IsHardwareAccelerated)
+            {
+                while (valuesAsBytes.Length >= Vector512<byte>.Count)
+                {
+                    Vector512<byte> vector = Vector512.Create(valuesAsBytes);
+                    Vector512<byte> isFalse = Vector512.Equals(vector, Vector512<byte>.Zero);
+
+                    ulong result = isFalse.ExtractMostSignificantBits();
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(ulong) * (i / 64)), ~result);
+                    i += Vector512<byte>.Count;
+                    valuesAsBytes = valuesAsBytes.Slice(Vector512<byte>.Count);
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated)
+            {
+                while (valuesAsBytes.Length >= Vector256<byte>.Count)
+                {
+                    Vector256<byte> vector = Vector256.Create(valuesAsBytes);
+                    Vector256<byte> isFalse = Vector256.Equals(vector, Vector256<byte>.Zero);
+
+                    uint result = isFalse.ExtractMostSignificantBits();
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32)), ~result);
+                    i += Vector256<byte>.Count;
+                    valuesAsBytes = valuesAsBytes.Slice(Vector256<byte>.Count);
+                }
+            }
+            else if (Vector128.IsHardwareAccelerated)
+            {
+                while (valuesAsBytes.Length >= Vector128<byte>.Count * 2)
+                {
+                    Vector128<byte> lowerVector = Vector128.Create(valuesAsBytes);
+                    Vector128<byte> lowerIsFalse = Vector128.Equals(lowerVector, Vector128<byte>.Zero);
+                    uint lowerResult = lowerIsFalse.ExtractMostSignificantBits();
+
+                    Vector128<byte> upperVector = Vector128.Create(valuesAsBytes.Slice(Vector128<byte>.Count));
+                    Vector128<byte> upperIsFalse = Vector128.Equals(upperVector, Vector128<byte>.Zero);
+                    uint upperResult = upperIsFalse.ExtractMostSignificantBits();
+
+                    Unsafe.WriteUnaligned(
+                        ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32)),
+                        ~((upperResult << 16) | lowerResult));
+                    i += Vector128<byte>.Count * 2;
+                    valuesAsBytes = valuesAsBytes.Slice(Vector128<byte>.Count * 2);
                 }
             }
 
-            return array;
+        Remainder:
+            for (; i < values.Length; i++)
+            {
+                if (values[i])
+                {
+                    (int byteIndex, int bitOffset) = Math.DivRem(i, BitsPerByte);
+                    _array[byteIndex] |= (byte)(1 << bitOffset);
+                }
+            }
         }
 
         /// <summary>
@@ -305,8 +367,22 @@ namespace System.Collections
         public BitArray(int[] values)
         {
             ArgumentNullException.ThrowIfNull(values);
+            if (values.Length > int.MaxValue / BitsPerInt32)
+            {
+                throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerInt32), nameof(values));
+            }
 
-            _array = CreateArray(values, out _bitLength);
+            _bitLength = values.Length * BitsPerInt32;
+            _array = AllocateByteArray(_bitLength);
+
+            if (BitConverter.IsLittleEndian)
+            {
+                MemoryMarshal.AsBytes(values).CopyTo(_array);
+            }
+            else
+            {
+                BinaryPrimitives.ReverseEndianness(values, MemoryMarshal.Cast<byte, int>((Span<byte>)_array));
+            }
         }
 
         /// <summary>
@@ -325,30 +401,22 @@ namespace System.Collections
         /// </remarks>
         public BitArray(ReadOnlySpan<int> values)
         {
-            _array = CreateArray(values, out _bitLength);
-        }
-
-        private static byte[] CreateArray(ReadOnlySpan<int> values, out int bitLength)
-        {
             if (values.Length > int.MaxValue / BitsPerInt32)
             {
                 throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerInt32), nameof(values));
             }
 
-            int length = values.Length * BitsPerInt32;
-            byte[] array = AllocateByteArray(length);
+            _bitLength = values.Length * BitsPerInt32;
+            _array = AllocateByteArray(_bitLength);
 
             if (BitConverter.IsLittleEndian)
             {
-                MemoryMarshal.AsBytes(values).CopyTo(array);
+                MemoryMarshal.AsBytes(values).CopyTo(_array);
             }
             else
             {
-                BinaryPrimitives.ReverseEndianness(values, MemoryMarshal.Cast<byte, int>((Span<byte>)array));
+                BinaryPrimitives.ReverseEndianness(values, MemoryMarshal.Cast<byte, int>((Span<byte>)_array));
             }
-
-            bitLength = length;
-            return array;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
@@ -215,7 +215,7 @@ namespace System.Collections
         {
             byte[] array = AllocateByteArray(values.Length);
 
-            int i = 0;
+            uint i = 0;
 
             if (!BitConverter.IsLittleEndian || values.Length < Vector256<byte>.Count)
             {
@@ -236,8 +236,8 @@ namespace System.Collections
                     Vector512<byte> isFalse = Vector512.Equals(vector, Vector512<byte>.Zero);
 
                     ulong result = isFalse.ExtractMostSignificantBits();
-                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(ulong) * (i / 64)), ~result);
-                    i += Vector512<byte>.Count;
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(ulong) * (i / 64u)), ~result);
+                    i += (uint)Vector512<byte>.Count;
                     valuesAsBytes = valuesAsBytes.Slice(Vector512<byte>.Count);
                 }
             }
@@ -249,8 +249,8 @@ namespace System.Collections
                     Vector256<byte> isFalse = Vector256.Equals(vector, Vector256<byte>.Zero);
 
                     uint result = isFalse.ExtractMostSignificantBits();
-                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32)), ~result);
-                    i += Vector256<byte>.Count;
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32u)), ~result);
+                    i += (uint)Vector256<byte>.Count;
                     valuesAsBytes = valuesAsBytes.Slice(Vector256<byte>.Count);
                 }
             }
@@ -267,20 +267,20 @@ namespace System.Collections
                     uint upperResult = upperIsFalse.ExtractMostSignificantBits();
 
                     Unsafe.WriteUnaligned(
-                        ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32)),
+                        ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32u)),
                         ~((upperResult << 16) | lowerResult));
-                    i += Vector128<byte>.Count * 2;
+                    i += (uint)Vector128<byte>.Count * 2u;
                     valuesAsBytes = valuesAsBytes.Slice(Vector128<byte>.Count * 2);
                 }
             }
 
         Remainder:
-            for (; i < values.Length; i++)
+            for (; i < (uint)values.Length; i++)
             {
-                if (values[i])
+                if (values[(int)i])
                 {
-                    (int byteIndex, int bitOffset) = Math.DivRem(i, BitsPerByte);
-                    array[byteIndex] |= (byte)(1 << bitOffset);
+                    (uint byteIndex, uint bitOffset) = Math.DivRem(i, BitsPerByte);
+                    array[byteIndex] |= (byte)(1 << (int)bitOffset);
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
@@ -172,10 +172,11 @@ namespace System.Collections
                 throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerByte), nameof(bytes));
             }
 
-            bitLength = bytes.Length * BitsPerByte;
-            byte[] array = AllocateByteArray(bitLength);
+            int length = bytes.Length * BitsPerByte;
+            byte[] array = AllocateByteArray(length);
 
             bytes.CopyTo(array);
+            bitLength = length;
             return array;
         }
 
@@ -192,7 +193,8 @@ namespace System.Collections
         {
             ArgumentNullException.ThrowIfNull(values);
 
-            _array = CreateArray(values, out _bitLength);
+            _array = CreateArray(values);
+            _bitLength = values.Length;
         }
 
         /// <summary>
@@ -205,15 +207,15 @@ namespace System.Collections
         /// </remarks>
         public BitArray(ReadOnlySpan<bool> values)
         {
-            _array = CreateArray(values, out _bitLength);
+            _array = CreateArray(values);
+            _bitLength = values.Length;
         }
 
-        private static byte[] CreateArray(ReadOnlySpan<bool> values, out int bitLength)
+        private static byte[] CreateArray(ReadOnlySpan<bool> values)
         {
-            bitLength = values.Length;
-            byte[] array = AllocateByteArray(bitLength);
+            byte[] array = AllocateByteArray(values.Length);
 
-            uint i = 0;
+            int i = 0;
 
             if (!BitConverter.IsLittleEndian || values.Length < Vector256<byte>.Count)
             {
@@ -234,8 +236,8 @@ namespace System.Collections
                     Vector512<byte> isFalse = Vector512.Equals(vector, Vector512<byte>.Zero);
 
                     ulong result = isFalse.ExtractMostSignificantBits();
-                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(ulong) * (i / 64u)), ~result);
-                    i += (uint)Vector512<byte>.Count;
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(ulong) * (i / 64)), ~result);
+                    i += Vector512<byte>.Count;
                     valuesAsBytes = valuesAsBytes.Slice(Vector512<byte>.Count);
                 }
             }
@@ -247,8 +249,8 @@ namespace System.Collections
                     Vector256<byte> isFalse = Vector256.Equals(vector, Vector256<byte>.Zero);
 
                     uint result = isFalse.ExtractMostSignificantBits();
-                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32u)), ~result);
-                    i += (uint)Vector256<byte>.Count;
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32)), ~result);
+                    i += Vector256<byte>.Count;
                     valuesAsBytes = valuesAsBytes.Slice(Vector256<byte>.Count);
                 }
             }
@@ -265,20 +267,20 @@ namespace System.Collections
                     uint upperResult = upperIsFalse.ExtractMostSignificantBits();
 
                     Unsafe.WriteUnaligned(
-                        ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32u)),
+                        ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32)),
                         ~((upperResult << 16) | lowerResult));
-                    i += (uint)Vector128<byte>.Count * 2u;
+                    i += Vector128<byte>.Count * 2;
                     valuesAsBytes = valuesAsBytes.Slice(Vector128<byte>.Count * 2);
                 }
             }
 
         Remainder:
-            for (; i < (uint)values.Length; i++)
+            for (; i < values.Length; i++)
             {
-                if (values[(int)i])
+                if (values[i])
                 {
-                    (uint byteIndex, uint bitOffset) = Math.DivRem(i, BitsPerByte);
-                    array[byteIndex] |= (byte)(1 << (int)bitOffset);
+                    (int byteIndex, int bitOffset) = Math.DivRem(i, BitsPerByte);
+                    array[byteIndex] |= (byte)(1 << bitOffset);
                 }
             }
 
@@ -333,8 +335,8 @@ namespace System.Collections
                 throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerInt32), nameof(values));
             }
 
-            bitLength = values.Length * BitsPerInt32;
-            byte[] array = AllocateByteArray(bitLength);
+            int length = values.Length * BitsPerInt32;
+            byte[] array = AllocateByteArray(length);
 
             if (BitConverter.IsLittleEndian)
             {
@@ -345,6 +347,7 @@ namespace System.Collections
                 BinaryPrimitives.ReverseEndianness(values, MemoryMarshal.Cast<byte, int>((Span<byte>)array));
             }
 
+            bitLength = length;
             return array;
         }
 


### PR DESCRIPTION
## Summary

- Restore the original `byte[]`, `bool[]`, and `int[]` constructor implementations to eliminate helper-call and inlining regressions.
- Keep separate implementations for the new `ReadOnlySpan<byte>`, `ReadOnlySpan<bool>`, and `ReadOnlySpan<int>` constructors.
- Use an `int` induction variable in the Boolean span constructor so span indexing and bounds analysis stay in the JIT's canonical signed form.

Fixes #131815

## Performance

Performance tracking identified regressions in three affected benchmark groups:

- `BitArrayBoolArrayCtor`: automated bisection tied the confirmed `Size: 512` regression to #131500 (16.73 ns to 22.65 ns, approximately +35%).
- `BitArrayIntArrayCtor`: additional regressions were reported at multiple input sizes.
- `BitArraySetLengthGrow(Size: 4)`: this benchmark includes construction from `byte[]`; automated bisection also flagged possible code-alignment noise, so it is included in the validation set.

This change prioritizes preserving the existing array-constructor performance over sharing implementation with the span overloads. Focused Windows x64 EgorBot runs cover all three benchmark groups on the original regression architecture.

## Validation

- Checked `System.Private.CoreLib` build
- Verified the restored array constructor bodies match their pre-#131500 implementations
- Two independent read-only reviews found no correctness, bounds-safety, endianness, or exception-behavior issues
- Full PR CI and focused EgorBot benchmarks will validate the updated commit

> [!NOTE]
> This pull request description was generated with GitHub Copilot and reviewed before publication.
