### PR TITLE
[browser][CoreCLR] Restore R2R coverage and gate unsupported priority-1 tests

### DIFF
--- a/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.csproj
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytesServerGC.csproj
@@ -1,12 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CLRTestEnvironmentVariable and GCStressIncompatible -->
+    <!-- Needed for CLRTestEnvironmentVariable, CLRTestTargetUnsupported, and GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- NativeAOT selects the Server GC implementation at link time -->
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <!-- DATAS heap-count adaptation is a CoreCLR Server GC behavior -->
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
+    <!-- TODO: Re-enable when CoreCLR WebAssembly supports server GC.
+         Tracked by https://github.com/dotnet/runtime/issues/131321. -->
+    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/GC/API/GC/GetTotalMemoryConcurrent.cs
+++ b/src/tests/GC/API/GC/GetTotalMemoryConcurrent.cs
@@ -19,13 +19,14 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
+using TestLibrary;
 using Xunit;
 
 public class GetTotalMemoryConcurrent
 {
     private static volatile bool s_stop;
 
-    [Fact]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
     public static void TestEntryPoint()
     {
         // A couple of seconds is far more than enough: the unfixed runtime fails almost immediately

--- a/src/tests/GC/API/GC/GetTotalMemoryConcurrent.csproj
+++ b/src/tests/GC/API/GC/GetTotalMemoryConcurrent.csproj
@@ -11,4 +11,7 @@
   <ItemGroup>
     <Compile Include="GetTotalMemoryConcurrent.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/regress/ddb/113574/113574.csproj
+++ b/src/tests/JIT/jit64/regress/ddb/113574/113574.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Only needed to run GCStress out-of-proc -->
+    <!-- Needed for CLRTestTargetUnsupported and to run GCStress out-of-proc -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
 
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- TODO: Re-enable when a WebAssembly JIT or equivalent makes the multi-billion-iteration loop stress practical.
+         Tracked by https://github.com/dotnet/runtime/issues/131321. -->
+    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/baseservices/TieredCompilation/BasicTest.cs
+++ b/src/tests/baseservices/TieredCompilation/BasicTest.cs
@@ -13,9 +13,6 @@ public static class BasicTest
     [ActiveIssue("missing assembly", TestPlatforms.Windows, runtimes: TestRuntimes.Mono)]
     [ActiveIssue("No crossgen folder under Core_Root", TestPlatforms.Android)]
     [ActiveIssue("missing assembly", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
-#if BROWSER_WASM_COMPOSITE_R2R_TEST
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/131767", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
-#endif
     [Fact]
     public static void TestEntryPoint()
     {

--- a/src/tests/baseservices/TieredCompilation/BasicTest_DefaultMode_R2r.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_DefaultMode_R2r.csproj
@@ -6,9 +6,7 @@
     <Optimize>true</Optimize>
 
     <!-- This is an explicit crossgen test -->
-    <AlwaysUseCrossGen2 Condition="'$(RuntimeFlavor)' != 'coreclr' or '$(TargetOS)' != 'browser'">true</AlwaysUseCrossGen2>
-    <CrossGenTest Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</CrossGenTest>
-    <DefineConstants>$(DefineConstants);BROWSER_WASM_COMPOSITE_R2R_TEST</DefineConstants>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- No crossgen folder under Core_Root -->
      <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff_R2r.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff_R2r.csproj
@@ -6,9 +6,7 @@
     <Optimize>true</Optimize>
 
     <!-- This is an explicit crossgen test -->
-    <AlwaysUseCrossGen2 Condition="'$(RuntimeFlavor)' != 'coreclr' or '$(TargetOS)' != 'browser'">true</AlwaysUseCrossGen2>
-    <CrossGenTest Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</CrossGenTest>
-    <DefineConstants>$(DefineConstants);BROWSER_WASM_COMPOSITE_R2R_TEST</DefineConstants>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- No crossgen folder under Core_Root -->
      <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn_R2r.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn_R2r.csproj
@@ -6,9 +6,7 @@
     <Optimize>true</Optimize>
 
     <!-- This is an explicit crossgen test -->
-    <AlwaysUseCrossGen2 Condition="'$(RuntimeFlavor)' != 'coreclr' or '$(TargetOS)' != 'browser'">true</AlwaysUseCrossGen2>
-    <CrossGenTest Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</CrossGenTest>
-    <DefineConstants>$(DefineConstants);BROWSER_WASM_COMPOSITE_R2R_TEST</DefineConstants>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- No crossgen folder under Core_Root -->
      <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOff_R2r.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOff_R2r.csproj
@@ -6,9 +6,7 @@
     <Optimize>true</Optimize>
 
     <!-- This is an explicit crossgen test -->
-    <AlwaysUseCrossGen2 Condition="'$(RuntimeFlavor)' != 'coreclr' or '$(TargetOS)' != 'browser'">true</AlwaysUseCrossGen2>
-    <CrossGenTest Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</CrossGenTest>
-    <DefineConstants>$(DefineConstants);BROWSER_WASM_COMPOSITE_R2R_TEST</DefineConstants>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- No crossgen folder under Core_Root -->
      <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r.csproj
@@ -6,9 +6,7 @@
     <Optimize>true</Optimize>
 
     <!-- This is an explicit crossgen test -->
-    <AlwaysUseCrossGen2 Condition="'$(RuntimeFlavor)' != 'coreclr' or '$(TargetOS)' != 'browser'">true</AlwaysUseCrossGen2>
-    <CrossGenTest Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</CrossGenTest>
-    <DefineConstants>$(DefineConstants);BROWSER_WASM_COMPOSITE_R2R_TEST</DefineConstants>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- No crossgen folder under Core_Root -->
      <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>

--- a/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.cs
+++ b/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using TestLibrary;
 
 /*
  * Issue description:
@@ -14,6 +15,12 @@ public class Test_foreground_shutdown
 {
     public static int Main()
     {
+        if (!PlatformDetection.IsMultithreadingSupported)
+        {
+            Console.WriteLine("Multithreading is not supported, skipping test.");
+            return 100;
+        }
+
         new Thread(() =>
         {
             Thread.Sleep(TimeSpan.FromSeconds(2));

--- a/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.csproj
+++ b/src/tests/baseservices/threading/regressions/2164/foreground-shutdown.csproj
@@ -9,4 +9,7 @@
   <ItemGroup>
     <Compile Include="foreground-shutdown.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>

--- a/src/tests/readytorun/DynamicMethodGCStress/DynamicMethodGCStress.cs
+++ b/src/tests/readytorun/DynamicMethodGCStress/DynamicMethodGCStress.cs
@@ -12,7 +12,6 @@ using TestLibrary;
 public static class Program
 {
     [ActiveIssue("timeout", TestPlatforms.Any)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/131767", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
     [Fact]
     public static void TestEntryPoint()
     {

--- a/src/tests/readytorun/DynamicMethodGCStress/DynamicMethodGCStress.csproj
+++ b/src/tests/readytorun/DynamicMethodGCStress/DynamicMethodGCStress.csproj
@@ -8,8 +8,7 @@
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
 
     <!-- This is an explicit crossgen test -->
-    <AlwaysUseCrossGen2 Condition="'$(RuntimeFlavor)' != 'coreclr' or '$(TargetOS)' != 'browser'">true</AlwaysUseCrossGen2>
-    <CrossGenTest Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</CrossGenTest>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/readytorun/GenericCycleDetection/Breadth1Test.cs
+++ b/src/tests/readytorun/GenericCycleDetection/Breadth1Test.cs
@@ -192,9 +192,8 @@ public class Program
             };
         }
     }
-    
+
     [ActiveIssue("These tests are not supposed to be run with mono.", TestRuntimes.Mono)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/131767", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
     [Fact]
     public static void BreadthTest()
     {

--- a/src/tests/readytorun/GenericCycleDetection/Breadth1Test.csproj
+++ b/src/tests/readytorun/GenericCycleDetection/Breadth1Test.csproj
@@ -4,8 +4,7 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
     <!-- This is an explicit crossgen test -->
-    <AlwaysUseCrossGen2 Condition="'$(RuntimeFlavor)' != 'coreclr' or '$(TargetOS)' != 'browser'">true</AlwaysUseCrossGen2>
-    <CrossGenTest Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</CrossGenTest>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- Without this flag Crossgen2 crashes after several minutes with arithmetic overflow -->
     <CrossGen2TestExtraArguments>--maxgenericcycle:1 --maxgenericcyclebreadth:1</CrossGen2TestExtraArguments>
   </PropertyGroup>

--- a/src/tests/readytorun/GenericCycleDetection/Depth1Test.cs
+++ b/src/tests/readytorun/GenericCycleDetection/Depth1Test.cs
@@ -33,9 +33,8 @@ public class Program
     private struct Oper3<T> {}
     private struct Oper4<T> {}
     private struct Oper5<T> {}
-    
+
     [ActiveIssue("These tests are not supposed to be run with mono.", TestRuntimes.Mono)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/131767", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
     [Fact]
     public static void BreadthTest()
     {

--- a/src/tests/readytorun/GenericCycleDetection/Depth1Test.csproj
+++ b/src/tests/readytorun/GenericCycleDetection/Depth1Test.csproj
@@ -4,8 +4,7 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
     <!-- This is an explicit crossgen test -->
-    <AlwaysUseCrossGen2 Condition="'$(RuntimeFlavor)' != 'coreclr' or '$(TargetOS)' != 'browser'">true</AlwaysUseCrossGen2>
-    <CrossGenTest Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</CrossGenTest>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- Without this flag Crossgen2 crashes after several minutes with arithmetic overflow -->
     <CrossGen2TestExtraArguments>--maxgenericcycle:1 --maxgenericcyclebreadth:-1</CrossGen2TestExtraArguments>
   </PropertyGroup>

--- a/src/tests/readytorun/fieldlayout/fieldlayout.csproj
+++ b/src/tests/readytorun/fieldlayout/fieldlayout.csproj
@@ -4,8 +4,7 @@
     <!-- Needed for IlasmRoundTripIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AlwaysUseCrossGen2 Condition="'$(RuntimeFlavor)' != 'coreclr' or '$(TargetOS)' != 'browser'">true</AlwaysUseCrossGen2>
-    <CrossGenTest Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</CrossGenTest>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/readytorun/fieldlayout/fieldlayouttests.cs
+++ b/src/tests/readytorun/fieldlayout/fieldlayouttests.cs
@@ -9,7 +9,6 @@ public class Test
     // This is done by touching the various types, and then relying on the verification logic in R2R images to detect failures.
     [ActiveIssue("These tests are not supposed to be run with mono.", TestRuntimes.Mono)]
     [ActiveIssue("https://github.com/dotnet/runtime/pull/131421", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/131767", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
     [Fact]
     public static void TestEntryPoint()
     {


### PR DESCRIPTION
## Summary

PR #131110 enabled CoreCLR browser-WASM out-of-process runtime tests. The newly enabled priority-1 coverage exposed eight unique failures.

Four were composite WebCIL/ReadyToRun failures tracked by #131767 and are fixed on `main` by #131354. This change removes their temporary `ActiveIssue` annotations and Crossgen2 bypasses, restoring the intended R2R coverage. The unrelated field-layout suppression for #131421 remains.

The other four tests are narrowly gated:

- `GC/API/GC/GetTotalAllocatedBytesServerGC` is excluded on CoreCLR browser, which does not provide Server GC.
- `GC/API/GC/GetTotalMemoryConcurrent` uses `PlatformDetection.IsMultithreadingSupported` through `ConditionalFact`.
- `baseservices/threading/regressions/2164/foreground-shutdown` retains its explicit `Main` and returns success before creating a thread when multithreading is unsupported.
- `JIT/jit64/regress/ddb/113574` is excluded only on CoreCLR browser because its multi-billion-iteration optimizing-JIT workload exceeds the browser interpreter's CI timeout.

The runtime capability checks skip single-threaded browser and WASI while preserving desktop and threaded-browser coverage. The Server GC and interpreter-workload exclusions are tracked in #131321.

## Testing

Built the Checked browser runtime from `main`, including #131354, then built and ran the complete priority-1 browser-WASM Node suite:

| Scope | Total | Passed | Failed | Skipped |
| --- | ---: | ---: | ---: | ---: |
| Full suite | 14,745 | 13,823 | 0 | 922 |
| Out-of-process subset | 672 | 560 | 0 | 112 |

The four former WebCIL/R2R failures now pass:

- `Regressions/coreclr/GitHub_49826/test49826`
- `Regressions/coreclr/GitHub_49982/test49982`
- `readytorun/tests/genericsload/callgenericctor`
- `readytorun/tests/genericsload/usegenericfield`

Additional focused validation for the runtime multithreading gates:

- 8 MSBuild evaluations across desktop, threaded browser, single-threaded browser, and single-threaded WASI; neither project is permanently marked unsupported.
- 2 targeted Checked browser builds, both with 0 warnings and 0 errors.
- 2 single-threaded browser wrapper runs, both passing with expected/actual exit code 100.
- Native `foreground-shutdown` execution exited with 100 after 2.28 seconds, confirming that its foreground thread still keeps the process alive after `Main` returns.

> [!NOTE]
> This pull request was created with assistance from GitHub Copilot.