### PR TITLE
Add kotlarmilos as a WebAssembly area owner

### DIFF
--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -166,8 +166,8 @@ Note: Editing this file doesn't update the mapping used by `@dotnet-policy-servi
 | os-ios           | @vitek-karas  | @kotlarmilos                                       |                 |
 | os-tizen         | @gbalykov     | @dotnet/samsung                                    |                 |
 | os-tvos          | @vitek-karas  | @kotlarmilos                                       |                 |
-| os-wasi          | @lewing       | @pavelsavara                                       |                 |
-| os-browser       | @lewing       | @pavelsavara                                       |                 |
+| os-wasi          | @lewing @kotlarmilos | @pavelsavara                                |                 |
+| os-browser       | @lewing @kotlarmilos | @pavelsavara                                |                 |
 
 ## Architectures
 
@@ -181,7 +181,7 @@ Note: Editing this file doesn't update the mapping used by `@dotnet-policy-servi
 | arch-loongarch64 | @shushanhf    | @LuckyXu-HF                                        |                 |
 | arch-riscv       | @gbalykov     | @dotnet/samsung                                    |                 |
 | arch-s390x       | @uweigand     | @uweigand                                          |                 |
-| arch-wasm        | @lewing       | @lewing, @pavelsavara                              |                 |
+| arch-wasm        | @lewing @kotlarmilos | @lewing, @pavelsavara                       |                 |
 
 ## Community Triagers
 

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -166,8 +166,8 @@ Note: Editing this file doesn't update the mapping used by `@dotnet-policy-servi
 | os-ios           | @vitek-karas  | @kotlarmilos                                       |                 |
 | os-tizen         | @gbalykov     | @dotnet/samsung                                    |                 |
 | os-tvos          | @vitek-karas  | @kotlarmilos                                       |                 |
-| os-wasi          | @lewing @kotlarmilos | @pavelsavara                                |                 |
-| os-browser       | @lewing @kotlarmilos | @pavelsavara                                |                 |
+| os-wasi          | @lewing       | @pavelsavara @kotlarmilos                          |                 |
+| os-browser       | @lewing       | @pavelsavara @kotlarmilos                          |                 |
 
 ## Architectures
 
@@ -181,7 +181,7 @@ Note: Editing this file doesn't update the mapping used by `@dotnet-policy-servi
 | arch-loongarch64 | @shushanhf    | @LuckyXu-HF                                        |                 |
 | arch-riscv       | @gbalykov     | @dotnet/samsung                                    |                 |
 | arch-s390x       | @uweigand     | @uweigand                                          |                 |
-| arch-wasm        | @lewing @kotlarmilos | @lewing, @pavelsavara                       |                 |
+| arch-wasm        | @lewing       | @lewing, @pavelsavara, @kotlarmilos                |                 |
 
 ## Community Triagers
 


### PR DESCRIPTION
Add `@kotlarmilos` beside `@pavelsavara` as an owner for `os-wasi`, `os-browser`, and `arch-wasm`.