### PR TITLE
createdump: fix macOS arm64 thread IDs in LLDB

### DIFF
--- a/src/coreclr/debug/createdump/dumpwritermacho.cpp
+++ b/src/coreclr/debug/createdump/dumpwritermacho.cpp
@@ -16,10 +16,15 @@ DumpWriter::WriteDump()
 
     BuildThreadLoadCommands();
 
+    BuildProcessMetadataNote();
+
     uint64_t fileOffset = 0;
     if (!WriteHeader(&fileOffset)) {
         return false;
     }
+
+    m_processMetadataNote.offset = fileOffset;
+    fileOffset += m_processMetadataNote.size;
 
     TRACE("Writing %zd thread commands to core file\n", m_threadLoadCommands.size());
 
@@ -54,6 +59,14 @@ DumpWriter::WriteDump()
         }
     }
 
+    // Write the process metadata note as the final load command
+    if (!WriteData(&m_processMetadataNote, m_processMetadataNote.cmdsize)) {
+        return false;
+    }
+    if (!WriteData(m_processMetadata.data(), m_processMetadata.size())) {
+        return false;
+    }
+
     // Write any segment alignment required to the core file
     if (alignment > 0)
     {
@@ -85,6 +98,33 @@ ConvertFlags(uint32_t flags)
         prot |= VM_PROT_EXECUTE;
     }
     return prot;
+}
+
+void
+DumpWriter::BuildProcessMetadataNote()
+{
+    // LLDB specifies the "process metadata" LC_NOTE as compact JSON whose
+    // thread entries correspond by position to the LC_THREAD commands.
+    m_processMetadata = "{\"threads\":[";
+    bool first = true;
+    for (const ThreadInfo* thread : m_crashInfo.Threads())
+    {
+        if (!first)
+        {
+            m_processMetadata.push_back(',');
+        }
+        first = false;
+        m_processMetadata.append("{\"thread_id\":");
+        m_processMetadata.append(std::to_string(thread->Tid()));
+        m_processMetadata.push_back('}');
+    }
+    m_processMetadata.append("]}");
+
+    m_processMetadataNote.cmd = LC_NOTE;
+    m_processMetadataNote.cmdsize = sizeof(note_command);
+    static_assert(sizeof(m_processMetadataNote.data_owner) == sizeof("process metadata") - 1);
+    memcpy(m_processMetadataNote.data_owner, "process metadata", sizeof(m_processMetadataNote.data_owner));
+    m_processMetadataNote.size = m_processMetadata.size();
 }
 
 void
@@ -189,6 +229,9 @@ DumpWriter::WriteHeader(uint64_t* pFileOffset)
         header.ncmds++;
         header.sizeofcmds += segment.cmdsize;
     }
+
+    header.ncmds++;
+    header.sizeofcmds += m_processMetadataNote.cmdsize;
 
     *pFileOffset = sizeof(mach_header_64) + header.sizeofcmds;
     

--- a/src/coreclr/debug/createdump/dumpwritermacho.h
+++ b/src/coreclr/debug/createdump/dumpwritermacho.h
@@ -28,6 +28,8 @@ private:
 
     std::vector<segment_command_64> m_segmentLoadCommands;
     std::vector<ThreadCommand> m_threadLoadCommands;
+    note_command m_processMetadataNote{};
+    std::string m_processMetadata;
     BYTE m_tempBuffer[0x4000];
 
     // no public copy constructor
@@ -43,6 +45,7 @@ public:
 
 private:
     bool WriteDiagInfo(size_t size);
+    void BuildProcessMetadataNote();
     void BuildSegmentLoadCommands();
     void BuildThreadLoadCommands();
     bool WriteHeader(uint64_t* pFileOffset);

--- a/src/coreclr/debug/createdump/specialthreadinfo.h
+++ b/src/coreclr/debug/createdump/specialthreadinfo.h
@@ -14,10 +14,10 @@
 
 #define SPECIAL_THREADINFO_SIGNATURE "THREADINFO"
 
-#if defined(__APPLE__) && (defined(HOST_ARM64) || defined(__arm64__) || defined(__aarch64__))
+#if defined(HOST_ARM64) || defined(__arm64__) || defined(__aarch64__)
 // Apple Silicon (arm64) macOS user-space VM is 47 bits. lldb's core reader
 // rejects segments above 0x7FFF_FFFF_FFFF, so use a 47-bit-valid address.
-const uint64_t SpecialThreadInfoAddress = 0x00007ffffff20000;
+const uint64_t SpecialThreadInfoAddress = 0x00007ffffff00000;
 #else
 const uint64_t SpecialThreadInfoAddress = 0x7fffffff00000000;
 #endif

--- a/src/coreclr/debug/createdump/specialthreadinfo.h
+++ b/src/coreclr/debug/createdump/specialthreadinfo.h
@@ -14,7 +14,13 @@
 
 #define SPECIAL_THREADINFO_SIGNATURE "THREADINFO"
 
+#if defined(__APPLE__) && (defined(HOST_ARM64) || defined(__arm64__) || defined(__aarch64__))
+// Apple Silicon (arm64) macOS user-space VM is 47 bits. lldb's core reader
+// rejects segments above 0x7FFF_FFFF_FFFF, so use a 47-bit-valid address.
+const uint64_t SpecialThreadInfoAddress = 0x00007ffffff20000;
+#else
 const uint64_t SpecialThreadInfoAddress = 0x7fffffff00000000;
+#endif
 
 struct SpecialThreadInfoHeader
 {


### PR DESCRIPTION
## Summary

- write the macOS arm64 createdump thread-info region at a 47-bit-valid address
- emit OS thread IDs using LLDB's `process metadata` `LC_NOTE` format
  - this is for future support so we can eventually remove the `SpecialThreadInfo`
- retain the existing special thread-info segment while consumers migrate to the LLDB format

## Motivation

Apple Silicon LLDB rejects the legacy `0x7fffffff00000000` synthetic segment and falls back to sequential thread IDs beginning at zero. SOS then cannot correlate LLDB threads with runtime OS thread IDs or retrieve the selected thread context.

Coordinated SOS reader change: https://github.com/dotnet/diagnostics/pull/5953

## Related precedent

This follows @steveisok's coordinated Apple Silicon fix for `SpecialDiagInfoAddress`:

- runtime writer: https://github.com/dotnet/runtime/pull/130443
- diagnostics readers: https://github.com/dotnet/diagnostics/pull/5823

## Testing

Draft pending coordinated diagnostics validation on macOS arm64.