### PR TITLE
Remove Signature consumer documentation

### DIFF
--- a/docs/design/datacontracts/Signature.md
+++ b/docs/design/datacontracts/Signature.md
@@ -79,12 +79,6 @@ ITypeHandle? ISignature.DecodeFieldSignature(BlobHandle blobHandle, ModuleHandle
 }
 ```
 
-### Other consumers
-
-`RuntimeSignatureDecoder` is shared infrastructure. Other contracts construct their own decoder and provider directly when they need to decode method or local signatures rather than going through this contract.
-
-The [CallingConvention](./CallingConvention.md) contract uses the same decoder with a provider that keeps signature classification and generic shape separate from an optional exact loaded `ITypeHandle`.
-
 ### Vararg call cookies
 
 `GetVarArgArgsBase` and `GetVarArgSignature` decode a `VASigCookie*` slot pushed by a vararg call site.


### PR DESCRIPTION
Removes the Signature contract's description of its downstream consumers, as requested in #130447.\n\n> [!NOTE]\n> This PR description and the changes were produced with the assistance of GitHub Copilot.