### PR TITLE
Add ILLink Copilot instructions

### DIFF
--- a/.github/instructions/conventions.instructions.md
+++ b/.github/instructions/conventions.instructions.md
@@ -6,8 +6,9 @@ applyTo: "src/**"
 
 Code conventions for any change under `src/`, applied when authoring and when reviewing. Also
 apply the language file for the code in question (`csharp`, `native`), `tests` for test changes,
-and any matching area file (`core-runtime`, `jit`, `system-net-*`, `extensions-*`, `compression`,
-`cdac`). Where a more specific file conflicts with a general one, the more specific file wins.
+and any matching area file (`core-runtime`, `jit`, `illink`, `system-net-*`, `extensions-*`,
+`compression`, `cdac`). Where a more specific file conflicts with a general one, the more
+specific file wins.
 
 Pull-request process — scope, benchmark evidence, API approval, backport — is in
 [`copilot-instructions.md`](/.github/copilot-instructions.md). Build and test workflow is in the

--- a/.github/instructions/csharp.instructions.md
+++ b/.github/instructions/csharp.instructions.md
@@ -5,8 +5,8 @@ applyTo: "**/*.cs"
 # C# (managed code)
 
 Conventions for C# changes across `src/`. Also apply `conventions` (all changes), `tests` (test
-files), and any matching area file (`core-runtime`, `jit`, `system-net-*`, `extensions-*`,
-`compression`, `cdac`). Native runtime code is covered by `native`.
+files), and any matching area file (`core-runtime`, `jit`, `illink`, `system-net-*`,
+`extensions-*`, `compression`, `cdac`). Native runtime code is covered by `native`.
 
 ## Correctness & Safety
 

--- a/.github/instructions/illink.instructions.md
+++ b/.github/instructions/illink.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "src/tools/illink/**,src/coreclr/tools/ILTrim*/**,src/coreclr/tools/aot/ILCompiler.Trimming.Tests/**"
+applyTo: "src/tools/illink/test/**,src/coreclr/tools/ILTrim.Tests/**,src/coreclr/tools/aot/ILCompiler.Trimming.Tests/**"
 ---
 
 # Shared trimming tests
@@ -7,4 +7,4 @@ applyTo: "src/tools/illink/**,src/coreclr/tools/ILTrim*/**,src/coreclr/tools/aot
 - Changes to shared test cases must pass in all applicable tools: ILLink, ILC, the ILLink
   analyzer, and ILTrim.
 - For unsupported ILTrim cases, follow the existing expected-failure conventions without
-  regressing behavior ILTrim already supports.
+  regressing behavior that ILTrim already supports.

--- a/.github/instructions/illink.instructions.md
+++ b/.github/instructions/illink.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "src/tools/illink/**,src/coreclr/tools/ILTrim*/**,src/coreclr/tools/aot/ILCompiler.Trimming.Tests/**"
+---
+
+# Shared trimming tests
+
+- Changes to shared test cases must pass in all applicable tools: ILLink, ILC, the ILLink
+  analyzer, and ILTrim.
+- For unsupported ILTrim cases, follow the existing expected-failure conventions without
+  regressing behavior ILTrim already supports.


### PR DESCRIPTION
Add path-scoped Copilot guidance for shared trimming tests so changes account for ILLink, ILC, the ILLink analyzer, and ILTrim. For unsupported ILTrim cases, the guidance points contributors to the existing expected-failure conventions while avoiding regressions in supported behavior.

> [!NOTE]
> This pull request was created with assistance from GitHub Copilot.