### PR TITLE
Avoid redundant boxing in DefaultInterpolatedStringHandler

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -279,7 +279,7 @@ namespace System.Runtime.CompilerServices
                 if (value is ISpanFormattable spanFormattableValue)
                 {
                     int charsWritten;
-                    while (!spanFormattableValue.TryFormat(_chars.Slice(_pos), out charsWritten, default, _provider)) // constrained call avoiding boxing for value types
+                    while (!spanFormattableValue.TryFormat(_chars.Slice(_pos), out charsWritten, default, _provider))
                     {
                         Grow();
                     }
@@ -346,7 +346,7 @@ namespace System.Runtime.CompilerServices
                 if (value is ISpanFormattable spanFormattableValue)
                 {
                     int charsWritten;
-                    while (!spanFormattableValue.TryFormat(_chars.Slice(_pos), out charsWritten, format, _provider)) // constrained call avoiding boxing for value types
+                    while (!spanFormattableValue.TryFormat(_chars.Slice(_pos), out charsWritten, format, _provider))
                     {
                         Grow();
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -276,10 +276,10 @@ namespace System.Runtime.CompilerServices
                     return;
                 }
 
-                if (value is ISpanFormattable)
+                if (value is ISpanFormattable spanFormattableValue)
                 {
                     int charsWritten;
-                    while (!((ISpanFormattable)value).TryFormat(_chars.Slice(_pos), out charsWritten, default, _provider)) // constrained call avoiding boxing for value types
+                    while (!spanFormattableValue.TryFormat(_chars.Slice(_pos), out charsWritten, default, _provider)) // constrained call avoiding boxing for value types
                     {
                         Grow();
                     }
@@ -343,10 +343,10 @@ namespace System.Runtime.CompilerServices
                     return;
                 }
 
-                if (value is ISpanFormattable)
+                if (value is ISpanFormattable spanFormattableValue)
                 {
                     int charsWritten;
-                    while (!((ISpanFormattable)value).TryFormat(_chars.Slice(_pos), out charsWritten, format, _provider)) // constrained call avoiding boxing for value types
+                    while (!spanFormattableValue.TryFormat(_chars.Slice(_pos), out charsWritten, format, _provider)) // constrained call avoiding boxing for value types
                     {
                         Grow();
                     }


### PR DESCRIPTION
This PR uses pattern matching instead of a separate type check followed by a cast to `ISpanFormattable`.
That cast sat inside the while loop, so the value (e.g. `int`) was boxed. The pattern match moves it out of the loop, where object stack allocation can eliminate it.

## Benchmark

| Method             | Job        | Toolchain            | Mean      | Error     | StdDev    | Median    | Min       | Max       | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------- |----------- |--------------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
| Interpolate_int    | Job-QIDXWP | \main\corerun.exe    | 20.825 ns | 0.2444 ns | 0.2041 ns | 20.789 ns | 20.418 ns | 21.194 ns |  1.00 |    0.00 | 0.0101 |      64 B |        1.00 |
| Interpolate_int    | Job-LHEBXT | \pr\corerun.exe | 18.969 ns | 0.1889 ns | 0.1577 ns | 18.900 ns | 18.760 ns | 19.242 ns |  0.91 |    0.01 | 0.0063 |      40 B |        0.62 |
|                    |            |                      |           |           |           |           |           |           |       |         |        |           |             |
| Interpolate_Guid   | Job-QIDXWP | \main\corerun.exe    | 23.183 ns | 0.4583 ns | 0.4707 ns | 23.023 ns | 22.556 ns | 24.503 ns |  1.00 |    0.00 | 0.0204 |     128 B |        1.00 |
| Interpolate_Guid   | Job-LHEBXT | \pr\corerun.exe | 22.677 ns | 0.2325 ns | 0.1941 ns | 22.722 ns | 22.351 ns | 22.996 ns |  0.98 |    0.02 | 0.0203 |     128 B |        1.00 |
|                    |            |                      |           |           |           |           |           |           |       |         |        |           |             |
| Interpolate_Enum   | Job-QIDXWP | \main\corerun.exe    | 18.852 ns | 0.2321 ns | 0.1938 ns | 18.883 ns | 18.465 ns | 19.159 ns |  1.00 |    0.00 | 0.0064 |      40 B |        1.00 |
| Interpolate_Enum   | Job-LHEBXT | \pr\corerun.exe | 18.924 ns | 0.2030 ns | 0.1695 ns | 18.894 ns | 18.716 ns | 19.202 ns |  1.00 |    0.01 | 0.0063 |      40 B |        1.00 |
|                    |            |                      |           |           |           |           |           |           |       |         |        |           |             |
| Interpolate_String | Job-QIDXWP | \main\corerun.exe    |  1.533 ns | 0.0177 ns | 0.0148 ns |  1.535 ns |  1.512 ns |  1.560 ns |  1.00 |    0.00 |      - |         - |          NA |
| Interpolate_String | Job-LHEBXT | \pr\corerun.exe |  1.507 ns | 0.0144 ns | 0.0120 ns |  1.507 ns |  1.490 ns |  1.525 ns |  0.98 |    0.01 |      - |         - |          NA |

<details><summary>Benchmark source</summary>

```csharp
    [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
    public class Perf_InterpolatedStringHandler
    {
        private int _int;
        private Guid _guid;
        private DayOfWeek _dayOfWeek;
        private string _string;

        [GlobalSetup]
        public void Setup()
        {
            _int = 1234567;
            _guid = Guid.NewGuid();
            _dayOfWeek = DayOfWeek.Tuesday;
            _string = "hello world";
        }

        [Benchmark]
        public string Interpolate_int() => $"{_int}";

        [Benchmark]
        public string Interpolate_Guid() => $"{_guid}";

        [Benchmark]
        public string Interpolate_Enum() => $"{_dayOfWeek}";

        [Benchmark]
        public string Interpolate_String() => $"{_string}";
    }
```

</details>