### PR TITLE
Fix Turkish casing on Android by deriving it from the locale name

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Icu.cs
@@ -14,7 +14,20 @@ namespace System.Globalization
         {
             Debug.Assert(localeName != null);
 
-            return CultureInfo.GetCultureInfo(localeName).CompareInfo.Compare("\u0131", "I", CompareOptions.IgnoreCase) == 0;
+            // ICU applies the Turkish dotted/dotless "i" casing rules to the "tr" and "az"
+            // languages. This is determined from the locale name rather than by probing the
+            // collation tailoring, because some platforms (notably Android, which uses the
+            // system ICU) do not ship the collation data that probe relies on, which would
+            // silently fall back to non-Turkish casing.
+            ReadOnlySpan<char> language = localeName.AsSpan();
+            int separatorIndex = language.IndexOfAny('-', '_');
+            if (separatorIndex >= 0)
+            {
+                language = language.Slice(0, separatorIndex);
+            }
+
+            return language.Equals("tr", StringComparison.OrdinalIgnoreCase) ||
+                   language.Equals("az", StringComparison.OrdinalIgnoreCase);
         }
 
         internal unsafe void IcuChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper)


### PR DESCRIPTION
Fixes #106560

### Root cause

`TextInfo.NeedsTurkishCasing` (src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Icu.cs) decides whether to use `ChangeCaseTurkish` by probing collation:

```csharp
return CultureInfo.GetCultureInfo(localeName).CompareInfo.Compare("\u0131", "I", CompareOptions.IgnoreCase) == 0;
```

On Android the runtime loads the platform's system ICU (`libicuuc.so`/`libicui18n.so`), which does not provide the collation tailoring this probe depends on. The probe therefore returns `false` for `tr-TR`, `IcuChangeCase` falls through to the non-Turkish `ChangeCase`, and `"i".ToUpper(tr-TR)` yields `I` (U+0049) rather than `İ` (U+0130).

The same collation gap is already acknowledged in the test suite, which skips the `'ı'` vs `'I'` `CurrentCultureIgnoreCase` cases on Android with a pointer to this issue (`src/libraries/System.Runtime/tests/System.Runtime.Tests/System/CharTests.cs:178`).

### Fix

Derive the flag from the locale's language subtag instead. ICU itself applies the dotted/dotless *i* rules to exactly the `tr` and `az` languages (`ucase.cpp` treats both as `LOC_TURKISH`), so this is equivalent to the collation probe on platforms where the probe worked, while being independent of the collation data actually shipped by the host.

### Testing

Not verified on a device — I do not have an Android emulator/runtime build available here, so this is based on source analysis. Casing behaviour on other platforms should be unchanged, since `tr`/`az` are the only languages for which CLDR collates U+0131 equal to `I` under `IgnoreCase`. The disabled casing assertions referencing #106560 would be the natural way to validate this on CI; I left them untouched, as the `Compare`-based assertions in `CharTests` exercise collation rather than casing and are not fixed by this change.

Note: @murathanoktem mentioned on the issue that they were investigating. Happy to close this in favour of their PR — I am posting it because I had the root cause isolated.
