### PR TITLE
Clarify ObjectInstance behavior when no owning object is available

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -145,11 +145,15 @@ namespace System.ComponentModel.DataAnnotations
         ///     <para>Consume this instance with caution!</para>
         /// </summary>
         /// <remarks>
+        ///     <para>
         ///     During validation, especially property-level validation, the object instance might be in an indeterminate state.
         ///     For example, the property being validated, as well as other properties on the instance might not have been
         ///     updated to their new values.
+        ///     </para>
+        ///     <para>
         ///     When validation is performed without an owning object (for example, validating standalone values),
         ///     <see cref="ObjectInstance" /> may be a placeholder and should not be treated as the owner of the value.
+        ///     </para>
         /// </remarks>
         public object ObjectInstance { get; }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -148,6 +148,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     During validation, especially property-level validation, the object instance might be in an indeterminate state.
         ///     For example, the property being validated, as well as other properties on the instance might not have been
         ///     updated to their new values.
+        ///     For ownerless parameters or standalone values (as in minimal APIs), <see cref="ObjectInstance" /> is a meaningless placeholder.
         /// </remarks>
         public object ObjectInstance { get; }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -152,7 +152,7 @@ namespace System.ComponentModel.DataAnnotations
         ///     </para>
         ///     <para>
         ///     When validation is performed without an owning object (for example, validating standalone values),
-        ///     <see cref="ObjectInstance" /> may be a placeholder and should not be treated as the owner of the value.
+        ///     <see cref="ObjectInstance" /> might be a placeholder and should not be treated as the owner of the value.
         ///     </para>
         /// </remarks>
         public object ObjectInstance { get; }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -148,7 +148,8 @@ namespace System.ComponentModel.DataAnnotations
         ///     During validation, especially property-level validation, the object instance might be in an indeterminate state.
         ///     For example, the property being validated, as well as other properties on the instance might not have been
         ///     updated to their new values.
-        ///     For ownerless parameters or standalone values (as in minimal APIs), <see cref="ObjectInstance" /> is a meaningless placeholder.
+        ///     When validation is performed without an owning object (for example, validating standalone values),
+        ///     <see cref="ObjectInstance" /> may be a placeholder and should not be treated as the owner of the value.
         /// </remarks>
         public object ObjectInstance { get; }
 


### PR DESCRIPTION
Updated the doc comment to make it clear that ObjectInstance has no meaningful value when validation is performed outside the context of an owning object, helping avoid incorrect assumptions by attribute authors.