### PR TITLE
Add defensive null‑check for pTargetMD

### DIFF
--- a/src/coreclr/vm/tailcallhelp.cpp
+++ b/src/coreclr/vm/tailcallhelp.cpp
@@ -297,7 +297,7 @@ bool TailCallHelp::GenerateGCDescriptor(
             {
 #ifndef TARGET_X86
                 // The generic instantiation arg is right after this pointer
-                if (reportInstArg)
+                if (reportInstArg && pTargetMD)
                 {
                     _ASSERTE(i == 0 || i == 1);
                     builder->WriteToken(argPos, pTargetMD->RequiresInstMethodDescArg() ? GCREFMAP_METHOD_PARAM : GCREFMAP_TYPE_PARAM);
@@ -326,7 +326,7 @@ bool TailCallHelp::GenerateGCDescriptor(
 
 #ifdef TARGET_X86
     // The generic instantiation arg is last
-    if (reportInstArg)
+    if (reportInstArg && pTargetMD)
     {
         const ArgBufferValue& val = layout.Values[layout.Values.GetCount() - 1];
         unsigned int argPos = (val.Offset - offsetof(TailCallArgBuffer, Args)) / TARGET_POINTER_SIZE;


### PR DESCRIPTION
`pCalleeMD` could be dereferenced even if it is `NULL` because there are no checks in place. Add checks in `GenerateGCDescriptor` method before accessing `pTargetMD` to prevent a potential null pointer dereference if the target method descriptor is not supplied. 

Signed-off-by: Aleksandr Dovydenkov <asd@altlinux.org>
Found by Linux Verification Center (linuxtesting.org) with SVACE.