### PR TITLE
Fix NativeAOT aggregate executable dSYM publish paths

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -52,7 +52,10 @@
       </ResolvedFileToPublish>
       <_AggregateExecutableShimSymbolRecursivePath Include="%(_AggregateExecutableReferencePath.ShimSymbol)/**/*"
                                              Condition="'$(_AggregateExecutable)' == 'true' and '$(CopyOutputSymbolsToPublishDirectory)' == 'true' and '$(NativeSymbolExt)' == '.dSYM' and Exists('%(_AggregateExecutableReferencePath.ShimSymbol)')">
-        <RelativePath>%(_AggregateExecutableReferencePath.AssemblyName)$(NativeSymbolExt)/%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+        <SymbolBundleName>%(_AggregateExecutableReferencePath.AssemblyName)$(NativeSymbolExt)</SymbolBundleName>
+      </_AggregateExecutableShimSymbolRecursivePath>
+      <_AggregateExecutableShimSymbolRecursivePath Update="@(_AggregateExecutableShimSymbolRecursivePath)">
+        <RelativePath>%(_AggregateExecutableShimSymbolRecursivePath.SymbolBundleName)/%(_AggregateExecutableShimSymbolRecursivePath.RecursiveDir)%(_AggregateExecutableShimSymbolRecursivePath.Filename)%(_AggregateExecutableShimSymbolRecursivePath.Extension)</RelativePath>
       </_AggregateExecutableShimSymbolRecursivePath>
       <ResolvedFileToPublish Include="@(_AggregateExecutableShimSymbolRecursivePath)"
                              Condition="'$(_AggregateExecutable)' == 'true' and '$(CopyOutputSymbolsToPublishDirectory)' == 'true'">

--- a/src/tests/nativeaot/AggregateExecutableLibrary/AggregateLibrary.csproj
+++ b/src/tests/nativeaot/AggregateExecutableLibrary/AggregateLibrary.csproj
@@ -16,6 +16,8 @@
     <CLRTestRunFile Condition="'$(TargetsWindows)' != 'true'">./native/ValidatorExe</CLRTestRunFile>
     <SkipInferOutputType>true</SkipInferOutputType>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <NativeDebugSymbols Condition="'$(TargetsOSX)' == 'true'">true</NativeDebugSymbols>
+    <CopyOutputSymbolsToPublishDirectory Condition="'$(TargetsOSX)' == 'true'">true</CopyOutputSymbolsToPublishDirectory>
     <!-- warning CS2008: No source files specified -->
     <NoWarn>$(NoWarn);CS2008</NoWarn>
   </PropertyGroup>
@@ -31,6 +33,12 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="UseDsymAggregateExecutableShimSymbols" BeforeTargets="ComputeAggregateExecutableInputs" Condition="'$(TargetsOSX)' == 'true'">
+    <PropertyGroup>
+      <NativeSymbolExt>.dSYM</NativeSymbolExt>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="WriteHelixExtraExecutablesList" AfterTargets="NativeCompile" Condition="'$(TargetsWindows)' != 'true'">
     <PropertyGroup>
       <_HelloExeRelative>$(BuildProjectRelativeDir)native/HelloExe</_HelloExeRelative>
@@ -38,5 +46,17 @@
     </PropertyGroup>
 
     <WriteLinesToFile File="$(TargetDir)helix-extra-executables.list" Lines="$(_HelloExeRelative)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+  </Target>
+
+  <Target Name="ValidateAggregateExecutableShimSymbols" AfterTargets="NativeCompile" Condition="'$(TargetsOSX)' == 'true'">
+    <ItemGroup>
+      <_ExpectedAggregateExecutableShimSymbol Include="HelloExe.dSYM/Contents/Info.plist" />
+      <_ExpectedAggregateExecutableShimSymbol Include="HelloExe.dSYM/Contents/Resources/DWARF/HelloExe" />
+      <_PublishedFileRelativePath Include="@(ResolvedFileToPublish->'%(RelativePath)')" />
+      <_MissingAggregateExecutableShimSymbol Include="@(_ExpectedAggregateExecutableShimSymbol)" Exclude="@(_PublishedFileRelativePath)" />
+    </ItemGroup>
+
+    <Error Condition="'@(_MissingAggregateExecutableShimSymbol)' != ''"
+           Text="Aggregate executable shim symbol files have incorrect publish paths: @(_MissingAggregateExecutableShimSymbol, ', ')" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary

- Preserve the metadata of each expanded aggregate executable shim dSYM entry when assigning its publish path.
- Prevent dSYM contents from collapsing to paths such as `HelloExe.dSYM/HelloExe.dll`, which can leave non-PE files with a `.dll` extension in packages.
- Extend the aggregate executable test on macOS to produce dSYM bundles and validate the expected `Contents/Info.plist` and `Contents/Resources/DWARF` paths.

dotnet/dotnet#8135 enabled publishing the ASP.NET Core NativeAOT tool symbols and exposed this issue during VMR package signing. The underlying publish-path logic came from dotnet/runtime#128553.

The resulting error was that every bundle file received the same destination:

`dotnet-dev-certs.dSYM/dotnet-dev-certs.dll`

The files overwrite each other, leaving a ~207-byte YAML relocation file named  `.dll` . SignTool classifies files by extension, passes it to PEReader and throws: `System.BadImageFormatException: Unknown file format`

## Testing

- `./build.sh clr+libs -lc release -rc checked`
- Confirmed the regression test fails with the original publish target.
- `./build.sh clr -rc release`
- `src/tests/build.sh -Test nativeaot/AggregateExecutableLibrary/AggregateLibrary.csproj -arm64 -release -nativeaot`
- `bash artifacts/tests/coreclr/osx.arm64.Release/nativeaot/AggregateExecutableLibrary/AggregateLibrary/AggregateLibrary.sh`

> [!NOTE]
> This PR description was generated with GitHub Copilot.