### PR TITLE
Don't attempt to unload cdac

### DIFF
--- a/src/coreclr/debug/daccess/cdac.cpp
+++ b/src/coreclr/debug/daccess/cdac.cpp
@@ -136,7 +136,9 @@ CDAC CDAC::Create(uint64_t descriptorAddr, ICorDebugDataTarget* target, IUnknown
     intptr_t handle;
     if (init(descriptorAddr, &ReadFromTargetCallback, &WriteToTargetCallback, &ReadThreadContext, &WriteThreadContext, allocCallback, target, &handle) != 0)
     {
+#ifndef HOST_UNIX
         ::FreeLibrary(cdacLib);
+#endif // HOST_UNIX
         return {};
     }
 
@@ -164,7 +166,9 @@ CDAC::~CDAC()
     }
 
     if (m_module != NULL)
+#ifndef HOST_UNIX
         ::FreeLibrary(m_module);
+#endif // HOST_UNIX
 }
 
 void CDAC::CreateSosInterface(IUnknown** sos)

--- a/src/coreclr/debug/daccess/cdac.cpp
+++ b/src/coreclr/debug/daccess/cdac.cpp
@@ -136,9 +136,6 @@ CDAC CDAC::Create(uint64_t descriptorAddr, ICorDebugDataTarget* target, IUnknown
     intptr_t handle;
     if (init(descriptorAddr, &ReadFromTargetCallback, &WriteToTargetCallback, &ReadThreadContext, &WriteThreadContext, allocCallback, target, &handle) != 0)
     {
-#ifndef HOST_UNIX
-        ::FreeLibrary(cdacLib);
-#endif // HOST_UNIX
         return {};
     }
 
@@ -163,13 +160,6 @@ CDAC::~CDAC()
         decltype(&cdac_reader_free) free = reinterpret_cast<decltype(&cdac_reader_free)>(::GetProcAddress(m_module, "cdac_reader_free"));
         _ASSERTE(free != nullptr);
         free(m_cdac_handle);
-    }
-
-    if (m_module != NULL)
-    {
-#ifndef HOST_UNIX
-        ::FreeLibrary(m_module);
-#endif // HOST_UNIX
     }
 }
 

--- a/src/coreclr/debug/daccess/cdac.cpp
+++ b/src/coreclr/debug/daccess/cdac.cpp
@@ -166,9 +166,11 @@ CDAC::~CDAC()
     }
 
     if (m_module != NULL)
+    {
 #ifndef HOST_UNIX
         ::FreeLibrary(m_module);
 #endif // HOST_UNIX
+    }
 }
 
 void CDAC::CreateSosInterface(IUnknown** sos)


### PR DESCRIPTION
As cDAC is a NativeAOT library, it cannot be safely unloaded. https://github.com/dotnet/runtime/pull/131960 should prevent an actual unmapping from happening, but this makes the intent clear.