### PR TITLE
Keep accepted sockets alive in TlsSession tests

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
@@ -2039,7 +2039,7 @@ namespace System.Net.Security.Tests
 
             using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
-            Socket serverSocket = await listener.AcceptAsync();
+            using Socket serverSocket = await listener.AcceptAsync();
             await connect;
 
             // Configure as non-blocking; TlsSession contract requires it.
@@ -2166,7 +2166,7 @@ namespace System.Net.Security.Tests
 
             using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
-            Socket serverSocket = await listener.AcceptAsync();
+            using Socket serverSocket = await listener.AcceptAsync();
             await connect;
 
             serverSocket.Blocking = false;
@@ -2265,7 +2265,7 @@ namespace System.Net.Security.Tests
 
                 using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
                 Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
-                Socket serverSocket = await listener.AcceptAsync();
+                using Socket serverSocket = await listener.AcceptAsync();
                 await connect;
 
                 serverSocket.Blocking = false;
@@ -2347,7 +2347,7 @@ namespace System.Net.Security.Tests
 
             using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
-            Socket serverSocket = await listener.AcceptAsync();
+            using Socket serverSocket = await listener.AcceptAsync();
             await connect;
 
             serverSocket.Blocking = false;
@@ -2427,7 +2427,7 @@ namespace System.Net.Security.Tests
 
             using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
-            Socket serverSocket = await listener.AcceptAsync();
+            using Socket serverSocket = await listener.AcceptAsync();
             await connect;
 
             serverSocket.Blocking = false;
@@ -2613,7 +2613,7 @@ namespace System.Net.Security.Tests
 
             using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
-            Socket serverSocket = await listener.AcceptAsync();
+            using Socket serverSocket = await listener.AcceptAsync();
             await connect;
             serverSocket.Blocking = false;
 
@@ -2954,7 +2954,7 @@ namespace System.Net.Security.Tests
 
             using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
-            Socket serverSocket = await listener.AcceptAsync();
+            using Socket serverSocket = await listener.AcceptAsync();
             await connect;
 
             serverSocket.Blocking = false;
@@ -3042,7 +3042,7 @@ namespace System.Net.Security.Tests
             // socket send buffer fills quickly and drives SSL_write into WANT_WRITE.
             clientUnderlying.ReceiveBufferSize = 512;
             Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
-            Socket serverSocket = await listener.AcceptAsync();
+            using Socket serverSocket = await listener.AcceptAsync();
             await connect;
 
             serverSocket.Blocking = false;


### PR DESCRIPTION
Addresses #131798

Keep each accepted server `Socket` alive and deterministically disposed for the full lifetime of the corresponding socket-bound `TlsSocketSession`. The declaration order ensures the session releases its ownership first, followed by the original socket wrapper.

This applies the ownership pattern consistently to all eight socket-bound test cases. The intermittent macOS reset was not reproduced locally, so this change hardens the suspected lifetime issue without claiming a locally confirmed reproduction.

Validation:
- The two tests reported in #131798 passed: 2 passed, 0 failed.
- The complete System.Net.Security functional test project passed: 5,017 passed, 29 skipped, 0 failed.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.