### PR TITLE
Disable GC/API/Refresh test when using segments GC flavor

### DIFF
--- a/src/tests/GC/API/Refresh/Refresh.cs
+++ b/src/tests/GC/API/Refresh/Refresh.cs
@@ -8,25 +8,26 @@ namespace Refresh
 {
     public static class Program
     {
-        static bool UsesGcWithRegions()
+        public static bool UsesGcWithRegions 
         {
-            if (GC.GetConfigurationVariables().TryGetValue("GCUseRegions", out object? value) && value is true)
+            get
             {
-                return true;
+                // This is a way to guess if the runtime is using GC with regions, since we have no precise way to query that.
+                // It works for this test since we don't set the GCRegionRange explicitly, and the default value is 0 
+                // for non-GC with regions runtimes, and non-zero for GC with regions runtimes.
+                if (GC.GetConfigurationVariables().TryGetValue("GCRegionRange", out object? value) &&
+                    value is long range && range != 0)
+                {
+                    return true;
+                }
+                return false;
             }
-            return false;
         }
 
         [SkipOnCoreClr("This test is not compatible with GC stress.", RuntimeTestModes.AnyGCStress)]
-        [Fact]
+        [ConditionalFact(typeof(Program), nameof(UsesGcWithRegions))]
         public static int TestEntryPoint()
         {
-            if (!UsesGcWithRegions())
-            {
-                Console.WriteLine("Test skipped because GC does not use regions and the GCHeapHardLimit configuration variable is not supported.");
-                return 100;
-            }
-
             long hundred_mb = 100 * 1024 * 1024;
             long two_hundred_mb = 2 * hundred_mb;
             AppContext.SetData("GCHeapHardLimit", (ulong)hundred_mb);

--- a/src/tests/GC/API/Refresh/Refresh.cs
+++ b/src/tests/GC/API/Refresh/Refresh.cs
@@ -8,10 +8,25 @@ namespace Refresh
 {
     public static class Program
     {
+        static bool UsesGcWithRegions()
+        {
+            if (GC.GetConfigurationVariables().TryGetValue("GCUseRegions", out object? value) && value is true)
+            {
+                return true;
+            }
+            return false;
+        }
+
         [SkipOnCoreClr("This test is not compatible with GC stress.", RuntimeTestModes.AnyGCStress)]
         [Fact]
         public static int TestEntryPoint()
         {
+            if (!UsesGcWithRegions())
+            {
+                Console.WriteLine("Test skipped because GC does not use regions and the GCHeapHardLimit configuration variable is not supported.");
+                return 100;
+            }
+
             long hundred_mb = 100 * 1024 * 1024;
             long two_hundred_mb = 2 * hundred_mb;
             AppContext.SetData("GCHeapHardLimit", (ulong)hundred_mb);


### PR DESCRIPTION
The test was disabled on architecture basis before for targets that don't support regions GC, but that doesn't work when testing with the clrgc.dll that is build with segments GC flavor on 64 bit architectures.

Close #130828