### PR TITLE
Prevent stale managed return values for Runtime Async suspension

### DIFF
--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -4625,7 +4625,12 @@ HRESULT CordbNativeCode::GetCallSignature(ULONG32 ILoffset, mdToken *pClass, mdT
     return GetSigParserFromFunction(mdFunction, pClass, parser, generics);
 }
 
-HRESULT CordbNativeCode::GetReturnValueVariableHomes(Instantiation *currentInstantiation, ULONG32 ILoffset, ULONG32 bufferSize, ULONG32 *pFetched, const ICorDebugInfo::NativeVarInfo **ppVarInfos)
+HRESULT CordbNativeCode::GetReturnValueVariableHomes(Instantiation *currentInstantiation,
+                                                     ULONG32 ILoffset,
+                                                     ULONG32 bufferSize,
+                                                     ULONG32 *pFetched,
+                                                     const ICorDebugInfo::NativeVarInfo **ppVarInfos,
+                                                     bool includeAsyncContinuationMarker)
 {
     if (pFetched == NULL)
         return E_INVALIDARG;
@@ -4651,7 +4656,11 @@ HRESULT CordbNativeCode::GetReturnValueVariableHomes(Instantiation *currentInsta
             continue;
         }
 
-        if (pNativeVarInfo->callReturnValueILOffset != ILoffset)
+        bool isAsyncContinuationMarker =
+            (pNativeVarInfo->callReturnValueILOffset & ICorDebugInfo::CALL_RETURN_ASYNC_CONTINUATION_FLAG) != 0;
+        ULONG32 callILOffset =
+            pNativeVarInfo->callReturnValueILOffset & ~ICorDebugInfo::CALL_RETURN_ASYNC_CONTINUATION_FLAG;
+        if (callILOffset != ILoffset || (isAsyncContinuationMarker && !includeAsyncContinuationMarker))
         {
             continue;
         }

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -5851,7 +5851,12 @@ public:
     VMPTR_MethodDesc GetVMNativeCodeMethodDescToken() { return m_vmNativeCodeMethodDescToken; };
 
     // Worker function for GetReturnValueLiveOffset.
-    HRESULT GetReturnValueVariableHomes(Instantiation *currentInstantiation, ULONG32 ILoffset, ULONG32 bufferSize, ULONG32 *pFetched, const ICorDebugInfo::NativeVarInfo **ppVarInfos);
+    HRESULT GetReturnValueVariableHomes(Instantiation *currentInstantiation,
+                                        ULONG32 ILoffset,
+                                        ULONG32 bufferSize,
+                                        ULONG32 *pFetched,
+                                        const ICorDebugInfo::NativeVarInfo **ppVarInfos,
+                                        bool includeAsyncContinuationMarker = false);
 
     // get total size of the code including both hot and cold regions
     ULONG32 GetSize();

--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -8800,20 +8800,36 @@ HRESULT CordbJITILFrame::GetReturnValueForILOffsetImpl(ULONG32 ILoffset, ICorDeb
     pCode->LoadNativeInfo();
 
     ULONG32 count = 0;
-    IfFailRet(pCode->GetReturnValueVariableHomes(&m_genericArgs, ILoffset, 0, &count, NULL));
+    IfFailRet(pCode->GetReturnValueVariableHomes(
+        &m_genericArgs, ILoffset, 0, &count, NULL, /* includeAsyncContinuationMarker */ true));
 
     NewArrayHolder<const ICorDebugInfo::NativeVarInfo *> varInfos(new const ICorDebugInfo::NativeVarInfo *[count]);
-    IfFailRet(pCode->GetReturnValueVariableHomes(&m_genericArgs, ILoffset, count, &count, varInfos));
+    IfFailRet(pCode->GetReturnValueVariableHomes(
+        &m_genericArgs, ILoffset, count, &count, varInfos, /* includeAsyncContinuationMarker */ true));
 
     const ICorDebugInfo::NativeVarInfo *pReturnVarInfo = NULL;
+    const ICorDebugInfo::NativeVarInfo *pAsyncContinuationVarInfo = NULL;
     ULONG32 currentOffset = m_nativeFrame->GetIPOffset();
     for (ULONG32 i = 0; i < count; ++i)
     {
         if (currentOffset == varInfos[i]->startOffset)
         {
-            pReturnVarInfo = varInfos[i];
-            break;
+            if ((varInfos[i]->callReturnValueILOffset &
+                 ICorDebugInfo::CALL_RETURN_ASYNC_CONTINUATION_FLAG) != 0)
+            {
+                pAsyncContinuationVarInfo = varInfos[i];
+            }
+            else
+            {
+                pReturnVarInfo = varInfos[i];
+            }
         }
+    }
+
+    if ((pAsyncContinuationVarInfo != NULL) &&
+        (m_nativeFrame->GetRegisterOrStackValue(pAsyncContinuationVarInfo) != 0))
+    {
+        return CORDBG_E_IL_VAR_NOT_AVAILABLE;
     }
 
     if (pReturnVarInfo == NULL)

--- a/src/coreclr/inc/cordebuginfo.h
+++ b/src/coreclr/inc/cordebuginfo.h
@@ -444,6 +444,11 @@ public:
                                        // so that the compression routines know the enum's range.
     };
 
+    // Set on NativeVarInfo::callReturnValueILOffset for the companion entry that describes the
+    // Runtime Async continuation return register. The remaining bits contain the original call
+    // IL offset.
+    static const uint32_t CALL_RETURN_ASYNC_CONTINUATION_FLAG = 0x80000000u;
+
     struct ILVarInfo
     {
         uint32_t        startOffset;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5776,7 +5776,11 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
     m_pLastNewIns->SetSVar(CALL_ARGS_SVAR);
 
     m_pLastNewIns->flags |= INTERP_INST_FLAG_CALL;
-    if (!tailcall && !newObj && !isCalli && callInfo.sig.retType != CORINFO_TYPE_VOID)
+    // The interpreter does not currently report the Runtime Async continuation state alongside
+    // the normal return-value home. Suppress MRV information for async calls rather than expose
+    // the return slot from a suspended call as if it were a completed result.
+    if (!tailcall && !newObj && !isCalli && !callInfo.sig.isAsyncCall() &&
+        callInfo.sig.retType != CORINFO_TYPE_VOID)
         m_pLastNewIns->flags |= INTERP_INST_FLAG_DBG_CALL_INSTRUCTION;
     m_pLastNewIns->info.pCallInfo = new (getAllocator(IMK_CallInfo)) InterpCallInfo();
     m_pLastNewIns->info.pCallInfo->pCallArgs = callArgs;

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1896,6 +1896,19 @@ void CodeGen::genEmitCallWithCurrentGC(EmitCallParams& params)
     }
 
     emittedCallReturnInfo->push_back(info);
+
+#ifndef TARGET_WASM
+    if (call->IsAsync())
+    {
+        // Emit a companion entry for the Runtime Async continuation return register. DBI uses it
+        // to distinguish synchronous completion (null continuation) from suspension before
+        // exposing the normal managed return-value register.
+        info.callILOffset =
+            (IL_OFFSET)((uint32_t)info.callILOffset | ICorDebugInfo::CALL_RETURN_ASYNC_CONTINUATION_FLAG);
+        info.returnValueLoc.storeVariableInRegisters(REG_ASYNC_CONTINUATION_RET, REG_NA);
+        emittedCallReturnInfo->push_back(info);
+    }
+#endif
 }
 
 /*****************************************************************************


### PR DESCRIPTION
## Summary

Prevent debuggers from exposing stale managed return values when a Runtime Async call suspends.

The JIT reports the async continuation register alongside managed-return-value debug information. DBI rejects the value while that continuation is non-null, while preserving return values for synchronously completed calls. Interpreter async calls suppress MRV homes until equivalent continuation-state information is available.

Partially addresses dotnet/runtime#121011.