### PR TITLE
[System.Net] Fix IPNetwork.Contains for mapped IPv4 addresses

### DIFF
--- a/src/libraries/System.Net.Primitives/src/System/Net/IPNetwork.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPNetwork.cs
@@ -78,7 +78,7 @@ namespace System.Net
                 return true;
             }
 
-            if (address.AddressFamily == AddressFamily.InterNetwork || address.IsIPv4MappedToIPv6)
+            if (BaseAddress.AddressFamily == AddressFamily.InterNetwork)
             {
                 uint mask = uint.MaxValue << (32 - PrefixLength);
                 if (BitConverter.IsLittleEndian)

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPNetworkTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPNetworkTest.cs
@@ -211,6 +211,16 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Theory]
+        [InlineData("2000::/3", "::ffff:1.2.3.4", false)]
+        [InlineData("::ffff:0:0/96", "::ffff:192.0.2.1", true)]
+        public void Contains_IPv4MappedAddressInIPv6Network_ReturnsExpected(string networkString, string addressString, bool expected)
+        {
+            IPNetwork network = IPNetwork.Parse(networkString);
+
+            Assert.Equal(expected, network.Contains(IPAddress.Parse(addressString)));
+        }
+
+        [Theory]
         [InlineData("0.0.0.0/0", "0.0.0.0", "127.127.127.127", "255.255.255.255")] // the whole IPv4 space
         [InlineData("0.0.0.0/0", "0.0.0.0", "::ffff:127.127.127.127", "::ffff:255.255.255.255")] // the whole IPv4 space
         [InlineData("::/0", "::", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")] // the whole IPv6 space


### PR DESCRIPTION
Fixes #131861

`IPNetwork.Contains` currently selects its comparison path from the queried address. An IPv4-mapped address can therefore select the IPv4 path even when the network itself is IPv6.

Select the comparison path from the network address family instead. This preserves support for querying IPv4 networks with IPv4-mapped addresses while ensuring IPv6 networks use 128-bit prefix semantics.

Adds coverage for mapped addresses both inside and outside IPv6 networks.

### Testing

- `./dotnet.sh build src/libraries/System.Net.Primitives/src/System.Net.Primitives.csproj`
- `./dotnet.sh build src/libraries/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj /t:Test` (6,311 passed)