### PR TITLE
[cDAC] Unwrap legacy AppDomain for method enumeration

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataAppDomain.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataAppDomain.cs
@@ -19,6 +19,7 @@ public sealed unsafe partial class ClrDataAppDomain : IXCLRDataAppDomain
     private readonly IXCLRDataAppDomain? _legacyImpl;
 
     public TargetPointer Address => _appDomain;
+    internal IXCLRDataAppDomain? LegacyImpl => _legacyImpl;
 
     public ClrDataAppDomain(Target target, TargetPointer appDomain, IXCLRDataAppDomain? legacyImpl)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -914,11 +914,9 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
         // which delegates some operations to it.
         ulong handleLocal = default;
         int hrLocal = default;
-        TargetPointer appDomainAddress = TargetPointer.Null;
         IXCLRDataAppDomain? legacyAppDomain = appDomain;
         if (appDomain is ClrDataAppDomain cdacAppDomain)
         {
-            appDomainAddress = cdacAppDomain.Address;
             legacyAppDomain = cdacAppDomain.LegacyImpl;
         }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -914,9 +914,17 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
         // which delegates some operations to it.
         ulong handleLocal = default;
         int hrLocal = default;
+        TargetPointer appDomainAddress = TargetPointer.Null;
+        IXCLRDataAppDomain? legacyAppDomain = appDomain;
+        if (appDomain is ClrDataAppDomain cdacAppDomain)
+        {
+            appDomainAddress = cdacAppDomain.Address;
+            legacyAppDomain = cdacAppDomain.LegacyImpl;
+        }
+
         if (_legacyProcess is not null)
         {
-            hrLocal = _legacyProcess.StartEnumMethodInstancesByAddress(address, appDomain, &handleLocal);
+            hrLocal = _legacyProcess.StartEnumMethodInstancesByAddress(address, legacyAppDomain, &handleLocal);
         }
 
         try


### PR DESCRIPTION
Ensure that the app domain is properly unwrapped to the legacy object for legacy validation.