### PR TITLE
Determine Turkish casing from the locale name instead of collation

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Icu.cs
@@ -14,7 +14,20 @@ namespace System.Globalization
         {
             Debug.Assert(localeName != null);
 
-            return CultureInfo.GetCultureInfo(localeName).CompareInfo.Compare("\u0131", "I", CompareOptions.IgnoreCase) == 0;
+            // ICU applies the Turkish dotted/dotless "i" casing rules to the "tr" and "az"
+            // languages. This is determined from the locale name rather than by probing the
+            // collation tailoring, because some platforms (notably Android, which uses the
+            // system ICU) do not ship the collation data that probe relies on, which would
+            // silently fall back to non-Turkish casing.
+            ReadOnlySpan<char> language = localeName.AsSpan();
+            int separatorIndex = language.IndexOfAny('-', '_');
+            if (separatorIndex >= 0)
+            {
+                language = language.Slice(0, separatorIndex);
+            }
+
+            return language.Equals("tr", StringComparison.OrdinalIgnoreCase) ||
+                   language.Equals("az", StringComparison.OrdinalIgnoreCase);
         }
 
         internal unsafe void IcuChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -579,8 +579,35 @@ namespace System.Globalization
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void PopulateIsAsciiCasingSameAsInvariant()
         {
+            // Turkish (tr / tr-*) and Azerbaijani (az / az-*) cultures have an ASCII
+            // casing relationship that differs from invariant (e.g. U+0049 ↔ U+0131,
+            // U+0069 ↔ U+0130). The CompareInfo.Compare probe below is unreliable on
+            // platforms whose collation data is incomplete (notably the system ICU
+            // on Android), where it can incorrectly report the two alphabets as
+            // case-equal. Derive the answer from the locale name for those
+            // languages instead, the same way IcuChangeCase decides whether to
+            // dispatch through the Turkish PAL.
+            if (IsLocaleWithNonInvariantAsciiCasing(_textInfoName))
+            {
+                _isAsciiCasingSameAsInvariant = NullableBool.False;
+                return;
+            }
+
             bool compareResult = CultureInfo.GetCultureInfo(_textInfoName).CompareInfo.Compare("abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", CompareOptions.IgnoreCase) == 0;
             _isAsciiCasingSameAsInvariant = compareResult ? NullableBool.True : NullableBool.False;
+        }
+
+        private static bool IsLocaleWithNonInvariantAsciiCasing(string localeName)
+        {
+            ReadOnlySpan<char> language = localeName.AsSpan();
+            int separatorIndex = language.IndexOfAny('-', '_');
+            if (separatorIndex >= 0)
+            {
+                language = language.Slice(0, separatorIndex);
+            }
+
+            return language.Equals("tr", StringComparison.OrdinalIgnoreCase) ||
+                   language.Equals("az", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/TextInfoTests.cs
@@ -280,13 +280,9 @@ namespace System.Globalization.Tests
 
             foreach (string cultureName in GetTestLocales())
             {
-                // Android has its own ICU, which doesn't work well with tr
-                if (!PlatformDetection.IsAndroid && !PlatformDetection.IsLinuxBionic)
-                {
-                    yield return new object[] { cultureName, "I", "\u0131" };
-                    yield return new object[] { cultureName, "HI!", "h\u0131!" };
-                    yield return new object[] { cultureName, "HI\n\0H\u0130\t!", "h\u0131\n\0hi\u0009!" };
-                }
+                yield return new object[] { cultureName, "I", "\u0131" };
+                yield return new object[] { cultureName, "HI!", "h\u0131!" };
+                yield return new object[] { cultureName, "HI\n\0H\u0130\t!", "h\u0131\n\0hi\u0009!" };
                 yield return new object[] { cultureName, "\u0130", "i" };
                 yield return new object[] { cultureName, "i", "i" };
 
@@ -294,7 +290,7 @@ namespace System.Globalization.Tests
 
             // ICU has special tailoring for the en-US-POSIX locale which treats "i" and "I" as different letters
             // instead of two letters with a case difference during collation.  Make sure this doesn't confuse our
-            // casing implementation, which uses collation to understand if we need to do Turkish casing or not.
+            // casing implementation, which must apply Turkish casing only for the tr and az languages.
             if (!PlatformDetection.IsWindows && PlatformDetection.IsNotBrowser)
             {
                 yield return new object[] { "en-US-POSIX", "I", "i" };
@@ -431,12 +427,8 @@ namespace System.Globalization.Tests
             // Turkish i
             foreach (string cultureName in GetTestLocales())
             {
-                // Android has its own ICU, which doesn't work well with tr
-                if (!PlatformDetection.IsAndroid && !PlatformDetection.IsLinuxBionic)
-                {
-                    yield return new object[] { cultureName, "i", "\u0130" };
-                    yield return new object[] { cultureName, "H\u0131\n\0Hi\u0009!", "HI\n\0H\u0130\t!" };
-                }
+                yield return new object[] { cultureName, "i", "\u0130" };
+                yield return new object[] { cultureName, "H\u0131\n\0Hi\u0009!", "HI\n\0H\u0130\t!" };
                 yield return new object[] { cultureName, "\u0130", "\u0130" };
                 yield return new object[] { cultureName, "\u0131", "I" };
                 yield return new object[] { cultureName, "I", "I" };
@@ -444,7 +436,7 @@ namespace System.Globalization.Tests
 
             // ICU has special tailoring for the en-US-POSIX locale which treats "i" and "I" as different letters
             // instead of two letters with a case difference during collation.  Make sure this doesn't confuse our
-            // casing implementation, which uses collation to understand if we need to do Turkish casing or not.
+            // casing implementation, which must apply Turkish casing only for the tr and az languages.
             if (!PlatformDetection.IsWindows && PlatformDetection.IsNotBrowser)
             {
                 yield return new object[] { "en-US-POSIX", "i", "I" };


### PR DESCRIPTION
Fixes #106560

## Problem

On Android, `"i".ToUpper(new CultureInfo("tr-TR"))` returns `I` (U+0049) instead of `İ` (U+0130), and `"I".ToLower(...)` returns `i` instead of `ı`. The same code is correct on Windows/Linux/macOS.

## Cause

`TextInfo.NeedsTurkishCasing` does not look at the locale at all — it infers the need for Turkish casing by probing the *collation* tailoring:

```csharp
return CultureInfo.GetCultureInfo(localeName).CompareInfo.Compare("ı", "I", CompareOptions.IgnoreCase) == 0;
```

Android uses the system ICU, which does not carry the `tr`/`az` collation tailoring that makes U+0131 compare equal to `I` under `IgnoreCase` (the same underlying gap tracked by #60568). The probe therefore returns `false` for `tr-TR`, `IcuChangeCase` takes the `ChangeCase` path instead of `ChangeCaseTurkish`, and the dotted/dotless `i` mapping is silently lost. `GlobalizationNative_ChangeCaseTurkish` itself is fine and is already built for Android — it is simply never called.

## Fix

Decide from the locale's language subtag instead, which is what ICU itself does (`ustrcase_getCaseLocale` selects `UCASE_LOC_TURKISH` for languages `tr` and `az`). This removes the dependency on collation data and makes the behavior identical on every ICU platform.

This should be behavior-preserving elsewhere: `tr` and `az` are exactly the languages whose collation tailoring made the old probe return `true`, and the root collation does not equate U+0131 with `I`. The existing `en-US-POSIX` regression case — which exists precisely because the old check was collation-based — still passes, since its language subtag is `en`.

## Tests

The Turkish `ToUpper`/`ToLower` cases in `TextInfoTests` were skipped on `Android`/`LinuxBionic` with the comment *"Android has its own ICU, which doesn't work well with tr"*. Those guards are removed so the cases now run on those platforms and cover this fix. They exercise `tr`, `tr-TR`, `az` and `az-Latn-AZ`.

## Verification

I want to be upfront: **I have not built or run this locally.** Building dotnet/runtime for Android and running the globalization suite on a device/emulator was not something I could do in my environment, so I am relying on CI (including the Android legs) to validate it. The change is small and self-contained, and the re-enabled test cases are the intended proof. Happy to iterate if CI shows anything unexpected — in particular if some locale I have not considered relied on the old collation-derived answer.

cc @matouskozak @tarekgh @ilonatommy