### PR TITLE
JIT: fix three wasm R2R codegen bugs

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4563,6 +4563,15 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication /* = false */, bool isPh
 
                     bool optimizeJump = isJumpAroundEmpty || isJumpToJoinFree;
 
+#ifdef TARGET_WASM
+                    // Don't reverse a wasm try/catch header's GT_WASM_JEXCEPT.
+                    //
+                    if (block->lastNode()->OperIs(GT_WASM_JEXCEPT))
+                    {
+                        optimizeJump = false;
+                    }
+#endif // TARGET_WASM
+
                     // We do not optimize jumps between two different try regions.
                     // However jumping to a block that is not in any try region is OK
                     //

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -4077,6 +4077,26 @@ GenTree* Compiler::impXplatIntrinsic(NamedIntrinsic        intrinsic,
         {
             assert(sig->numArgs == 2);
 
+#if defined(TARGET_WASM)
+            {
+                // An out-of-range constant lane index cannot be encoded by extract_lane, so
+                // fall back to the throwing software implementation. A non-constant index is
+                // handled by the jump-table expansion during lowering.
+                GenTree* indexOp = impStackTop(0).val;
+
+                if (indexOp->OperIsConst())
+                {
+                    ssize_t imm8  = indexOp->AsIntCon()->IconValue();
+                    ssize_t count = simdSize / genTypeSize(simdBaseType);
+
+                    if ((imm8 < 0) || (imm8 >= count))
+                    {
+                        return nullptr;
+                    }
+                }
+            }
+#endif // TARGET_WASM
+
             op2 = impPopStack().val;
             op1 = impSIMDPopStack();
 
@@ -5277,6 +5297,24 @@ GenTree* Compiler::impXplatIntrinsic(NamedIntrinsic        intrinsic,
                 {
                     // Using software fallback if index is out of range (throw exception)
                     return nullptr;
+                }
+            }
+#elif defined(TARGET_WASM)
+            {
+                // An out-of-range constant lane index cannot be encoded by replace_lane, so
+                // fall back to the throwing software implementation. A non-constant index is
+                // handled by the jump-table expansion during lowering.
+                GenTree* indexOp = impStackTop(1).val;
+
+                if (indexOp->OperIsConst())
+                {
+                    ssize_t imm8  = indexOp->AsIntCon()->IconValue();
+                    ssize_t count = simdSize / genTypeSize(simdBaseType);
+
+                    if ((imm8 < 0) || (imm8 >= count))
+                    {
+                        return nullptr;
+                    }
                 }
             }
 #endif

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -16400,18 +16400,14 @@ void ValueNumStore::PeelOffsets(ValueNum* vn, target_ssize_t* offset)
 
         if (IsVNConstantNonHandle(app.GetArg(0)) && (app.GetArg(0) != VNForNull()))
         {
-            // Ref/byref constants are stored as host size_t, so read them as such and truncate.
+            // Ref/byref constants are stored as host size_t; GetConstantInt64 reads them as such.
             //
-            *offset += varTypeIsGC(TypeOfVN(app.GetArg(0)))
-                           ? (target_ssize_t)CoercedConstantValue<ssize_t>(app.GetArg(0))
-                           : ConstantValue<target_ssize_t>(app.GetArg(0));
+            *offset += (target_ssize_t)GetConstantInt64(app.GetArg(0));
             *vn = app.GetArg(1);
         }
         else if (IsVNConstantNonHandle(app.GetArg(1)) && (app.GetArg(1) != VNForNull()))
         {
-            *offset += varTypeIsGC(TypeOfVN(app.GetArg(1)))
-                           ? (target_ssize_t)CoercedConstantValue<ssize_t>(app.GetArg(1))
-                           : ConstantValue<target_ssize_t>(app.GetArg(1));
+            *offset += (target_ssize_t)GetConstantInt64(app.GetArg(1));
             *vn = app.GetArg(0);
         }
         else

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -16400,12 +16400,18 @@ void ValueNumStore::PeelOffsets(ValueNum* vn, target_ssize_t* offset)
 
         if (IsVNConstantNonHandle(app.GetArg(0)) && (app.GetArg(0) != VNForNull()))
         {
-            *offset += ConstantValue<target_ssize_t>(app.GetArg(0));
+            // Ref/byref constants are stored as host size_t, so read them as such and truncate.
+            //
+            *offset += varTypeIsGC(TypeOfVN(app.GetArg(0)))
+                           ? (target_ssize_t)CoercedConstantValue<ssize_t>(app.GetArg(0))
+                           : ConstantValue<target_ssize_t>(app.GetArg(0));
             *vn = app.GetArg(1);
         }
         else if (IsVNConstantNonHandle(app.GetArg(1)) && (app.GetArg(1) != VNForNull()))
         {
-            *offset += ConstantValue<target_ssize_t>(app.GetArg(1));
+            *offset += varTypeIsGC(TypeOfVN(app.GetArg(1)))
+                           ? (target_ssize_t)CoercedConstantValue<ssize_t>(app.GetArg(1))
+                           : ConstantValue<target_ssize_t>(app.GetArg(1));
             *vn = app.GetArg(0);
         }
         else


### PR DESCRIPTION
Found by ReadyToRun-compiling and running the src/tests/JIT test tree on wasm.

- fgUpdateFlowGraph: don't reverse a wasm try/catch header's GT_WASM_JEXCEPT. Its edge polarity is load-bearing for try_table codegen (false = try entry, true = catch-resumption dispatcher).
- valuenum PeelOffsets: read ref/byref constant offsets as host size_t. They are stored as size_t; reading them as target_ssize_t is a wrong-sized read on wasm.
- Vector Get/WithElement import: fall back to the throwing software implementation for an out-of-range constant lane index on wasm; a non-constant index still uses the jump-table lowering.