### PR TITLE
Use ubuntu-slim for trivial GitHub Actions

### DIFF
--- a/.github/workflows/check-no-merge-label.yml
+++ b/.github/workflows/check-no-merge-label.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   check-labels:
     if: github.repository == 'dotnet/runtime'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - name: Check 'NO-MERGE' label
       run: |

--- a/.github/workflows/check-service-labels.yml
+++ b/.github/workflows/check-service-labels.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   check-labels:
     if: github.repository == 'dotnet/runtime'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - name: Check 'Servicing-approved' label
       run: |


### PR DESCRIPTION
`ubuntu-slim` is a GitHub runner that well suited for performing "trivial" tasks that don't actually clone the repo, but do meta tasks like apply and read labels from issues and pull request. `-slim` instances generally have faster startup time and lower cost.

There are possibly other places `-slim` instances can be used but I thought we could start with these two and see how it goes.