### PR TITLE
Reenable the GC/Regressions/Github/Runtime_76219 test

### DIFF
--- a/src/tests/GC/Regressions/Github/Runtime_76219/Runtime_76219.cs
+++ b/src/tests/GC/Regressions/Github/Runtime_76219/Runtime_76219.cs
@@ -9,7 +9,6 @@ using TestLibrary;
 public class Runtime_76219
 {
     [MethodImpl(MethodImplOptions.Synchronized)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/78899", TestRuntimes.CoreCLR)]
     [Fact]
     public static void TestEntryPoint()
     {

--- a/src/tests/GC/Regressions/Github/Runtime_76219/Runtime_76219.csproj
+++ b/src/tests/GC/Regressions/Github/Runtime_76219/Runtime_76219.csproj
@@ -3,11 +3,7 @@
     <!-- Needed for GC.WaitForPendingFinalizers -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
-    <!-- Move it out of CI for 78899 -->
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- Test crashes on osx arm64 under GC stress even though the test body is skipped via ActiveIssue. -->
-    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/78899 -->
-    <CLRTestTargetUnsupported>true</CLRTestTargetUnsupported>
 
     <!-- This test needs GCStress mode but it doesn't take long to execute
          so is fine to keep it in the inner loop -->


### PR DESCRIPTION
The test seems to be passing now. I cannot repro the original failures on x86 Windows or arm64 macOS.

Close #78899