### PR TITLE
Use current BFP rounding mode for s390x integer-to-double conversion

### DIFF
--- a/src/mono/mono/mini/mini-s390x.c
+++ b/src/mono/mono/mini/mini-s390x.c
@@ -4870,7 +4870,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_ICONV_TO_R_UN: {
 			if (mono_hwcap_s390x_has_fpe) {
-				s390_cdlfbr (code, ins->dreg, 4, ins->sreg1, 0);
+				s390_cdlfbr (code, ins->dreg, 0, ins->sreg1, 0);
 			} else {
 				s390_llgfr (code, s390_r0, ins->sreg1);
 				s390_cdgbr (code, ins->dreg, s390_r0);
@@ -4879,7 +4879,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_LCONV_TO_R_UN: {
 			if (mono_hwcap_s390x_has_fpe) {
-				s390_cdlgbr (code, ins->dreg, 4, ins->sreg1, 0);
+				s390_cdlgbr (code, ins->dreg, 0, ins->sreg1, 0);
 			} else {
 				short int *jump;
 				s390_lgdr  (code, s390_r0, s390_r15);


### PR DESCRIPTION
The previous implementation explicitly encoded round-to-nearest, ties-to-even (`M3 = 4`) for the s390x integer-to-double conversion.

This change switches to `M3 = 0`, allowing the instruction to use the current BFP rounding mode. Since the CLI initializes the floating-point environment to IEEE-754 round-to-nearest and managed code cannot modify it, this preserves the required semantics while relying on the runtime-configured floating-point control state.

Verified by the existing BigInteger conversion regression tests.