### PR TITLE
[wasm][mono][AOT] Emit Nullable<T> gsharedvt box/unbox wrappers for corelib value types

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6287,6 +6287,37 @@ add_generic_instances (MonoAotCompile *acfg)
 			add_instances_of (acfg, klass, insts, ninsts, TRUE);
 
 		/*
+		 * Nullable<T>.Box/Unbox have variable-size signatures that the llvmonly gsharedvt
+		 * runtime cannot share, so they are resolved to concrete methods and gsharedvt
+		 * callers are adapted with out/in-sig wrappers that are only emitted when those
+		 * concrete methods are AOT-compiled (see add_generic_class_with_depth). When corelib
+		 * is AOT-compiled but the consuming assembly is interpreted, value types such as
+		 * Int128 are never instantiated as Nullable<T> in corelib's metadata, so the wrappers
+		 * are absent and boxing such a value through the non-generic IEnumerator.Current traps
+		 * with a "function signature mismatch" (#131537). Explicitly instantiate Nullable<T>
+		 * for the corelib value types whose gsharedvt layout is otherwise absent (the small
+		 * primitives are already covered by existing corelib Nullable usage); missing names
+		 * are skipped, and already-added instances are deduplicated by add_generic_class.
+		 */
+		{
+			MonoType *nullable_insts [32];
+			int nullable_ninsts = 0;
+			const char *nullable_vtypes [] = {
+				"Int128", "UInt128", "Half", "Decimal", "Guid",
+				"DateTime", "DateTimeOffset", "TimeSpan", "DateOnly", "TimeOnly",
+				"IntPtr", "UIntPtr"
+			};
+			for (size_t i = 0; i < G_N_ELEMENTS (nullable_vtypes); ++i) {
+				MonoClass *k = mono_class_try_load_from_name (acfg->image, "System", nullable_vtypes [i]);
+				if (k)
+					nullable_insts [nullable_ninsts ++] = m_class_get_byval_arg (k);
+			}
+			klass = mono_class_try_load_from_name (acfg->image, "System", "Nullable`1");
+			if (klass && nullable_ninsts)
+				add_instances_of (acfg, klass, nullable_insts, nullable_ninsts, TRUE);
+		}
+
+		/*
 		 * Add a managed-to-native wrapper of Array.GetGenericValue_icall<object>, which is
 		 * used for all instances of GetGenericValue_icall by the AOT runtime.
 		 */

--- a/src/tests/Loader/classloader/generics/regressions/131537/test131537.cs
+++ b/src/tests/Loader/classloader/generics/regressions/131537/test131537.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+// Regression test for https://github.com/dotnet/runtime/issues/131537
+// (WASM manifestation of https://github.com/dotnet/runtime/issues/66220).
+//
+// Constructing a non-generic Queue from a List<Nullable<T>> enumerates the list
+// through the non-generic IEnumerator, whose Current getter boxes each element
+// Nullable<T> -> object. On Mono WASM with an AOT'd corelib and this assembly
+// running in the interpreter (the WasmTestOnChrome-MONO-ST configuration), the
+// concrete Nullable<T> is never instantiated in the AOT'd corelib's TYPESPEC
+// table, so the required gsharedvt out-sig wrapper object(Nullable<T>) is not
+// emitted and the boxing call traps with "function signature mismatch".
+public class Test_131537
+{
+    [Fact]
+    public static void BoxNullableThroughNonGenericEnumerator()
+    {
+        RoundTrip(new List<Int128?> { 1, 2, 3 });
+        RoundTrip(new List<UInt128?> { 1, 2, 3 });
+        RoundTrip(new List<Half?> { (Half)1, (Half)2, (Half)3 });
+        RoundTrip(new List<decimal?> { 1m, 2m, 3m });
+        RoundTrip(new List<Guid?> { Guid.Empty, Guid.NewGuid() });
+        RoundTrip(new List<DateTime?> { DateTime.UnixEpoch, DateTime.MaxValue });
+        RoundTrip(new List<DateTimeOffset?> { DateTimeOffset.UnixEpoch, DateTimeOffset.MaxValue });
+        RoundTrip(new List<TimeSpan?> { TimeSpan.Zero, TimeSpan.FromSeconds(5) });
+    }
+
+    private static void RoundTrip<T>(List<T> source)
+    {
+        // Queue(ICollection) enumerates via the non-generic IEnumerator, boxing
+        // each element T -> object. This is the call that crashes when the
+        // object(Nullable<T>) gsharedvt out-sig wrapper is missing.
+        var queue = new Queue(source);
+        Assert.Equal(source.Count, queue.Count);
+
+        int i = 0;
+        foreach (object boxed in queue)
+        {
+            Assert.Equal(source[i], (T)boxed);
+            i++;
+        }
+    }
+}

--- a/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
+++ b/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test131537.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Reproduce the WasmTestOnChrome-MONO-ST configuration from #131537:
+         corelib is AOT'd but this test assembly runs in the interpreter, so the
+         object(Nullable<T>) gsharedvt out-sig wrapper is not emitted by AOT.
+         This item is ignored on non-wasm-AOT runtimes. -->
+    <_AOT_InternalForceInterpretAssemblies Include="test131537.dll" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## What

When Mono compiles corelib with AOT but the consuming assembly runs **interpreted** (the `WasmTestOnChrome-MONO-ST` configuration), boxing a `Nullable<T>` element through the non-generic `IEnumerator.Current` — e.g. `new System.Collections.Queue(new List<Int128?>{...})` — traps with **`function signature mismatch`**. This PR emits the required `object(Nullable<T>)` / `Nullable<T>(object)` gsharedvt out/in-sig wrappers for a set of corelib value types during corelib AOT.

Fixes #131537.

## Why

`Nullable<T>.Box`/`Unbox` have variable-size-by-value signatures that the llvmonly minimal gsharedvt cannot share, so they are resolved to concrete per-`T` methods and gsharedvt callers are adapted with an out/in-sig wrapper. That wrapper is only emitted when the concrete `Nullable<T>` is AOT-compiled (see `add_generic_class_with_depth`, added in #131049). When corelib is AOT'd but the consumer is interpreted, `Nullable<Int128>` is never in corelib's TYPESPEC, so the wrapper is absent → trap. The AOT'd corelib `List<T>.Enumerator.IEnumerator.get_Current` reaches this via its `MONO_RGCTX_INFO_NULLABLE_CLASS_BOX` rgctx entry, so the concrete payload is only known at runtime and is invisible to the AOT compiler unless the instantiation is rooted.

This completes the AOT-compiler half of #131049 for corelib value types.

## Scope

This intentionally covers **only a fixed set of corelib value types**:
`Int128`, `UInt128`, `Half`, `Decimal`, `Guid`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `DateOnly`, `TimeOnly`, `IntPtr`, `UIntPtr`. (The small primitives were already covered by existing corelib `Nullable` usage; the newly-added numeric types `Int128`/`UInt128`/`Half` are the ones the failing `System.Text.Json` test hits.)

**It does NOT fix `Nullable<T>` of value types defined in an interpreted user assembly.** Those still crash — with a *different* symptom (`MONO_WASM: null function`) when the struct's gsharedvt layout matches a covered corelib type, or the same `function signature mismatch` for a novel layout — because the concrete `Nullable<CustomStruct>.Box` **body** cannot be pre-emitted by the AOT compiler. That is a separate, runtime-side problem tracked in **#131945** (with repro and a fix proposal).

## Change

- `src/mono/mono/mini/aot-compiler.c`: in the corelib block of `add_generic_instances`, instantiate `Nullable<T>` for the value types above via `add_instances_of` → `add_generic_class` → the #131049 Box/Unbox path, which emits the wrappers. Missing type names are skipped; already-added instances are deduplicated.
- `src/tests/Loader/classloader/generics/regressions/131537/`: regression test that boxes `Int128?`/`UInt128?`/`Half?`/`decimal?`/`Guid?`/`DateTime?`/`DateTimeOffset?`/`TimeSpan?` through `Queue(ICollection)` and round-trips the values. The test csproj sets `_AOT_InternalForceInterpretAssemblies` so it reproduces the AOT-corelib + interpreted-assembly configuration in wasm-AOT lanes; it passes trivially elsewhere.

## Testing

Verified locally on WASM Mono AOT (interpreted app + AOT'd corelib):
- **Before:** boxing `Nullable<Int128>` traps with `Assertion ... mini_get_gsharedvt_wrapper ... object:gsharedvt_out_sig (... ValueTuple<byte, ValueTuple<long,long>>&, ...) while running in aot-only mode`, `WASM EXIT 1`.
- **After:** all covered types round-trip, `WASM EXIT 0`.

This also re-greens the `NullableInt128s`/`NullableUInt128s`/`NullableHalfs` cases of `System.Text.Json` `Number_AsCollectionElement_RoundTrip` on Browser (re-enabled by #131049), so the `!PlatformDetection.IsBrowser` guard does not need to be restored.

> [!NOTE]
> This pull request was prepared with GitHub Copilot.