### PR TITLE
[LoongArch64] Fix some crash CoreRoot tests under --gcstresslevel=4 like Methodical_{r2|d2}.

### DIFF
--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -6806,11 +6806,12 @@ void CodeGen::genPopCalleeSavedRegisters(bool jmpEpilog)
         if ((localFrameSize + (m_compiler->compCalleeRegsPushed << 3)) > 2040)
         {
             remainingSPSize = localFrameSize & -16;
-            genStackPointerAdjustment(remainingSPSize, REG_RA, nullptr, /* reportUnwindData */ true);
+            genStackPointerAdjustment(remainingSPSize, REG_RA, nullptr, /* reportUnwindData */ false);
 
             remainingSPSize = totalFrameSize - remainingSPSize;
             FP_offset       = localFrameSize & 0xf;
         }
+        m_compiler->unwindSetFrameReg(REG_FPBASE, FP_offset);
     }
 
     JITDUMP("    calleeSaveSPOffset=%d\n", FP_offset + 16);

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -125,7 +125,9 @@ inline bool emitter::emitInsMayWriteToGCReg(instruction ins)
             ((INS_vpickve2gr_h <= ins) && (ins <= INS_vpickve2gr_bu)) ||
             ((INS_xvpickve2gr_d <= ins) && (ins <= INS_xvpickve2gr_wu))
 #endif
-                ) ? true : false;
+                )
+               ? true
+               : false;
 }
 
 bool emitter::emitInsWritesToLclVarStackLoc(instrDesc* id)
@@ -1334,7 +1336,8 @@ void emitter::emitIns_R_R_I(
         code |= (reg2 & 0x1f) << 5; // xj/vj/rj
         code |= (imm & 0x3) << 10;  // ui2
     }
-    else if (((INS_vslli_b <= ins) && (ins <= INS_vpickve2gr_hu)) || ((INS_xvpickve2gr_w <= ins) && (ins <= INS_xvsat_bu)))
+    else if (((INS_vslli_b <= ins) && (ins <= INS_vpickve2gr_hu)) ||
+             ((INS_xvpickve2gr_w <= ins) && (ins <= INS_xvsat_bu)))
     {
 #ifdef DEBUG
         if ((INS_vinsgr2vr_h == ins) || (INS_xvinsgr2vr_w == ins))

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -119,7 +119,14 @@ inline bool emitter::emitInsMayWriteToGCReg(instruction ins)
 {
     assert(ins != INS_invalid);
     // NOTE: please reference the file "instrsloongarch64.h" for details !!!
-    return (INS_mov <= ins) && (ins <= INS_jirl) ? true : false;
+    return (((INS_mov <= ins) && (ins <= INS_jirl)) || (ins == INS_movfcsr2gr) || (ins == INS_movcf2gr)
+#ifdef FEATURE_SIMD
+            || (ins == INS_vpickve2gr_d) || (ins == INS_vpickve2gr_du) || (ins == INS_vpickve2gr_w)
+            || (ins == INS_vpickve2gr_wu) || (ins == INS_vpickve2gr_hu) || (ins == INS_vpickve2gr_hu)
+            || (ins == vpickve2gr_b) || (ins == INS_vpickve2gr_bu) || (ins == xvpickve2gr_d)
+            || (ins == xvpickve2gr_du) || (ins == xvpickve2gr_w) || (ins == xvpickve2gr_wu)
+#endif
+           )? true : false;
 }
 
 bool emitter::emitInsWritesToLclVarStackLoc(instrDesc* id)

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -121,12 +121,14 @@ inline bool emitter::emitInsMayWriteToGCReg(instruction ins)
     // NOTE: please reference the file "instrsloongarch64.h" for details !!!
     return (((INS_mov <= ins) && (ins <= INS_jirl)) || (ins == INS_movfcsr2gr) || (ins == INS_movcf2gr)
 #ifdef FEATURE_SIMD
-            || (ins == INS_vpickve2gr_d) || (ins == INS_vpickve2gr_du) || (ins == INS_vpickve2gr_w)
-            || (ins == INS_vpickve2gr_wu) || (ins == INS_vpickve2gr_hu) || (ins == INS_vpickve2gr_hu)
-            || (ins == vpickve2gr_b) || (ins == INS_vpickve2gr_bu) || (ins == xvpickve2gr_d)
-            || (ins == xvpickve2gr_du) || (ins == xvpickve2gr_w) || (ins == xvpickve2gr_wu)
+            || (ins == INS_vpickve2gr_d) || (ins == INS_vpickve2gr_du) || (ins == INS_vpickve2gr_w) ||
+            (ins == INS_vpickve2gr_wu) || (ins == INS_vpickve2gr_hu) || (ins == INS_vpickve2gr_hu) ||
+            (ins == vpickve2gr_b) || (ins == INS_vpickve2gr_bu) || (ins == xvpickve2gr_d) || (ins == xvpickve2gr_du) ||
+            (ins == xvpickve2gr_w) || (ins == xvpickve2gr_wu)
 #endif
-           )? true : false;
+                )
+               ? true
+               : false;
 }
 
 bool emitter::emitInsWritesToLclVarStackLoc(instrDesc* id)

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -121,14 +121,11 @@ inline bool emitter::emitInsMayWriteToGCReg(instruction ins)
     // NOTE: please reference the file "instrsloongarch64.h" for details !!!
     return (((INS_mov <= ins) && (ins <= INS_jirl)) || (ins == INS_movfcsr2gr) || (ins == INS_movcf2gr)
 #ifdef FEATURE_SIMD
-            || (ins == INS_vpickve2gr_d) || (ins == INS_vpickve2gr_du) || (ins == INS_vpickve2gr_w) ||
-            (ins == INS_vpickve2gr_wu) || (ins == INS_vpickve2gr_hu) || (ins == INS_vpickve2gr_hu) ||
-            (ins == vpickve2gr_b) || (ins == INS_vpickve2gr_bu) || (ins == xvpickve2gr_d) || (ins == xvpickve2gr_du) ||
-            (ins == xvpickve2gr_w) || (ins == xvpickve2gr_wu)
+            || ((INS_vpickve2gr_d <= ins) && (ins <= INS_vpickve2gr_wu)) ||
+            ((INS_vpickve2gr_h <= ins) && (ins <= INS_vpickve2gr_bu)) ||
+            ((INS_xvpickve2gr_d <= ins) && (ins <= INS_xvpickve2gr_wu))
 #endif
-                )
-               ? true
-               : false;
+                ) ? true : false;
 }
 
 bool emitter::emitInsWritesToLclVarStackLoc(instrDesc* id)
@@ -1266,7 +1263,7 @@ void emitter::emitIns_R_R_I(
         code |= (reg2 & 0x1f) << 5;  // rj
         code |= (imm & 0xfff) << 10; // si12
     }
-    else if (((INS_vinsgr2vr_d <= ins) && (ins <= INS_vreplvei_d)) || (INS_xvrepl128vei_d == ins))
+    else if (((INS_vinsgr2vr_d <= ins) && (ins <= INS_vpickve2gr_du)) || (INS_xvrepl128vei_d == ins))
     {
 #ifdef DEBUG
         if (INS_vinsgr2vr_d == ins)
@@ -1291,7 +1288,7 @@ void emitter::emitIns_R_R_I(
         code |= (reg2 & 0x1f) << 5;
         code |= (imm & 0x1) << 10; // ui1
     }
-    else if (((INS_vinsgr2vr_w <= ins) && (ins <= INS_vreplvei_w)) ||
+    else if (((INS_vpickve2gr_w <= ins) && (ins <= INS_vreplvei_w)) ||
              ((INS_xvinsve0_d <= ins) && (ins <= INS_xvpickve2gr_du)))
     {
 #ifdef DEBUG
@@ -1337,7 +1334,7 @@ void emitter::emitIns_R_R_I(
         code |= (reg2 & 0x1f) << 5; // xj/vj/rj
         code |= (imm & 0x3) << 10;  // ui2
     }
-    else if (((INS_vslli_b <= ins) && (ins <= INS_vreplvei_h)) || ((INS_xvslli_b <= ins) && (ins <= INS_xvsat_bu)))
+    else if (((INS_vslli_b <= ins) && (ins <= INS_vpickve2gr_hu)) || ((INS_xvpickve2gr_w <= ins) && (ins <= INS_xvsat_bu)))
     {
 #ifdef DEBUG
         if ((INS_vinsgr2vr_h == ins) || (INS_xvinsgr2vr_w == ins))
@@ -1365,7 +1362,7 @@ void emitter::emitIns_R_R_I(
         code |= (reg2 & 0x1f) << 5; // vj(xj)
         code |= (imm & 0x7) << 10;  // ui3
     }
-    else if (((INS_vslli_h <= ins) && (ins <= INS_vreplvei_b)) || ((INS_xvslli_h <= ins) && (ins <= INS_xvsat_hu)))
+    else if (((INS_vpickve2gr_b <= ins) && (ins <= INS_vreplvei_b)) || ((INS_xvslli_h <= ins) && (ins <= INS_xvsat_hu)))
     {
 #ifdef DEBUG
         if (INS_vinsgr2vr_b == ins)
@@ -1373,12 +1370,7 @@ void emitter::emitIns_R_R_I(
             assert(isVectorRegister(reg1));      // vd/xd
             assert(isGeneralRegisterOrR0(reg2)); // rj
         }
-        else if (INS_vpickve2gr_b == ins)
-        {
-            assert(isGeneralRegisterOrR0(reg1)); // rd
-            assert(isVectorRegister(reg2));      // vj/xj
-        }
-        else if (INS_vpickve2gr_bu == ins)
+        else if ((INS_vpickve2gr_b == ins) || (INS_vpickve2gr_bu == ins))
         {
             assert(isGeneralRegisterOrR0(reg1)); // rd
             assert(isVectorRegister(reg2));      // vj/xj

--- a/src/coreclr/jit/instrsloongarch64.h
+++ b/src/coreclr/jit/instrsloongarch64.h
@@ -1075,13 +1075,13 @@ INST(vldrepl_b,         "vldrepl.b",        LD, 0x30800000,0xffc00000,DF_S_RGX)
 INST(vst,               "vst",              ST, 0x2c400000,0xffc00000,DF_S_RGX)
 // ui1
 INST(vinsgr2vr_d,       "vinsgr2vr.d",      0,  0x72ebf000,0xfffff800,DF_S_RGX) // vd,rj,ui1
+INST(vreplvei_d,        "vreplvei.d",       0,  0x72f7f000,0xfffff800,DF_S_2RX) // vd,vj,ui1
 INST(vpickve2gr_d,      "vpickve2gr.d",     0,  0x72eff000,0xfffff800,DF_S_GRX) // rd,vj,ui1
 INST(vpickve2gr_du,     "vpickve2gr.du",    0,  0x72f3f000,0xfffff800,DF_S_GRX) // rd,vj,ui1
-INST(vreplvei_d,        "vreplvei.d",       0,  0x72f7f000,0xfffff800,DF_S_2RX) // vd,vj,ui1
 // ui2
-INST(vinsgr2vr_w,       "vinsgr2vr.w",      0,  0x72ebe000,0xfffff000,DF_S_RGX) // vd,rj,ui2
 INST(vpickve2gr_w,      "vpickve2gr.w",     0,  0x72efe000,0xfffff000,DF_S_GRX) // rd,vj,ui2
 INST(vpickve2gr_wu,     "vpickve2gr.wu",    0,  0x72f3e000,0xfffff000,DF_S_GRX) // rd,vj,ui2
+INST(vinsgr2vr_w,       "vinsgr2vr.w",      0,  0x72ebe000,0xfffff000,DF_S_RGX) // vd,rj,ui2
 INST(vreplvei_w,        "vreplvei.w",       0,  0x72f7e000,0xfffff000,DF_S_2RX) // vd,vj,ui2
 // ui3
 INST(vslli_b,           "vslli.b",          0,  0x732c2000,0xffffe000,DF_S_2R3IU) // vd,vj,ui3
@@ -1097,11 +1097,13 @@ INST(vbitseti_b,        "vbitseti.b",       0,  0x73142000,0xffffe000,DF_S_2R3IU
 INST(vbitrevi_b,        "vbitrevi.b",       0,  0x73182000,0xffffe000,DF_S_2R3IU)
 INST(vsat_b,            "vsat.b",           0,  0x73242000,0xffffe000,DF_S_2R3IU)
 INST(vsat_bu,           "vsat.bu",          0,  0x73282000,0xffffe000,DF_S_2R3IU)
+INST(vreplvei_h,        "vreplvei.h",       0,  0x72f7c000,0xffffe000,DF_S_2R3IU) // vd,vj,ui3
 INST(vinsgr2vr_h,       "vinsgr2vr.h",      0,  0x72ebc000,0xffffe000,DF_S_RGX)   // vd,rj,ui3
 INST(vpickve2gr_h,      "vpickve2gr.h",     0,  0x72efc000,0xffffe000,DF_S_GRX)   // rd,vj,ui3
 INST(vpickve2gr_hu,     "vpickve2gr.hu",    0,  0x72f3c000,0xffffe000,DF_S_GRX)   // rd,vj,ui3
-INST(vreplvei_h,        "vreplvei.h",       0,  0x72f7c000,0xffffe000,DF_S_2R3IU) // vd,vj,ui3
 // ui4
+INST(vpickve2gr_b,      "vpickve2gr.b",     0,  0x72ef8000,0xffffc000,DF_S_GRX)   // rd,vj,ui4
+INST(vpickve2gr_bu,     "vpickve2gr.bu",    0,  0x72f38000,0xffffc000,DF_S_GRX)   // rd,vj,ui4
 INST(vslli_h,           "vslli.h",          0,  0x732c4000,0xffffc000,DF_S_2R4IU) // vd,vj,ui4
 INST(vsrli_h,           "vsrli.h",          0,  0x73304000,0xffffc000,DF_S_2R4IU)
 INST(vsrai_h,           "vsrai.h",          0,  0x73344000,0xffffc000,DF_S_2R4IU)
@@ -1128,8 +1130,6 @@ INST(vbitrevi_h,        "vbitrevi.h",       0,  0x73184000,0xffffc000,DF_S_2R4IU
 INST(vsat_h,            "vsat.h",           0,  0x73244000,0xffffc000,DF_S_2R4IU)
 INST(vsat_hu,           "vsat.hu",          0,  0x73284000,0xffffc000,DF_S_2R4IU)
 INST(vinsgr2vr_b,       "vinsgr2vr.b",      0,  0x72eb8000,0xffffc000,DF_S_RGX)   // vd,rj,ui4
-INST(vpickve2gr_b,      "vpickve2gr.b",     0,  0x72ef8000,0xffffc000,DF_S_GRX)   // rd,vj,ui4
-INST(vpickve2gr_bu,     "vpickve2gr.bu",    0,  0x72f38000,0xffffc000,DF_S_GRX)   // rd,vj,ui4
 INST(vreplvei_b,        "vreplvei.b",       0,  0x72f78000,0xffffc000,DF_S_2R4IU) // vd,vj,ui4
 // ui5
 INST(vslei_bu,          "vslei.bu",         0,  0x72840000,0xffff8000,DF_S_2R5IU) // vd,vj,ui5
@@ -1837,6 +1837,8 @@ INST(xvinsgr2vr_d,      "xvinsgr2vr.d",     0,  0x76ebe000,0xfffff000,DF_A_RGX) 
 INST(xvpickve2gr_d,     "xvpickve2gr.d",    0,  0x76efe000,0xfffff000,DF_A_GRX)  // rd,xj,ui2
 INST(xvpickve2gr_du,    "xvpickve2gr.du",   0,  0x76f3e000,0xfffff000,DF_A_GRX)  // rd,xj,ui2
 // ui3
+INST(xvpickve2gr_w,     "xvpickve2gr.w",    0,  0x76efc000,0xffffe000,DF_A_GRX)   // rd,xj,ui3
+INST(xvpickve2gr_wu,    "xvpickve2gr.wu",   0,  0x76f3c000,0xffffe000,DF_A_GRX)   // rd,xj,ui3
 INST(xvslli_b,          "xvslli.b",         0,  0x772c2000,0xffffe000,DF_A_2R3IU) // xd,xj,ui3
 INST(xvsrli_b,          "xvsrli.b",         0,  0x77302000,0xffffe000,DF_A_2R3IU)
 INST(xvsrai_b,          "xvsrai.b",         0,  0x77342000,0xffffe000,DF_A_2R3IU)
@@ -1864,8 +1866,6 @@ INST(xvbitclri_b,       "xvbitclri.b",      0,  0x77102000,0xffffe000,DF_A_2R3IU
 INST(xvbitseti_b,       "xvbitseti.b",      0,  0x77142000,0xffffe000,DF_A_2R3IU)
 INST(xvbitrevi_b,       "xvbitrevi.b",      0,  0x77182000,0xffffe000,DF_A_2R3IU)
 INST(xvinsgr2vr_w,      "xvinsgr2vr.w",     0,  0x76ebc000,0xffffe000,DF_A_RGX)   // xd,rj,ui3
-INST(xvpickve2gr_w,     "xvpickve2gr.w",    0,  0x76efc000,0xffffe000,DF_A_GRX)   // rd,xj,ui3
-INST(xvpickve2gr_wu,    "xvpickve2gr.wu",   0,  0x76f3c000,0xffffe000,DF_A_GRX)   // rd,xj,ui3
 INST(xvsat_b,           "xvsat.b",          0,  0x77242000,0xffffe000,DF_A_2R3IU) // vd,xj,ui3
 INST(xvsat_bu,          "xvsat.bu",         0,  0x77282000,0xffffe000,DF_A_2R3IU) // vd,xj,ui3
 // ui4

--- a/src/coreclr/nativeaot/Runtime/loongarch64/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/loongarch64/GcProbe.S
@@ -131,7 +131,6 @@ NESTED_END RhpGcProbeHijack
 
 .global C_FUNC(RhpThrowHwEx)
 
-// Wait for GC function
 NESTED_ENTRY RhpWaitForGC, _TEXT, NoHandler
     PUSH_PROBE_FRAME $a4, $a3, $t3
 
@@ -144,14 +143,12 @@ NESTED_END RhpWaitForGC
 
 .global C_FUNC(RhpGcPoll2)
 
-// GC Poll function
 LEAF_ENTRY RhpGcPoll
     PREPARE_EXTERNAL_VAR_INDIRECT_W RhpTrapThreads, $a0
     bnez  $a0, C_FUNC(RhpGcPollRare)
     jirl  $r0, $ra, 0
 LEAF_END RhpGcPoll
 
-// Rare GC Poll function
 NESTED_ENTRY RhpGcPollRare, _TEXT, NoHandler
     PUSH_COOP_PINVOKE_FRAME  $a0
     bl  RhpGcPoll2

--- a/src/coreclr/nativeaot/Runtime/loongarch64/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/loongarch64/GcProbe.S
@@ -50,7 +50,7 @@
 
     // Perform the rest of the PInvokeTransitionFrame initialization.
     st.d  \threadReg, $sp, OFFSETOF__PInvokeTransitionFrame__m_pThread   // Thread * (unused by stackwalker)
-    st.d  \BITMASK, $sp, OFFSETOF__PInvokeTransitionFrame__m_pThread + 8 // save the register bitmask passed in by caller
+    st.d  \BITMASK, $sp, OFFSETOF__PInvokeTransitionFrame__m_Flags       // save the register bitmask passed in by caller
 
     addi.d  \trashReg, $sp,  PROBE_FRAME_SIZE                            // recover value of caller's SP
     st.d  \trashReg, $sp, 0x68                                           // save caller's SP
@@ -104,15 +104,13 @@
     //
     // Fix the stack by restoring the original return address
     //
-    // Load m_pvHijackedReturnAddress
     ld.d  $ra, $a4, OFFSETOF__Thread__m_pvHijackedReturnAddress
 
     //
     // Clear hijack state
     //
-    // Clear m_ppvHijackedReturnAddressLocation and m_pvHijackedReturnAddress
     st.d  $zero, $a4, OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation
-    st.d  $zero, $a4, OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation + 8
+    st.d  $zero, $a4, OFFSETOF__Thread__m_pvHijackedReturnAddress
 .endm
 
 //
@@ -133,6 +131,7 @@ NESTED_END RhpGcProbeHijack
 
 .global C_FUNC(RhpThrowHwEx)
 
+// Wait for GC function
 NESTED_ENTRY RhpWaitForGC, _TEXT, NoHandler
     PUSH_PROBE_FRAME $a4, $a3, $t3
 
@@ -145,19 +144,20 @@ NESTED_END RhpWaitForGC
 
 .global C_FUNC(RhpGcPoll2)
 
+// GC Poll function
 LEAF_ENTRY RhpGcPoll
     PREPARE_EXTERNAL_VAR_INDIRECT_W RhpTrapThreads, $a0
     bnez  $a0, C_FUNC(RhpGcPollRare)
     jirl  $r0, $ra, 0
 LEAF_END RhpGcPoll
 
+// Rare GC Poll function
 NESTED_ENTRY RhpGcPollRare, _TEXT, NoHandler
     PUSH_COOP_PINVOKE_FRAME  $a0
     bl  RhpGcPoll2
     POP_COOP_PINVOKE_FRAME
     jirl  $r0, $ra, 0
 NESTED_END RhpGcPollRare
-
 
 #ifdef FEATURE_GC_STRESS
 

--- a/src/coreclr/nativeaot/Runtime/loongarch64/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/loongarch64/PInvoke.S
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 #include <unixasmmacros.inc>
 #include "AsmOffsets.inc"
 
@@ -43,6 +42,6 @@ LEAF_ENTRY RhpPInvokeReturn, _TEXT
         bnez  $t0, 0f  // TrapThreadsFlags_None = 0
         jirl  $r0, $ra, 0
 0:
-        // passing transition frame pointer in x0
+        // passing transition frame pointer in a0
         b  C_FUNC(RhpWaitForGC2)
 LEAF_END RhpPInvokeReturn, _TEXT

--- a/src/coreclr/nativeaot/Runtime/loongarch64/UniversalTransition.S
+++ b/src/coreclr/nativeaot/Runtime/loongarch64/UniversalTransition.S
@@ -46,7 +46,7 @@
 //
 // RhpUniversalTransition
 //
-// At input to this function, a0-7, f0-7 and the stack may contain any number of arguments.
+// At input to this function, a0-a7, f0-f7 and the stack may contain any number of arguments.
 //
 // In addition, there are 2 extra arguments passed in the intra-procedure-call scratch register:
 //  t7 will contain the managed function that is to be called by this transition function
@@ -99,7 +99,7 @@
         fst.d  $f6, $sp, FLOAT_ARG_OFFSET + 0x30
         fst.d  $f7, $sp, FLOAT_ARG_OFFSET + 0x38
 
-        // Space for return buffer data (0x40 bytes)
+        // Space for return buffer data (0x10 bytes)
 
         // Save argument registers
         st.d  $a0, $sp, ARGUMENT_REGISTERS_OFFSET

--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosloongarch64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosloongarch64.inc
@@ -150,7 +150,7 @@ C_FUNC(\Name):
     INLINE_GET_TLS_VAR  \target, C_FUNC(tls_CurrentThread)
 .endm
 
-// Target cannot be x0.
+// Target cannot be a0.
 .macro INLINE_GET_ALLOC_CONTEXT_BASE target
     INLINE_GET_TLS_VAR  \target, C_FUNC(tls_CurrentThread)
 .endm

--- a/src/coreclr/runtime/loongarch64/AllocFast.S
+++ b/src/coreclr/runtime/loongarch64/AllocFast.S
@@ -14,7 +14,7 @@
         //
         // a0 contains MethodTable pointer
         //
-        ld.w  $a2, $a0, OFFSETOF__ee_alloc_context + OFFSETOF__MethodTable__m_uBaseSize
+        ld.w  $a2, $a0, OFFSETOF__MethodTable__m_uBaseSize
 
         //
         // a0: MethodTable pointer

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -1886,7 +1886,7 @@ template <typename GcInfoEncoding> OBJECTREF* TGcInfoDecoder<GcInfoEncoding>::Ge
     }
     else if (regNum < 22)
     {
-        return (OBJECTREF*)*(DWORD64**)(&pRD->volatileCurrContextPointers.A0 + (regNum - 4));//A0=4.
+        return (OBJECTREF*)*(DWORD64**)(&pRD->volatileCurrContextPointers.A0 + (regNum - 4)); // A0=4.
     }
 
     return (OBJECTREF*)*(DWORD64**)(&pRD->pCurrentContextPointers->S0 + (regNum-23));
@@ -1900,7 +1900,7 @@ template <typename GcInfoEncoding> bool TGcInfoDecoder<GcInfoEncoding>::IsScratc
     return (regNum <= 21 && ((regNum >= 4) || (regNum == 1)));
 }
 
-template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRegisterToGC(
+template <typename GcInfoEncoding> void TGcInfoDecoder<GcInfoEncoding>::ReportRegisterToGC( // LOONGARCH64
                                 int             regNum,
                                 unsigned        gcFlags,
                                 PREGDISPLAY     pRD,


### PR DESCRIPTION
* Fix the instruction range in emitter::emitInsMayWriteToGCReg().
* Fix the REG_FPBASE unwind data record with large Frame type in epilog.
* Amend some outdated code and notes in nativeaot.