### PR TITLE
Consolidate libraries Helix submissions

### DIFF
--- a/eng/pipelines/libraries/helix.yml
+++ b/eng/pipelines/libraries/helix.yml
@@ -2,6 +2,7 @@ parameters:
   runtimeFlavor: ''
   archType: ''
   buildConfig: ''
+  helixBuildConfig: ''
   creator: ''
   helixQueues: ''
   osGroup: ''
@@ -24,7 +25,7 @@ steps:
           /p:RuntimeFlavor=${{ parameters.runtimeFlavor }}
           /p:TargetArchitecture=${{ parameters.archType }}
           /p:TargetRuntimeIdentifier=${{ parameters.targetRid }}
-          /p:Configuration=${{ parameters.buildConfig }}
+          /p:Configuration=${{ coalesce(parameters.helixBuildConfig, parameters.buildConfig) }}
           /p:TargetOS=${{ parameters.osGroup }}
           /p:MonoForceInterpreter=${{ parameters.interpreter }}
           /p:TestScope=${{ parameters.testScope }}

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -289,12 +289,16 @@ extends:
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
           buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
           platforms:
           - linux_x64
           - linux_musl_x64
           - osx_arm64
           - windows_x64
+          variables:
+            - name: librariesContainsChange
+              value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
           jobParameters:
             nameSuffix: CoreCLR_Libraries
             buildArgs: -s clr+libs+libs.tests -rc Release -c $(_BuildConfig) /p:ArchiveTests=true
@@ -312,14 +316,16 @@ extends:
                   tarCompression: $(tarCompression)
                   artifactName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
                   displayName: Build Assets
-              - template: /eng/pipelines/common/upload-artifact-step.yml
+              - template: /eng/pipelines/libraries/helix.yml
                 parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/helix
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: CoreCLR_Libraries_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: coreclr_release
+                  testScope: innerloop
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+                  condition: >-
+                    or(
+                      eq(variables['librariesContainsChange'], true),
+                      eq(variables['isRollingBuild'], true))
             condition: >-
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
@@ -329,9 +335,13 @@ extends:
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
           buildConfig: release
           platforms:
           - windows_x86
+          variables:
+            - name: librariesContainsChange
+              value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
           jobParameters:
             nameSuffix: CoreCLR_Libraries
             buildArgs: -s clr+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
@@ -346,14 +356,17 @@ extends:
                   tarCompression: $(tarCompression)
                   artifactName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
                   displayName: Build Assets
-              - template: /eng/pipelines/common/upload-artifact-step.yml
+              - template: /eng/pipelines/libraries/helix.yml
                 parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/helix
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: CoreCLR_Libraries_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+                  helixBuildConfig: Release
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: coreclr_release
+                  testScope: innerloop
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+                  condition: >-
+                    or(
+                      eq(variables['librariesContainsChange'], true),
+                      eq(variables['isRollingBuild'], true))
             condition: >-
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
@@ -397,10 +410,17 @@ extends:
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          helixQueueGroup: libraries
           buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
           platforms:
           - linux_arm64
           - osx_arm64
+          variables:
+            - name: librariesContainsChange
+              value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+            - name: coreclrContainsChange
+              value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
           jobParameters:
             nameSuffix: Libraries_CheckedCoreCLR
             buildArgs: -s clr+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:ArchiveTests=true
@@ -419,14 +439,19 @@ extends:
                   tarCompression: $(tarCompression)
                   artifactName: Libraries_CheckedCoreCLR_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
                   displayName: Build Assets
-              - template: /eng/pipelines/common/upload-artifact-step.yml
+              - template: /eng/pipelines/libraries/helix.yml
                 parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/helix
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: Libraries_CheckedCoreCLR_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: coreclr_checked
+                  testScope: innerloop
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+                  condition: >-
+                    or(
+                      eq(variables['coreclrContainsChange'], true),
+                      and(
+                        eq(variables['osGroup'], 'osx'),
+                        eq(variables['librariesContainsChange'], true)),
+                      eq(variables['isRollingBuild'], true))
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/native-test-assets-variables.yml
                 parameters:
@@ -478,10 +503,15 @@ extends:
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          helixQueueGroup: libraries
           buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
           platforms:
           - linux_musl_x64
           - windows_x86
+          variables:
+            - name: coreclrContainsChange
+              value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
           jobParameters:
             nameSuffix: Libraries_CheckedCoreCLR
             buildArgs: -s clr+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:ArchiveTests=true
@@ -496,14 +526,16 @@ extends:
                   tarCompression: $(tarCompression)
                   artifactName: Libraries_CheckedCoreCLR_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
                   displayName: Build Assets
-              - template: /eng/pipelines/common/upload-artifact-step.yml
+              - template: /eng/pipelines/libraries/helix.yml
                 parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/helix
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: Libraries_CheckedCoreCLR_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: coreclr_checked
+                  testScope: innerloop
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+                  condition: >-
+                    or(
+                      eq(variables['coreclrContainsChange'], true),
+                      eq(variables['isRollingBuild'], true))
             condition: >-
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -577,6 +609,8 @@ extends:
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          helixQueueGroup: libraries
           buildConfig: checked
           platforms:
           - linux_x64
@@ -600,14 +634,13 @@ extends:
                   tarCompression: $(tarCompression)
                   artifactName: CoreCLR_ReleaseLibraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
                   displayName: Build Assets
-              - template: /eng/pipelines/common/upload-artifact-step.yml
+              - template: /eng/pipelines/libraries/helix.yml
                 parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/helix
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: CoreCLR_ReleaseLibraries_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+                  helixBuildConfig: Release
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: coreclr_checked
+                  testScope: innerloop
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             condition: >-
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -1860,147 +1893,6 @@ extends:
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Libraries Release Test Execution against a release coreclr runtime
-      # Only when the PR contains a libraries change
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: Release
-          platforms:
-          - windows_x86
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          jobParameters:
-            isOfficialBuild: false
-            testScope: innerloop
-            liveRuntimeBuildConfig: release
-            unifiedArtifactsName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-            helixArtifactsName: CoreCLR_Libraries_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-            unifiedBuildNameSuffix: CoreCLR_Libraries
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
-            condition: >-
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Libraries Debug Test Execution against a release coreclr runtime
-      # Only when the PR contains a libraries change
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          - windows_x64
-          - osx_arm64
-          - linux_x64
-          - linux_musl_x64
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          jobParameters:
-            isOfficialBuild: false
-            testScope: innerloop
-            liveRuntimeBuildConfig: release
-            unifiedArtifactsName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(debugOnPrReleaseOnRolling)
-            helixArtifactsName: CoreCLR_Libraries_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(debugOnPrReleaseOnRolling)
-            unifiedBuildNameSuffix: CoreCLR_Libraries
-            unifiedBuildConfigOverride: ${{ variables.debugOnPrReleaseOnRolling }}
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
-            condition: >-
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-      # The next three jobs run checked coreclr + <either debug or release in PR> libraries tests.
-      # The matrix looks like the following, where the right columns specify which configurations
-      # the libraries tests are built in.
-      # ________________________________________
-      # | Platform         | PR      | Rolling |
-      # | ---------------- | ------- | ------- |
-      # | linux-arm64      | Debug   | Release |
-      # | windows-x86      | Debug   | Release |
-      # | linux-musl-x64   | Debug   | Release |
-      # | osx-arm64        | Debug   | Release |
-      # | linux-musl-arm   | Release | Release |
-      # | linux-musl-arm64 | Release | Release |
-      # | linux-x64        | Release | Release |
-      # | windows-x64      | Release | Release |
-
-      #
-      # Debug (PR) / Release (rolling) Libraries Test Execution against a checked runtime
-      # Only when the PR contains a coreclr change
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          - linux_arm64
-          - windows_x86
-          - linux_musl_x64
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          helixQueueGroup: libraries
-          jobParameters:
-            testScope: innerloop
-            liveRuntimeBuildConfig: checked
-            unifiedArtifactsName: Libraries_CheckedCoreCLR_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-            helixArtifactsName: Libraries_CheckedCoreCLR_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-            unifiedBuildNameSuffix: Libraries_CheckedCoreCLR
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
-            condition: >-
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Release Libraries Test Execution against a checked runtime
-      # Only if CoreCLR or Libraries is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: Release
-          platforms:
-          - linux_musl_arm
-          - linux_musl_arm64
-          - linux_x64
-          - windows_x64
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          helixQueueGroup: libraries
-          jobParameters:
-            testScope: innerloop
-            liveRuntimeBuildConfig: checked
-            unifiedArtifactsName: CoreCLR_ReleaseLibraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_Checked
-            helixArtifactsName: CoreCLR_ReleaseLibraries_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_Checked
-            unifiedBuildNameSuffix: CoreCLR_ReleaseLibraries
-            unifiedBuildConfigOverride: checked
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
-            condition: >-
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-          - osx_arm64
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          helixQueueGroup: libraries
-          jobParameters:
-            testScope: innerloop
-            liveRuntimeBuildConfig: checked
-            unifiedArtifactsName: Libraries_CheckedCoreCLR_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-            helixArtifactsName: Libraries_CheckedCoreCLR_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-            unifiedBuildNameSuffix: Libraries_CheckedCoreCLR
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
-            condition: >-
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
       #


### PR DESCRIPTION
With the Helix Job Monitor enabled, Helix submissions no longer need dedicated Azure DevOps jobs to wait for test completion.

Move the libraries Helix submissions into the combined CoreCLR/libraries build jobs, where both the runtime and test payloads are already available. This removes 13 artifact-only test-run jobs and avoids publishing and downloading their libraries test artifacts.

The existing platform matrices, Helix queues, path-based submission conditions, runtime configurations, and test-run names are preserved. The shared libraries Helix template now accepts a separate submission configuration for producer jobs whose build configuration differs from the libraries test configuration.

> [!NOTE]
> This pull request was prepared with GitHub Copilot.