### PR TITLE
JIT: fold wasm address modes into the load/store memarg

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1334,7 +1334,23 @@ bool CodeGen::genCreateAddrMode(GenTree*  addr,
 // TODO-WASM: Prove whether a given addressing mode obeys the Wasm rules.
 // See https://github.com/dotnet/runtime/pull/122897#issuecomment-3721304477 for more details.
 #if defined(TARGET_WASM)
-    return false;
+    // Wasm only folds "base + constant" into the memarg. See "Lowering::GetFoldableAddrMode" for why a GC-typed
+    // base and a non-negative constant prove the addition does not wrap. A relocatable constant cannot fold
+    // because that would drop the relocation.
+    //
+    if (!addr->OperIs(GT_ADD) || addr->gtOverflow() || !varTypeIsGC(addr->gtGetOp1()) ||
+        !addr->gtGetOp2()->IsCnsIntOrI() || addr->gtGetOp2()->AsIntCon()->ImmedValNeedsReloc(m_compiler) ||
+        (addr->gtGetOp2()->AsIntCon()->IconValue() < 0))
+    {
+        return false;
+    }
+
+    *revPtr = false;
+    *rv1Ptr = addr->gtGetOp1();
+    *rv2Ptr = nullptr;
+    *mulPtr = 0;
+    *cnsPtr = addr->gtGetOp2()->AsIntCon()->IconValue();
+    return true;
 #endif // TARGET_WASM
     /*
         The following indirections are valid address modes on x86/x64:

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2948,13 +2948,20 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 
     if ((tree->gtFlags & GTF_IND_NONFAULTING) == 0)
     {
-        regNumber addrReg = GetMultiUseOperandReg(addr);
-        genEmitNullCheck(addrReg);
+        // "Base" is the address itself unless it is a contained address mode, which is never materialized.
+        //
+        genEmitNullCheck(GetMultiUseOperandReg(tree->Base()));
     }
 
     // TODO-WASM: Memory barriers
 
-    if (addr->isContained())
+    if (addr->isContained() && addr->OperIs(GT_LEA))
+    {
+        // The contained address mode's offset folds into the memarg; its base is already pushed.
+        //
+        GetEmitter()->emitIns_I(ins_Load(type), emitActualTypeSize(type), addr->AsAddrMode()->Offset());
+    }
+    else if (addr->isContained())
     {
         // A contained address constant folds into the memarg offset, so emit just the image base here.
         //
@@ -2987,7 +2994,10 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GenTree* data = tree->Data();
     GenTree* addr = tree->Addr();
 
-    assert(!addr->isContained());
+    // Only a contained address mode is expected; its offset folds into the memarg below.
+    //
+    assert(!addr->isContained() || addr->OperIs(GT_LEA));
+    const cnsval_ssize_t offset = addr->isContained() ? addr->AsAddrMode()->Offset() : 0;
 
     // We must consume the operands in the proper execution order,
     // so that liveness is updated appropriately.
@@ -2996,8 +3006,9 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
 
     if ((tree->gtFlags & GTF_IND_NONFAULTING) == 0)
     {
-        regNumber addrReg = GetMultiUseOperandReg(addr);
-        genEmitNullCheck(addrReg);
+        // "Base" is the address itself unless it is a contained address mode, which is never materialized.
+        //
+        genEmitNullCheck(GetMultiUseOperandReg(tree->Base()));
     }
 
     GCInfo::WriteBarrierForm writeBarrierForm = gcInfo.gcIsWriteBarrierCandidate(tree);
@@ -3014,7 +3025,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
         if (type == TYP_SIMD8)
         {
             // stack: [addr, value] -> store the low 8 bytes.
-            GetEmitter()->emitIns_MemargLane(INS_v128_store64_lane, EA_8BYTE, 0, 0);
+            GetEmitter()->emitIns_MemargLane(INS_v128_store64_lane, EA_8BYTE, offset, 0);
         }
         else if (type == TYP_SIMD12)
         {
@@ -3022,7 +3033,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
         }
         else
         {
-            GetEmitter()->emitIns_I(ins_Store(type), emitActualTypeSize(type), 0);
+            GetEmitter()->emitIns_I(ins_Store(type), emitActualTypeSize(type), offset);
         }
     }
 

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2423,12 +2423,21 @@ PhaseStatus Compiler::fgWasmSpillRefs()
             //  them. If we can somehow guarantee that all callees will spill their ref parameters
             //  immediately, we could do this before the block above.
 
-            // Remove used nodes from defs list, they're no longer meaningfully 'live'.
-            tree->VisitOperands([&defs](GenTree* op) {
+            // Remove used nodes from defs list, they're no longer meaningfully 'live'. A contained operand is
+            //  not itself on the operand stack, so look through it to the operands that are.
+            auto removeUses = [&defs](GenTree* op, auto& recurse) -> void {
                 if (!op->IsValue())
-                    return GenTree::VisitResult::Continue;
+                    return;
+                if (op->isContained())
+                {
+                    op->VisitOperands([&recurse](GenTree* innerOp) {
+                        recurse(innerOp, recurse);
+                        return GenTree::VisitResult::Continue;
+                    });
+                    return;
+                }
                 if (!op->TypeIs(TYP_REF, TYP_BYREF))
-                    return GenTree::VisitResult::Continue;
+                    return;
 
                 for (size_t i = defs.size(); i > 0; i--)
                 {
@@ -2439,7 +2448,16 @@ PhaseStatus Compiler::fgWasmSpillRefs()
                         break;
                     }
                 }
+            };
 
+            // A contained node is part of its parent, so it is visited as part of the parent instead.
+            if (tree->isContained())
+            {
+                continue;
+            }
+
+            tree->VisitOperands([&removeUses](GenTree* op) {
+                removeUses(op, removeUses);
                 return GenTree::VisitResult::Continue;
             });
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5768,7 +5768,18 @@ bool Compiler::gtMarkAddrMode(GenTree* addr, int* pCostEx, int* pCostSz, var_typ
             }
         }
 #elif defined(TARGET_WASM)
-        NYI_WASM("gtMarkAddrMode");
+        // Only "base + cns" is an addressing mode on Wasm. The constant folds into the memarg, which grows by
+        // the size of its ULEB encoding.
+        //
+        assert((base != nullptr) && (idx == nullptr));
+
+        addrModeCostEx += base->GetCostEx();
+        addrModeCostSz += base->GetCostSz();
+
+        for (target_size_t value = static_cast<target_size_t>(cns); value >= 0x80; value >>= 7)
+        {
+            addrModeCostSz += 1;
+        }
 #else
 #error "Unknown TARGET"
 #endif

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -451,10 +451,11 @@ private:
 #endif // TARGET_XARCH
 
 #ifdef TARGET_WASM
-    static void SetMultiplyUsed(GenTree* node DEBUGARG(const char* reason));
-    GenTree*    LowerNeg(GenTreeOp* node);
-    void        LowerIndexAddr(GenTreeIndexAddr* indexAddr);
-    void        LowerCkfinite(GenTreeOp* node);
+    static void      SetMultiplyUsed(GenTree* node DEBUGARG(const char* reason));
+    GenTreeAddrMode* GetFoldableAddrMode(GenTreeIndir* indirNode);
+    GenTree*         LowerNeg(GenTreeOp* node);
+    void             LowerIndexAddr(GenTreeIndexAddr* indexAddr);
+    void             LowerCkfinite(GenTreeOp* node);
 #endif
 
     bool TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* parent);

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -154,6 +154,52 @@ GenTree* Lowering::LowerStoreLoc(GenTreeLclVarCommon* storeLoc)
 }
 
 //------------------------------------------------------------------------
+// GetFoldableAddrMode: Get the address mode of an indirection whose offset can fold into the memarg.
+//
+// Arguments:
+//    indirNode - The indirection node of interest
+//
+// Return Value:
+//    The address node, or nullptr if its offset cannot be folded.
+//
+// Notes:
+//    The memarg offset is added in infinite precision, while "i32.add" wraps, so the two only differ when
+//    "base + offset" would exceed the address space. Require a GC-typed base and a non-negative offset: a
+//    GC-typed base points into a live object, so an address that far out of range is already invalid, and
+//    morph keeps such addresses with their base (see the "varTypeIsGC" guards in "fgOptimizeAddition" and
+//    "fgMorphSmpOp"). Where they differ we now trap instead of reading wrapped low memory. Note the offset
+//    must be checked here rather than on the original constant, because "SetOffset" truncates it to "int".
+//
+//    SIMD12 indirections re-materialize the address for the trailing lane access, and write barriers pass the
+//    whole address to a helper, so neither can fold.
+//
+GenTreeAddrMode* Lowering::GetFoldableAddrMode(GenTreeIndir* indirNode)
+{
+    GenTree* const addr = indirNode->Addr();
+
+    if (!addr->OperIs(GT_LEA) || indirNode->TypeIs(TYP_SIMD12) ||
+        ((addr->gtLIRFlags & LIR::Flags::MultiplyUsed) != LIR::Flags::None))
+    {
+        return nullptr;
+    }
+
+    GenTreeAddrMode* const lea = addr->AsAddrMode();
+
+    if (!lea->HasBase() || lea->HasIndex() || !varTypeIsGC(lea->Base()) || (lea->Offset() < 0))
+    {
+        return nullptr;
+    }
+
+    if (indirNode->OperIs(GT_STOREIND) &&
+        m_compiler->codeGen->gcInfo.gcIsWriteBarrierStoreIndNode(indirNode->AsStoreInd()))
+    {
+        return nullptr;
+    }
+
+    return lea;
+}
+
+//------------------------------------------------------------------------
 // LowerStoreIndir: Determine addressing mode for an indirection, and whether operands are contained.
 //
 // Arguments:
@@ -171,7 +217,11 @@ GenTree* Lowering::LowerStoreIndir(GenTreeStoreInd* node)
         // SIMD12 stores also re-materialize the address for the trailing lane store, so force it there as well -
         // unless the address is a re-materializable LCL_ADDR (the local-to-stack store rewrite), which codegen
         // re-emits directly.
-        SetMultiplyUsed(node->Addr() DEBUGARG("LowerStoreIndir Addr (null check or simd12 lane store)"));
+        // A foldable address is never materialized, so the base is what gets re-used.
+        //
+        GenTreeAddrMode* const foldable = GetFoldableAddrMode(node);
+        SetMultiplyUsed((foldable != nullptr ? foldable->Base() : node->Addr())
+                            DEBUGARG("LowerStoreIndir Addr (null check or simd12 lane store)"));
     }
 
     ContainCheckStoreIndir(node);
@@ -463,15 +513,22 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
         return;
     }
 
+    GenTreeAddrMode* const foldable = GetFoldableAddrMode(indirNode);
+
     if (indirNode->OperIs(GT_IND) &&
         (((indirNode->gtFlags & GTF_IND_NONFAULTING) == 0) || indirNode->TypeIs(TYP_SIMD12)))
     {
         // SIMD12 loads re-materialize the address for the trailing lane load, so force it there regardless.
-        SetMultiplyUsed(indirNode->Addr() DEBUGARG("ContainCheckIndir load Addr (null check or simd12 lane load)"));
+        // A foldable address is never materialized, so the base is what gets re-used.
+        //
+        SetMultiplyUsed((foldable != nullptr ? foldable->Base() : indirNode->Addr())
+                            DEBUGARG("ContainCheckIndir load Addr (null check or simd12 lane load)"));
     }
 
-    // TODO-WASM-CQ: contain suitable LEAs here. Take note of the fact that for this to be correct we must prove the
-    // LEA doesn't overflow. It will involve creating a new frontend node to represent "nuw" (offset) addition.
+    if (foldable != nullptr)
+    {
+        MakeSrcContained(indirNode, foldable);
+    }
 
     // Contain a relocatable address constant so it folds into the load's memarg offset.
     //

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -442,11 +442,7 @@ void WasmRegAlloc::CollectReferencesForNode(GenTree* node)
     switch (node->OperGet())
     {
         case GT_NULLCHECK:
-            if (node->gtGetOp1()->gtLIRFlags & LIR::Flags::MultiplyUsed)
-            {
-                ConsumeTemporaryRegForOperand(node->gtGetOp1()
-                                                  DEBUGARG("Orphaned GT_NULLCHECK with multiply-used flag"));
-            }
+            CollectReferencesForNullCheck(node->AsIndir());
             break;
 
         case GT_LCL_VAR:
@@ -661,6 +657,24 @@ void WasmRegAlloc::CollectReferencesForBinop(GenTreeOp* binopNode)
 }
 
 //------------------------------------------------------------------------
+// CollectReferencesForNullCheck: Collect virtual register references for a null check.
+//
+// Arguments:
+//    node - The GT_NULLCHECK node.
+//
+void WasmRegAlloc::CollectReferencesForNullCheck(GenTreeIndir* node)
+{
+    // "Base" is the address itself unless it is a contained address mode, which is never materialized.
+    //
+    GenTree* const base = node->Base();
+
+    if (base->gtLIRFlags & LIR::Flags::MultiplyUsed)
+    {
+        ConsumeTemporaryRegForOperand(base DEBUGARG("Orphaned GT_NULLCHECK with multiply-used flag"));
+    }
+}
+
+//------------------------------------------------------------------------
 // CollectReferencesForIndir: Collect virtual register references for an indirection.
 //
 // Arguments:
@@ -668,8 +682,9 @@ void WasmRegAlloc::CollectReferencesForBinop(GenTreeOp* binopNode)
 //
 void WasmRegAlloc::CollectReferencesForIndir(GenTreeIndir* node)
 {
-    GenTree* const addr = node->Addr();
-    ConsumeTemporaryRegForOperand(addr DEBUGARG("indirection address"));
+    // "Base" is the address itself unless it is a contained address mode, which is never materialized.
+    //
+    ConsumeTemporaryRegForOperand(node->Base() DEBUGARG("indirection address"));
 
     if (node->OperIs(GT_STOREIND) && node->TypeIs(TYP_SIMD12))
     {

--- a/src/coreclr/jit/regallocwasm.h
+++ b/src/coreclr/jit/regallocwasm.h
@@ -161,6 +161,7 @@ private:
     void      CollectReferencesForCast(GenTreeOp* castNode);
     void      CollectReferencesForBinop(GenTreeOp* binOpNode);
     void      CollectReferencesForIndir(GenTreeIndir* node);
+    void      CollectReferencesForNullCheck(GenTreeIndir* node);
     void      CollectReferencesForBlockStore(GenTreeBlk* node);
     void      CollectReferencesForLclVar(GenTreeLclVar* lclVar);
     void      CollectReferencesForIndexAddr(GenTreeIndexAddr* indexAddrNode);


### PR DESCRIPTION
Report "base + constant" as an address mode on wasm and contain the resulting LEA in its indirection, so the constant becomes the memarg offset instead of a separate "i32.const; i32.add".

Folding is limited to a GC-typed base with a non-negative, non-relocatable offset, which proves the addition cannot wrap. SIMD12 indirections and write-barrier stores are excluded because both need the whole address.

Also replaces the live NYI_WASM in gtMarkAddrMode with a cost model, and teaches fgWasmSpillRefs to look through contained operands.

SPC R2R code section: 16,139,362 -> 15,823,756 bytes (-1.96%).