### PR TITLE
[mono][wasm] Fix delegate over static abstract interface method under gsharedvt

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -11978,6 +11978,9 @@ mono_ldptr:
 					MonoInst *method_ins = emit_get_rgctx_virt_method (cfg, -1, constrained_class, cmethod, MONO_RGCTX_INFO_VIRT_METHOD);
 					MonoInst *obj = handle_alloc (cfg, ctor_method->klass, FALSE, dele_context_used);
 
+					if (!obj)
+						CHECK_CFG_ERROR;
+
 					if (obj) {
 						/* Set the target field (typically null for a static method) */
 						if (!MONO_INS_IS_PCONST_NULL (target_ins)) {

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -11963,6 +11963,54 @@ mono_ldptr:
 				mono_method_has_unmanaged_callers_only_attribute (cmethod);
 
 			/*
+			 * ldftn of a static virtual (static abstract) interface method resolved through gsharedvt
+			 * followed by a delegate creation. The target method is only known at runtime (via the rgctx),
+			 * so the generic newobj ctor-call fallback below cannot be used: under llvmonly it would call
+			 * the runtime delegate ctor with an extra rgctx argument it does not accept, producing a wasm
+			 * signature mismatch. Create the delegate directly and let the runtime initialize it from
+			 * del->method instead.
+			 */
+			if (gshared_static_virtual && cfg->llvm_only && (sp > stack_start) && (next_ip + 4 < end) && ip_in_bb (cfg, cfg->cbb, next_ip) && (next_ip [0] == CEE_NEWOBJ)) {
+				MonoMethod *ctor_method = mini_get_method (cfg, method, read32 (next_ip + 1), NULL, generic_context);
+				if (ctor_method && (m_class_get_parent (ctor_method->klass) == mono_defaults.multicastdelegate_class)) {
+					int dele_context_used = mini_class_check_context_used (cfg, ctor_method->klass);
+					MonoInst *target_ins = sp [-1];
+					MonoInst *method_ins = emit_get_rgctx_virt_method (cfg, -1, constrained_class, cmethod, MONO_RGCTX_INFO_VIRT_METHOD);
+					MonoInst *obj = handle_alloc (cfg, ctor_method->klass, FALSE, dele_context_used);
+
+					if (obj) {
+						/* Set the target field (typically null for a static method) */
+						if (!MONO_INS_IS_PCONST_NULL (target_ins)) {
+							if (!mini_debug_options.weak_memory_model)
+								mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_REL);
+							MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, obj->dreg, MONO_STRUCT_OFFSET (MonoDelegate, target), target_ins->dreg);
+							if (cfg->gen_write_barriers) {
+								MonoInst *ptr;
+								int dreg = alloc_preg (cfg);
+								EMIT_NEW_BIALU_IMM (cfg, ptr, OP_PADD_IMM, dreg, obj->dreg, MONO_STRUCT_OFFSET (MonoDelegate, target));
+								mini_emit_write_barrier (cfg, ptr, target_ins);
+							}
+						}
+						/* del->method = runtime-resolved implementation; init_delegate derives the rest */
+						MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, obj->dreg, MONO_STRUCT_OFFSET (MonoDelegate, method), method_ins->dreg);
+
+						MonoInst *init_args [2];
+						init_args [0] = obj;
+						EMIT_NEW_PCONST (cfg, init_args [1], NULL);
+						mono_emit_jit_icall (cfg, mini_llvmonly_init_delegate, init_args);
+
+						constrained_class = NULL;
+						sp --;
+						*sp = obj;
+						sp ++;
+						next_ip += 5;
+						il_op = MONO_CEE_NEWOBJ;
+						break;
+					}
+				}
+			}
+
+			/*
 			 * Optimize the common case of ldftn+delegate creation
 			 */
 			if (!gshared_static_virtual && (sp > stack_start) && (next_ip + 4 < end) && ip_in_bb (cfg, cfg->cbb, next_ip) && (next_ip [0] == CEE_NEWOBJ)) {

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_130545.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_130545.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Xunit;
+
+// Regression test for https://github.com/dotnet/runtime/issues/130545
+//
+// Creating a delegate over a static abstract interface method that is resolved
+// through generic sharing (gsharedvt) trapped under Mono wasm AOT (llvmonly) with
+// "function signature mismatch": the generic newobj delegate-ctor fallback passed a
+// runtime generic-sharing argument to the runtime delegate constructor, which does
+// not accept one, so the containing static constructor's call_indirect hit a wasm
+// signature mismatch. This mirrors the SixLabors.ImageSharp PixelOperations<TPixel>
+// shape from the original report.
+//
+// The reproduction is AOT-heuristic sensitive: the value-type generic method
+// (Decode<Rgba32>) must stay on the shared gsharedvt path, which is why it is
+// reached only through reflection and why the surrounding types (a non-generic
+// IPixel base with its own static abstract, a second static abstract factory,
+// a derived PixelOperations override and the FromRgba32/FromRgba32Bytes work in
+// Decode) are all present - reducing them further lets the JIT specialize the
+// method and masks the bug. Verified against the Mono wasm AOT browser sample.
+namespace GitHub_130545
+{
+    public interface IPixel
+    {
+        static abstract int GetPixelTypeInfo();
+
+        Rgba32 ToRgba32();
+    }
+
+    public interface IPackedVector<TPacked>
+        where TPacked : struct
+    {
+        TPacked PackedValue { get; set; }
+    }
+
+    public interface IPixel<TSelf> : IPixel, IEquatable<TSelf>
+        where TSelf : unmanaged, IPixel<TSelf>
+    {
+        static abstract PixelOperations<TSelf> CreatePixelOperations();
+
+        static abstract TSelf FromRgba32(Rgba32 source);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Rgba32 : IPixel<Rgba32>, IPackedVector<uint>
+    {
+        public byte R;
+        public byte G;
+        public byte B;
+        public byte A;
+
+        public uint PackedValue
+        {
+            get => Unsafe.As<Rgba32, uint>(ref this);
+            set => Unsafe.As<Rgba32, uint>(ref this) = value;
+        }
+
+        public static int GetPixelTypeInfo() => 32;
+
+        public static PixelOperations<Rgba32> CreatePixelOperations() => new PixelOperations();
+
+        public static Rgba32 FromRgba32(Rgba32 source) => source;
+
+        public readonly Rgba32 ToRgba32() => this;
+
+        public readonly bool Equals(Rgba32 other) =>
+            R == other.R && G == other.G && B == other.B && A == other.A;
+
+        // Mirrors ImageSharp's nested Rgba32.PixelOperations : PixelOperations<Rgba32>.
+        internal sealed class PixelOperations : PixelOperations<Rgba32>
+        {
+            public override void FromRgba32Bytes(Span<Rgba32> destination)
+            {
+                for (int i = 0; i < destination.Length; i++)
+                {
+                    destination[i] = new Rgba32 { R = 8, G = 8, B = 8, A = 255 };
+                }
+            }
+        }
+    }
+
+    public class PixelOperations<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        // The static constructor builds a Lazy<> from the static-abstract method group
+        // TPixel.CreatePixelOperations (ldftn of a static virtual + newobj delegate).
+        private static readonly Lazy<PixelOperations<TPixel>> s_instance = new(TPixel.CreatePixelOperations, true);
+
+        public static PixelOperations<TPixel> Instance => s_instance.Value;
+
+        public virtual void FromRgba32Bytes(Span<TPixel> destination)
+        {
+        }
+    }
+
+    public static class PngDecoder
+    {
+        public static Rgba32 Decode<TPixel>()
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            PixelOperations<TPixel> ops = PixelOperations<TPixel>.Instance;
+
+            Rgba32 source = new() { R = 1, G = 2, B = 3, A = 4 };
+            Span<TPixel> destination = stackalloc TPixel[1];
+            for (int i = 0; i < destination.Length; i++)
+            {
+                destination[i] = TPixel.FromRgba32(source);
+            }
+
+            ops.FromRgba32Bytes(destination);
+            return destination[0].ToRgba32();
+        }
+    }
+
+    public class Test
+    {
+        [Fact]
+        public static void DelegateOverStaticAbstractThroughGsharedvt()
+        {
+            // Invoke through reflection so the runtime uses the shared (gsharedvt)
+            // instantiation of Decode<TPixel>. A direct Decode<Rgba32>() call would be
+            // fully specialized and hide the regression (it is a known workaround).
+            MethodInfo decode = typeof(PngDecoder)
+                .GetMethod(nameof(PngDecoder.Decode))!
+                .MakeGenericMethod(typeof(Rgba32));
+
+            Rgba32 result = (Rgba32)decode.Invoke(null, null)!;
+
+            // The nested Rgba32.PixelOperations override sets every pixel to (8, 8, 8, 255).
+            Assert.Equal(8, result.R);
+            Assert.Equal(8, result.G);
+            Assert.Equal(8, result.B);
+            Assert.Equal(255, result.A);
+        }
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_130545.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_130545.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #130545

## Problem

Under Mono WebAssembly AOT (`llvmonly`), reaching a static field initialized from a static-abstract interface method through a value-type generic instantiation (gsharedvt) traps with:

```
MONO_WASM: function signature mismatch
```

The original report is the SixLabors.ImageSharp `PixelOperations<TPixel>` shape, where `PixelOperations<TPixel>..cctor` builds a `Lazy<>` from the static-abstract method group `TPixel.CreatePixelOperations`. It is AOT-only — the same code runs fine interpreted, and disabling `RunAOTCompilation` avoids it.

## Root cause

In `mono_method_to_ir`, the `CEE_LDFTN` + delegate-`newobj` peephole that normally routes delegate creation through the optimized `llvmonly` path (`mini_llvmonly_init_delegate`) is guarded by `!gshared_static_virtual`. For a static-abstract method resolved via gsharedvt, that guard skips the fast path and falls back to a generic `newobj Func<T>::.ctor` call.

Because `mono_method_needs_static_rgctx_invoke(Func<T>::.ctor)` returns `true`, the `call_indirect` in the containing cctor is emitted with an extra generic-sharing argument (a 4-parameter signature), but the real target is the 3-parameter runtime delegate constructor (`ves_icall_mono_delegate_ctor`). A 4-argument call to a 3-parameter function is a hard wasm signature mismatch, so the cctor traps. This is the only case that uses the generic `newobj` delegate-ctor fallback under `llvmonly`, which is why only this shape reproduces.

## Fix

Handle `gshared_static_virtual` in the `llvmonly` delegate-ctor path: resolve the target via `MONO_RGCTX_INFO_VIRT_METHOD`, set `del->method`, and create the delegate directly through `mini_llvmonly_init_delegate` (which derives `method_ptr`/`invoke_impl` correctly), instead of the generic `newobj` constructor call. The change is gated on `cfg->llvm_only`.

## Test

Adds a positive regression `[Fact]` under `Loader/classloader/StaticVirtualMethods/Regression` that mirrors the `PixelOperations<TPixel>` shape and reaches it through `MakeGenericMethod` to stay on the shared gsharedvt path.

Verified against the Mono wasm AOT browser sample:

| Runtime | Result |
|---|---|
| Without the fix | `function signature mismatch`, `WASM EXIT 1` |
| With the fix | correct decode result, `WASM EXIT 0` |

The reproduction is AOT-heuristic sensitive (documented in the test): reducing the surrounding types further lets the JIT fully specialize the generic method and masks the bug.

> [!NOTE]
> This PR description was drafted with GitHub Copilot.