### PR TITLE
Fix profiler ELT callbacks for Runtime Async suspension

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -583,6 +583,7 @@ protected:
 #ifdef PROFILING_SUPPORTED
     void genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed);
     void genProfilingLeaveCallback(unsigned helper);
+    void genProfilingLeaveCallbackForAsyncSuspend(regNumber continuationReg);
 #endif // PROFILING_SUPPORTED
 
     //

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7502,6 +7502,64 @@ void CodeGen::genSwiftErrorReturn(GenTree* treeNode)
 }
 #endif // SWIFT_SUPPORT
 
+#ifdef PROFILING_SUPPORTED
+//------------------------------------------------------------------------
+// genProfilingLeaveCallbackForAsyncSuspend:
+//   Emit a profiler Leave callback for a Runtime Async suspension and preserve
+//   the continuation across the helper call.
+//
+// Arguments:
+//   continuationReg - Register containing the continuation to return.
+//
+// Notes:
+//   A suspension Leave represents the end of a physical execution segment, not
+//   logical method completion. The normal return registers therefore do not
+//   contain a semantic method result. The final completion path continues to
+//   use the normal return codegen and exposes its actual return value.
+//
+void CodeGen::genProfilingLeaveCallbackForAsyncSuspend(regNumber continuationReg)
+{
+#ifdef TARGET_ARM
+    // The ARM32 Leave helper preserves REG_PROFILER_RET_SCRATCH, which is also the dedicated
+    // Runtime Async continuation register. For integer/soft-float returns it preserves R0 by
+    // moving it through this scratch register; for void and hard-float returns R0 is overwritten
+    // and the scratch register itself is preserved.
+    static_assert(REG_ASYNC_CONTINUATION_RET == REG_PROFILER_RET_SCRATCH);
+    bool r0InUse;
+    if (m_compiler->info.compRetType == TYP_VOID)
+    {
+        r0InUse = false;
+    }
+    else if (varTypeIsFloating(m_compiler->info.compRetType) ||
+             m_compiler->IsHfa(m_compiler->info.compMethodInfo->args.retTypeClass))
+    {
+        r0InUse = m_compiler->info.compIsVarArgs || m_compiler->opts.compUseSoftFP;
+    }
+    else
+    {
+        r0InUse = true;
+    }
+
+    if (!r0InUse)
+    {
+        inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, continuationReg, /* canSkip */ true);
+        gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
+        genProfilingLeaveCallback(CORINFO_HELP_PROF_FCN_LEAVE);
+        return;
+    }
+#endif
+
+    // The Leave helper preserves the normal return register, but may overwrite the dedicated
+    // Runtime Async continuation register because it is an argument register on supported ABIs.
+    // Temporarily use the normal return register to carry the continuation across the callback.
+    inst_Mov(TYP_REF, REG_INTRET, continuationReg, /* canSkip */ true);
+    gcInfo.gcMarkRegPtrVal(REG_INTRET, TYP_REF);
+    genProfilingLeaveCallback(CORINFO_HELP_PROF_FCN_LEAVE);
+    inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, REG_INTRET, /* canSkip */ true);
+    gcInfo.gcMarkRegSetNpt(genRegMask(REG_INTRET));
+}
+#endif // PROFILING_SUPPORTED
+
 //------------------------------------------------------------------------
 // genReturnSuspend:
 //   Generate code for a GT_RETURN_SUSPEND node
@@ -7519,51 +7577,7 @@ void CodeGen::genReturnSuspend(GenTreeUnOp* treeNode)
 #ifdef PROFILING_SUPPORTED
     if (m_compiler->compIsProfilerHookNeeded())
     {
-#ifdef TARGET_ARM
-        // The ARM32 Leave helper preserves REG_PROFILER_RET_SCRATCH, which is also the dedicated
-        // Runtime Async continuation register. For integer/soft-float returns it preserves R0 by
-        // moving it through this scratch register; for void and hard-float returns R0 is overwritten
-        // and the scratch register itself is preserved.
-        static_assert(REG_ASYNC_CONTINUATION_RET == REG_PROFILER_RET_SCRATCH);
-        bool r0InUse;
-        if (m_compiler->info.compRetType == TYP_VOID)
-        {
-            r0InUse = false;
-        }
-        else if (varTypeIsFloating(m_compiler->info.compRetType) ||
-                 m_compiler->IsHfa(m_compiler->info.compMethodInfo->args.retTypeClass))
-        {
-            r0InUse = m_compiler->info.compIsVarArgs || m_compiler->opts.compUseSoftFP;
-        }
-        else
-        {
-            r0InUse = true;
-        }
-        if (r0InUse)
-        {
-            inst_Mov(TYP_REF, REG_INTRET, reg, /* canSkip */ true);
-            gcInfo.gcMarkRegPtrVal(REG_INTRET, TYP_REF);
-            genProfilingLeaveCallback(CORINFO_HELP_PROF_FCN_LEAVE);
-            inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, REG_INTRET, /* canSkip */ true);
-            gcInfo.gcMarkRegSetNpt(genRegMask(REG_INTRET));
-        }
-        else
-        {
-            inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, reg, /* canSkip */ true);
-            gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
-            genProfilingLeaveCallback(CORINFO_HELP_PROF_FCN_LEAVE);
-        }
-#else
-        // The Leave helper preserves the normal return register, but may overwrite the dedicated
-        // Runtime Async continuation register because it is an argument register on supported
-        // ABIs. Temporarily use the normal return register to carry the continuation across the
-        // callback, then restore the dedicated register.
-        inst_Mov(TYP_REF, REG_INTRET, reg, /* canSkip */ true);
-        gcInfo.gcMarkRegPtrVal(REG_INTRET, TYP_REF);
-        genProfilingLeaveCallback(CORINFO_HELP_PROF_FCN_LEAVE);
-        inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, REG_INTRET, /* canSkip */ true);
-        gcInfo.gcMarkRegSetNpt(genRegMask(REG_INTRET));
-#endif
+        genProfilingLeaveCallbackForAsyncSuspend(reg);
     }
     else
 #endif

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7515,7 +7515,62 @@ void CodeGen::genReturnSuspend(GenTreeUnOp* treeNode)
     assert(op->TypeIs(TYP_REF));
 
     regNumber reg = genConsumeReg(op);
-    inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, reg, /* canSkip */ true);
+
+#ifdef PROFILING_SUPPORTED
+    if (m_compiler->compIsProfilerHookNeeded())
+    {
+#ifdef TARGET_ARM
+        // The ARM32 Leave helper preserves REG_PROFILER_RET_SCRATCH, which is also the dedicated
+        // Runtime Async continuation register. For integer/soft-float returns it preserves R0 by
+        // moving it through this scratch register; for void and hard-float returns R0 is overwritten
+        // and the scratch register itself is preserved.
+        static_assert(REG_ASYNC_CONTINUATION_RET == REG_PROFILER_RET_SCRATCH);
+        bool r0InUse;
+        if (m_compiler->info.compRetType == TYP_VOID)
+        {
+            r0InUse = false;
+        }
+        else if (varTypeIsFloating(m_compiler->info.compRetType) ||
+                 m_compiler->IsHfa(m_compiler->info.compMethodInfo->args.retTypeClass))
+        {
+            r0InUse = m_compiler->info.compIsVarArgs || m_compiler->opts.compUseSoftFP;
+        }
+        else
+        {
+            r0InUse = true;
+        }
+        if (r0InUse)
+        {
+            inst_Mov(TYP_REF, REG_INTRET, reg, /* canSkip */ true);
+            gcInfo.gcMarkRegPtrVal(REG_INTRET, TYP_REF);
+            genProfilingLeaveCallback(CORINFO_HELP_PROF_FCN_LEAVE);
+            inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, REG_INTRET, /* canSkip */ true);
+            gcInfo.gcMarkRegSetNpt(genRegMask(REG_INTRET));
+        }
+        else
+        {
+            inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, reg, /* canSkip */ true);
+            gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
+            genProfilingLeaveCallback(CORINFO_HELP_PROF_FCN_LEAVE);
+        }
+#else
+        // The Leave helper preserves the normal return register, but may overwrite the dedicated
+        // Runtime Async continuation register because it is an argument register on supported
+        // ABIs. Temporarily use the normal return register to carry the continuation across the
+        // callback, then restore the dedicated register.
+        inst_Mov(TYP_REF, REG_INTRET, reg, /* canSkip */ true);
+        gcInfo.gcMarkRegPtrVal(REG_INTRET, TYP_REF);
+        genProfilingLeaveCallback(CORINFO_HELP_PROF_FCN_LEAVE);
+        inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, REG_INTRET, /* canSkip */ true);
+        gcInfo.gcMarkRegSetNpt(genRegMask(REG_INTRET));
+#endif
+    }
+    else
+#endif
+    {
+        inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, reg, /* canSkip */ true);
+    }
+
     gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
 
     ReturnTypeDesc retTypeDesc = m_compiler->compRetTypeDesc;

--- a/src/tests/profiler/elt/runtimeasyncelt.cs
+++ b/src/tests/profiler/elt/runtimeasyncelt.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Profiler.Tests;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using TestLibrary;
+
+internal static class RuntimeAsyncELT
+{
+    private static readonly Guid ProfilerGuid = new("D1C7A5B2-6E04-4D7F-9A31-2B84C6F0E915");
+
+    public static int Main(string[] args)
+    {
+        if (!PlatformDetection.IsICorProfilerEnterLeaveHooksEnabled)
+        {
+            return 100;
+        }
+
+        if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
+        {
+            return RunTest();
+        }
+
+        return ProfilerTestRunner.Run(
+            profileePath: Assembly.GetExecutingAssembly().Location,
+            testName: "RuntimeAsyncELT",
+            profilerClsid: ProfilerGuid,
+            profileeOptions: ProfileeOptions.OptimizationSensitive,
+            envVars: new Dictionary<string, string>
+            {
+                ["DOTNET_RuntimeAsync"] = "1"
+            });
+    }
+
+    private static async Task<long> Work(int iterations)
+    {
+        long sum = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            await Task.Yield();
+            sum += i;
+        }
+        return sum;
+    }
+
+    private static async Task WorkVoid(int iterations)
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            await Task.Yield();
+        }
+    }
+
+    private static async Task<double> WorkDouble(int iterations)
+    {
+        double sum = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            await Task.Yield();
+            sum += i + 0.5;
+        }
+        return sum;
+    }
+
+    private static async Task<int> RunAsync()
+    {
+        long total = 0;
+        for (int i = 0; i < 5; i++)
+        {
+            total += await Work(4);
+        }
+
+        await WorkVoid(2);
+        double floatingResult = await WorkDouble(2);
+
+        return total == 30 && floatingResult == 2.0 ? 100 : 1;
+    }
+
+    private static int RunTest() => RunAsync().GetAwaiter().GetResult();
+}

--- a/src/tests/profiler/elt/runtimeasyncelt.csproj
+++ b/src/tests/profiler/elt/runtimeasyncelt.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <Optimize>true</Optimize>
+    <Features>runtime-async=on</Features>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+    <ProjectReference Include="../common/profiler_common.csproj" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/profiler/native/CMakeLists.txt
+++ b/src/tests/profiler/native/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOURCES
     rejitprofiler/ilrewriter.cpp
     rejitprofiler/sigparse.cpp
     releaseondetach/releaseondetach.cpp
+    runtimeasyncelt/runtimeasynceltprofiler.cpp
     transitions/transitions.cpp
     profiler.def
     profiler.cpp

--- a/src/tests/profiler/native/classfactory.cpp
+++ b/src/tests/profiler/native/classfactory.cpp
@@ -20,6 +20,7 @@
 #include "nullprofiler/nullprofiler.h"
 #include "rejitprofiler/rejitprofiler.h"
 #include "releaseondetach/releaseondetach.h"
+#include "runtimeasyncelt/runtimeasynceltprofiler.h"
 #include "transitions/transitions.h"
 #include "multiple/multiple.h"
 #include "inlining/inlining.h"
@@ -126,6 +127,10 @@ HRESULT STDMETHODCALLTYPE ClassFactory::CreateInstance(IUnknown *pUnkOuter, REFI
     else if (clsid == ReleaseOnDetach::GetClsid())
     {
         profiler = new ReleaseOnDetach();
+    }
+    else if (clsid == RuntimeAsyncELTProfiler::GetClsid())
+    {
+        profiler = new RuntimeAsyncELTProfiler();
     }
     else if (clsid == Transitions::GetClsid())
     {

--- a/src/tests/profiler/native/runtimeasyncelt/runtimeasynceltprofiler.cpp
+++ b/src/tests/profiler/native/runtimeasyncelt/runtimeasynceltprofiler.cpp
@@ -5,6 +5,10 @@
 
 namespace
 {
+const WCHAR* const TargetNames[] = {WCHAR("Work"), WCHAR("WorkVoid"), WCHAR("WorkDouble")};
+const char* const TargetDisplayNames[] = {"Work", "WorkVoid", "WorkDouble"};
+const int ExpectedCallbackCounts[] = {25, 3, 3};
+
 void STDMETHODCALLTYPE EnterStub(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO)
 {
     SHUTDOWNGUARD_RETVOID();
@@ -27,12 +31,19 @@ RuntimeAsyncELTProfiler* RuntimeAsyncELTProfiler::s_instance = nullptr;
 
 RuntimeAsyncELTProfiler::RuntimeAsyncELTProfiler()
     : Profiler(),
-      _target(0),
-      _enters(0),
-      _leaves(0),
-      _depth(0),
       _sequenceFailures(0)
 {
+    static_assert(sizeof(TargetNames) / sizeof(TargetNames[0]) == TargetCount);
+    static_assert(sizeof(TargetDisplayNames) / sizeof(TargetDisplayNames[0]) == TargetCount);
+    static_assert(sizeof(ExpectedCallbackCounts) / sizeof(ExpectedCallbackCounts[0]) == TargetCount);
+
+    for (int i = 0; i < TargetCount; i++)
+    {
+        _targets[i] = 0;
+        _enters[i] = 0;
+        _leaves[i] = 0;
+        _depth[i] = 0;
+    }
 }
 
 GUID RuntimeAsyncELTProfiler::GetClsid()
@@ -68,7 +79,22 @@ HRESULT RuntimeAsyncELTProfiler::JITCompilationFinished(
 {
     SHUTDOWNGUARD();
 
-    if (FAILED(hrStatus) || GetFunctionIDName(functionId) != WCHAR("Work"))
+    if (FAILED(hrStatus))
+    {
+        return S_OK;
+    }
+
+    String functionName = GetFunctionIDName(functionId);
+    int targetIndex = -1;
+    for (int i = 0; i < TargetCount; i++)
+    {
+        if (functionName == TargetNames[i])
+        {
+            targetIndex = i;
+            break;
+        }
+    }
+    if (targetIndex < 0)
     {
         return S_OK;
     }
@@ -77,7 +103,7 @@ HRESULT RuntimeAsyncELTProfiler::JITCompilationFinished(
     if (moduleName.find(L"runtimeasyncelt") != std::wstring::npos)
     {
         FunctionID expected = 0;
-        _target.compare_exchange_strong(expected, functionId);
+        _targets[targetIndex].compare_exchange_strong(expected, functionId);
     }
 
     return S_OK;
@@ -85,13 +111,14 @@ HRESULT RuntimeAsyncELTProfiler::JITCompilationFinished(
 
 void RuntimeAsyncELTProfiler::Enter(FunctionID functionId)
 {
-    if (functionId != _target.load())
+    int targetIndex = GetTargetIndex(functionId);
+    if (targetIndex < 0)
     {
         return;
     }
 
-    _enters++;
-    if (_depth.fetch_add(1) != 0)
+    _enters[targetIndex]++;
+    if (_depth[targetIndex].fetch_add(1) != 0)
     {
         _sequenceFailures++;
     }
@@ -99,13 +126,14 @@ void RuntimeAsyncELTProfiler::Enter(FunctionID functionId)
 
 void RuntimeAsyncELTProfiler::Leave(FunctionID functionId)
 {
-    if (functionId != _target.load())
+    int targetIndex = GetTargetIndex(functionId);
+    if (targetIndex < 0)
     {
         return;
     }
 
-    _leaves++;
-    if (_depth.fetch_sub(1) != 1)
+    _leaves[targetIndex]++;
+    if (_depth[targetIndex].fetch_sub(1) != 1)
     {
         _sequenceFailures++;
     }
@@ -116,21 +144,33 @@ HRESULT RuntimeAsyncELTProfiler::Shutdown()
     HRESULT hr = Profiler::Shutdown();
     s_instance = nullptr;
 
-    printf("RuntimeAsyncELTProfiler: enters=%d leaves=%d depth=%d sequenceFailures=%d\n",
-           _enters.load(), _leaves.load(), _depth.load(), _sequenceFailures.load());
-
-    if (SUCCEEDED(hr) && _target != 0 && _enters == 25 && _leaves == 25 &&
-        _depth == 0 && _sequenceFailures == 0)
+    bool passed = SUCCEEDED(hr) && _sequenceFailures == 0;
+    for (int i = 0; i < TargetCount; i++)
     {
-        printf("PROFILER TEST PASSES\n");
+        printf("RuntimeAsyncELTProfiler: %s enters=%d leaves=%d depth=%d\n",
+               TargetDisplayNames[i], _enters[i].load(), _leaves[i].load(), _depth[i].load());
+        passed &= _targets[i].load() != 0 &&
+                  _enters[i].load() == ExpectedCallbackCounts[i] &&
+                  _leaves[i].load() == ExpectedCallbackCounts[i] &&
+                  _depth[i].load() == 0;
     }
-    else
-    {
-        printf("PROFILER TEST FAILED\n");
-    }
+    printf("RuntimeAsyncELTProfiler: sequenceFailures=%d\n", _sequenceFailures.load());
+    printf(passed ? "PROFILER TEST PASSES\n" : "PROFILER TEST FAILED\n");
 
     fflush(stdout);
     return hr;
+}
+
+int RuntimeAsyncELTProfiler::GetTargetIndex(FunctionID functionId)
+{
+    for (int i = 0; i < TargetCount; i++)
+    {
+        if (_targets[i].load() == functionId)
+        {
+            return i;
+        }
+    }
+    return -1;
 }
 
 ModuleID RuntimeAsyncELTProfiler::GetModuleId(FunctionID functionId)

--- a/src/tests/profiler/native/runtimeasyncelt/runtimeasynceltprofiler.cpp
+++ b/src/tests/profiler/native/runtimeasyncelt/runtimeasynceltprofiler.cpp
@@ -1,0 +1,149 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "runtimeasynceltprofiler.h"
+
+namespace
+{
+void STDMETHODCALLTYPE EnterStub(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO)
+{
+    SHUTDOWNGUARD_RETVOID();
+    RuntimeAsyncELTProfiler::Instance()->Enter(functionId.functionID);
+}
+
+void STDMETHODCALLTYPE LeaveStub(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO)
+{
+    SHUTDOWNGUARD_RETVOID();
+    RuntimeAsyncELTProfiler::Instance()->Leave(functionId.functionID);
+}
+
+void STDMETHODCALLTYPE TailcallStub(FunctionIDOrClientID, COR_PRF_ELT_INFO)
+{
+    SHUTDOWNGUARD_RETVOID();
+}
+}
+
+RuntimeAsyncELTProfiler* RuntimeAsyncELTProfiler::s_instance = nullptr;
+
+RuntimeAsyncELTProfiler::RuntimeAsyncELTProfiler()
+    : Profiler(),
+      _target(0),
+      _enters(0),
+      _leaves(0),
+      _depth(0),
+      _sequenceFailures(0)
+{
+}
+
+GUID RuntimeAsyncELTProfiler::GetClsid()
+{
+    // {D1C7A5B2-6E04-4D7F-9A31-2B84C6F0E915}
+    GUID clsid = {0xd1c7a5b2, 0x6e04, 0x4d7f, {0x9a, 0x31, 0x2b, 0x84, 0xc6, 0xf0, 0xe9, 0x15}};
+    return clsid;
+}
+
+HRESULT RuntimeAsyncELTProfiler::Initialize(IUnknown* pCorProfilerInfoUnk)
+{
+    HRESULT hr = Profiler::Initialize(pCorProfilerInfoUnk);
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    s_instance = this;
+
+    hr = pCorProfilerInfo->SetEventMask2(
+        COR_PRF_MONITOR_ENTERLEAVE | COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_ENABLE_FRAME_INFO,
+        0);
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    return pCorProfilerInfo->SetEnterLeaveFunctionHooks3WithInfo(EnterStub, LeaveStub, TailcallStub);
+}
+
+HRESULT RuntimeAsyncELTProfiler::JITCompilationFinished(
+    FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
+{
+    SHUTDOWNGUARD();
+
+    if (FAILED(hrStatus) || GetFunctionIDName(functionId) != WCHAR("Work"))
+    {
+        return S_OK;
+    }
+
+    std::wstring moduleName = GetModuleIDName(GetModuleId(functionId)).ToWString();
+    if (moduleName.find(L"runtimeasyncelt") != std::wstring::npos)
+    {
+        FunctionID expected = 0;
+        _target.compare_exchange_strong(expected, functionId);
+    }
+
+    return S_OK;
+}
+
+void RuntimeAsyncELTProfiler::Enter(FunctionID functionId)
+{
+    if (functionId != _target.load())
+    {
+        return;
+    }
+
+    _enters++;
+    if (_depth.fetch_add(1) != 0)
+    {
+        _sequenceFailures++;
+    }
+}
+
+void RuntimeAsyncELTProfiler::Leave(FunctionID functionId)
+{
+    if (functionId != _target.load())
+    {
+        return;
+    }
+
+    _leaves++;
+    if (_depth.fetch_sub(1) != 1)
+    {
+        _sequenceFailures++;
+    }
+}
+
+HRESULT RuntimeAsyncELTProfiler::Shutdown()
+{
+    HRESULT hr = Profiler::Shutdown();
+    s_instance = nullptr;
+
+    printf("RuntimeAsyncELTProfiler: enters=%d leaves=%d depth=%d sequenceFailures=%d\n",
+           _enters.load(), _leaves.load(), _depth.load(), _sequenceFailures.load());
+
+    if (SUCCEEDED(hr) && _target != 0 && _enters == 25 && _leaves == 25 &&
+        _depth == 0 && _sequenceFailures == 0)
+    {
+        printf("PROFILER TEST PASSES\n");
+    }
+    else
+    {
+        printf("PROFILER TEST FAILED\n");
+    }
+
+    fflush(stdout);
+    return hr;
+}
+
+ModuleID RuntimeAsyncELTProfiler::GetModuleId(FunctionID functionId)
+{
+    ClassID classId = 0;
+    ModuleID moduleId = 0;
+    mdToken token = 0;
+    ULONG32 typeArgumentCount = 0;
+    ClassID typeArguments[SHORT_LENGTH];
+    COR_PRF_FRAME_INFO frameInfo = 0;
+
+    HRESULT hr = pCorProfilerInfo->GetFunctionInfo2(
+        functionId, frameInfo, &classId, &moduleId, &token,
+        SHORT_LENGTH, &typeArgumentCount, typeArguments);
+    return SUCCEEDED(hr) ? moduleId : 0;
+}

--- a/src/tests/profiler/native/runtimeasyncelt/runtimeasynceltprofiler.h
+++ b/src/tests/profiler/native/runtimeasyncelt/runtimeasynceltprofiler.h
@@ -22,12 +22,15 @@ public:
     static RuntimeAsyncELTProfiler* Instance() { return s_instance; }
 
 private:
+    static const int TargetCount = 3;
+
+    int GetTargetIndex(FunctionID functionId);
     ModuleID GetModuleId(FunctionID functionId);
 
     static RuntimeAsyncELTProfiler* s_instance;
-    std::atomic<FunctionID> _target;
-    std::atomic<int> _enters;
-    std::atomic<int> _leaves;
-    std::atomic<int> _depth;
+    std::atomic<FunctionID> _targets[TargetCount];
+    std::atomic<int> _enters[TargetCount];
+    std::atomic<int> _leaves[TargetCount];
+    std::atomic<int> _depth[TargetCount];
     std::atomic<int> _sequenceFailures;
 };

--- a/src/tests/profiler/native/runtimeasyncelt/runtimeasynceltprofiler.h
+++ b/src/tests/profiler/native/runtimeasyncelt/runtimeasynceltprofiler.h
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "../profiler.h"
+
+class RuntimeAsyncELTProfiler : public Profiler
+{
+public:
+    RuntimeAsyncELTProfiler();
+
+    static GUID GetClsid();
+    HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pCorProfilerInfoUnk) override;
+    HRESULT STDMETHODCALLTYPE Shutdown() override;
+    HRESULT STDMETHODCALLTYPE JITCompilationFinished(
+        FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock) override;
+
+    void Enter(FunctionID functionId);
+    void Leave(FunctionID functionId);
+
+    static RuntimeAsyncELTProfiler* Instance() { return s_instance; }
+
+private:
+    ModuleID GetModuleId(FunctionID functionId);
+
+    static RuntimeAsyncELTProfiler* s_instance;
+    std::atomic<FunctionID> _target;
+    std::atomic<int> _enters;
+    std::atomic<int> _leaves;
+    std::atomic<int> _depth;
+    std::atomic<int> _sequenceFailures;
+};


### PR DESCRIPTION
## Summary

Emit profiler `Leave` callbacks when Runtime Async methods suspend, pairing the existing `Enter` callbacks emitted on initial invocation and resume. This makes ELT callbacks consistently represent physical execution segments.

Preserves the continuation across profiler callbacks on all supported ABIs and adds Windows/Linux regression coverage for `Task`, `Task<long>`, and `Task<double>` methods.

Fixes dotnet/runtime#122488.