### PR TITLE
Clarify why and make text and sequence streams non-seekable

### DIFF
--- a/src/libraries/System.Memory/src/Resources/Strings.resx
+++ b/src/libraries/System.Memory/src/Resources/Strings.resx
@@ -147,13 +147,10 @@
   <data name="BufferMaximumSizeExceeded" xml:space="preserve">
     <value>Cannot allocate a buffer of size {0}.</value>
   </data>
+  <data name="NotSupported_UnseekableStream" xml:space="preserve">
+    <value>Stream does not support seeking.</value>
+  </data>
   <data name="NotSupported_UnwritableStream" xml:space="preserve">
     <value>Stream does not support writing.</value>
-  </data>
-  <data name="IO_SeekBeforeBegin" xml:space="preserve">
-    <value>An attempt was made to move the position before the beginning of the stream.</value>
-  </data>
-  <data name="Argument_InvalidSeekOrigin" xml:space="preserve">
-    <value>Invalid seek origin.</value>
   </data>
 </root>

--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequenceStream.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequenceStream.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace System.Buffers
 {
     /// <summary>
-    /// Provides a read-only, non-seekable <see cref="Stream"/> over a <see cref="ReadOnlySequence{Byte}"/>.
+    /// Provides a read-only, non-seekable <see cref="Stream"/> for reading from a <see cref="ReadOnlySequence{Byte}"/>.
     /// </summary>
     /// <remarks>
     /// <para>The underlying sequence is not copied; reads are served directly from its segments.</para>
@@ -49,8 +49,9 @@ namespace System.Buffers
         private void EnsureNotDisposed() => ObjectDisposedException.ThrowIf(_isDisposed, this);
 
         /// <inheritdoc />
-        // Keep Length and Position unsupported to match the standard contract for streams where
-        // CanSeek is false, even though the underlying sequence can provide its length cheaply.
+        // Keep Length and Position unsupported to match the standard contract encoded by the
+        // stream conformance tests for streams where CanSeek is false, even though the underlying
+        // sequence can provide its length cheaply.
         public override long Length => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
 
         /// <inheritdoc />
@@ -153,17 +154,17 @@ namespace System.Buffers
                 return Task.FromCanceled(cancellationToken);
             }
 
-            if (_sequence.Slice(_position).IsEmpty)
+            ReadOnlySequence<byte> remaining = _sequence.Slice(_position);
+            if (remaining.IsEmpty)
             {
                 return Task.CompletedTask;
             }
 
-            return CopyToAsyncCore(destination, cancellationToken);
+            return CopyToAsyncCore(remaining, destination, cancellationToken);
         }
 
-        private async Task CopyToAsyncCore(Stream destination, CancellationToken cancellationToken)
+        private async Task CopyToAsyncCore(ReadOnlySequence<byte> remaining, Stream destination, CancellationToken cancellationToken)
         {
-            ReadOnlySequence<byte> remaining = _sequence.Slice(_position);
             foreach (ReadOnlyMemory<byte> segment in remaining)
             {
                 await destination.WriteAsync(segment, cancellationToken).ConfigureAwait(false);

--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequenceStream.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequenceStream.cs
@@ -35,6 +35,7 @@ namespace System.Buffers
         public override bool CanRead => !_isDisposed;
 
         /// <inheritdoc />
+        /// <summary>Gets a value indicating whether the <see cref="ReadOnlySequenceStream"/> supports seeking.</summary>
         // Keep this intentionally non-seekable: backward positioning requires traversing segments
         // again from the beginning, making repeated seeks worst-case O(N). ReadOnlySequence<T>
         // segment boundaries may be indirectly controlled by an untrusted network client through
@@ -49,12 +50,16 @@ namespace System.Buffers
         private void EnsureNotDisposed() => ObjectDisposedException.ThrowIf(_isDisposed, this);
 
         /// <inheritdoc />
+        /// <summary>Gets the length of the stream. This property is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         // Keep Length and Position unsupported to match the standard contract encoded by the
         // stream conformance tests for streams where CanSeek is false, even though the underlying
         // sequence can provide its length cheaply.
         public override long Length => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
 
         /// <inheritdoc />
+        /// <summary>Gets or sets the position within the current stream. This property is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override long Position
         {
             get => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
@@ -174,18 +179,28 @@ namespace System.Buffers
         }
 
         /// <inheritdoc />
+        /// <summary>Writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Asynchronously writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Asynchronously writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Sets the current position of the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
 
         /// <inheritdoc />
@@ -196,6 +211,8 @@ namespace System.Buffers
             cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) : Task.CompletedTask;
 
         /// <inheritdoc />
+        /// <summary>Sets the length of the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void SetLength(long value) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc />

--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequenceStream.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequenceStream.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace System.Buffers
 {
     /// <summary>
-    /// Provides a seekable, read-only <see cref="Stream"/> over a <see cref="ReadOnlySequence{Byte}"/>.
+    /// Provides a read-only, non-seekable <see cref="Stream"/> over a <see cref="ReadOnlySequence{Byte}"/>.
     /// </summary>
     /// <remarks>
     /// <para>The underlying sequence is not copied; reads are served directly from its segments.</para>
@@ -18,7 +18,6 @@ namespace System.Buffers
     {
         private ReadOnlySequence<byte> _sequence;
         private SequencePosition _position;
-        private long _absolutePosition;
         private bool _isDisposed;
         private CachedCompletedInt32Task _lastReadTask;
 
@@ -30,15 +29,19 @@ namespace System.Buffers
         {
             _sequence = source;
             _position = source.Start;
-            _absolutePosition = 0;
-            _isDisposed = false;
         }
 
         /// <inheritdoc />
         public override bool CanRead => !_isDisposed;
 
         /// <inheritdoc />
-        public override bool CanSeek => !_isDisposed;
+        // Keep this intentionally non-seekable: backward positioning requires traversing segments
+        // again from the beginning, making repeated seeks worst-case O(N). ReadOnlySequence<T>
+        // segment boundaries may be indirectly controlled by an untrusted network client through
+        // packet framing, so even correct stitching logic can produce adversarial fragmentation.
+        // Consumers must remain resilient against the worst technically compliant implementation
+        // rather than assuming ASP.NET-like segmentation.
+        public override bool CanSeek => false;
 
         /// <inheritdoc />
         public override bool CanWrite => false;
@@ -46,43 +49,15 @@ namespace System.Buffers
         private void EnsureNotDisposed() => ObjectDisposedException.ThrowIf(_isDisposed, this);
 
         /// <inheritdoc />
-        public override long Length
-        {
-            get
-            {
-                EnsureNotDisposed();
-                return _sequence.Length;
-            }
-        }
+        // Keep Length and Position unsupported to match the standard contract for streams where
+        // CanSeek is false, even though the underlying sequence can provide its length cheaply.
+        public override long Length => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
 
         /// <inheritdoc />
         public override long Position
         {
-            get
-            {
-                EnsureNotDisposed();
-                return _absolutePosition;
-            }
-            set
-            {
-                EnsureNotDisposed();
-                ArgumentOutOfRangeException.ThrowIfNegative(value);
-
-                if (value >= _sequence.Length)
-                {
-                    _position = _sequence.End;
-                }
-                else if (value >= _absolutePosition)
-                {
-                    _position = _sequence.GetPosition(value - _absolutePosition, _position);
-                }
-                else
-                {
-                    _position = _sequence.GetPosition(value, _sequence.Start);
-                }
-
-                _absolutePosition = value;
-            }
+            get => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
+            set => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
         }
 
         /// <inheritdoc />
@@ -97,11 +72,6 @@ namespace System.Buffers
         {
             EnsureNotDisposed();
 
-            if (_absolutePosition >= _sequence.Length)
-            {
-                return 0;
-            }
-
             ReadOnlySequence<byte> remaining = _sequence.Slice(_position);
             int n = (int)Math.Min(remaining.Length, buffer.Length);
             if (n <= 0)
@@ -111,7 +81,6 @@ namespace System.Buffers
 
             remaining.Slice(0, n).CopyTo(buffer);
             _position = _sequence.GetPosition(n, _position);
-            _absolutePosition += n;
             return n;
         }
 
@@ -159,19 +128,18 @@ namespace System.Buffers
             ValidateCopyToArguments(destination, bufferSize);
             EnsureNotDisposed();
 
-            if (_absolutePosition >= _sequence.Length)
+            ReadOnlySequence<byte> remaining = _sequence.Slice(_position);
+            if (remaining.IsEmpty)
             {
                 return;
             }
 
-            ReadOnlySequence<byte> remaining = _sequence.Slice(_position);
             foreach (ReadOnlyMemory<byte> segment in remaining)
             {
                 destination.Write(segment.Span);
             }
 
             _position = _sequence.End;
-            _absolutePosition = _sequence.Length;
         }
 
         /// <inheritdoc />
@@ -185,7 +153,7 @@ namespace System.Buffers
                 return Task.FromCanceled(cancellationToken);
             }
 
-            if (_absolutePosition >= _sequence.Length)
+            if (_sequence.Slice(_position).IsEmpty)
             {
                 return Task.CompletedTask;
             }
@@ -202,7 +170,6 @@ namespace System.Buffers
             }
 
             _position = _sequence.End;
-            _absolutePosition = _sequence.Length;
         }
 
         /// <inheritdoc />
@@ -218,43 +185,7 @@ namespace System.Buffers
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            EnsureNotDisposed();
-
-            long basePosition = origin switch
-            {
-                SeekOrigin.Begin => 0L,
-                SeekOrigin.Current => _absolutePosition,
-                SeekOrigin.End => _sequence.Length,
-                _ => throw new ArgumentException(SR.Argument_InvalidSeekOrigin, nameof(origin))
-            };
-
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, long.MaxValue - basePosition);
-
-            long absolutePosition = basePosition + offset;
-
-            if (absolutePosition < 0)
-            {
-                throw new IOException(SR.IO_SeekBeforeBegin);
-            }
-
-            if (absolutePosition >= _sequence.Length)
-            {
-                _position = _sequence.End;
-            }
-            else if (absolutePosition >= _absolutePosition)
-            {
-                _position = _sequence.GetPosition(absolutePosition - _absolutePosition, _position);
-            }
-            else
-            {
-                _position = _sequence.GetPosition(absolutePosition, _sequence.Start);
-            }
-
-            _absolutePosition = absolutePosition;
-            return absolutePosition;
-        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
 
         /// <inheritdoc />
         public override void Flush() { }

--- a/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceStream.ConformanceTests.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceStream.ConformanceTests.cs
@@ -4,13 +4,12 @@ using System.IO;
 using System.Buffers;
 using System.IO.Tests;
 using System.Threading.Tasks;
-using Xunit;
 
 namespace System.Memory.Tests
 {
     public class ROSequenceStreamConformanceTests : StandaloneStreamConformanceTests
     {
-        protected override bool CanSeek => true;
+        protected override bool CanSeek => false;
         protected override bool CanSetLength => false;
         protected override bool NopFlushCompletesSynchronously => true;
 
@@ -34,27 +33,6 @@ namespace System.Memory.Tests
 
         protected override Task<Stream?> CreateReadWriteStreamCore(byte[]? initialData)
             => Task.FromResult<Stream?>(null);
-
-        public override async Task Seek_PastEnd_ReadReturns0(SeekMode mode)
-        {
-            await base.Seek_PastEnd_ReadReturns0(mode);
-
-            // ReadOnlySequenceStream-specific: seeking past end against an empty sequence
-            // is allowed, Position reflects the requested offset, and reads stay at 0.
-            var stream = new ReadOnlySequenceStream(ReadOnlySequence<byte>.Empty);
-            Assert.Equal(0, stream.Length);
-            Assert.Equal(0, stream.Position);
-
-            byte[] buffer = new byte[10];
-            Assert.Equal(0, stream.Read(buffer, 0, 10));
-
-            stream.Seek(0, SeekOrigin.Begin);
-            Assert.Equal(0, stream.Position);
-
-            long newPosition = stream.Seek(1, SeekOrigin.Begin);
-            Assert.Equal(1, newPosition);
-            Assert.Equal(1, stream.Position);
-        }
     }
 
     /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
@@ -7,11 +7,8 @@ using System.Threading.Tasks;
 namespace System.IO
 {
     /// <summary>
-    /// Provides a seekable, read-only <see cref="Stream"/> over a <see cref="ReadOnlyMemory{Byte}"/>.
+    /// Provides a seekable, read-only <see cref="Stream"/> for reading a <see cref="ReadOnlyMemory{Byte}"/>.
     /// </summary>
-    /// <remarks>
-    /// <para>The stream cannot be written to. <see cref="CanWrite"/> always returns <see langword="false"/>.</para>
-    /// </remarks>
     public sealed class ReadOnlyMemoryStream : Stream
     {
         private ReadOnlyMemory<byte> _memory;
@@ -22,7 +19,11 @@ namespace System.IO
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyMemoryStream"/> class over the specified <see cref="ReadOnlyMemory{Byte}"/>.
         /// </summary>
-        /// <param name="source">The <see cref="ReadOnlyMemory{Byte}"/> to wrap.</param>
+        /// <param name="source">The memory region from which to create the stream.</param>
+        /// <remarks>
+        /// The existing contents of <paramref name="source"/> are immediately readable.
+        /// Clear rented or reused memory before constructing the stream if its existing contents should not be exposed.
+        /// </remarks>
         public ReadOnlyMemoryStream(ReadOnlyMemory<byte> source)
         {
             _memory = source;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace System.IO
 {
     /// <summary>
-    /// Provides a seekable, read-only <see cref="Stream"/> for reading a <see cref="ReadOnlyMemory{Byte}"/>.
+    /// Provides a seekable, read-only <see cref="Stream"/> for reading from a <see cref="ReadOnlyMemory{Byte}"/>.
     /// </summary>
     public sealed class ReadOnlyMemoryStream : Stream
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/ReadOnlyMemoryStream.cs
@@ -215,21 +215,33 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
+        /// <summary>Sets the length of the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void SetLength(long value) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Writes a byte to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void WriteByte(byte value) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Asynchronously writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Asynchronously writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringStream.cs
@@ -9,7 +9,7 @@ namespace System.IO
 {
     /// <summary>
     /// Provides a read-only, non-seekable <see cref="Stream"/> that encodes a <see cref="string"/> or
-    /// <see cref="ReadOnlyMemory{Char}"/> into bytes on-the-fly using a specified <see cref="System.Text.Encoding"/>.
+    /// <see cref="ReadOnlyMemory{Char}"/> into bytes on-the-fly using a specified <see cref="Encoding"/>.
     /// </summary>
     /// <remarks>
     /// <para>This stream never emits a byte order mark (BOM). Callers who need a BOM can prepend it themselves.</para>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringStream.cs
@@ -74,6 +74,7 @@ namespace System.IO
         public override bool CanRead => !_disposed;
 
         /// <inheritdoc/>
+        /// <summary>Gets a value indicating whether the <see cref="StringStream"/> supports seeking.</summary>
         // Keep this intentionally non-seekable: backward positioning requires re-running the
         // encoder from the beginning, making repeated seeks worst-case O(N).
         public override bool CanSeek => false;
@@ -82,9 +83,13 @@ namespace System.IO
         public override bool CanWrite => false;
 
         /// <inheritdoc/>
+        /// <summary>Gets the length of the stream. This property is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override long Length => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
 
         /// <inheritdoc/>
+        /// <summary>Gets or sets the position within the current stream. This property is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override long Position
         {
             get => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
@@ -271,21 +276,33 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
+        /// <summary>Sets the current position of the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException(SR.NotSupported_UnseekableStream);
 
         /// <inheritdoc/>
+        /// <summary>Sets the length of the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void SetLength(long value) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Asynchronously writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>
+        /// <summary>Asynchronously writes a sequence of bytes to the stream. This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
+        /// <exception cref="NotSupportedException">In all cases.</exception>
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => throw new NotSupportedException(SR.NotSupported_UnwritableStream);
 
         /// <inheritdoc/>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringStream.cs
@@ -74,6 +74,8 @@ namespace System.IO
         public override bool CanRead => !_disposed;
 
         /// <inheritdoc/>
+        // Keep this intentionally non-seekable: backward positioning requires re-running the
+        // encoder from the beginning, making repeated seeks worst-case O(N).
         public override bool CanSeek => false;
 
         /// <inheritdoc/>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/WritableMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/WritableMemoryStream.cs
@@ -217,6 +217,8 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
+        /// <summary>Writes a byte to the stream.</summary>
+        /// <exception cref="NotSupportedException">Writing the byte would exceed the fixed capacity of the stream.</exception>
         public override void WriteByte(byte value)
         {
             EnsureNotClosed();
@@ -236,6 +238,8 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
+        /// <summary>Writes a sequence of bytes to the stream.</summary>
+        /// <exception cref="NotSupportedException">Writing the bytes would exceed the fixed capacity of the stream.</exception>
         public override void Write(byte[] buffer, int offset, int count)
         {
             ValidateBufferArguments(buffer, offset, count);
@@ -243,6 +247,8 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
+        /// <summary>Writes a sequence of bytes to the stream.</summary>
+        /// <exception cref="NotSupportedException">Writing the bytes would exceed the fixed capacity of the stream.</exception>
         public override void Write(ReadOnlySpan<byte> buffer)
         {
             EnsureNotClosed();
@@ -269,6 +275,8 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
+        /// <summary>Asynchronously writes a sequence of bytes to the stream.</summary>
+        /// <exception cref="NotSupportedException">Writing the bytes would exceed the fixed capacity of the stream.</exception>
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
@@ -284,6 +292,8 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
+        /// <summary>Asynchronously writes a sequence of bytes to the stream.</summary>
+        /// <exception cref="NotSupportedException">Writing the bytes would exceed the fixed capacity of the stream.</exception>
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             EnsureNotClosed();
@@ -298,6 +308,10 @@ namespace System.IO
         }
 
         /// <inheritdoc/>
+        /// <summary>Sets the length of the current stream to the specified value.</summary>
+        /// <param name="value">The length to set.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is negative.</exception>
+        /// <exception cref="NotSupportedException">The current stream is not resizable and <paramref name="value"/> is larger than the current capacity.</exception>
         public override void SetLength(long value)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(value);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/WritableMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/WritableMemoryStream.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace System.IO
 {
     /// <summary>
-    /// Provides a seekable, writable <see cref="Stream"/> over a <see cref="Memory{Byte}"/>.
+    /// Provides a seekable <see cref="Stream"/> for reading from and writing to a <see cref="Memory{Byte}"/>.
     /// </summary>
     public sealed class WritableMemoryStream : Stream
     {
@@ -20,7 +20,11 @@ namespace System.IO
         /// <summary>
         /// Initializes a new instance of the <see cref="WritableMemoryStream"/> class over the specified <see cref="Memory{Byte}"/>.
         /// </summary>
-        /// <param name="buffer">The <see cref="Memory{Byte}"/> to wrap.</param>
+        /// <param name="buffer">The memory region from which to create the stream.</param>
+        /// <remarks>
+        /// The existing contents of <paramref name="buffer"/> are immediately readable.
+        /// Clear rented or reused memory before constructing the stream if its existing contents should not be exposed.
+        /// </remarks>
         public WritableMemoryStream(Memory<byte> buffer)
         {
             _memory = buffer;

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/StringStream/StringStreamTests_String.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/StringStream/StringStreamTests_String.cs
@@ -70,10 +70,15 @@ namespace System.IO.Tests
         [Fact]
         public void StreamCapabilities()
         {
-            var stream = new StringStream("test", Encoding.UTF8);
+            using var stream = new StringStream("test", Encoding.UTF8);
+
             Assert.True(stream.CanRead);
             Assert.False(stream.CanSeek);
             Assert.False(stream.CanWrite);
+            Assert.Throws<NotSupportedException>(() => stream.Length);
+            Assert.Throws<NotSupportedException>(() => stream.Position);
+            Assert.Throws<NotSupportedException>(() => stream.Position = 0);
+            Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

- clarify that `ReadOnlyMemoryStream` and `WritableMemoryStream` immediately expose their backing memory contents
- make `ReadOnlySequenceStream` intentionally non-seekable and remove its seek state and traversal logic
- keep `StringStream` intentionally non-seekable and document why backward positioning would require rerunning the encoder
- make `Length`, `Position`, and `Seek` consistently throw the standard unseekable-stream `NotSupportedException`
- update stream conformance and focused unit coverage
- For Writable memory stream, added ctor remarks suggesting users to clear rented or reused memory before constructing the stream if its existing contents should not be exposed.

## Rationale

Backward positioning requires replaying work from the beginning. For `ReadOnlySequenceStream`, that means traversing segments whose boundaries may be indirectly controlled by an untrusted network client through packet framing. Even correct stitching can therefore produce adversarial fragmentation, and consumers must tolerate the worst technically compliant segmentation rather than assuming ASP.NET-like behavior. For `StringStream`, backward positioning requires rerunning the encoder. Repeated seeks can turn both cases into worst-case O(N) work.

## Validation

- checked and Release CoreLib builds
- System.Memory build
- 405 focused `ReadOnlySequenceStream` conformance tests
- 275 focused `StringStream` conformance/unit tests

> [!NOTE]
> This pull request description was generated with GitHub Copilot.