### PR TITLE
[browser] Package CoreCLR browser-wasm native relink headers in the runtime pack

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -270,6 +270,19 @@
         "
         IsNative="true" />
 
+      <!-- Headers included by the CoreCLR native relink generated sources (see BrowserWasmApp.CoreCLR.targets).
+           The browserhost CMakeLists installs them into the host sharedFramework; mirrors the Mono include\wasm handling. -->
+      <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(IsTestsCommonProject)' != 'true'"
+                             Include="$(HostSharedFrameworkDir)include\callhelpers.hpp"
+                             NativeSubDirectory="include"
+                             IsNative="true" />
+      <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(IsTestsCommonProject)' != 'true'"
+                             Include="
+        $(HostSharedFrameworkDir)include\minipal\entrypoints.h;
+        $(HostSharedFrameworkDir)include\minipal\utils.h;"
+                             NativeSubDirectory="include\minipal"
+                             IsNative="true" />
+
       <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'Mono'"
                              Include="
         $(LibrariesNativeArtifactsPath)dotnet.d.ts;

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj
@@ -93,4 +93,26 @@
       <ReferenceCopyLocalPaths Include="@(CoreCLRCrossTargetFiles)" />
     </ItemGroup>
   </Target>
+
+  <!--
+    WASM CoreCLR ships the VM/minipal headers needed to relink dotnet.native.wasm with emcc
+    (see BrowserWasmApp.CoreCLR.targets). The browserhost CMakeLists installs them under
+    sharedFramework/include, but the generic runtime-file harvest (eng/liveBuilds.targets) only
+    globs the top level of sharedFramework, so the include/ subtree is dropped. Harvest it here,
+    mirroring how the Mono pack ships its relink headers under native/include.
+  -->
+  <Target Name="AddCoreCLRWasmIncludeFiles"
+          Condition="'$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi'"
+          AfterTargets="AddRuntimeFilesToPackage">
+    <ItemGroup>
+      <!-- Glob first, then map in a separate item so %(RecursiveDir) refers to the globbed
+           items (preserving the include/minipal subtree) instead of self-referencing (MSB4120). -->
+      <_CoreCLRWasmIncludeFile Include="$(CoreCLRSharedFrameworkDir)include\**\*.*" />
+      <ReferenceCopyLocalPaths Include="@(_CoreCLRWasmIncludeFile)">
+        <TargetPath>runtimes/$(RuntimeIdentifier)/native/include/%(RecursiveDir)</TargetPath>
+        <IsNative>true</IsNative>
+        <ExcludeFromDataFiles>true</ExcludeFromDataFiles>
+      </ReferenceCopyLocalPaths>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj
@@ -94,13 +94,6 @@
     </ItemGroup>
   </Target>
 
-  <!--
-    WASM CoreCLR ships the VM/minipal headers needed to relink dotnet.native.wasm with emcc
-    (see BrowserWasmApp.CoreCLR.targets). The browserhost CMakeLists installs them under
-    sharedFramework/include, but the generic runtime-file harvest (eng/liveBuilds.targets) only
-    globs the top level of sharedFramework, so the include/ subtree is dropped. Harvest it here,
-    mirroring how the Mono pack ships its relink headers under native/include.
-  -->
   <Target Name="AddCoreCLRWasmIncludeFiles"
           Condition="'$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi'"
           AfterTargets="AddRuntimeFilesToPackage">

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj
@@ -93,19 +93,4 @@
       <ReferenceCopyLocalPaths Include="@(CoreCLRCrossTargetFiles)" />
     </ItemGroup>
   </Target>
-
-  <Target Name="AddCoreCLRWasmIncludeFiles"
-          Condition="'$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi'"
-          AfterTargets="AddRuntimeFilesToPackage">
-    <ItemGroup>
-      <!-- Glob first, then map in a separate item so %(RecursiveDir) refers to the globbed
-           items (preserving the include/minipal subtree) instead of self-referencing (MSB4120). -->
-      <_CoreCLRWasmIncludeFile Include="$(CoreCLRSharedFrameworkDir)include\**\*.*" />
-      <ReferenceCopyLocalPaths Include="@(_CoreCLRWasmIncludeFile)">
-        <TargetPath>runtimes/$(RuntimeIdentifier)/native/include/%(RecursiveDir)</TargetPath>
-        <IsNative>true</IsNative>
-        <ExcludeFromDataFiles>true</ExcludeFromDataFiles>
-      </ReferenceCopyLocalPaths>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -207,6 +207,16 @@
     <Copy SourceFiles="@(_MicrosoftNetCoreAppRuntimePackNativeDirFiles)"
           DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)"
           SkipUnchangedFiles="true" />
+
+    <!-- Headers included by the CoreCLR native relink generated sources (see BrowserWasmApp.CoreCLR.targets),
+         installed into the host sharedFramework by the browserhost CMakeLists. Kept in sync with the
+         runtime-pack harvest in eng/liveBuilds.targets. -->
+    <Copy SourceFiles="$(HostSharedFrameworkDir)include\callhelpers.hpp"
+          DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)include"
+          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(HostSharedFrameworkDir)include\minipal\entrypoints.h;$(HostSharedFrameworkDir)include\minipal\utils.h"
+          DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)include\minipal"
+          SkipUnchangedFiles="true" />
   </Target>
 
   <!-- WASI CoreCLR: stage libWasiHost.a into the runtime pack native dir for the per-app relink,


### PR DESCRIPTION
## Problem

Follow-up to #131646. That PR made CoreCLR browser-wasm **native relink** work from a restored/packaged SDK, and one part of it shipped the VM/minipal headers (`callhelpers.hpp`, `minipal/entrypoints.h`, `minipal/utils.h`) needed by the relink into the `Microsoft.NETCore.App.Runtime.browser-wasm` runtime pack under `native/include`. It:

- `src/native/corehost/browserhost/CMakeLists.txt` — `install(... DESTINATION sharedFramework/include ...)` the three headers.
- `src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props` — declared them as `PlatformManifestFileEntry`.

But the headers still don't end up in the pack. Inspecting a daily `wasm-tools` pack (`11.0.0-rc.1.26404.112`), `runtimes/browser-wasm/native/` has `dotnet.native.wasm` + libs but **no `include/` dir**, so `BrowserWasmApp.CoreCLR.targets` sees `Exists($(MicrosoftNetCoreAppRuntimePackRidNativeDir)include\callhelpers.hpp) == false`, falls back to the in-repo source path (absent in a restored SDK), and native relink fails again with:

```
callhelpers-pinvoke.cpp:10:10: fatal error: 'callhelpers.hpp' file not found
```

## Root cause

The browserhost `install(... DESTINATION sharedFramework/include ...)` places the headers in the **host** shared framework (`$(HostSharedFrameworkDir)/include`) — the same dir the runtime pack already harvests `libBrowserHost.a` / `dotnet.native.js` / `dotnet.native.wasm` from. But nothing harvests the `include/` subtree, so the headers are dropped. The platform-manifest declaration doesn't help — validation is *pack ⊆ manifest*, so a missing file never fails the build.

Mono already ships its relink headers correctly, harvesting them via `LibrariesRuntimeFiles` with `NativeSubDirectory="include\wasm"`.

## Fix

Harvest the headers through the standard mechanisms, sourced from the host shared framework where the CMake install actually puts them:

- **`eng/liveBuilds.targets`** — add the headers to `LibrariesRuntimeFiles` with `NativeSubDirectory="include"` / `include\minipal` (feeds the **nupkg**), mirroring the Mono `include\wasm` handling.
- **`src/native/corehost/corehost.proj`** (`CopyWasmNativeFiles`) — stage them into the in-tree runtime-pack **layout** (`MicrosoftNetCoreAppRuntimePackNativeDir`) alongside the other browser host files, so an in-tree `clr+libs+host` build's layout is also relink-capable.

## Validation

End-to-end `build.cmd -os browser -subset clr+libs+host+packs -c Debug` (0 warnings, 0 errors). The headers are produced by the real browserhost CMake install and land in all three places with the `minipal/` subdir preserved:

```
# host sharedFramework (CMake install)
artifacts/bin/browser-wasm.Debug/sharedFramework/include/callhelpers.hpp
artifacts/bin/browser-wasm.Debug/sharedFramework/include/minipal/{entrypoints.h,utils.h}

# in-tree runtime-pack layout (CopyWasmNativeFiles)
artifacts/bin/microsoft.netcore.app.runtime.browser-wasm/Debug/runtimes/browser-wasm/native/include/...

# shipping nupkg (LibrariesRuntimeFiles harvest)
runtimes/browser-wasm/native/include/callhelpers.hpp
runtimes/browser-wasm/native/include/minipal/entrypoints.h
runtimes/browser-wasm/native/include/minipal/utils.h
```

This is exactly what `BrowserWasmApp.CoreCLR.targets` probes for, so `_VmWasmIncludeDir` / `_MinipalIncludeDir` now resolve from the runtime pack instead of falling back to the missing in-repo path.

## Notes

- WASI CoreCLR relink has the same latent gap (the header install was only added to `browserhost/CMakeLists.txt`), and could be addressed separately.
- `CopyWasmNativeFiles` (layout) and `LibrariesRuntimeFiles` (nupkg) duplicate the browser host-file list today; unifying them is a larger cleanup left as a follow-up.

Related: https://github.com/dotnet/runtime/issues/128362
