### PR TITLE
Update Helix Job Monitor and turn it on for the `runtime` pipeline

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -27,7 +27,7 @@
       ]
     },
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26421.1",
+      "version": "11.0.0-beta.26424.2",
       "commands": [
         "dotnet-helix-job-monitor"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -27,7 +27,7 @@
       ]
     },
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26404.8",
+      "version": "11.0.0-beta.26406.8",
       "commands": [
         "dotnet-helix-job-monitor"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -27,7 +27,7 @@
       ]
     },
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26406.8",
+      "version": "11.0.0-beta.26407.3",
       "commands": [
         "dotnet-helix-job-monitor"
       ]

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -62,6 +62,12 @@ parameters:
   type: number
   default: 30
 
+# Maximum number of work items whose results may be downloaded, parsed, and
+# uploaded concurrently.
+- name: testResultUploadParallelism
+  type: number
+  default: 8
+
 # When 'true' (the default), Helix work items that exit 0 but have failed AzDO test results
 # are treated as failed: they count toward the monitor's exit code and are resubmitted by a
 # later invocation's retry pass. Set to 'false' to fall back to exit-code-only outcomes.
@@ -206,6 +212,7 @@ jobs:
         --max-wait-minutes            "$((${{ parameters.timeoutInMinutes }} - 5))" # Set the tool's timeout slightly lower than the Azure DevOps job timeout to allow it to exit gracefully.
         --stage-name                  '$(System.StageName)'
         --stage-attempt               '$(System.StageAttempt)'
+        --test-result-upload-parallelism '${{ parameters.testResultUploadParallelism }}'
       )
 
       organization='${{ parameters.organization }}'

--- a/eng/common/core-templates/job/helix-job-monitor.yml
+++ b/eng/common/core-templates/job/helix-job-monitor.yml
@@ -197,6 +197,7 @@ jobs:
         --fail-on-failed-tests        '${{ parameters.failWorkItemsWithFailedTests }}'
         --allow-no-helix-jobs         '${{ parameters.allowNoHelixJobs }}'
         --use-fully-qualified-test-name '${{ parameters.useFullyQualifiedTestName }}'
+        --verbose
         --max-wait-minutes            "$((${{ parameters.timeoutInMinutes }} - 5))" # Set the tool's timeout slightly lower than the Azure DevOps job timeout to allow it to exit gracefully.
         --stage-name                  '$(System.StageName)'
         --stage-attempt               '$(System.StageAttempt)'

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -50,7 +50,7 @@ pr:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -71,6 +71,7 @@ extends:
           parameters:
             helixAccessToken: $(HelixApiAccessToken)
             timeoutInMinutes: 540
+            testResultUploadParallelism: 48
             # Some path-filtered builds intentionally submit no Helix jobs.
             allowNoHelixJobs: true
 


### PR DESCRIPTION
## Summary
- update `Microsoft.DotNet.Helix.JobMonitor` to `11.0.0-beta.26424.2` from Arcade build `20260824.2`
- pick up the scalable result-processing rewrite from dotnet/arcade#17331, including build-scoped discovery, parallel incremental result uploads, retry-aware state, rate-limit handling, and final drain/status reporting
- add the template's configurable result-upload parallelism and run runtime CI with parallelism `48`
- enable the monitor in the runtime pipeline while allowing path-filtered builds with no Helix submissions