### PR TITLE
Ensure that Native AOT libraries are not unloaded

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -108,7 +108,7 @@ extern "C" bool RhRegisterOSModule(void * pModule,
     void * pvUnboxingStubsStartRange, uint32_t cbUnboxingStubsRange,
     void ** pClasslibFunctions, uint32_t nClasslibFunctions);
 
-void* PalGetModuleHandleFromPointer(void* pointer);
+void* PalGetModuleHandleFromPointer(void* pointer, bool pinModule = false);
 
 #if defined(HOST_X86) && defined(HOST_WINDOWS)
 #define STRINGIFY(s) #s

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -290,6 +290,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-Wl,-z,nobtcfi" Condition="'$(_targetOS)' == 'openbsd'" />
       <!-- Opt out of OpenBSD's execute-only text so NativeAOT can read its own stub bytes (RhGetCodeTarget). -->
       <LinkerArg Include="-Wl,--no-execute-only" Condition="'$(_targetOS)' == 'openbsd'" />
+      <!-- NativeAOT shared libraries should not be unloaded -->
+      <LinkerArg Include="-Wl,-z,nodelete" Condition="'$(_targetOS)' == 'linux' and '$(NativeLib)' == 'Shared'" />
       <!-- this workaround can be deleted once the minimum supported glibc version
            (runtime's official build machine's glibc version) is at least 2.33
            see https://github.com/bminor/glibc/commit/99468ed45f5a58f584bab60364af937eb6f8afda -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -291,7 +291,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- Opt out of OpenBSD's execute-only text so NativeAOT can read its own stub bytes (RhGetCodeTarget). -->
       <LinkerArg Include="-Wl,--no-execute-only" Condition="'$(_targetOS)' == 'openbsd'" />
       <!-- NativeAOT shared libraries should not be unloaded -->
-      <LinkerArg Include="-Wl,-z,nodelete" Condition="'$(_targetOS)' == 'linux' and '$(NativeLib)' == 'Shared'" />
+      <LinkerArg Include="-Wl,-z,nodelete" Condition="'$(_IsApplePlatform)'  != 'true' and '$(NativeLib)' == 'Shared'" />
       <!-- this workaround can be deleted once the minimum supported glibc version
            (runtime's official build machine's glibc version) is at least 2.33
            see https://github.com/bminor/glibc/commit/99468ed45f5a58f584bab60364af937eb6f8afda -->

--- a/src/coreclr/nativeaot/Runtime/Pal.h
+++ b/src/coreclr/nativeaot/Runtime/Pal.h
@@ -235,7 +235,7 @@ void PalSleep(uint32_t milliseconds);
 UInt32_BOOL PalSwitchToThread();
 UInt32_BOOL PalAreShadowStacksEnabled();
 HANDLE PalCreateEventW(_In_opt_ LPSECURITY_ATTRIBUTES pEventAttributes, UInt32_BOOL manualReset, UInt32_BOOL initialState, _In_opt_z_ LPCWSTR pName);
-HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer);
+HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer, bool pinModule = false);
 
 #ifdef TARGET_UNIX
 typedef int32_t (*PHARDWARE_EXCEPTION_HANDLER)(uintptr_t faultCode, uintptr_t faultAddress, PAL_LIMITED_CONTEXT* palContext, uintptr_t* arg0Reg, uintptr_t* arg1Reg);

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -367,7 +367,7 @@ extern "C" bool RhInitialize(bool isDll)
     g_safeToShutdownTracing = !isDll;
 #endif
 
-    if (!InitDLL(PalGetModuleHandleFromPointer((void*)&RhInitialize)))
+    if (!InitDLL(PalGetModuleHandleFromPointer((void*)&RhInitialize, isDll)))
         return false;
 
     return true;

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -862,6 +862,7 @@ HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer, bool pinModule)
         {
             // NativeAOT runtime state cannot be safely unloaded.
             // Keep the extra reference for the lifetime of the process.
+            // Unloading is disabled via `-z,nodelete` linker option on ELF platforms.
             dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
         }
 #else

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -862,7 +862,7 @@ HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer, bool pinModule)
         {
             // NativeAOT runtime state cannot be safely unloaded.
             // Keep the extra reference for the lifetime of the process.
-            (void)dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
+            dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
         }
 #else
         (void)pinModule;

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -857,15 +857,12 @@ HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer, bool pinModule)
     int st = dladdr(pointer, &info);
     if (st != 0)
     {
-#if defined(RTLD_NODELETE)
+#if defined(HOST_OSX)
         if (pinModule && info.dli_fname != nullptr)
         {
             // NativeAOT runtime state cannot be safely unloaded.
-            void* module = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NODELETE);
-            if (module != nullptr)
-            {
-                dlclose(module);
-            }
+            // Keep the extra reference for the lifetime of the process.
+            (void)dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
         }
 #else
         (void)pinModule;

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -854,18 +854,15 @@ HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer)
     if (st != 0)
     {
 #if defined(RTLD_NODELETE)
-        if (info.dli_fname == nullptr)
+        if (info.dli_fname != nullptr)
         {
-            return NULL;
+            // NativeAOT runtime state cannot be safely unloaded.
+            void* module = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NODELETE);
+            if (module != nullptr)
+            {
+                dlclose(module);
+            }
         }
-
-        // NativeAOT runtime state cannot be safely unloaded.
-        void* module = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NODELETE);
-        if (module == nullptr)
-        {
-            return NULL;
-        }
-        dlclose(module);
 #endif
 
         moduleHandle = info.dli_fbase;

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -853,6 +853,21 @@ HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer)
     int st = dladdr(pointer, &info);
     if (st != 0)
     {
+#if defined(RTLD_NODELETE)
+        if (info.dli_fname == nullptr)
+        {
+            return NULL;
+        }
+
+        // NativeAOT runtime state cannot be safely unloaded.
+        void* module = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NODELETE);
+        if (module == nullptr)
+        {
+            return NULL;
+        }
+        dlclose(module);
+#endif
+
         moduleHandle = info.dli_fbase;
     }
 #endif //!defined(HOST_WASM)

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -846,10 +846,6 @@ HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer, bool pinModule)
 {
     HANDLE moduleHandle = NULL;
 
-#if defined(HOST_WASM)
-    (void)pinModule;
-#endif
-
     // Emscripten's implementation of dladdr corrupts memory,
     // but always returns 0 for the module handle, so just skip the call
 #if !defined(HOST_WASM)
@@ -865,8 +861,6 @@ HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer, bool pinModule)
             // Unloading is disabled via `-z,nodelete` linker option on ELF platforms.
             dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
         }
-#else
-        (void)pinModule;
 #endif
 
         moduleHandle = info.dli_fbase;

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -842,9 +842,13 @@ bool PalStartEventPipeHelperThread(_In_ BackgroundCallback callback, _In_opt_ vo
     return PalStartBackgroundWork(callback, pCallbackContext, UInt32_FALSE);
 }
 
-HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer)
+HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer, bool pinModule)
 {
     HANDLE moduleHandle = NULL;
+
+#if defined(HOST_WASM)
+    (void)pinModule;
+#endif
 
     // Emscripten's implementation of dladdr corrupts memory,
     // but always returns 0 for the module handle, so just skip the call
@@ -854,7 +858,7 @@ HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer)
     if (st != 0)
     {
 #if defined(RTLD_NODELETE)
-        if (info.dli_fname != nullptr)
+        if (pinModule && info.dli_fname != nullptr)
         {
             // NativeAOT runtime state cannot be safely unloaded.
             void* module = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NODELETE);
@@ -863,6 +867,8 @@ HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer)
                 dlclose(module);
             }
         }
+#else
+        (void)pinModule;
 #endif
 
         moduleHandle = info.dli_fbase;

--- a/src/coreclr/nativeaot/Runtime/windows/PalMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalMinWin.cpp
@@ -921,14 +921,15 @@ bool PalStartEventPipeHelperThread(_In_ BackgroundCallback callback, _In_opt_ vo
     return PalStartBackgroundWork(callback, pCallbackContext, FALSE);
 }
 
-HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer)
+HANDLE PalGetModuleHandleFromPointer(_In_ void* pointer, bool pinModule)
 {
-    // The runtime is not designed to be unloadable today. Use GET_MODULE_HANDLE_EX_FLAG_PIN to prevent
-    // the module from ever unloading.
+    // The runtime is not designed to be unloadable today.
+    DWORD flags = GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+        (pinModule ? GET_MODULE_HANDLE_EX_FLAG_PIN : GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT);
 
     HMODULE module;
     if (!GetModuleHandleExW(
-        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
+        flags,
         (LPCWSTR)pointer,
         &module))
     {

--- a/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.cpp
+++ b/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.cpp
@@ -77,8 +77,7 @@ int main(int argc, char* argv[])
 #ifdef TARGET_WINDOWS
     FreeLibrary(handle);
 #else
-    // TODO: How to pin the library in memory on Unix?
-    // dlclose(handle);
+    dlclose(handle);
 #endif
 
     return 100;


### PR DESCRIPTION
Ensure that NAOT libraries are not unloaded by opening them with the `RTLD_NODELETE` flag. Mac and glibc support this flag, and musl libc does not support unloading libraries.
Fixes #64629