### PR TITLE
Fix broken relative links in docs

### DIFF
--- a/docs/design/datacontracts/data_descriptor.md
+++ b/docs/design/datacontracts/data_descriptor.md
@@ -142,7 +142,7 @@ The toplevel dictionary will contain:
 * optional `"sub-descriptors": SUB_DESCRIPTORS_DESCRIPTOR` see below
 
 Additional toplevel keys may be present. For example, the in-memory data descriptor will contain a
-`"contracts"` key (see [contract descriptor](./contract_descriptor.md#Compatible_contracts)) for the
+`"contracts"` key (see [contract descriptor](./contract-descriptor.md#Compatible_contracts)) for the
 set of compatible contracts.
 
 ### Baseline data descriptor identifier

--- a/docs/design/datacontracts/datacontracts_design.md
+++ b/docs/design/datacontracts/datacontracts_design.md
@@ -12,7 +12,7 @@ Diagnostic data contract addressed these challenges by eliminating the need for 
 Data contracts represent the manner in which a tool which is not the runtime can reliably understand and observe the behavior of the runtime. Contracts are defined by their documentation, and the runtime describes what contracts are applicable to understanding that runtime.
 
 ## Data Contract Descriptor
-The physical layout of this data is defined in [the contract descriptor](./contract_descriptor.md) doc. Its practical effects are discussed here.
+The physical layout of this data is defined in [the contract descriptor](./contract-descriptor.md) doc. Its practical effects are discussed here.
 
 The Data Contract Descriptor has a set of records of the following forms.
 

--- a/docs/design/features/globalization-icu-wasm.md
+++ b/docs/design/features/globalization-icu-wasm.md
@@ -16,7 +16,7 @@ Only one value for `WasmIcuDataFileName` can be set. It can also be a custom fil
 
 ## Custom ICU
 
-The easiest way to build ICU is to open https://github.com/dotnet/icu/ it in [Codespaces](docs\workflow\Codespaces.md). See files in https://github.com/dotnet/icu/tree/dotnet/main/icu-filters, and read https://unicode-org.github.io/icu/userguide/icu_data/buildtool.html#locale-slicing. Build your own filter or edit the existing file.
+The easiest way to build ICU is to open https://github.com/dotnet/icu/ it in [Codespaces](../../workflow/Codespaces.md). See files in https://github.com/dotnet/icu/tree/dotnet/main/icu-filters, and read https://unicode-org.github.io/icu/userguide/icu_data/buildtool.html#locale-slicing. Build your own filter or edit the existing file.
 We advise to edit the filters **only by adding/removing locales** from the `localeFilter/includelist` to avoid removing important data. We recommend not to remove "en-US" locale from the localeFilter/includelist because it is used as a fallback. Removing it for when
 - `<PredefinedCulturesOnly>true</PredefinedCulturesOnly>`: results in `Encountered infinite recursion while looking for resource in System.Private.Corelib.` exception
 - when predefined cultures only is not set: results in resolving data from ICU's `root.txt` files, e.g. `CultureInfo.DateTimeFormat.GetDayName(DateTime.Today.DayOfWeek)` will return an abbreviated form: `Mon` instead of `Monday`.

--- a/docs/workflow/debugging/mono/wasm-debugging.md
+++ b/docs/workflow/debugging/mono/wasm-debugging.md
@@ -530,7 +530,7 @@ Replace it with this (note that for a `blazor` project, `Blazor.start` needs an 
 
 ## References
 
-- [Testing Libraries on WebAssembly](../testing/libraries/testing-wasm.md)
+- [Testing Libraries on WebAssembly](../../testing/libraries/testing-wasm.md)
 - [Debugging WebAssembly Libraries](../testing/libraries/debugging-wasm.md)
-- [WASI Support](../../src/mono/wasi/README.md)
-- [VS Code Debugging Guide](debugging/libraries/debugging-vscode.md)
+- [WASI Support](../../../../src/mono/wasi/README.md)
+- [VS Code Debugging Guide](../libraries/debugging-vscode.md)

--- a/docs/workflow/wasm-documentation.md
+++ b/docs/workflow/wasm-documentation.md
@@ -63,10 +63,10 @@ After building the runtime, use the `generate-coreclr-helpers` script for your p
 - **[JSInterop in Wasm](https://learn.microsoft.com/en-us/aspnet/core/client-side/dotnet-interop/wasm-browser-app)** - JavaScript interoperability for WebAssembly applications
 
 ### Globalization and ICU
-- **[ICU for WebAssembly](../../design/features/globalization-icu-wasm.md)** - Globalization and ICU database configuration
+- **[ICU for WebAssembly](../design/features/globalization-icu-wasm.md)** - Globalization and ICU database configuration
 
 ### Testing WebAssembly Changes
-For testing WebAssembly implementation changes end-to-end, see the [testing documentation](../testing/mono/testing.md#testing-webassembly).
+For testing WebAssembly implementation changes end-to-end, see the [testing documentation](testing/mono/testing.md#testing-webassembly).
 
 ## Advanced Topics
 


### PR DESCRIPTION
Eight markdown links in `docs/` point at paths that do not resolve, so they 404 on GitHub. In every case the target file is present in the repo and only the link text is wrong — these are relative-path mistakes, not missing documentation.

## The fixes

| File | Link | Why it breaks |
|---|---|---|
| `docs/workflow/wasm-documentation.md` | `../../design/...` → `../design/...` | The doc is in `docs/workflow/`, so `../../` escapes the repo root |
| `docs/workflow/wasm-documentation.md` | `../testing/mono/testing.md` → `testing/mono/testing.md` | `../` lands in `docs/`, but the target is under `docs/workflow/` |
| `docs/workflow/debugging/mono/wasm-debugging.md` | `../testing/...` → `../../testing/...` | Off by one level from `docs/workflow/debugging/mono/` |
| `docs/workflow/debugging/mono/wasm-debugging.md` | `../../src/mono/wasi/README.md` → `../../../../src/...` | Needs four levels to reach the repo root |
| `docs/workflow/debugging/mono/wasm-debugging.md` | `debugging/libraries/...` → `../libraries/...` | Resolved as if the doc were in `docs/workflow/` |
| `docs/design/datacontracts/data_descriptor.md` | `contract_descriptor.md` → `contract-descriptor.md` | The file is spelled with a hyphen |
| `docs/design/datacontracts/datacontracts_design.md` | `contract_descriptor.md` → `contract-descriptor.md` | Same |
| `docs/design/features/globalization-icu-wasm.md` | `docs\workflow\Codespaces.md` → `../../workflow/Codespaces.md` | Windows backslashes, and resolved from the repo root rather than the document's directory |

The `contract_descriptor.md` one is worth calling out because `data_descriptor.md` links to that same file **correctly** twice elsewhere (lines 102 and 300, as `contract-descriptor.md`), so this is an inconsistency inside a single document rather than a rename that was missed.

## How these were found, and what was left alone

I resolved every relative markdown link in `docs/**/*.md` against a full checkout, decoding `%20` and normalising `.`/`..` before deciding anything. The sweep produced 39 candidates; these 8 are the ones where the target exists and the link is simply pointing at the wrong place. After the change the same sweep no longer reports them.

The remaining 31 were **not** touched, for these reasons:

- **Not links at all** — my pattern also matched things shaped like `[...](...)` in prose and code: generic type argument lists in `viewing-jit-dumps.md`, literal `...` placeholders in `libraries-packaging.md`, schemeless URLs (`www.llvm.org`, `aka.ms/aspnet/benchmarks`), and a link that carries a title attribute (`[doc](path "doc")` in `unix-instructions.md`, whose target does exist).
- **Imported external content** — `docs/design/mono/web/*` came from the old mono-project.com site and uses site-absolute paths like `/docs/advanced/aot/`; `docs/design/coreclr/profiling/davbr-blog-archive/*` is an archived blog with filenames containing spaces and `&#32;` entities. Rewriting either is a separate decision about archived material, not a link fix.
- **Target genuinely absent** — I could not fix these without guessing what was intended, so I am listing them rather than changing them:
  - `debugging-wasm.md`, referenced from `wasm-documentation.md:42` and `wasm-debugging.md:534`. No file by that name exists anywhere in the repo.
  - `docs/workflow/building/coreclr/crossgen.md`, referenced from `source-generator-pinvokes.md:7` and `glossary.md:45`.
  - `package-projects.md`, referenced from `adding-api-guidelines.md:4`. There is a `libraries-packaging.md` in the same directory, but I did not want to assume that is the replacement.
  - `.github/prompts/add-new-jit-ee-api.prompt.md`, referenced from `updating-jitinterface.md:29`. That directory contains only `docs.prompt.md`.

  Happy to fix any of those in a follow-up if someone can confirm the intended targets.

## A note on anchors

Two links in `data_descriptor.md` use anchors that do not match any heading GitHub generates: `#Compatible_contracts` and `#Contract_descriptor`, where the headings are `### Compatible contracts` and `## Contract descriptor`. I have **not** changed them, because the page now loads correctly and the exact anchor style is a call for the doc owners. Mentioning it in case it is worth a separate pass.

## Verification

- Every replacement target was confirmed to exist in a full clone of `main`.
- The re-run sweep confirms all 8 now resolve.
- Documentation only: 5 files, `+8/-8`, no code or build changes.
- There is no markdown link checker in CI (I looked under `.github/` and `eng/`), which is consistent with these going unnoticed.

## AI disclosure

AI-assisted (Claude Code). The tool was used to run the link-resolution sweep described above and to draft this description. The findings were verified before opening: each target was checked against a full checkout, each corrected path was re-resolved, and the false positives listed above were reviewed one by one and deliberately excluded. I have reviewed and understood the change and take responsibility for it.
