### PR TITLE
Fix AV in gc_heap::init_heap_segment

### DIFF
--- a/src/coreclr/gc/card_table.cpp
+++ b/src/coreclr/gc/card_table.cpp
@@ -221,7 +221,7 @@ void gc_heap::get_card_table_element_layout (uint8_t* start, uint8_t* end, size_
     for (int element = brick_table_element; element <= total_bookkeeping_elements; element++)
     {
         layout[element] = layout[element - 1] + sizes[element - 1];
-        if ((element != total_bookkeeping_elements) && (sizes[element] != 0))
+        if (element != total_bookkeeping_elements)
         {
             layout[element] = ALIGN_UP(layout[element], alignment[element]);
         }

--- a/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.cs
+++ b/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+public class Runtime_129681
+{
+    private const int StorageLength = 8192;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        object[] storage = new object[StorageLength];
+        int index = 0;
+
+        try
+        {
+            while (index < storage.Length)
+            {
+                storage[index++] = GC.AllocateArray<byte>(16 * 1024, pinned: true);
+            }
+        }
+        catch (OutOfMemoryException)
+        {
+        }
+
+        try
+        {
+            while (index < storage.Length)
+            {
+                storage[index++] = GC.AllocateArray<byte>(256, pinned: true);
+            }
+        }
+        catch (OutOfMemoryException)
+        {
+        }
+
+        try
+        {
+            while (index < storage.Length)
+            {
+                storage[index++] = GC.AllocateArray<byte>(1, pinned: true);
+            }
+        }
+        catch (OutOfMemoryException)
+        {
+            return;
+        }
+
+        throw new Exception("The configured GC heap hard limit was not reached.");
+    }
+}

--- a/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
+++ b/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
 
     <CLRTestBatchPreCommands><![CDATA[
       $(CLRTestBatchPreCommands)

--- a/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
+++ b/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <CLRTestPriority>1</CLRTestPriority>
+
+    <CLRTestBatchPreCommands><![CDATA[
+      $(CLRTestBatchPreCommands)
+      set DOTNET_GCStress=0xC
+      set DOTNET_GCHeapHardLimit=0x4000000
+      set DOTNET_GCRegionRange=0x4000000
+      set DOTNET_GCRegionSize=0x100000
+      ]]></CLRTestBatchPreCommands>
+    <CLRTestBashPreCommands><![CDATA[
+      $(CLRTestBashPreCommands)
+      export DOTNET_GCStress=0xC
+      export DOTNET_GCHeapHardLimit=0x4000000
+      export DOTNET_GCRegionRange=0x4000000
+      export DOTNET_GCRegionSize=0x100000
+      ]]></CLRTestBashPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There is a bug in get_card_table_element_layout /
get_card_table_commit_layout that results in the last page of the seg_mapping_table_element not being committed in case there was no mark_array_element. That happens when concurrent GC is disabled.

The change fixes that by ensuring that every layout[element] is aligned according to its alignment requirements even when its size is 0. That allows the get_card_table_commit_layout to set commit end of the seg_mapping_table_element to include the last page even when the mark_array_element is not present.

The problem happens because when a memory page is shared by multiple card table elements, the commit range for the first element on that page doesn't include that page and the next element is supposed to do the commit.

Close #129681