### PR TITLE
Enable Moq HostTests on ios

### DIFF
--- a/eng/testing/ILLinkDescriptors/ILLink.Descriptors.Castle.xml
+++ b/eng/testing/ILLinkDescriptors/ILLink.Descriptors.Castle.xml
@@ -7,6 +7,9 @@
     <type fullname="Castle.DynamicProxy.Internal.InterfaceMethodWithoutTargetInvocation" />
   </assembly>
   <assembly fullname="Moq">
+    <!-- Moq creates awaitable factories (e.g. TaskFactory`1) with Activator.CreateInstance
+         when supplying default return values for mocked async members. -->
+    <namespace fullname="Moq.Async" />
     <type fullname="Moq.Internals.InterfaceProxy">
       <method signature="System.Void .ctor()" />
     </type>

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -593,7 +593,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/128405", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.CoreCLR)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public async Task HostStopAsyncCanBeCancelledEarly()
         {
@@ -626,7 +625,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/128405", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.CoreCLR)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public async Task HostStopAsyncUsesDefaultTimeoutIfGivenTokenDoesNotFire()
         {
@@ -660,7 +658,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/128405", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.CoreCLR)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public async Task WebHostStopAsyncUsesDefaultTimeoutIfNoTokenProvided()
         {
@@ -1218,7 +1215,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/128405", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.CoreCLR)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void Dispose_DisposesAppConfigurationProviders()
         {
@@ -1244,7 +1240,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/128405", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.CoreCLR)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void Dispose_DisposesHostConfigurationProviders()
         {
@@ -1321,7 +1316,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/128405", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.CoreCLR)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public async Task DisposeAsync_DisposesAppConfigurationProviders()
         {
@@ -1347,7 +1341,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/128405", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.CoreCLR)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public async Task DisposeAsync_DisposesHostConfigurationProviders()
         {

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Microsoft.Extensions.Hosting.Unit.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Microsoft.Extensions.Hosting.Unit.Tests.csproj
@@ -17,6 +17,8 @@
     <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs" Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
     <Content Include="testroot\**\*" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="appSettings.json" CopyToOutputDirectory="PreserveNewest" />
+
+    <TrimmerRootDescriptor Include="$(ILLinkDescriptorsPath)ILLink.Descriptors.Castle.xml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These use some reflection APIs which were not working on trimming enabled workloads. Expand the trimming descriptor for Moq assembly so the required types are preserved.

Fixes https://github.com/dotnet/runtime/issues/128405