### PR TITLE
Allow runtime monitor stages with no Helix jobs

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -69,6 +69,8 @@ extends:
           parameters:
             helixAccessToken: $(HelixApiAccessToken)
             timeoutInMinutes: 540
+            # Some path-filtered builds intentionally submit no Helix jobs.
+            allowNoHelixJobs: true
 
       #
       # Build CoreCLR verticals where we don't run host tests


### PR DESCRIPTION
## Summary

- Allow the runtime Helix monitor to succeed when path-filtered stages submit no Helix jobs.
- Uses the existing Arcade-exposed llowNoHelixJobs template option.

Fixes #131956

> [!NOTE]
> This pull request description was generated with GitHub Copilot.