### PR TITLE
Improve TlsSession error diagnostics

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -1364,7 +1364,10 @@ internal static partial class Interop
             }
         }
 
-        private static Exception? GetSslError(int result, Ssl.SslErrorCode retVal)
+        // Builds the most specific inner exception available for a failed SSL_* call:
+        // errno / the ERR_LIB_SYS queue entry for SSL_ERROR_SYSCALL, the error queue for
+        // SSL_ERROR_SSL.
+        internal static Exception? GetSslError(int result, Ssl.SslErrorCode retVal)
         {
             Exception? innerError;
             switch (retVal)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -127,7 +127,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetAcceptMovingWriteBuffer")]
         internal static partial void SslSetAcceptMovingWriteBuffer(SafeSslHandle ssl);
 
-        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslDoHandshake")]
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslDoHandshake", SetLastError = true)]
         internal static partial int SslDoHandshake(SafeSslHandle ssl, out SslErrorCode error);
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslHandshake", SetLastError = true)]

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.OpenSsl.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.OpenSsl.cs
@@ -229,7 +229,7 @@ namespace System.Net.Security
                 result = TlsOperationStatus.Complete;
                 return;
             }
-            result = MapSslError(err, SR.net_ssl_handshake_failed_error);
+            result = MapSslError(err, ret, SR.net_ssl_handshake_failed_error);
         }
 
         partial void TryFastRead(Span<byte> buffer, ref int bytesRead, ref TlsOperationStatus? result)
@@ -253,7 +253,7 @@ namespace System.Net.Security
                 result = TlsOperationStatus.Complete;
                 return;
             }
-            result = MapSslError(err, SR.net_ssl_decrypt_failed);
+            result = MapSslError(err, ret, SR.net_ssl_decrypt_failed);
         }
 
         partial void TryFastWrite(ReadOnlySpan<byte> buffer, ref int bytesWritten, ref TlsOperationStatus? result)
@@ -277,7 +277,7 @@ namespace System.Net.Security
                 result = TlsOperationStatus.Complete;
                 return;
             }
-            result = MapSslError(err, SR.net_ssl_encrypt_failed);
+            result = MapSslError(err, ret, SR.net_ssl_encrypt_failed);
         }
 
         private SafeSslHandle EnsureFdSslHandle()
@@ -293,19 +293,29 @@ namespace System.Net.Security
 
         // Translates a non-progress SslErrorCode into either a status the caller
         // can act on (NeedMoreData / DestinationTooSmall / Closed) or, for a real
-        // failure, an AuthenticationException whose inner SslException carries the
-        // OpenSSL error-queue reason (formatted via SR-backed template). The template
-        // is picked per operation so exceptions surface consistently with SslStream's
-        // OpenSSL error handling.
-        private static TlsOperationStatus MapSslError(Interop.Ssl.SslErrorCode error, string sslErrorTemplate)
+        // failure, an AuthenticationException whose inner SslException names the
+        // SslErrorCode and carries the most specific diagnostic available as its own
+        // inner exception. The template is picked per operation so exceptions surface
+        // consistently with SslStream's OpenSSL error handling.
+        //
+        // 'result' is the raw SSL_* return value; it is required to tell a protocol
+        // violating EOF (0) from an I/O error (-1) when the code is SSL_ERROR_SYSCALL.
+        private static TlsOperationStatus MapSslError(Interop.Ssl.SslErrorCode error, int result, string sslErrorTemplate)
         {
             return error switch
             {
                 Interop.Ssl.SslErrorCode.SSL_ERROR_WANT_READ => TlsOperationStatus.NeedMoreData,
                 Interop.Ssl.SslErrorCode.SSL_ERROR_WANT_WRITE => TlsOperationStatus.DestinationTooSmall,
                 Interop.Ssl.SslErrorCode.SSL_ERROR_ZERO_RETURN => TlsOperationStatus.Closed,
-                _ => throw new AuthenticationException(SR.net_auth_SSPI, Interop.OpenSsl.CreateSslException(sslErrorTemplate)),
+                _ => throw new AuthenticationException(SR.net_auth_SSPI, CreateDiagnosticSslException(error, result, sslErrorTemplate)),
             };
+        }
+
+        private static Interop.OpenSsl.SslException CreateDiagnosticSslException(Interop.Ssl.SslErrorCode error, int result, string sslErrorTemplate)
+        {
+            Exception? detail = Interop.OpenSsl.GetSslError(result, error);
+            Interop.Crypto.ErrClearError();
+            return new Interop.OpenSsl.SslException(SR.Format(sslErrorTemplate, error), detail);
         }
     }
 }

--- a/src/native/libs/System.Security.Cryptography.Native/pal_bio.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_bio.c
@@ -556,6 +556,7 @@ static int SocketReplayBioRead(BIO* bio, char* buf, int len)
     SocketReplayBioCtx* ctx = GetSocketReplayBioCtx(bio);
     if (ctx == NULL)
     {
+        errno = EBADF;
         return -1;
     }
 
@@ -577,6 +578,8 @@ static int SocketReplayBioRead(BIO* bio, char* buf, int len)
     // Prefix exhausted; delegate to the socket.
     if (ctx->fd < 0)
     {
+        // See SocketReplayBioWrite: deterministic errno beats a stale one.
+        errno = EBADF;
         return -1;
     }
 
@@ -622,6 +625,10 @@ static int SocketReplayBioWrite(BIO* bio, const char* buf, int len)
     SocketReplayBioCtx* ctx = GetSocketReplayBioCtx(bio);
     if (ctx == NULL || ctx->fd < 0)
     {
+        // No fd bound (or the BIO was torn down). Report a deterministic errno so the
+        // managed SSL_ERROR_SYSCALL path has something to surface; without it the caller
+        // would observe whatever errno happened to be left over from an unrelated call.
+        errno = EBADF;
         return -1;
     }
 
@@ -638,6 +645,14 @@ static int SocketReplayBioWrite(BIO* bio, const char* buf, int len)
     if (n > 0)
     {
         return (int)n;
+    }
+
+    if (n == 0)
+    {
+        // send() accepted nothing without reporting an error. Nothing was flushed, so
+        // ask OpenSSL to retry rather than surfacing a bogus errno from an earlier call.
+        BIO_set_retry_write(bio);
+        return -1;
     }
 
     if (errno == EAGAIN || errno == EWOULDBLOCK)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -10,6 +10,7 @@
 #include "pal_x509.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <string.h>
 #include <stdbool.h>
 
@@ -402,6 +403,10 @@ int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num, int32_t* e
 
     int32_t result = SSL_write(ssl, buf, num);
 
+    // Capture errno before SSL_get_error so a failing send() inside the BIO stays
+    // diagnosable; on SSL_ERROR_SYSCALL errno is the caller's primary diagnostic.
+    int savedErrno = errno;
+
     if (result > 0)
     {
         *error = SSL_ERROR_NONE;
@@ -411,6 +416,7 @@ int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num, int32_t* e
         *error = CryptoNative_SslGetError(ssl, result);
     }
 
+    errno = savedErrno;
     return result;
 }
 
@@ -420,6 +426,9 @@ int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num, int32_t* error)
 
     int32_t result = SSL_read(ssl, buf, num);
 
+    // See CryptoNative_SslWrite: preserve errno across SSL_get_error.
+    int savedErrno = errno;
+
     if (result > 0)
     {
         *error = SSL_ERROR_NONE;
@@ -429,6 +438,7 @@ int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num, int32_t* error)
         *error = CryptoNative_SslGetError(ssl, result);
     }
 
+    errno = savedErrno;
     return result;
 }
 
@@ -508,7 +518,10 @@ int32_t CryptoNative_SslDoHandshake(SSL* ssl, int32_t* errorCode)
 {
     ERR_clear_error();
     int32_t ret = SSL_do_handshake(ssl);
+    // See CryptoNative_SslWrite: preserve errno across SSL_get_error.
+    int savedErrno = errno;
     *errorCode = (ret <= 0) ? SSL_get_error(ssl, ret) : 0;
+    errno = savedErrno;
     return ret;
 }
 


### PR DESCRIPTION
This makes TlsSession use the same code for creating exceptions as in SslStream, so that it correctly reports all cases.
