### PR TITLE
Add Runtime Async profiler API coverage

### DIFF
--- a/src/tests/profiler/native/CMakeLists.txt
+++ b/src/tests/profiler/native/CMakeLists.txt
@@ -30,6 +30,8 @@ set(SOURCES
     rejitprofiler/ilrewriter.cpp
     rejitprofiler/sigparse.cpp
     releaseondetach/releaseondetach.cpp
+    runtimeasyncapis/runtimeasyncapisprofiler.cpp
+    runtimeasynctypes/runtimeasynctypesprofiler.cpp
     transitions/transitions.cpp
     profiler.def
     profiler.cpp

--- a/src/tests/profiler/native/classfactory.cpp
+++ b/src/tests/profiler/native/classfactory.cpp
@@ -20,6 +20,8 @@
 #include "nullprofiler/nullprofiler.h"
 #include "rejitprofiler/rejitprofiler.h"
 #include "releaseondetach/releaseondetach.h"
+#include "runtimeasyncapis/runtimeasyncapisprofiler.h"
+#include "runtimeasynctypes/runtimeasynctypesprofiler.h"
 #include "transitions/transitions.h"
 #include "multiple/multiple.h"
 #include "inlining/inlining.h"
@@ -126,6 +128,14 @@ HRESULT STDMETHODCALLTYPE ClassFactory::CreateInstance(IUnknown *pUnkOuter, REFI
     else if (clsid == ReleaseOnDetach::GetClsid())
     {
         profiler = new ReleaseOnDetach();
+    }
+    else if (clsid == RuntimeAsyncApisProfiler::GetClsid())
+    {
+        profiler = new RuntimeAsyncApisProfiler();
+    }
+    else if (clsid == RuntimeAsyncTypesProfiler::GetClsid())
+    {
+        profiler = new RuntimeAsyncTypesProfiler();
     }
     else if (clsid == Transitions::GetClsid())
     {

--- a/src/tests/profiler/native/runtimeasyncapis/runtimeasyncapisprofiler.cpp
+++ b/src/tests/profiler/native/runtimeasyncapis/runtimeasyncapisprofiler.cpp
@@ -50,6 +50,8 @@ bool RuntimeAsyncApisProfiler::IsTarget(FunctionID functionId)
 
 HRESULT RuntimeAsyncApisProfiler::JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock)
 {
+    SHUTDOWNGUARD();
+
     if (IsTarget(functionId))
     {
         _jitStarts++;
@@ -60,6 +62,8 @@ HRESULT RuntimeAsyncApisProfiler::JITCompilationStarted(FunctionID functionId, B
 HRESULT RuntimeAsyncApisProfiler::JITCompilationFinished(
     FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
 {
+    SHUTDOWNGUARD();
+
     if (!IsTarget(functionId))
     {
         return S_OK;
@@ -117,12 +121,16 @@ HRESULT RuntimeAsyncApisProfiler::JITCompilationFinished(
 
 HRESULT RuntimeAsyncApisProfiler::ExceptionThrown(ObjectID thrownObjectId)
 {
+    SHUTDOWNGUARD();
+
     _exceptionsThrown++;
     return S_OK;
 }
 
 HRESULT RuntimeAsyncApisProfiler::ExceptionSearchFunctionEnter(FunctionID functionId)
 {
+    SHUTDOWNGUARD();
+
     if (functionId == _target.load())
     {
         _targetSearches++;
@@ -132,6 +140,8 @@ HRESULT RuntimeAsyncApisProfiler::ExceptionSearchFunctionEnter(FunctionID functi
 
 HRESULT RuntimeAsyncApisProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)
 {
+    SHUTDOWNGUARD();
+
     if (functionId == _target.load())
     {
         _targetUnwinds++;
@@ -141,6 +151,8 @@ HRESULT RuntimeAsyncApisProfiler::ExceptionUnwindFunctionEnter(FunctionID functi
 
 HRESULT RuntimeAsyncApisProfiler::ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId)
 {
+    SHUTDOWNGUARD();
+
     _catchers++;
     return S_OK;
 }

--- a/src/tests/profiler/native/runtimeasyncapis/runtimeasyncapisprofiler.cpp
+++ b/src/tests/profiler/native/runtimeasyncapis/runtimeasyncapisprofiler.cpp
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "runtimeasyncapisprofiler.h"
+
+RuntimeAsyncApisProfiler::RuntimeAsyncApisProfiler()
+    : Profiler(),
+      _failures(0),
+      _target(0),
+      _jitStarts(0),
+      _jitFinishes(0),
+      _ipRoundTrips(0),
+      _ilMappings(0),
+      _exceptionsThrown(0),
+      _targetSearches(0),
+      _targetUnwinds(0),
+      _catchers(0)
+{
+}
+
+GUID RuntimeAsyncApisProfiler::GetClsid()
+{
+    // {9A20F5D8-47B1-4E63-82CD-1F7690AB34E2}
+    GUID clsid = {0x9a20f5d8, 0x47b1, 0x4e63, {0x82, 0xcd, 0x1f, 0x76, 0x90, 0xab, 0x34, 0xe2}};
+    return clsid;
+}
+
+HRESULT RuntimeAsyncApisProfiler::Initialize(IUnknown* pCorProfilerInfoUnk)
+{
+    HRESULT hr = Profiler::Initialize(pCorProfilerInfoUnk);
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    return pCorProfilerInfo->SetEventMask2(
+        COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_MONITOR_EXCEPTIONS, 0);
+}
+
+bool RuntimeAsyncApisProfiler::IsTarget(FunctionID functionId)
+{
+    if (GetFunctionIDName(functionId) != WCHAR("Work"))
+    {
+        return false;
+    }
+
+    std::wstring moduleName = GetModuleIDName(GetModuleId(functionId)).ToWString();
+    return moduleName.find(L"runtimeasyncapis") != std::wstring::npos;
+}
+
+HRESULT RuntimeAsyncApisProfiler::JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock)
+{
+    if (IsTarget(functionId))
+    {
+        _jitStarts++;
+    }
+    return S_OK;
+}
+
+HRESULT RuntimeAsyncApisProfiler::JITCompilationFinished(
+    FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
+{
+    if (!IsTarget(functionId))
+    {
+        return S_OK;
+    }
+
+    _target = functionId;
+    if (FAILED(hrStatus))
+    {
+        _failures++;
+        return S_OK;
+    }
+
+    _jitFinishes++;
+
+    COR_PRF_CODE_INFO codeInfos[16];
+    ULONG32 codeInfoCount = 0;
+    HRESULT hr = pCorProfilerInfo->GetCodeInfo2(
+        functionId, static_cast<ULONG32>(sizeof(codeInfos) / sizeof(codeInfos[0])),
+        &codeInfoCount, codeInfos);
+    if (FAILED(hr) || codeInfoCount == 0)
+    {
+        _failures++;
+    }
+    else
+    {
+        FunctionID roundTrip = 0;
+        hr = pCorProfilerInfo->GetFunctionFromIP(
+            reinterpret_cast<LPCBYTE>(codeInfos[0].startAddress), &roundTrip);
+        if (SUCCEEDED(hr) && roundTrip == functionId)
+        {
+            _ipRoundTrips++;
+        }
+        else
+        {
+            _failures++;
+        }
+    }
+
+    COR_DEBUG_IL_TO_NATIVE_MAP mappings[512];
+    ULONG32 mappingCount = 0;
+    hr = pCorProfilerInfo->GetILToNativeMapping(
+        functionId, static_cast<ULONG32>(sizeof(mappings) / sizeof(mappings[0])),
+        &mappingCount, mappings);
+    if (SUCCEEDED(hr) && mappingCount > 0)
+    {
+        _ilMappings++;
+    }
+    else
+    {
+        _failures++;
+    }
+
+    return S_OK;
+}
+
+HRESULT RuntimeAsyncApisProfiler::ExceptionThrown(ObjectID thrownObjectId)
+{
+    _exceptionsThrown++;
+    return S_OK;
+}
+
+HRESULT RuntimeAsyncApisProfiler::ExceptionSearchFunctionEnter(FunctionID functionId)
+{
+    if (functionId == _target.load())
+    {
+        _targetSearches++;
+    }
+    return S_OK;
+}
+
+HRESULT RuntimeAsyncApisProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)
+{
+    if (functionId == _target.load())
+    {
+        _targetUnwinds++;
+    }
+    return S_OK;
+}
+
+HRESULT RuntimeAsyncApisProfiler::ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId)
+{
+    _catchers++;
+    return S_OK;
+}
+
+HRESULT RuntimeAsyncApisProfiler::Shutdown()
+{
+    HRESULT hr = Profiler::Shutdown();
+
+    printf("RuntimeAsyncApisProfiler: failures=%d jit=%d/%d ip=%d il=%d "
+           "thrown=%d searches=%d unwinds=%d catchers=%d\n",
+           _failures.load(), _jitStarts.load(), _jitFinishes.load(),
+           _ipRoundTrips.load(), _ilMappings.load(), _exceptionsThrown.load(),
+           _targetSearches.load(), _targetUnwinds.load(), _catchers.load());
+
+    bool passed =
+        SUCCEEDED(hr) &&
+        _failures == 0 &&
+        _target != 0 &&
+        _jitStarts > 0 &&
+        _jitFinishes > 0 &&
+        _ipRoundTrips > 0 &&
+        _ilMappings > 0 &&
+        _exceptionsThrown > 0 &&
+        (_targetSearches > 0 || _targetUnwinds > 0) &&
+        _catchers > 0;
+
+    printf(passed ? "PROFILER TEST PASSES\n" : "PROFILER TEST FAILED\n");
+    fflush(stdout);
+    return hr;
+}
+
+ModuleID RuntimeAsyncApisProfiler::GetModuleId(FunctionID functionId)
+{
+    ClassID classId = 0;
+    ModuleID moduleId = 0;
+    mdToken token = 0;
+    ULONG32 typeArgumentCount = 0;
+    ClassID typeArguments[SHORT_LENGTH];
+    COR_PRF_FRAME_INFO frameInfo = 0;
+
+    HRESULT hr = pCorProfilerInfo->GetFunctionInfo2(
+        functionId, frameInfo, &classId, &moduleId, &token,
+        SHORT_LENGTH, &typeArgumentCount, typeArguments);
+    return SUCCEEDED(hr) ? moduleId : 0;
+}

--- a/src/tests/profiler/native/runtimeasyncapis/runtimeasyncapisprofiler.h
+++ b/src/tests/profiler/native/runtimeasyncapis/runtimeasyncapisprofiler.h
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "../profiler.h"
+
+class RuntimeAsyncApisProfiler : public Profiler
+{
+public:
+    RuntimeAsyncApisProfiler();
+
+    static GUID GetClsid();
+    HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pCorProfilerInfoUnk) override;
+    HRESULT STDMETHODCALLTYPE Shutdown() override;
+    HRESULT STDMETHODCALLTYPE JITCompilationStarted(
+        FunctionID functionId, BOOL fIsSafeToBlock) override;
+    HRESULT STDMETHODCALLTYPE JITCompilationFinished(
+        FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock) override;
+    HRESULT STDMETHODCALLTYPE ExceptionThrown(ObjectID thrownObjectId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionEnter(FunctionID functionId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionEnter(FunctionID functionId) override;
+    HRESULT STDMETHODCALLTYPE ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId) override;
+
+private:
+    bool IsTarget(FunctionID functionId);
+    ModuleID GetModuleId(FunctionID functionId);
+
+    std::atomic<int> _failures;
+    std::atomic<FunctionID> _target;
+    std::atomic<int> _jitStarts;
+    std::atomic<int> _jitFinishes;
+    std::atomic<int> _ipRoundTrips;
+    std::atomic<int> _ilMappings;
+    std::atomic<int> _exceptionsThrown;
+    std::atomic<int> _targetSearches;
+    std::atomic<int> _targetUnwinds;
+    std::atomic<int> _catchers;
+};

--- a/src/tests/profiler/native/runtimeasynctypes/runtimeasynctypesprofiler.cpp
+++ b/src/tests/profiler/native/runtimeasynctypes/runtimeasynctypesprofiler.cpp
@@ -42,6 +42,8 @@ HRESULT RuntimeAsyncTypesProfiler::Initialize(IUnknown* pCorProfilerInfoUnk)
 
 HRESULT RuntimeAsyncTypesProfiler::ClassLoadStarted(ClassID classId)
 {
+    SHUTDOWNGUARD();
+
     _classLoadStarts++;
     std::lock_guard<std::mutex> lock(_stateLock);
     _classLoadsInProgress.insert(classId);
@@ -50,6 +52,8 @@ HRESULT RuntimeAsyncTypesProfiler::ClassLoadStarted(ClassID classId)
 
 HRESULT RuntimeAsyncTypesProfiler::ClassLoadFinished(ClassID classId, HRESULT hrStatus)
 {
+    SHUTDOWNGUARD();
+
     _classLoadFinishes++;
 
     {
@@ -154,6 +158,8 @@ bool RuntimeAsyncTypesProfiler::CheckContinuationApis(ClassID classId)
 HRESULT RuntimeAsyncTypesProfiler::GarbageCollectionStarted(
     int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason)
 {
+    SHUTDOWNGUARD();
+
     _gcStarts++;
     std::lock_guard<std::mutex> lock(_stateLock);
     _objectClasses.clear();
@@ -164,6 +170,8 @@ HRESULT RuntimeAsyncTypesProfiler::GarbageCollectionStarted(
 HRESULT RuntimeAsyncTypesProfiler::ObjectReferences(
     ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[])
 {
+    SHUTDOWNGUARD();
+
     bool metadataLess = CheckContinuationApis(classId);
 
     std::lock_guard<std::mutex> lock(_stateLock);
@@ -211,6 +219,8 @@ void RuntimeAsyncTypesProfiler::AnalyzeObjectGraph()
 
 HRESULT RuntimeAsyncTypesProfiler::GarbageCollectionFinished()
 {
+    SHUTDOWNGUARD();
+
     AnalyzeObjectGraph();
     return S_OK;
 }

--- a/src/tests/profiler/native/runtimeasynctypes/runtimeasynctypesprofiler.cpp
+++ b/src/tests/profiler/native/runtimeasynctypes/runtimeasynctypesprofiler.cpp
@@ -1,0 +1,252 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "runtimeasynctypesprofiler.h"
+
+RuntimeAsyncTypesProfiler::RuntimeAsyncTypesProfiler()
+    : Profiler(),
+      _failures(0),
+      _classLoadStarts(0),
+      _classLoadFinishes(0),
+      _classLoadPairFailures(0),
+      _arrayClassLoads(0),
+      _continuationClassLoads(0),
+      _gcStarts(0),
+      _classInfo1Incomplete(0),
+      _classInfo2Incomplete(0),
+      _classLayoutIncomplete(0),
+      _continuationContractFailures(0),
+      _nilTokenLeaks(0),
+      _continuationObjects(0),
+      _continuationArrayEdges(0)
+{
+}
+
+GUID RuntimeAsyncTypesProfiler::GetClsid()
+{
+    // {7F4E1A63-92C5-4D81-AB37-560EC294F108}
+    GUID clsid = {0x7f4e1a63, 0x92c5, 0x4d81, {0xab, 0x37, 0x56, 0x0e, 0xc2, 0x94, 0xf1, 0x08}};
+    return clsid;
+}
+
+HRESULT RuntimeAsyncTypesProfiler::Initialize(IUnknown* pCorProfilerInfoUnk)
+{
+    HRESULT hr = Profiler::Initialize(pCorProfilerInfoUnk);
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    return pCorProfilerInfo->SetEventMask2(COR_PRF_MONITOR_CLASS_LOADS | COR_PRF_MONITOR_GC, 0);
+}
+
+HRESULT RuntimeAsyncTypesProfiler::ClassLoadStarted(ClassID classId)
+{
+    _classLoadStarts++;
+    std::lock_guard<std::mutex> lock(_stateLock);
+    _classLoadsInProgress.insert(classId);
+    return S_OK;
+}
+
+HRESULT RuntimeAsyncTypesProfiler::ClassLoadFinished(ClassID classId, HRESULT hrStatus)
+{
+    _classLoadFinishes++;
+
+    {
+        std::lock_guard<std::mutex> lock(_stateLock);
+        if (_classLoadsInProgress.erase(classId) == 0)
+        {
+            _classLoadPairFailures++;
+        }
+    }
+
+    if (FAILED(hrStatus))
+    {
+        _failures++;
+        return S_OK;
+    }
+
+    CorElementType baseElementType = ELEMENT_TYPE_END;
+    ClassID baseClassId = 0;
+    ULONG rank = 0;
+    HRESULT hr = pCorProfilerInfo->IsArrayClass(classId, &baseElementType, &baseClassId, &rank);
+    if (hr == S_OK)
+    {
+        _arrayClassLoads++;
+    }
+    else if (hr == S_FALSE)
+    {
+        ModuleID moduleId = 0;
+        mdTypeDef token = 0;
+        ClassID parentClassId = 0;
+        ULONG32 typeArgumentCount = 0;
+        hr = pCorProfilerInfo->GetClassIDInfo2(
+            classId, &moduleId, &token, &parentClassId, 0, &typeArgumentCount, nullptr);
+        if (hr == CORPROF_E_DATAINCOMPLETE)
+        {
+            _continuationClassLoads++;
+        }
+    }
+    else
+    {
+        _failures++;
+    }
+
+    return S_OK;
+}
+
+bool RuntimeAsyncTypesProfiler::CheckContinuationApis(ClassID classId)
+{
+    ModuleID moduleId = 0;
+    mdTypeDef token = 0;
+    ClassID parentClassId = 0;
+    ULONG32 typeArgumentCount = 0;
+
+    HRESULT info2 = pCorProfilerInfo->GetClassIDInfo2(
+        classId, &moduleId, &token, &parentClassId, 0, &typeArgumentCount, nullptr);
+    if (info2 == CORPROF_E_DATAINCOMPLETE)
+    {
+        _classInfo2Incomplete++;
+    }
+    bool info2ReturnedNilToken = info2 == S_OK && IsNilToken(token);
+
+    moduleId = 0;
+    token = 0;
+    HRESULT info1 = pCorProfilerInfo->GetClassIDInfo(classId, &moduleId, &token);
+    if (info1 == CORPROF_E_DATAINCOMPLETE)
+    {
+        _classInfo1Incomplete++;
+    }
+    bool info1ReturnedNilToken = info1 == S_OK && IsNilToken(token);
+
+    COR_FIELD_OFFSET fieldOffsets[64];
+    ULONG fieldCount = 0;
+    ULONG classSize = 0;
+    HRESULT layout = pCorProfilerInfo->GetClassLayout(
+        classId,
+        fieldOffsets,
+        static_cast<ULONG>(sizeof(fieldOffsets) / sizeof(fieldOffsets[0])),
+        &fieldCount,
+        &classSize);
+    if (layout == CORPROF_E_DATAINCOMPLETE)
+    {
+        _classLayoutIncomplete++;
+    }
+
+    bool metadataLess = info1 == CORPROF_E_DATAINCOMPLETE ||
+                        info2 == CORPROF_E_DATAINCOMPLETE ||
+                        layout == CORPROF_E_DATAINCOMPLETE;
+    if (metadataLess &&
+        (info1 != CORPROF_E_DATAINCOMPLETE ||
+         info2 != CORPROF_E_DATAINCOMPLETE ||
+         layout != CORPROF_E_DATAINCOMPLETE))
+    {
+        _continuationContractFailures++;
+    }
+    if (metadataLess && (info1ReturnedNilToken || info2ReturnedNilToken))
+    {
+        _nilTokenLeaks++;
+    }
+
+    return metadataLess;
+}
+
+HRESULT RuntimeAsyncTypesProfiler::GarbageCollectionStarted(
+    int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason)
+{
+    _gcStarts++;
+    std::lock_guard<std::mutex> lock(_stateLock);
+    _objectClasses.clear();
+    _continuationEdges.clear();
+    return S_OK;
+}
+
+HRESULT RuntimeAsyncTypesProfiler::ObjectReferences(
+    ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[])
+{
+    bool metadataLess = CheckContinuationApis(classId);
+
+    std::lock_guard<std::mutex> lock(_stateLock);
+    _objectClasses[objectId] = classId;
+    if (metadataLess)
+    {
+        _continuationObjects++;
+        for (ULONG i = 0; i < cObjectRefs; i++)
+        {
+            if (objectRefIds[i] != 0)
+            {
+                _continuationEdges.emplace_back(objectId, objectRefIds[i]);
+            }
+        }
+    }
+
+    return S_OK;
+}
+
+void RuntimeAsyncTypesProfiler::AnalyzeObjectGraph()
+{
+    int arrayEdges = 0;
+    std::lock_guard<std::mutex> lock(_stateLock);
+    for (const auto& edge : _continuationEdges)
+    {
+        auto target = _objectClasses.find(edge.second);
+        if (target == _objectClasses.end())
+        {
+            continue;
+        }
+
+        CorElementType baseElementType = ELEMENT_TYPE_END;
+        ClassID baseClassId = 0;
+        ULONG rank = 0;
+        if (pCorProfilerInfo->IsArrayClass(
+                target->second, &baseElementType, &baseClassId, &rank) == S_OK &&
+            rank == 1)
+        {
+            arrayEdges++;
+        }
+    }
+
+    _continuationArrayEdges += arrayEdges;
+}
+
+HRESULT RuntimeAsyncTypesProfiler::GarbageCollectionFinished()
+{
+    AnalyzeObjectGraph();
+    return S_OK;
+}
+
+HRESULT RuntimeAsyncTypesProfiler::Shutdown()
+{
+    HRESULT hr = Profiler::Shutdown();
+
+    printf("RuntimeAsyncTypesProfiler: failures=%d classLoads=%d/%d pairFailures=%d "
+           "arrays=%d continuations=%d info1=%d info2=%d layout=%d contractFailures=%d "
+           "nilTokens=%d gcStarts=%d continuationObjects=%d arrayEdges=%d\n",
+           _failures.load(),
+           _classLoadStarts.load(), _classLoadFinishes.load(), _classLoadPairFailures.load(),
+           _arrayClassLoads.load(), _continuationClassLoads.load(),
+           _classInfo1Incomplete.load(), _classInfo2Incomplete.load(),
+           _classLayoutIncomplete.load(), _continuationContractFailures.load(),
+           _nilTokenLeaks.load(), _gcStarts.load(), _continuationObjects.load(),
+           _continuationArrayEdges.load());
+
+    bool passed =
+        SUCCEEDED(hr) &&
+        _failures == 0 &&
+        _classLoadStarts == _classLoadFinishes &&
+        _classLoadPairFailures == 0 &&
+        _arrayClassLoads > 0 &&
+        _continuationClassLoads > 0 &&
+        _gcStarts > 0 &&
+        _classInfo1Incomplete > 0 &&
+        _classInfo2Incomplete > 0 &&
+        _classLayoutIncomplete > 0 &&
+        _continuationContractFailures == 0 &&
+        _nilTokenLeaks == 0 &&
+        _continuationObjects > 0 &&
+        _continuationArrayEdges > 0;
+
+    printf(passed ? "PROFILER TEST PASSES\n" : "PROFILER TEST FAILED\n");
+    fflush(stdout);
+    return hr;
+}

--- a/src/tests/profiler/native/runtimeasynctypes/runtimeasynctypesprofiler.h
+++ b/src/tests/profiler/native/runtimeasynctypes/runtimeasynctypesprofiler.h
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "../profiler.h"
+
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+class RuntimeAsyncTypesProfiler : public Profiler
+{
+public:
+    RuntimeAsyncTypesProfiler();
+
+    static GUID GetClsid();
+    HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pCorProfilerInfoUnk) override;
+    HRESULT STDMETHODCALLTYPE Shutdown() override;
+    HRESULT STDMETHODCALLTYPE ClassLoadStarted(ClassID classId) override;
+    HRESULT STDMETHODCALLTYPE ClassLoadFinished(ClassID classId, HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE GarbageCollectionStarted(
+        int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason) override;
+    HRESULT STDMETHODCALLTYPE GarbageCollectionFinished() override;
+    HRESULT STDMETHODCALLTYPE ObjectReferences(
+        ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[]) override;
+
+private:
+    bool CheckContinuationApis(ClassID classId);
+    void AnalyzeObjectGraph();
+
+    std::atomic<int> _failures;
+    std::atomic<int> _classLoadStarts;
+    std::atomic<int> _classLoadFinishes;
+    std::atomic<int> _classLoadPairFailures;
+    std::atomic<int> _arrayClassLoads;
+    std::atomic<int> _continuationClassLoads;
+    std::atomic<int> _gcStarts;
+    std::atomic<int> _classInfo1Incomplete;
+    std::atomic<int> _classInfo2Incomplete;
+    std::atomic<int> _classLayoutIncomplete;
+    std::atomic<int> _continuationContractFailures;
+    std::atomic<int> _nilTokenLeaks;
+    std::atomic<int> _continuationObjects;
+    std::atomic<int> _continuationArrayEdges;
+
+    std::mutex _stateLock;
+    std::unordered_set<ClassID> _classLoadsInProgress;
+    std::unordered_map<ObjectID, ClassID> _objectClasses;
+    std::vector<std::pair<ObjectID, ObjectID>> _continuationEdges;
+};

--- a/src/tests/profiler/runtimeasyncapis/runtimeasyncapis.cs
+++ b/src/tests/profiler/runtimeasyncapis/runtimeasyncapis.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Profiler.Tests;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+
+internal static class RuntimeAsyncApis
+{
+    private static readonly Guid ProfilerGuid = new("9A20F5D8-47B1-4E63-82CD-1F7690AB34E2");
+
+    public static int Main(string[] args)
+    {
+        if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
+        {
+            return RunTest();
+        }
+
+        return ProfilerTestRunner.Run(
+            profileePath: Assembly.GetExecutingAssembly().Location,
+            testName: "RuntimeAsyncApis",
+            profilerClsid: ProfilerGuid,
+            profileeOptions: ProfileeOptions.OptimizationSensitive,
+            envVars: new Dictionary<string, string>
+            {
+                ["DOTNET_RuntimeAsync"] = "1"
+            });
+    }
+
+    private static async Task<int> Work()
+    {
+        await Task.Yield();
+        throw new InvalidOperationException("Runtime Async profiler exception");
+    }
+
+    private static async Task<int> RunAsync()
+    {
+        try
+        {
+            await Work();
+        }
+        catch (InvalidOperationException)
+        {
+            return 100;
+        }
+
+        return 1;
+    }
+
+    private static int RunTest() => RunAsync().GetAwaiter().GetResult();
+}

--- a/src/tests/profiler/runtimeasyncapis/runtimeasyncapis.csproj
+++ b/src/tests/profiler/runtimeasyncapis/runtimeasyncapis.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <Optimize>true</Optimize>
+    <Features>runtime-async=on</Features>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+    <ProjectReference Include="../common/profiler_common.csproj" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/profiler/runtimeasyncapis/runtimeasyncapis.csproj
+++ b/src/tests/profiler/runtimeasyncapis/runtimeasyncapis.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <OutputType>exe</OutputType>
     <Optimize>true</Optimize>
-    <Features>runtime-async=on</Features>
+    <Features>$(Features);runtime-async=on</Features>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/runtimeasynctypes/runtimeasynctypes.cs
+++ b/src/tests/profiler/runtimeasynctypes/runtimeasynctypes.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Profiler.Tests;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+
+internal static class RuntimeAsyncTypes
+{
+    private struct Payload
+    {
+        public int Value;
+    }
+
+    private static readonly Guid ProfilerGuid = new("7F4E1A63-92C5-4D81-AB37-560EC294F108");
+    private static readonly TaskCompletionSource<int> Gate =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public static int Main(string[] args)
+    {
+        if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
+        {
+            return RunTest();
+        }
+
+        return ProfilerTestRunner.Run(
+            profileePath: Assembly.GetExecutingAssembly().Location,
+            testName: "RuntimeAsyncTypes",
+            profilerClsid: ProfilerGuid,
+            envVars: new Dictionary<string, string>
+            {
+                ["DOTNET_RuntimeAsync"] = "1"
+            });
+    }
+
+    private static async Task<int> Suspended(Payload[] payload)
+    {
+        await Gate.Task;
+        return payload[0].Value;
+    }
+
+    private static int RunTest()
+    {
+        const int ContinuationCount = 32;
+        Task<int>[] suspended = new Task<int>[ContinuationCount];
+        for (int i = 0; i < suspended.Length; i++)
+        {
+            Payload[] payload = new Payload[16];
+            payload[0].Value = i;
+            suspended[i] = Suspended(payload);
+        }
+
+        for (int i = 0; i < 10; i++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+        }
+
+        Gate.SetResult(0);
+        Task.WaitAll(suspended);
+        return 100;
+    }
+}

--- a/src/tests/profiler/runtimeasynctypes/runtimeasynctypes.csproj
+++ b/src/tests/profiler/runtimeasynctypes/runtimeasynctypes.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <Optimize>true</Optimize>
+    <Features>runtime-async=on</Features>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+    <ProjectReference Include="../common/profiler_common.csproj" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/profiler/runtimeasynctypes/runtimeasynctypes.csproj
+++ b/src/tests/profiler/runtimeasynctypes/runtimeasynctypes.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <OutputType>exe</OutputType>
     <Optimize>true</Optimize>
-    <Features>runtime-async=on</Features>
+    <Features>$(Features);runtime-async=on</Features>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

Add in-tree Runtime Async profiler coverage for:

- array and metadata-less continuation `ClassLoad` callbacks
- `GetClassIDInfo`, `GetClassIDInfo2`, and `GetClassLayout` rejection behavior
- continuation-to-captured-array GC reference traversal
- JIT callbacks, FunctionID/native-IP round-tripping, and IL-to-native mappings
- exception search, unwind, and catcher callbacks

Validated on Windows x64 and Linux x64.

Relates to dotnet/runtime#120799 and dotnet/runtime#120800.