### PR TITLE
Harden async-profiler dispatcher/wrapper frame name contract for callstack stitching.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -917,6 +917,7 @@ namespace System.Runtime.CompilerServices
 #pragma warning restore CA1822
 
             [StackTraceHidden]
+            // Diagnostic tooling depends on this name when classifying async callstack frames.
             // NOTE, any changes done to this method need to be replicated in InstrumentedDispatchContinuations as well.
             private unsafe void DispatchContinuations()
             {
@@ -1045,6 +1046,7 @@ namespace System.Runtime.CompilerServices
             }
 
             [StackTraceHidden]
+            // Diagnostic tooling depends on this name when classifying async callstack frames.
             private unsafe void InstrumentedDispatchContinuations(AsyncInstrumentation.Flags flags)
             {
                 // Intentionally skip initialization for this state; the Push

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.CoreCLR.cs
@@ -268,6 +268,8 @@ namespace System.Runtime.CompilerServices
             }
 
             [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+            // The Continuation_Wrapper_N method names below are formatted from NameTemplate; diagnostic tooling
+            // depends on these names when classifying async callstack frames.
             private static unsafe Continuation? Continuation_Wrapper_0(Continuation continuation, ref byte resultLoc)
             {
                 return continuation.ResumeInfo->Resume(continuation, ref resultLoc);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncProfiler.cs
@@ -11,7 +11,6 @@ using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Serializer = System.Runtime.CompilerServices.AsyncProfiler.EventBuffer.Serializer;
 
 namespace System.Runtime.CompilerServices
@@ -194,7 +193,7 @@ namespace System.Runtime.CompilerServices
                         ActiveEventKeywords = eventKeywords;
                     }
 
-                    string? eventBufferSizeEnv = System.Environment.GetEnvironmentVariable("DOTNET_AsyncProfilerEventSource_EventBufferSize");
+                    string? eventBufferSizeEnv = System.Environment.GetEnvironmentVariable("DOTNET_AsyncProfiler_EventBufferSize");
                     if (eventBufferSizeEnv != null && uint.TryParse(eventBufferSizeEnv, out uint eventBufferSize))
                     {
                         eventBufferSize = Math.Max(eventBufferSize, 1024);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncStateMachineDispatcher.cs
@@ -257,6 +257,8 @@ namespace System.Runtime.CompilerServices
         ulong DispatcherId { get; }
     }
 
+    // Diagnostic tooling depends on this type name (together with the MoveNext method name) when classifying
+    // async callstack frames.
     internal sealed class AsyncStateMachineDispatcher : Task<VoidTaskResult>, IAsyncStateMachineBox, IAsyncStateMachineDispatcher
     {
         private IAsyncStateMachineBox? _inner;
@@ -279,6 +281,8 @@ namespace System.Runtime.CompilerServices
 
         internal sealed override void ExecuteDirectly(Thread? threadPoolThread) => MoveNext();
 
+        [StackTraceHidden]
+        // Diagnostic tooling depends on this name when classifying async callstack frames.
         public unsafe void MoveNext()
         {
             IAsyncStateMachineBox? inner = _inner;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -325,6 +325,7 @@ namespace System.Runtime.CompilerServices
                 return (ulong)_dispatcherId;
             }
 
+            [StackTraceHidden]
             private protected override void InstrumentedMoveNext(Thread? threadPoolThread, AsyncInstrumentation.Flags flags)
             {
                 if (_isLeaf)
@@ -336,6 +337,8 @@ namespace System.Runtime.CompilerServices
                 base.InstrumentedMoveNext(threadPoolThread, flags);
             }
 
+            [StackTraceHidden]
+            // Diagnostic tooling depends on this name when classifying async callstack frames.
             private unsafe void MoveNextAsDispatcher(Thread? threadPoolThread, AsyncInstrumentation.Flags flags)
             {
                 AsyncStateMachineDispatcherInfo info;
@@ -496,6 +499,7 @@ namespace System.Runtime.CompilerServices
                 MoveNext(threadPoolThread, flags);
             }
 
+            [StackTraceHidden]
             private protected virtual void InstrumentedMoveNext(Thread? threadPoolThread, AsyncInstrumentation.Flags flags)
             {
                 AsyncStateMachineDispatcherInfo.ResumeAsyncMethod(this, flags);

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -132,6 +132,161 @@ namespace System.Threading.Tasks.Tests
         // condition alongside the shared gates.
         public static bool IsNotMonoRuntime => PlatformDetection.IsNotMonoRuntime;
 
+        // Gate for the async dispatch-frame name-contract tests below: they reflect into CoreCLR-specific
+        // internal types, which is only reliable on the CoreCLR JIT (not Mono, and not NativeAOT where
+        // reflection is metadata-trimmed).
+        public static bool IsCoreClrJitRuntime =>
+            PlatformDetection.IsNotMonoRuntime && !PlatformDetection.IsNativeAot;
+
+        // Async dispatch-frame NAME contract (shared helpers; V1-specific tests live in AsyncProfilerV1Tests.cs
+        // and V2-specific tests in AsyncProfilerV2Tests.cs).
+        private const BindingFlags DeclaredInstanceMethod =
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+        private static Type GetCoreLibType(string fullName)
+        {
+            Type? type = typeof(object).Assembly.GetType(fullName, throwOnError: false);
+            Assert.True(type is not null, $"Type '{fullName}' was not found in System.Private.CoreLib.");
+            return type!;
+        }
+
+        private static Type GetCoreLibNestedType(string declaringTypeFullName, string nestedTypeName)
+        {
+            Type? nested = GetCoreLibType(declaringTypeFullName).GetNestedType(nestedTypeName, BindingFlags.NonPublic);
+            Assert.True(nested is not null, $"Nested type '{nestedTypeName}' was not found on '{declaringTypeFullName}'.");
+            return nested!;
+        }
+
+        // AsyncProfiler.ContinuationWrapper - the V2 wrapper pool the stitcher keys off by name.
+        private static Type ContinuationWrapperType =>
+            GetCoreLibNestedType("System.Runtime.CompilerServices.AsyncProfiler", "ContinuationWrapper");
+
+        // Asserts the async dispatch method the stitcher recognizes by name still exists under that name.
+        // Keys mirror the string constants in the stitcher's AsyncStitchBoundary classifier.
+        private static void AssertAsyncDispatchMethodExists(string key)
+        {
+            MethodInfo? method = key switch
+            {
+                "V1.MoveNextAsDispatcher" =>
+                    GetCoreLibNestedType("System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1", "AsyncProfilerAsyncStateMachineBox`1")
+                        .GetMethod("MoveNextAsDispatcher", DeclaredInstanceMethod),
+                "V1.AsyncStateMachineDispatcher.MoveNext" =>
+                    GetCoreLibType("System.Runtime.CompilerServices.AsyncStateMachineDispatcher")
+                        .GetMethod("MoveNext", DeclaredInstanceMethod),
+                "V2.DispatchContinuations" =>
+                    GetCoreLibNestedType("System.Runtime.CompilerServices.AsyncHelpers", "RuntimeAsyncTask`1")
+                        .GetMethod("DispatchContinuations", DeclaredInstanceMethod),
+                "V2.InstrumentedDispatchContinuations" =>
+                    GetCoreLibNestedType("System.Runtime.CompilerServices.AsyncHelpers", "RuntimeAsyncTask`1")
+                        .GetMethod("InstrumentedDispatchContinuations", DeclaredInstanceMethod),
+                _ => throw new ArgumentOutOfRangeException(nameof(key), key, "Unknown async dispatch method key."),
+            };
+
+            Assert.True(method is not null,
+                $"Async dispatch method for contract key '{key}' was not found; the CPU stitcher recognizes it by name.");
+        }
+
+        // ------------------------------------------------------------------------------------------------
+        // Real-callstack boundary layout.
+        //
+        // Beyond asserting the boundary methods exist (name contract above), these helpers capture the actual
+        // physical managed stack from inside a resumed async continuation and verify the stitcher-recognized
+        // boundary frames are present in the expected leaf->root order -- exactly what an unfiltered CPU sample
+        // would contain. StackTrace.GetFrames() does NOT drop [StackTraceHidden] frames on any runtime (only
+        // ToString filters them), so the boundary frames are visible even though they are hidden from managed
+        // stack traces.
+        // ------------------------------------------------------------------------------------------------
+
+        // Maps a captured frame's method identity to its stitcher boundary label, or null if not a boundary.
+        private static string? ClassifyAsyncBoundaryFrame(DiagnosticMethodInfo? info)
+        {
+            if (info is null)
+            {
+                return null;
+            }
+
+            string name = info.Name;
+            string typeName = info.DeclaringTypeName ?? string.Empty;
+
+            return name switch
+            {
+                _ when name.StartsWith("Continuation_Wrapper_", StringComparison.Ordinal) => "Wrapper",
+                "DispatchContinuations" => "V2.DispatchContinuations",
+                "InstrumentedDispatchContinuations" => "V2.InstrumentedDispatchContinuations",
+                "MoveNextAsDispatcher" => "V1.MoveNextAsDispatcher",
+                "MoveNext" when typeName.EndsWith("AsyncStateMachineDispatcher", StringComparison.Ordinal)
+                    => "V1.AsyncStateMachineDispatcher.MoveNext",
+                _ => null,
+            };
+        }
+
+        // Captures the current thread's physical managed stack UNFILTERED and returns the stitcher-recognized
+        // async boundary labels in leaf->root order. Must be called from inside a resumed async continuation
+        // (while the async profiler is active) so the dispatch machinery is on the stack.
+        private static List<string> CaptureAsyncBoundarySequence() => CaptureAsyncStack().Boundaries;
+
+        // Captures the physical stack once and returns, both leaf->root: the stitcher boundary labels, and the
+        // per-frame declaring type names. The declaring type names let inline-completion tests locate a
+        // still-completing child's state-machine frame (its method name is the compiler-generated MoveNext, so
+        // it is identified by its declaring state-machine type name) relative to the resuming parent frame.
+        private static (List<string> Boundaries, List<string> DeclaringTypeNames) CaptureAsyncStack()
+        {
+            var boundaries = new List<string>();
+            var typeNames = new List<string>();
+            foreach (StackFrame frame in new StackTrace(fNeedFileInfo: false).GetFrames())
+            {
+                DiagnosticMethodInfo? info = DiagnosticMethodInfo.Create(frame);
+                typeNames.Add(info?.DeclaringTypeName ?? string.Empty);
+
+                string? label = ClassifyAsyncBoundaryFrame(info);
+                if (label is not null)
+                {
+                    boundaries.Add(label);
+                }
+            }
+
+            return (boundaries, typeNames);
+        }
+
+        // Asserts that expectedLeafToRoot appears as an ordered subsequence of the captured boundary labels
+        // (leaf->root). Subsequence (not contiguous) matching tolerates unrelated frames between boundaries
+        // and repeated boundaries from nested resumes, while still enforcing the required relative order.
+        private static void AssertBoundarySubsequence(List<string> capturedLeafToRoot, params string[] expectedLeafToRoot)
+        {
+            int matched = 0;
+            foreach (string label in capturedLeafToRoot)
+            {
+                if (matched < expectedLeafToRoot.Length && label == expectedLeafToRoot[matched])
+                {
+                    matched++;
+                }
+            }
+
+            Assert.True(matched == expectedLeafToRoot.Length,
+                $"Expected async boundary frames [{string.Join(" -> ", expectedLeafToRoot)}] (leaf->root) were not all " +
+                $"present in order. Captured boundaries (leaf->root): [{string.Join(" -> ", capturedLeafToRoot)}].");
+        }
+
+        // Asserts each expected fragment appears (as a substring of a declaring type name) as an ordered
+        // subsequence of the captured declaring type names (leaf->root), tolerating unrelated frames between.
+        // Used to locate specific user state-machine frames by the method name embedded in their generated type.
+        private static void AssertFrameOrder(List<string> capturedLeafToRoot, params string[] expectedFragmentsLeafToRoot)
+        {
+            int matched = 0;
+            foreach (string typeName in capturedLeafToRoot)
+            {
+                if (matched < expectedFragmentsLeafToRoot.Length &&
+                    typeName.Contains(expectedFragmentsLeafToRoot[matched], StringComparison.Ordinal))
+                {
+                    matched++;
+                }
+            }
+
+            Assert.True(matched == expectedFragmentsLeafToRoot.Length,
+                $"Expected frames [{string.Join(" -> ", expectedFragmentsLeafToRoot)}] (leaf->root) were not all present " +
+                $"in order. Captured declaring types (leaf->root): [{string.Join(" -> ", capturedLeafToRoot)}].");
+        }
+
         private const string AsyncProfilerEventSourceName = "System.Runtime.CompilerServices.AsyncProfilerEventSource";
         private const string WrapperNameTemplate = "Continuation_Wrapper_{0}";
         private static readonly string WrapperNamePrefix = WrapperNameTemplate.Substring(0, WrapperNameTemplate.IndexOf("{0}", StringComparison.Ordinal));

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV1Tests.cs
@@ -3381,5 +3381,125 @@ namespace System.Threading.Tasks.Tests
                 }
             }
         }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_ResumeDispatchStack_ContainsExpectedBoundaryFrames(StrongBox<List<string>> capture)
+        {
+            await Task.Yield();
+            capture.Value = CaptureAsyncBoundarySequence();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
+        public void StateMachineAsync_ResumeDispatchStack()
+        {
+            var capture = new StrongBox<List<string>>();
+
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
+            {
+                RunScenario(() => StateMachineAsync_ResumeDispatchStack_ContainsExpectedBoundaryFrames(capture));
+            });
+
+            // DumpAllEvents(events);
+
+            Assert.True(capture.Value is not null,
+                "The state-machine continuation did not run (no boundary sequence was captured).");
+
+            // A V1 leaf resume runs through MoveNextAsDispatcher.
+            AssertBoundarySubsequence(capture.Value!, "V1.MoveNextAsDispatcher");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        private static async ValueTask StateMachineAsync_PoolingResumeDispatchStack_ContainsExpectedBoundaryFrames(StrongBox<List<string>> capture)
+        {
+            await Task.Yield();
+            capture.Value = CaptureAsyncBoundarySequence();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
+        public void StateMachineAsync_PoolingResumeDispatchStack()
+        {
+            var capture = new StrongBox<List<string>>();
+
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
+            {
+                RunScenario(() => StateMachineAsync_PoolingResumeDispatchStack_ContainsExpectedBoundaryFrames(capture).AsTask());
+            });
+
+            // DumpAllEvents(events);
+
+            Assert.True(capture.Value is not null,
+                "The pooling state-machine continuation did not run (no boundary sequence was captured).");
+
+            AssertBoundarySubsequence(capture.Value!, "V1.AsyncStateMachineDispatcher.MoveNext");
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_InlineCompletionClimb_Child(Task childGate)
+        {
+            await childGate;
+        }
+
+        [RuntimeAsyncMethodGeneration(false)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task StateMachineAsync_InlineCompletionClimb_ContainsExpectedBoundaryFrames(
+            Task childTask, StrongBox<(List<string> Boundaries, List<string> Types)> capture)
+        {
+            // This continuation is resumed inline as the child's continuation while the child is still
+            // completing, so the child's frames (its dispatch boundary + state-machine MoveNext) remain on the
+            // physical stack beneath this capture point -- the inline-completion layout the CPU stitcher must
+            // account for via completed-frame trimming.
+            await childTask;
+            capture.Value = CaptureAsyncStack();
+        }
+
+        [ConditionalFact(typeof(AsyncProfilerTests), nameof(IsStateMachineAsyncAndThreadingSupported))]
+        public void StateMachineAsync_InlineCompletionClimb()
+        {
+            var capture = new StrongBox<(List<string> Boundaries, List<string> Types)>();
+
+            var events = CollectEvents(ResumeStateMachineAsyncCallstackKeyword | StateMachineAsyncCoreKeywords, () =>
+            {
+                RunScenarioAndFlush(async () =>
+                {
+                    var childGate = new TaskCompletionSource();
+
+                    // Child suspends on childGate; parent suspends awaiting child.
+                    Task child = StateMachineAsync_InlineCompletionClimb_Child(childGate.Task);
+                    Task parent = StateMachineAsync_InlineCompletionClimb_ContainsExpectedBoundaryFrames(child, capture);
+
+                    // Completing the child inline resumes the parent inline (the climb under test): the child's
+                    // still-completing frames stay on the physical stack beneath the parent's resume.
+                    childGate.SetResult();
+
+                    await parent;
+                    await child;
+                });
+            });
+
+            // DumpAllEvents(events);
+
+            Assert.True(capture.Value.Boundaries is not null,
+                "The inline completion climb did not run (no stack was captured).");
+
+            // The still-completing child's state-machine frame remains on the stack below the resuming parent
+            // (leaf->root: parent above child), so a CPU sample here sees the completed child leaf frame.
+            AssertFrameOrder(capture.Value.Types,
+                nameof(StateMachineAsync_InlineCompletionClimb_ContainsExpectedBoundaryFrames),
+                nameof(StateMachineAsync_InlineCompletionClimb_Child));
+
+            // The child was resumed as a leaf through MoveNextAsDispatcher, and that boundary is still on the
+            // stack beneath the parent, so the completed leaf frame is paired with its dispatch boundary.
+            Assert.Contains("V1.MoveNextAsDispatcher", capture.Value.Boundaries);
+        }
+
+        [ConditionalTheory(nameof(IsStateMachineAsyncSupported))]
+        [InlineData("V1.MoveNextAsDispatcher")]
+        [InlineData("V1.AsyncStateMachineDispatcher.MoveNext")]
+        public void V1AsyncDispatchMethod_NameContract_IsStable(string key) =>
+            AssertAsyncDispatchMethodExists(key);
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerV2Tests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -2628,6 +2629,64 @@ namespace System.Threading.Tasks.Tests
                 "Expected a single ResetAsyncThreadContext window containing both a ResumeStateMachineAsyncContextKeyword " +
                 "(StateMachine) and a ResumeRuntimeAsyncContext (Runtime), proving the reset-replay merge walker traversed " +
                 "a mixed StateMachine+Runtime chain and exercised both branches of its address-ordered recursion.");
+        }
+
+        [ConditionalFact(nameof(IsRuntimeAsyncSupported), nameof(IsCoreClrJitRuntime))]
+        public void V2ContinuationWrapper_NameContract_IsStable()
+        {
+            // Pin the name/count the CPU stitcher hardcodes, rather than reflecting the runtime's
+            // NameTemplate/COUNT (which would let a drift in either value pass silently): assert every
+            // expected wrapper method exists, and that there is no wrapper one past the expected count.
+            const string WrapperNamePrefix = "Continuation_Wrapper_";
+            const int WrapperCount = 32;
+
+            Type wrapper = ContinuationWrapperType;
+
+            for (int i = 0; i < WrapperCount; i++)
+            {
+                string name = WrapperNamePrefix + i;
+                Assert.True(wrapper.GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static) is not null,
+                    $"Missing continuation wrapper method '{name}'; the CPU stitcher recognizes wrapper frames by this name.");
+            }
+
+            string oneBeyond = WrapperNamePrefix + WrapperCount;
+            Assert.True(wrapper.GetMethod(oneBeyond, BindingFlags.NonPublic | BindingFlags.Static) is null,
+                $"Unexpected continuation wrapper method '{oneBeyond}'; the wrapper count changed and the CPU stitcher must be updated to match.");
+        }
+
+        [ConditionalTheory(nameof(IsRuntimeAsyncSupported), nameof(IsCoreClrJitRuntime))]
+        [InlineData("V2.DispatchContinuations")]
+        [InlineData("V2.InstrumentedDispatchContinuations")]
+        public void V2AsyncDispatchMethod_NameContract_IsStable(string key) =>
+            AssertAsyncDispatchMethodExists(key);
+
+        [RuntimeAsyncMethodGeneration(true)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task RuntimeAsync_ResumeDispatchStack_ContainsExpectedBoundaryFrames(StrongBox<List<string>> capture)
+        {
+            await Task.Yield();
+            capture.Value = CaptureAsyncBoundarySequence();
+        }
+
+        [ConditionalFact(nameof(IsRuntimeAsyncAndThreadingSupported))]
+        public void RuntimeAsync_ResumeDispatchStack()
+        {
+            var capture = new StrongBox<List<string>>();
+
+            var events = CollectEvents(AllRuntimeAsyncKeywords, () =>
+            {
+                RunScenario(() => RuntimeAsync_ResumeDispatchStack_ContainsExpectedBoundaryFrames(capture));
+            });
+
+            // DumpAllEvents(events);
+
+            Assert.True(capture.Value is not null,
+                "The runtime-async continuation did not run (no boundary sequence was captured).");
+
+            AssertBoundarySubsequence(capture.Value!,
+                "Wrapper",
+                "V2.InstrumentedDispatchContinuations",
+                "V2.DispatchContinuations");
         }
     }
 }


### PR DESCRIPTION
## Changes

**Runtime (`System.Private.CoreLib`)**
- Add `[StackTraceHidden]` to the V1 dispatch frames (`InstrumentedMoveNext`, `MoveNextAsDispatcher`, `AsyncStateMachineDispatcher.MoveNext`) so V1 matches the already-hidden V2 dispatch frames. These frames stay out of managed stack traces but remain in the physical stack and in stack-trace metadata.
- Add name-contract comments (placed uniformly below the attribute) on the methods and types diagnostic tooling depends on by name.
- Rename the (not-yet-shipped) env var `DOTNET_AsyncProfilerEventSource_EventBufferSize` → `DOTNET_AsyncProfiler_EventBufferSize`; remove an unused `using`.

**Tests (`System.Threading.Tasks.Tests`)**
- **Name-contract tests** pin the identifiers the stitcher hardcodes: V1/V2 dispatch methods, and the V2 continuation wrappers (all 32 exist, none beyond — hardcoded rather than reflected so drift can't pass silently).
- **Frame-capture tests** capture the unfiltered physical managed stack from inside a resumed continuation and assert the boundary frames appear in the expected leaf→root order:
  - `RuntimeAsync_ResumeDispatchStack` (V2 single-yield)
  - `StateMachineAsync_ResumeDispatchStack` (V1 single-yield)
  - `StateMachineAsync_PoolingResumeDispatchStack` (V1 pooling → standalone
    `AsyncStateMachineDispatcher`)
  - `StateMachineAsync_InlineCompletionClimb` (V1 inline completion, child frames remain beneath the resuming parent)
- Frame identity is resolved via `DiagnosticMethodInfo` (stack-trace metadata) rather than `StackFrame.GetMethod()` (reflection), so the tests work on CoreCLR, Mono, and NativeAOT — the latter trims reflection metadata but preserves stack-trace metadata (including names for `[StackTraceHidden]` Ecma methods).

Tests are gated by runtime capability: V1 tests run on CoreCLR + Mono; V2 tests run on CoreCLR (+ NativeAOT for the frame-capture test); reflection-based name-contract tests are CoreCLR/Mono only.

## Risk / compatibility

- No change to async dispatch behavior. `[StackTraceHidden]` only affects stack-trace *display*, and the newly-hidden V1 `InstrumentedMoveNext` frames are only present when the async profiler is active.
- The env-var rename targets an unshipped diagnostic knob, so it is not a breaking change.