### PR TITLE
Deduplicate minipal thread ID TLS cache.

### DIFF
--- a/src/native/minipal/CMakeLists.txt
+++ b/src/native/minipal/CMakeLists.txt
@@ -29,7 +29,10 @@ if(NOT WIN32 AND NOT HOST_WASM AND NOT (CLR_CMAKE_TARGET_ARCH_WASM AND NOT CLR_C
 endif()
 
 if(CLR_CMAKE_HOST_UNIX)
-    list(APPEND SOURCES cpucount.c)
+    list(APPEND SOURCES
+        cpucount.c
+        thread.c
+    )
 endif()
 
 # Provide an object library for scenarios where we ship static libraries

--- a/src/native/minipal/thread.c
+++ b/src/native/minipal/thread.c
@@ -4,5 +4,5 @@
 #include <minipal/thread.h>
 
 #if !defined(__wasm) || defined(_REENTRANT)
-MINIPAL_THREAD_LOCAL size_t minipal_cached_thread_id;
+PLATFORM_THREAD_LOCAL size_t minipal_cached_thread_id;
 #endif

--- a/src/native/minipal/thread.c
+++ b/src/native/minipal/thread.c
@@ -1,7 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#include <minipal/thread.h>
+#include <stddef.h>
+#include <minipal/utils.h>
 
 #if !defined(__wasm) || defined(_REENTRANT)
 PLATFORM_THREAD_LOCAL size_t minipal_cached_thread_id;

--- a/src/native/minipal/thread.c
+++ b/src/native/minipal/thread.c
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <minipal/thread.h>
+
+#if !defined(__wasm) || defined(_REENTRANT)
+MINIPAL_THREAD_LOCAL size_t minipal_cached_thread_id;
+#endif

--- a/src/native/minipal/thread.h
+++ b/src/native/minipal/thread.h
@@ -41,6 +41,14 @@
 extern "C" {
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__) && defined(__cplusplus)
+// GCC doesn't support _Thread_local in C++ mode. __thread provides the same
+// static TLS initialization semantics without C++ thread_local initialization checks.
+#define MINIPAL_THREAD_LOCAL __thread
+#else
+#define MINIPAL_THREAD_LOCAL _Thread_local
+#endif
+
 /**
  * Get the current thread ID without caching in a TLS variable.
  *
@@ -79,6 +87,10 @@ static inline size_t minipal_get_current_thread_id_no_cache(void)
     return tid;
 }
 
+#if !defined(__wasm) || defined(_REENTRANT)
+extern MINIPAL_THREAD_LOCAL size_t minipal_cached_thread_id;
+#endif
+
 /**
  * Get the current thread ID.
  *
@@ -90,20 +102,12 @@ static inline size_t minipal_get_current_thread_id(void)
     return minipal_get_current_thread_id_no_cache();
 
 #else // !__wasm || _REENTRANT
-#if defined(__GNUC__) && !defined(__clang__) && defined(__cplusplus)
-    // gcc doesn't like _Thread_local when __cplusplus is defined.
-    // although thread_local is C2x, which other compilers don't allow with C11.
-    static thread_local size_t tid = 0;
-#else
-    static _Thread_local size_t tid = 0;
-#endif
-
-    if (!tid)
+    if (!minipal_cached_thread_id)
     {
-        tid = minipal_get_current_thread_id_no_cache();
+        minipal_cached_thread_id = minipal_get_current_thread_id_no_cache();
     }
 
-    return tid;
+    return minipal_cached_thread_id;
 #endif // __wasm && !_REENTRANT
 }
 

--- a/src/native/minipal/thread.h
+++ b/src/native/minipal/thread.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
+#include <minipal/utils.h>
 
 #if defined(__linux__)
 #include <unistd.h>
@@ -39,14 +40,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__) && defined(__cplusplus)
-// GCC doesn't support _Thread_local in C++ mode. __thread provides the same
-// static TLS initialization semantics without C++ thread_local initialization checks.
-#define MINIPAL_THREAD_LOCAL __thread
-#else
-#define MINIPAL_THREAD_LOCAL _Thread_local
 #endif
 
 /**
@@ -88,7 +81,7 @@ static inline size_t minipal_get_current_thread_id_no_cache(void)
 }
 
 #if !defined(__wasm) || defined(_REENTRANT)
-extern MINIPAL_THREAD_LOCAL size_t minipal_cached_thread_id;
+extern PLATFORM_THREAD_LOCAL size_t minipal_cached_thread_id;
 #endif
 
 /**


### PR DESCRIPTION
## Summary

Deduplicate the TLS cache used by `minipal_get_current_thread_id`.

Fixes #131954.

## Root cause

`minipal_get_current_thread_id` previously declared its cached thread ID as a function-local `static thread_local` variable in `thread.h`.

Because the function has internal linkage, each translation unit using it could emit a separate 8-byte TLS slot. Enabling the in-process crash reporter added another consumer, increasing `libcoreclr.so`'s TLS footprint enough to exceed glibc's optional static TLS allocation on Linux ARM64.

This caused glibc to resolve CoreCLR TLS accesses through `_dl_tlsdesc_dynamic` instead of `_dl_tlsdesc_return`, adding overhead to allocation, thread-static access, and other common runtime paths.

## Changes

- Move the cached thread ID into a single minipal compilation unit.
- Externally declare the shared TLS variable from `thread.h`.
- Use a common macro for the C and C++ TLS storage-class spellings.

## Validation

A test with two independent C and C++ translation units showed:

- Before: two local 8-byte TLS slots and a 16-byte TLS segment.
- After: one shared 8-byte TLS slot.
- GCC C++ emits no TLS dynamic-initialization relocation for the shared variable.