### PR TITLE
[crossgen2][wasm] Shrink Code Section Relocs

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.Serialization;
 using ILCompiler.ObjectWriter;
 
 namespace ILCompiler.DependencyAnalysis
@@ -696,6 +697,31 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        public static unsafe int WriteVariableLengthValue(RelocType relocType, byte* location, long value)
+        {
+            Debug.Assert(IsVariableLength(relocType));
+            switch (relocType)
+            {
+                case RelocType.WASM_TYPE_INDEX_LEB:
+                case RelocType.WASM_GLOBAL_INDEX_LEB:
+                case RelocType.WASM_FUNCTION_INDEX_LEB:
+                case RelocType.WASM_MEMORY_ADDR_LEB:
+                case RelocType.WASM_MEMORY_ADDR_REL_LEB:
+                case RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB:
+                    DwarfHelper.WriteULEB128(new Span<byte>((byte*)location, WASM_PADDED_RELOC_SIZE_32), checked((ulong)value));
+                    return (int)DwarfHelper.SizeOfULEB128((ulong)value);
+
+                case RelocType.WASM_TABLE_INDEX_SLEB:
+                case RelocType.WASM_MEMORY_ADDR_SLEB:
+                case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
+                    DwarfHelper.WriteSLEB128(new Span<byte>((byte*)location, WASM_PADDED_RELOC_SIZE_32), value);
+                    return (int)DwarfHelper.SizeOfSLEB128(value);
+                default:
+                    Debug.Fail("Invalid variable-length RelocType: " + relocType);
+                    return 0;
+            }
+        }
+
         public static readonly int MaxSize = 8;
         // Note: Please update the above field if the max size
         // changes when adding a new case to this method.
@@ -740,6 +766,45 @@ namespace ILCompiler.DependencyAnalysis
 
                 _ => throw new NotSupportedException(),
             };
+        }
+
+        public static bool IsVariableLength(RelocType relocType)
+        {
+            return relocType switch
+            {
+                RelocType.WASM_FUNCTION_INDEX_LEB or
+                RelocType.WASM_TABLE_INDEX_SLEB or
+                RelocType.WASM_TYPE_INDEX_LEB or
+                RelocType.WASM_GLOBAL_INDEX_LEB or
+                RelocType.WASM_MEMORY_ADDR_LEB or
+                RelocType.WASM_MEMORY_ADDR_SLEB or
+                RelocType.WASM_MEMORY_ADDR_REL_LEB or
+                RelocType.WASM_MEMORY_ADDR_REL_SLEB or
+                RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB => true,
+                _ => false,
+            };
+        }
+
+        public static int ActualSize(RelocType relocType, long resolvedValue)
+        {
+            Debug.Assert(IsVariableLength(relocType));
+            switch (relocType)
+            {
+                case RelocType.WASM_FUNCTION_INDEX_LEB:
+                case RelocType.WASM_TYPE_INDEX_LEB:
+                case RelocType.WASM_GLOBAL_INDEX_LEB:
+                case RelocType.WASM_MEMORY_ADDR_LEB:
+                case RelocType.WASM_MEMORY_ADDR_REL_LEB:
+                case RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB:
+                    return (int)DwarfHelper.SizeOfULEB128((ulong)resolvedValue);
+                case RelocType.WASM_TABLE_INDEX_SLEB:
+                case RelocType.WASM_MEMORY_ADDR_SLEB:
+                case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
+                    return (int)DwarfHelper.SizeOfSLEB128(resolvedValue);
+                default:
+                    Debug.Fail("Invalid reloc type");
+                    return 0;
+            }
         }
 
         public static unsafe long ReadValue(RelocType relocType, void* location)

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.Serialization;
 using ILCompiler.ObjectWriter;
 
 namespace ILCompiler.DependencyAnalysis

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/Dwarf/DwarfHelper.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/Dwarf/DwarfHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.IO;
 using System.Numerics;
 
@@ -123,29 +124,38 @@ namespace ILCompiler.ObjectWriter
             return value;
         }
 
-        public static ulong? ReadULEB128(Stream source, out int bytesRead)
+        internal static ulong? ReadULEB128(Stream source, out int bytesRead)
         {
-            ulong value = 0;
-            byte @byte;
-            int shift = 0;
-            long startPos = source.Position;
+            Debug.Assert(source.CanSeek);
+            Debug.Assert(source.Length >= 0);
 
-            do
+            ulong value = 0;
+            int shift = 0;
+            bytesRead = 0;
+
+            while (true)
             {
                 int b = source.ReadByte();
                 if (b < 0)
                 {
-                    bytesRead = (int)(source.Position - startPos);
-                    return null;
+                    if (bytesRead == 0)
+                    {
+                        return null;
+                    }
+
+                    throw new InvalidDataException("Unexpected end of stream while reading a ULEB128 value.");
                 }
 
-                @byte = (byte)b;
+                byte @byte = (byte)b;
+                bytesRead++;
                 value |= ((ulong)@byte & 0x7f) << shift;
-                shift += 7;
-            } while ((@byte & 0x80) != 0);
+                if ((@byte & 0x80) == 0)
+                {
+                    return value;
+                }
 
-            bytesRead = (int)(source.Position - startPos);
-            return value;
+                shift += 7;
+            }
         }
 
         public static long ReadSLEB128(ReadOnlySpan<byte> buffer) => ReadSLEB128(buffer, out _);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/Dwarf/DwarfHelper.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/Dwarf/DwarfHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.IO;
 using System.Numerics;
 
 namespace ILCompiler.ObjectWriter
@@ -119,6 +120,31 @@ namespace ILCompiler.ObjectWriter
             } while ((@byte & 0x80) != 0);
 
             bytesRead = pos;
+            return value;
+        }
+
+        public static ulong? ReadULEB128(Stream source, out int bytesRead)
+        {
+            ulong value = 0;
+            byte @byte;
+            int shift = 0;
+            long startPos = source.Position;
+
+            do
+            {
+                int b = source.ReadByte();
+                if (b < 0)
+                {
+                    bytesRead = (int)(source.Position - startPos);
+                    return null;
+                }
+
+                @byte = (byte)b;
+                value |= ((ulong)@byte & 0x7f) << shift;
+                shift += 7;
+            } while ((@byte & 0x80) != 0);
+
+            bytesRead = (int)(source.Position - startPos);
             return value;
         }
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -700,10 +700,8 @@ namespace ILCompiler.ObjectWriter
                     {
                         MemoryStream destStream = new MemoryStream((int)originalStream.Length);
                         originalStream.Position = 0;
-                        //originalStream.CopyTo(stream);
-                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0, shrink: false);
+                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0, shrink: true);
                         section.Stream = destStream;
-                        Console.WriteLine("Saved: {0} bytes of relocations in section {1}", originalStream.Length - destStream.Length, section.Name);
                         // originalStream may be disposed, section.Stream now points to resolved stream
                     }
                 }
@@ -875,33 +873,6 @@ namespace ILCompiler.ObjectWriter
             src.GetBuffer().AsSpan((int)srcPos, (int)count).CopyTo(dest.GetBuffer().AsSpan((int)destPos, (int)count));
         }
 
-        private static List<Segment> SplitBlob(Stream src, long start, long end, List<SymbolicRelocation> relocs)
-        {
-            // Build up a list of segments to describe this blob. Each blob is a byte range of [start, end) that is either a relocation or plain data (Reloc == null).
-            // This allows us to resolve each slice of the section with possible shrinkage of the max-sized relocations in between.
-            List<Segment> segments = new();
-            if (relocs.First().Offset > 0)
-            {
-                segments.Add(new Segment(0, relocs.First().Offset, null));
-            }
-
-            for (int i = 0; i < relocs.Count; i++)
-            {
-                SymbolicRelocation curReloc = relocs[i];
-                SymbolicRelocation? nextReloc = null;
-                if (i < relocs.Count - 1)
-                {
-                   nextReloc = relocs[i + 1]; 
-                }
-                segments.Add(new Segment(curReloc.Offset, Relocation.GetSize(curReloc.Type) + curReloc.Offset, curReloc));
-                long nextStart = curReloc.Offset + Relocation.GetSize(curReloc.Type);
-                long nextEnd = nextReloc is not null ? nextReloc.Offset : end;
-                segments.Add(new Segment(nextStart, nextEnd, null));
-            }
-            Debug.Assert(segments.First().Start == 0 && segments.Last().End == end);
-            return segments;
-        }
-
         private record CodeBlob(long Size, long Start, long End);
 
         private List<CodeBlob> ParseCodeBlobs(Stream sectionStream)
@@ -944,8 +915,6 @@ namespace ILCompiler.ObjectWriter
             for (int b = 0; b < blobs.Count; b++)
             {
                 CodeBlob blob = blobs[b];
-                //var blobRelocs = relocs.Where(reloc => reloc.Offset >= blob.Start && reloc.Offset < blob.End).ToList();
-
                 Debug.Assert(writeCursor <= blobs[b].Start, $"Write cursor {writeCursor} is beyond the start of blob {blobs[b].Start}");
 
                 bool hasRelocs = relocCursor < relocs.Count && relocs[relocCursor].Offset >= blob.Start && relocs[relocCursor].Offset < blob.End;
@@ -1215,7 +1184,6 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private record Segment(long Start, long End, SymbolicRelocation? Reloc);
         private void ResolveRelocations(int sectionIndex, Stream sectionStream, MemoryStream dstStream, List<SymbolicRelocation> relocs, long sectionStart = 0, bool shrink = false)
         {
             if (relocs.Count == 0)
@@ -1244,11 +1212,6 @@ namespace ILCompiler.ObjectWriter
             sectionStream.CopyTo(dstStream);
             for (int i = 0; i < relocs.Count; i++)
             {
-                if (i % 10000 == 0)
-                {
-                    Console.WriteLine("Resolving relocation {0}/{1} in section {2}", i, relocs.Count, sectionIndex);
-                }
-
                 SymbolicRelocation reloc = relocs[i];
                 ResolveReloc(sectionIndex, dstStream, srcPos: sectionStart + reloc.Offset, dstStream, destPos: sectionStart + reloc.Offset, reloc, relocScratchBuffer);
             }

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -701,8 +701,7 @@ namespace ILCompiler.ObjectWriter
                         MemoryStream destStream = new MemoryStream((int)originalStream.Length);
                         originalStream.Position = 0;
                         //originalStream.CopyTo(stream);
-                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0, shrink: false);
-                        destStream.SetLength(destStream.Position);
+                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0, shrink: true);
                         section.Stream = destStream;
                         Console.WriteLine("Saved: {0} bytes of relocations in section {1}", originalStream.Length - destStream.Length, section.Name);
                         // originalStream may be disposed, section.Stream now points to resolved stream
@@ -734,6 +733,7 @@ namespace ILCompiler.ObjectWriter
 
                 if (_resolvableRelocations.TryGetValue(section.Index, out List<SymbolicRelocation> relocations))
                 {
+                    MemoryStream sectionStream = new MemoryStream((int)section.Stream.Length);
                     // We emit all Webcil sections into one stream, and copy data / resolve relocations directly into this combined stream.
                     // As a result, the real offsets that relocs in our list have need to be calculated based on the section's
                     // position within the Webcil segment
@@ -869,20 +869,10 @@ namespace ILCompiler.ObjectWriter
         // TODO-WASM: Currently, all Wasm relocs are resolved to 5 byte values unconditionally (the same size as the original placeholder padding), which is wasteful.
         // We should remove the padding and shrink the resolved values to their minimal size so we don't bloat the binary size.
 #nullable enable
-        static void CopyOnly(Stream src, Stream dst, byte[] scratchBuff, int count)
+        static void CopyOnly(MemoryStream src, long srcPos, MemoryStream dest, long destPos, long count)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(count);
-            while (count > 0)
-            {
-                int toRead = Math.Min(scratchBuff.Length, count);
-                int read = src.Read(scratchBuff, 0, toRead);
-                if (read == 0)
-                {
-                    throw new EndOfStreamException();
-                }
-                dst.Write(scratchBuff, 0, read);
-                count -= read;
-            }
+            src.GetBuffer().AsSpan((int)srcPos, (int)count).CopyTo(dest.GetBuffer().AsSpan((int)destPos, (int)count));
         }
 
         private static List<Segment> SplitBlob(Stream src, long start, long end, List<SymbolicRelocation> relocs)
@@ -930,7 +920,7 @@ namespace ILCompiler.ObjectWriter
             return blobs;
         }
 
-        private void ResolveCodeRelocations(int sectionIndex, Stream sectionStream, MemoryStream dstStream, List<CodeBlob> blobs, List<SymbolicRelocation> relocs)
+        private void ResolveCodeRelocations(int sectionIndex, MemoryStream sectionStream, List<CodeBlob> blobs, List<SymbolicRelocation> relocs, bool shrink = false)
         {
             long maxBlobSize = blobs.Max(blob => blob.End - blob.Start);
             // for each blob:
@@ -938,70 +928,98 @@ namespace ILCompiler.ObjectWriter
             //  copy over the blob's contents to the temporary stream, resolving relocations in sorted order 
             //  write the temporary stream to the destination stream with the new size
             MemoryStream tempStream = new MemoryStream((int)maxBlobSize);
-            byte[] copyBuffer = new byte[4096];
+            tempStream.SetLength(maxBlobSize);
             byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
             int[] blobShrink = new int[blobs.Count];
 
             blobs.Sort((a, b) => a.Start.CompareTo(b.Start));
             relocs.Sort((a, b) => a.Offset.CompareTo(b.Offset));
 
+            long writeCursor = 0;
+            int relocCursor = 0;
+
+            // No relocations in this blob, just copy it over, but shrink the size ULEB down to the minimum
+            byte[] countBuffer = new byte[5];
+
+            // Invariant: writeCursor is where we are writing to in the sectionStream. Further, writeCursor is always less than or equal to the start of the current blob we are processing.
             for (int b = 0; b < blobs.Count; b++)
             {
                 CodeBlob blob = blobs[b];
-                var blobRelocs = relocs.Where(reloc => reloc.Offset >= blob.Start && reloc.Offset < blob.End).ToList();
+                //var blobRelocs = relocs.Where(reloc => reloc.Offset >= blob.Start && reloc.Offset < blob.End).ToList();
 
-                tempStream.Position = 0;
-                if (blobRelocs.Count > 0)
+                Debug.Assert(writeCursor <= blobs[b].Start, $"Write cursor {writeCursor} is beyond the start of blob {blobs[b].Start}");
+
+                bool hasRelocs = relocCursor < relocs.Count && relocs[relocCursor].Offset >= blob.Start && relocs[relocCursor].Offset < blob.End;
+                if (hasRelocs)
                 {
+                    tempStream.Position = 0;
                     sectionStream.Position = blob.Start;
-                    if (blobRelocs.First().Offset > 0)
+                    SymbolicRelocation firstReloc = relocs[relocCursor];
+
+                    if (firstReloc.Offset > 0)
                     {
                         // Copy the initial data in the blob before the first relocation
-                        CopyOnly(sectionStream, tempStream, copyBuffer, (int)blobRelocs.First().Offset - (int)blob.Start);
+                        int initialSize = (int)firstReloc.Offset - (int)blob.Start;
+                        CopyOnly(sectionStream, sectionStream.Position, tempStream, tempStream.Position, initialSize);
+                        sectionStream.Position += initialSize;
+                        tempStream.Position += initialSize;
                     }
-                    Debug.Assert(sectionStream.Position == blobRelocs.First().Offset, $"Section stream position sectionStream.Position does not match first reloc offset {blobRelocs.First().Offset}");
+                    Debug.Assert(sectionStream.Position == firstReloc.Offset, $"Section stream position sectionStream.Position does not match first reloc offset {firstReloc.Offset}");
 
-                    for (int i = 0; i < blobRelocs.Count; i++)
+                    while (relocCursor < relocs.Count && relocs[relocCursor].Offset < blob.End)
                     {
-                        SymbolicRelocation curReloc = blobRelocs[i];
+                        SymbolicRelocation curReloc = relocs[relocCursor];
                         SymbolicRelocation? nextReloc = null;
-                        if (i < blobRelocs.Count - 1)
+                        // look ahead to the next relocation, if any, to determine how much data is between this relocation and the next one
+                        if (relocCursor + 1 < relocs.Count && relocs[relocCursor + 1].Offset < blob.End)
                         {
-                            nextReloc = blobRelocs[i + 1];
+                            nextReloc = relocs[relocCursor + 1];
                         }
 
-                        int size = ResolveReloc(sectionIndex, sectionStream, tempStream, curReloc, relocScratchBuffer);
+                        int size = ResolveReloc(sectionIndex, sectionStream, curReloc.Offset, tempStream, tempStream.Position, curReloc, relocScratchBuffer, shrink: shrink);
                         blobShrink[b] += (int)Relocation.GetSize(curReloc.Type) - size;
 
                         long nextStart = curReloc.Offset + Relocation.GetSize(curReloc.Type);
                         long nextEnd = nextReloc is not null ? nextReloc.Offset : blob.End;
-                        Debug.Assert(tempStream.Position <= sectionStream.Position);
-                        CopyOnly(sectionStream, tempStream, copyBuffer, (int)(nextEnd - nextStart));
-                    }
-                    Debug.Assert(tempStream.Position <= blob.Size, $"Temp stream position {tempStream.Position} exceeds blob size {blob.Size}");
-                    tempStream.SetLength(tempStream.Position);
+                        long betweenSize = nextEnd - nextStart;
 
-                    Span<byte> countBuffer = stackalloc byte[(int)DwarfHelper.SizeOfULEB128((ulong)tempStream.Length)];
-                    DwarfHelper.WriteULEB128(countBuffer, (ulong)tempStream.Length);
-                    dstStream.Write(countBuffer);
+                        Debug.Assert(nextStart == sectionStream.Position);
+                        CopyOnly(sectionStream, sectionStream.Position, tempStream, tempStream.Position, (int)betweenSize);
+                        sectionStream.Position += betweenSize;
+                        tempStream.Position += betweenSize;
+                        relocCursor++;
+                    }
+
+                    Debug.Assert(tempStream.Position <= blob.Size && blob.Size <= tempStream.Length, $"Temp stream position {tempStream.Position} exceeds blob size {blob.Size}");
+
+                    long tempStreamLength = tempStream.Position;
+
+                    // Write the temp stream back into the original stream with a NEW length prefix, starting at writeCursor
+                    DwarfHelper.WriteULEB128(countBuffer, (ulong)tempStreamLength);
+                    sectionStream.Position = writeCursor;
+                    sectionStream.Write(countBuffer, 0, (int)DwarfHelper.SizeOfULEB128((ulong)tempStreamLength));
+                    writeCursor = sectionStream.Position; // set writeCursor to the position after the length prefix we just wrote
 
                     tempStream.Position = 0;
-                    tempStream.CopyTo(dstStream);
+                    tempStream.CopyTo(sectionStream);
+
+                    writeCursor += tempStreamLength;
                 }
                 else
                 {
-                    Span<byte> countBuffer = stackalloc byte[(int)DwarfHelper.SizeOfULEB128((ulong)blob.Size)];
                     DwarfHelper.WriteULEB128(countBuffer, (ulong)blob.Size);
-                    dstStream.Write(countBuffer);
-                    // No relocations in this blob, just copy it over
-                    sectionStream.Position = blob.Start;
-                    CopyOnly(src: sectionStream, dst: dstStream, scratchBuff: copyBuffer, count: (int)(blob.End - blob.Start));
+                    sectionStream.Position = writeCursor;
+                    sectionStream.Write(countBuffer, 0, (int)DwarfHelper.SizeOfULEB128((ulong)blob.Size));
+                    writeCursor = sectionStream.Position;
+
+                    CopyOnly(src: sectionStream, srcPos: blob.Start, dest: sectionStream, destPos: writeCursor, count: blob.Size);
+                    writeCursor += blob.Size;
                 }
             }
-            dstStream.SetLength(dstStream.Position);
+            sectionStream.SetLength(writeCursor);
 
-            dstStream.Position = 0;
-            List<CodeBlob> newBlobs = ParseCodeBlobs(dstStream);
+            sectionStream.Position = 0;
+            List<CodeBlob> newBlobs = ParseCodeBlobs(sectionStream);
             Debug.Assert(newBlobs.Count == blobs.Count);
 
             for (int i = 0; i < newBlobs.Count; i++)
@@ -1010,7 +1028,7 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private unsafe int ResolveReloc(int sectionIndex, Stream sectionStream, MemoryStream dstStream, SymbolicRelocation reloc,  byte[] relocScratchBuffer, long? destPos = null, bool shrink = false)
+        private unsafe int ResolveReloc(int sectionIndex, MemoryStream sourceStream, long srcPos, MemoryStream destStream, long destPos, SymbolicRelocation reloc,  byte[] relocScratchBuffer, bool shrink = false)
         {
             WebcilSection? curSectionAsWebcil = null;
             uint webcilVirtualStart = 0;
@@ -1178,24 +1196,21 @@ namespace ILCompiler.ObjectWriter
                         throw new NotSupportedException($"Relocation type {reloc.Type} not yet implemented");
                 }
 
-                return WriteRelocFromDataSpan(reloc, pData, dstStream, actualLength ?? relocLength);
+                return WriteRelocFromDataSpan(reloc, pData, actualLength ?? relocLength);
             }
 
             Span<byte> ReadRelocToDataSpan(SymbolicRelocation reloc, byte[] buffer)
             {
                 Span<byte> relocContents = buffer.AsSpan(0, Relocation.GetSize(reloc.Type));
-                sectionStream.Position = reloc.Offset;
-                sectionStream.ReadExactly(relocContents);
+                sourceStream.Position = srcPos;
+                sourceStream.ReadExactly(relocContents);
                 return relocContents;
             }
 
-            int WriteRelocFromDataSpan(SymbolicRelocation reloc, byte* pData, MemoryStream dstStream, int length)
+            int WriteRelocFromDataSpan(SymbolicRelocation reloc, byte* pData, int length)
             {
-                if (destPos is  not null)
-                {
-                    dstStream.Position = (long)destPos;
-                }
-                dstStream.Write(new Span<byte>(pData, length));
+                destStream.Position = destPos;
+                destStream.Write(new Span<byte>(pData, length));
                 return length;
             }
         }
@@ -1213,7 +1228,9 @@ namespace ILCompiler.ObjectWriter
             {
                 List<CodeBlob> blobs = ParseCodeBlobs(sectionStream);
                 sectionStream.Position = 0;
-                ResolveCodeRelocations(sectionIndex, sectionStream, dstStream, blobs, relocs);
+                sectionStream.CopyTo(dstStream);
+                dstStream.Position = 0;
+                ResolveCodeRelocations(sectionIndex, dstStream, blobs, relocs, shrink);
                 return;
             }
 
@@ -1230,8 +1247,7 @@ namespace ILCompiler.ObjectWriter
                 }
 
                 SymbolicRelocation reloc = relocs[i];
-                long? destPos = sectionStart + reloc.Offset;
-                ResolveReloc(sectionIndex, sectionStream, dstStream, reloc, relocScratchBuffer, destPos: destPos);
+                ResolveReloc(sectionIndex, dstStream, srcPos: sectionStart + reloc.Offset, dstStream, destPos: sectionStart + reloc.Offset, reloc, relocScratchBuffer);
             }
             dstStream.Position = sectionStream.Length + startPos;
         }

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -861,9 +861,6 @@ namespace ILCompiler.ObjectWriter
             return rva >= section.Header.VirtualAddress && rva < section.Header.VirtualAddress + section.Header.VirtualSize;
         }
 
-
-        // TODO-WASM: Currently, all Wasm relocs are resolved to 5 byte values unconditionally (the same size as the original placeholder padding), which is wasteful.
-        // We should remove the padding and shrink the resolved values to their minimal size so we don't bloat the binary size.
 #nullable enable
         static void CopyOnly(MemoryStream src, long srcPos, MemoryStream dest, long destPos, long count)
         {
@@ -889,13 +886,21 @@ namespace ILCompiler.ObjectWriter
             return blobs;
         }
 
+        /// <summary>
+        /// Resolve relocations in the code section, shrinking the size of all ULEB relocations to their minimal size.
+        /// This requires code blobs to be pre-split so that we can shrink the size of relocs in each blob independently, and then re-encode the blob with its new size.
+        /// </summary>
+        // We use an in-place copying strategy here with a read cursor (sectionStream.Position) and a separate write cursor where (write <= read),
+        // since the resolved blobs will always be equal to or smaller in size than the original blobs.
+        // Within the blobs, we split on relocations and copy the data between them, resolving each relocation to its minimal size.
         private void ResolveCodeRelocations(int sectionIndex, MemoryStream sectionStream, List<CodeBlob> blobs, List<SymbolicRelocation> relocs, bool shrink = false)
         {
+            if (blobs.Count == 0 && relocs.Count > 0)
+            {
+                throw new InvalidDataException();
+            }
+
             long maxBlobSize = blobs.Max(blob => blob.End - blob.Start);
-            // for each blob:
-            //  select relocations that are in the blob's range
-            //  copy over the blob's contents to the temporary stream, resolving relocations in sorted order 
-            //  write the temporary stream to the destination stream with the new size
             MemoryStream tempStream = new MemoryStream((int)maxBlobSize);
             byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
             int[] blobShrink = new int[blobs.Count];
@@ -906,7 +911,6 @@ namespace ILCompiler.ObjectWriter
             long writeCursor = 0;
             int relocCursor = 0;
 
-            // No relocations in this blob, just copy it over, but shrink the size ULEB down to the minimum
             byte[] countBuffer = new byte[5];
 
             // Invariant: writeCursor is where we are writing to in the sectionStream. Further, writeCursor is always less than or equal to the start of the current blob we are processing.
@@ -920,7 +924,7 @@ namespace ILCompiler.ObjectWriter
                 {
                     tempStream.Position = 0;
                     tempStream.SetLength(blob.Size);
-                    sectionStream.Position = blob.Start;
+                    sectionStream.Position = blob.Start; // sectionStream.Position is now our read cursor
                     SymbolicRelocation firstReloc = relocs[relocCursor];
 
                     if (firstReloc.Offset > 0)
@@ -974,6 +978,7 @@ namespace ILCompiler.ObjectWriter
                 }
                 else
                 {
+                    // No relocations in this blob. Copy the blob as-is but shrink the length prefix if possible.
                     DwarfHelper.WriteULEB128(countBuffer, (ulong)blob.Size);
                     sectionStream.Position = writeCursor;
                     sectionStream.Write(countBuffer, 0, (int)DwarfHelper.SizeOfULEB128((ulong)blob.Size));
@@ -986,13 +991,16 @@ namespace ILCompiler.ObjectWriter
             sectionStream.SetLength(writeCursor);
 
             sectionStream.Position = 0;
+
+#if DEBUG
+            // The number of code blobs should not have changed.    
             List<CodeBlob> newBlobs = ParseCodeBlobs(sectionStream);
             Debug.Assert(newBlobs.Count == blobs.Count);
-
             for (int i = 0; i < newBlobs.Count; i++)
             {
                 Debug.Assert(newBlobs[i].Size + blobShrink[i] == blobs[i].Size);
             }
+#endif
         }
 
         private unsafe int ResolveReloc(int sectionIndex, MemoryStream sourceStream, long srcPos, MemoryStream destStream, long destPos, SymbolicRelocation reloc,  byte[] relocScratchBuffer, bool shrink = false)

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -731,7 +730,6 @@ namespace ILCompiler.ObjectWriter
 
                 if (_resolvableRelocations.TryGetValue(section.Index, out List<SymbolicRelocation> relocations))
                 {
-                    MemoryStream sectionStream = new MemoryStream((int)section.Stream.Length);
                     // We emit all Webcil sections into one stream, and copy data / resolve relocations directly into this combined stream.
                     // As a result, the real offsets that relocs in our list have need to be calculated based on the section's
                     // position within the Webcil segment
@@ -873,14 +871,14 @@ namespace ILCompiler.ObjectWriter
             src.GetBuffer().AsSpan((int)srcPos, (int)count).CopyTo(dest.GetBuffer().AsSpan((int)destPos, (int)count));
         }
 
-        private record CodeBlob(long Size, long Start, long End);
+        private readonly record struct CodeBlob(long Size, long Start, long End);
 
         private List<CodeBlob> ParseCodeBlobs(Stream sectionStream)
         {
             List<CodeBlob> blobs = new();
             while (true)
             {
-                ulong? decoded = DwarfHelper.ReadULEB128(sectionStream, out int actualLength);
+                ulong? decoded = DwarfHelper.ReadULEB128(sectionStream, out _);
                 if (decoded is null) break; // end of stream
 
                 Debug.Assert(sectionStream.Position + (long)decoded <= sectionStream.Length);
@@ -1186,6 +1184,9 @@ namespace ILCompiler.ObjectWriter
 
         private void ResolveRelocations(int sectionIndex, Stream sectionStream, MemoryStream dstStream, List<SymbolicRelocation> relocs, long sectionStart = 0, bool shrink = false)
         {
+            Debug.Assert(sectionStream.CanSeek);
+            Debug.Assert(sectionStream.Length >= 0);
+
             if (relocs.Count == 0)
             {
                 sectionStream.CopyTo(dstStream);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -140,7 +141,7 @@ namespace ILCompiler.ObjectWriter
 
             for (int i = 0; i < funcletKinds.Length; i++)
             {
-                 WasmFuncType funcletSignature = GetFuncletType(funcletKinds[i], pointerType);
+                WasmFuncType funcletSignature = GetFuncletType(funcletKinds[i], pointerType);
                 RegisterFunctionSymbol(new Utf8String($"{mangledNodeName}_funclet_{i}"));
                 RegisterStubIndexAndSignature(funcletSignature);
             }
@@ -697,11 +698,13 @@ namespace ILCompiler.ObjectWriter
                 {
                     using (Stream originalStream = section.Stream)
                     {
-                        MemoryStream stream = new MemoryStream((int)originalStream.Length);
+                        MemoryStream destStream = new MemoryStream((int)originalStream.Length);
                         originalStream.Position = 0;
-                        originalStream.CopyTo(stream);
-                        ResolveRelocations(index, stream, relocations, sectionStart: 0);
-                        section.Stream = stream;
+                        //originalStream.CopyTo(stream);
+                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0);
+                        destStream.SetLength(destStream.Position);
+                        section.Stream = destStream;
+                        Console.WriteLine("Saved: {0} bytes of relocations in section {1}", originalStream.Length - destStream.Length, section.Name);
                         // originalStream may be disposed, section.Stream now points to resolved stream
                     }
                 }
@@ -728,17 +731,21 @@ namespace ILCompiler.ObjectWriter
                 // Move stream position forward to account for inter-section padding (precalculated in BuildWebcilDataSegment())
                 webcilStream.Position = section.Header.PointerToRawData;
                 section.Stream.Position = 0;
-                section.Stream.CopyTo(webcilStream);
-                long bytesWritten = (long)webcilStream.Position - (long)section.Header.PointerToRawData;
-                Debug.Assert(section.Header.SizeOfRawData - bytesWritten == section.Padding, $"Unexpected padding: {section.Header.SizeOfRawData - bytesWritten} != {section.Padding}");
 
                 if (_resolvableRelocations.TryGetValue(section.Index, out List<SymbolicRelocation> relocations))
                 {
-                    // We emit all Webcil sections into one stream, and resolve relocations directly into this combined stream.
-                    // As a result, the section-relative offsets that relocs in our list have need to be calculated based on the section's
+                    // We emit all Webcil sections into one stream, and copy data / resolve relocations directly into this combined stream.
+                    // As a result, the real offsets that relocs in our list have need to be calculated based on the section's
                     // position within the Webcil segment
-                    ResolveRelocations(section.Index, webcilStream, relocations, sectionStart: (long)section.Header.PointerToRawData);
+                    ResolveRelocations(section.Index, section.Stream, webcilStream, relocations, sectionStart: (long)section.Header.PointerToRawData);
                 }
+                else
+                {
+                    section.Stream.CopyTo(webcilStream);
+                }
+
+                long bytesWritten = (long)webcilStream.Position - (long)section.Header.PointerToRawData;
+                Debug.Assert(section.Header.SizeOfRawData - bytesWritten == section.Padding, $"Unexpected padding: {section.Header.SizeOfRawData - bytesWritten} != {section.Padding}");
             }
 
             if (_webcilSegment.Sections.Length > 0)
@@ -858,10 +865,151 @@ namespace ILCompiler.ObjectWriter
             return rva >= section.Header.VirtualAddress && rva < section.Header.VirtualAddress + section.Header.VirtualSize;
         }
 
+
         // TODO-WASM: Currently, all Wasm relocs are resolved to 5 byte values unconditionally (the same size as the original placeholder padding), which is wasteful.
         // We should remove the padding and shrink the resolved values to their minimal size so we don't bloat the binary size.
 #nullable enable
-        private unsafe void ResolveRelocations(int sectionIndex, MemoryStream sectionStream, List<SymbolicRelocation> relocs, long sectionStart = 0)
+        static void CopyOnly(Stream src, Stream dst, byte[] scratchBuff, int count)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+            while (count > 0)
+            {
+                int toRead = Math.Min(scratchBuff.Length, count);
+                int read = src.Read(scratchBuff, 0, toRead);
+                if (read == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+                dst.Write(scratchBuff, 0, read);
+                count -= read;
+            }
+        }
+
+        private static List<Segment> SplitBlob(Stream src, long start, long end, List<SymbolicRelocation> relocs)
+        {
+            // Build up a list of segments to describe this blob. Each blob is a byte range of [start, end) that is either a relocation or plain data (Reloc == null).
+            // This allows us to resolve each slice of the section with possible shrinkage of the max-sized relocations in between.
+            List<Segment> segments = new();
+            if (relocs.First().Offset > 0)
+            {
+                segments.Add(new Segment(0, relocs.First().Offset, null));
+            }
+
+            for (int i = 0; i < relocs.Count; i++)
+            {
+                SymbolicRelocation curReloc = relocs[i];
+                SymbolicRelocation? nextReloc = null;
+                if (i < relocs.Count - 1)
+                {
+                   nextReloc = relocs[i + 1]; 
+                }
+                segments.Add(new Segment(curReloc.Offset, Relocation.GetSize(curReloc.Type) + curReloc.Offset, curReloc));
+                long nextStart = curReloc.Offset + Relocation.GetSize(curReloc.Type);
+                long nextEnd = nextReloc is not null ? nextReloc.Offset : end;
+                segments.Add(new Segment(nextStart, nextEnd, null));
+            }
+            Debug.Assert(segments.First().Start == 0 && segments.Last().End == end);
+            return segments;
+        }
+
+        private record CodeBlob(long Size, long Start, long End);
+
+        private List<CodeBlob> ParseCodeBlobs(Stream sectionStream)
+        {
+            List<CodeBlob> blobs = new();
+            while (true)
+            {
+                ulong? decoded = DwarfHelper.ReadULEB128(sectionStream, out int actualLength);
+                if (decoded is null) break; // end of stream
+
+                Debug.Assert(sectionStream.Position + (long)decoded <= sectionStream.Length);
+                blobs.Add(new CodeBlob((long)decoded, sectionStream.Position, sectionStream.Position + (long)decoded));
+                sectionStream.Position += (long)decoded;
+            }
+
+            return blobs;
+        }
+
+        private void ResolveCodeRelocations(int sectionIndex, Stream sectionStream, MemoryStream dstStream, List<CodeBlob> blobs, List<SymbolicRelocation> relocs)
+        {
+            long maxBlobSize = blobs.Max(blob => blob.End - blob.Start);
+            // for each blob:
+            //  select relocations that are in the blob's range
+            //  copy over the blob's contents to the temporary stream, resolving relocations in sorted order 
+            //  write the temporary stream to the destination stream with the new size
+            MemoryStream tempStream = new MemoryStream((int)maxBlobSize);
+            byte[] copyBuffer = new byte[4096];
+            int[] blobShrink = new int[blobs.Count];
+
+            blobs.Sort((a, b) => a.Start.CompareTo(b.Start));
+            relocs.Sort((a, b) => a.Offset.CompareTo(b.Offset));
+
+            for (int b = 0; b < blobs.Count; b++)
+            {
+                CodeBlob blob = blobs[b];
+                var blobRelocs = relocs.Where(reloc => reloc.Offset >= blob.Start && reloc.Offset < blob.End).ToList();
+
+                tempStream.Position = 0;
+                if (blobRelocs.Count > 0)
+                {
+                    sectionStream.Position = blob.Start;
+                    if (blobRelocs.First().Offset > 0)
+                    {
+                        // Copy the initial data in the blob before the first relocation
+                        CopyOnly(sectionStream, tempStream, copyBuffer, (int)blobRelocs.First().Offset - (int)blob.Start);
+                    }
+                    Debug.Assert(sectionStream.Position == blobRelocs.First().Offset, $"Section stream position sectionStream.Position does not match first reloc offset {blobRelocs.First().Offset}");
+
+                    for (int i = 0; i < blobRelocs.Count; i++)
+                    {
+                        SymbolicRelocation curReloc = blobRelocs[i];
+                        SymbolicRelocation? nextReloc = null;
+                        if (i < blobRelocs.Count - 1)
+                        {
+                            nextReloc = blobRelocs[i + 1];
+                        }
+
+                        int size = ResolveReloc(sectionIndex, sectionStream, tempStream, curReloc);
+                        blobShrink[b] += (int)Relocation.GetSize(curReloc.Type) - size;
+
+                        long nextStart = curReloc.Offset + Relocation.GetSize(curReloc.Type);
+                        long nextEnd = nextReloc is not null ? nextReloc.Offset : blob.End;
+                        Debug.Assert(tempStream.Position <= sectionStream.Position);
+                        CopyOnly(sectionStream, tempStream, copyBuffer, (int)(nextEnd - nextStart));
+                    }
+                    Debug.Assert(tempStream.Position <= blob.Size, $"Temp stream position {tempStream.Position} exceeds blob size {blob.Size}");
+                    tempStream.SetLength(tempStream.Position);
+
+                    Span<byte> countBuffer = stackalloc byte[(int)DwarfHelper.SizeOfULEB128((ulong)tempStream.Length)];
+                    DwarfHelper.WriteULEB128(countBuffer, (ulong)tempStream.Length);
+                    dstStream.Write(countBuffer);
+
+                    tempStream.Position = 0;
+                    tempStream.CopyTo(dstStream);
+                }
+                else
+                {
+                    Span<byte> countBuffer = stackalloc byte[(int)DwarfHelper.SizeOfULEB128((ulong)blob.Size)];
+                    DwarfHelper.WriteULEB128(countBuffer, (ulong)blob.Size);
+                    dstStream.Write(countBuffer);
+                    // No relocations in this blob, just copy it over
+                    sectionStream.Position = blob.Start;
+                    CopyOnly(src: sectionStream, dst: dstStream, scratchBuff: copyBuffer, count: (int)(blob.End - blob.Start));
+                }
+            }
+            dstStream.SetLength(dstStream.Position);
+
+            dstStream.Position = 0;
+            List<CodeBlob> newBlobs = ParseCodeBlobs(dstStream);
+            Debug.Assert(newBlobs.Count == blobs.Count);
+
+            for (int i = 0; i < newBlobs.Count; i++)
+            {
+                Debug.Assert(newBlobs[i].Size + blobShrink[i] == blobs[i].Size);
+            }
+        }
+
+        private unsafe int ResolveReloc(int sectionIndex, Stream sectionStream, MemoryStream dstStream, SymbolicRelocation reloc, long? destPos = null)
         {
             byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
 
@@ -873,159 +1021,188 @@ namespace ILCompiler.ObjectWriter
                 webcilVirtualStart = curSection.Header.VirtualAddress;
             }
 
-            // If we have a webcil section, we expect it to have a nonzero section start. This is because for webcil,
-            // we should have written the webcil header and each of the section headers (always non-zero size) before any
-            // section contents
-            Debug.Assert(curSectionAsWebcil is null || sectionStart != 0);
-
-            foreach (SymbolicRelocation reloc in relocs)
+            int size = Relocation.GetSize(reloc.Type);
+            if (size > relocScratchBuffer.Length)
             {
-                int size = Relocation.GetSize(reloc.Type);
-                if (size > relocScratchBuffer.Length)
-                {
-                    throw new InvalidOperationException($"Unsupported relocation size for relocation: {reloc.Type}");
-                }
-
-                SymbolDefinition definedSymbol = _definedSymbols[reloc.SymbolName];
-
-                // The virtual address of the relocation we are resolving
-                uint virtualRelocOffset = 0;
-                if (curSectionAsWebcil is not null)
-                {
-                    virtualRelocOffset = webcilVirtualStart + (uint)reloc.Offset;
-                    Debug.Assert(IsWithinSection(virtualRelocOffset, curSectionAsWebcil));
-                }
-
-                // The virtual address of the symbol this relocation refers to
-                uint virtualSymbolImageOffset = 0;
-                WebcilSection? symbolWebcilSection = null;
-
-                // TODO-Wasm: Enforce the below boolean as an assert once we are emitting proper Wasm code
-                // relocs for all code containing nodes
-                // ---> bool betweenWebcilSections = false;
-                if (_sections[definedSymbol.SectionIndex] is WebcilSection targetSection)
-                {
-                    symbolWebcilSection = targetSection;
-                    virtualSymbolImageOffset = symbolWebcilSection.Header.VirtualAddress + (uint)definedSymbol.Value;
-                    Debug.Assert(IsWithinSection(virtualSymbolImageOffset, symbolWebcilSection));
-                }
-
-                // We need a pinned raw pointer here for manipulation with Relocation.WriteValue
-                fixed (byte* pData = ReadRelocToDataSpan(reloc, relocScratchBuffer, sectionStart))
-                {
-                    long addend = Relocation.ReadValue(reloc.Type, pData);
-                    int relocLength = Relocation.GetSize(reloc.Type);
-
-                    switch (reloc.Type)
-                    {
-                        case RelocType.WASM_TYPE_INDEX_LEB:
-                        case RelocType.WASM_GLOBAL_INDEX_LEB:
-                        case RelocType.WASM_TABLE_INDEX_I32:
-                        case RelocType.WASM_TABLE_INDEX_I64:
-                        case RelocType.WASM_TABLE_INDEX_SLEB:
-                        case RelocType.WASM_TABLE_INDEX_REL_I32:
-                        case RelocType.WASM_FUNCTION_INDEX_LEB:
-                        {
-                            // These relocations reference a wasm structural index (function, type,
-                            // table entry, or well-known global). For R2R we self-resolve them here to
-                            // the index assigned when the symbol was registered into its index space.
-                            if (!_wasmSymbolManager.TryGetSymbol(reloc.SymbolName, out WasmSymbol symbol))
-                            {
-                                throw new InvalidOperationException($"Symbol '{reloc.SymbolName}' was not registered. Relocation type {reloc.Type}.");
-                            }
-                            Relocation.WriteValue(reloc.Type, pData, symbol.Index + addend);
-                            break;
-                        }
-
-                        case RelocType.IMAGE_REL_BASED_ABSOLUTE:
-                            // No action required
-                            break;
-
-                        case RelocType.IMAGE_REL_BASED_DIR64:
-                        case RelocType.IMAGE_REL_BASED_HIGHLOW:
-                            // This is an ImageBase-relative value in PE, but our image base
-                            // for Webcil is virtual address 0
-                            Debug.Assert(symbolWebcilSection != null);
-                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + 0 + addend);
-                            break;
-                        case RelocType.IMAGE_REL_BASED_ADDR32NB:
-                            Debug.Assert(symbolWebcilSection != null);
-                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
-                            break;
-                        case RelocType.IMAGE_REL_BASED_REL32:
-                        case RelocType.IMAGE_REL_BASED_RELPTR32:
-                            Debug.Assert(symbolWebcilSection != null);
-                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset - (virtualRelocOffset + relocLength) + addend);
-                            break;
-                        case RelocType.IMAGE_REL_FILE_ABSOLUTE:
-                            Debug.Assert(symbolWebcilSection != null);
-                            long fileOffset = symbolWebcilSection.Header.PointerToRawData + definedSymbol.Value;
-                            Relocation.WriteValue(reloc.Type, pData, fileOffset + addend);
-                            break;
-                        case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
-                        {
-                            // These relocs should be for cases of the form:
-                            //  global.get $imageBase
-                            //  i32.const <reloc>
-                            //  i32.add
-                            //  i32.load 0
-                            // So, the relocated address value should always represent an offset relative to image base.
-                            // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's
-                            // flag mapping
-                            if (symbolWebcilSection is null)
-                            {
-                                throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_SLEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
-                            }
-
-                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
-                            break;
-                        }
-                        case RelocType.WASM_MEMORY_ADDR_REL_LEB:
-                        {
-                            // These relocs should be for cases of the form:
-                            //  global.get $imageBase
-                            //  i32.load <reloc>
-                            // So, the relocated address value should always represent an offset relative to image base.
-                            // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's
-                            // flag mapping
-                            if (symbolWebcilSection is null)
-                            {
-                                throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_LEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
-                            }
-
-                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
-                            break;
-                        }
-                        case RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB:
-                        {
-                            WasmSymbol symbol = _wasmSymbolManager.GetSymbol(RtlRestoreContextTagName);
-                            Debug.Assert(symbol.IndexSpace == WasmIndexSpace.Tag);
-                            Relocation.WriteValue(reloc.Type, pData, symbol.Index + addend);
-                            break;
-                        }
-                        default:
-                            // TODO-WASM: add other cases as needed;
-                            // ignoring other reloc types for now
-                            throw new NotSupportedException($"Relocation type {reloc.Type} not yet implemented");
-                    }
-
-                    WriteRelocFromDataSpan(reloc, pData, sectionStart);
-                }
+                throw new InvalidOperationException($"Unsupported relocation size for relocation: {reloc.Type}");
             }
 
-            Span<byte> ReadRelocToDataSpan(SymbolicRelocation reloc, byte[] buffer, long sectionStart)
+            SymbolDefinition definedSymbol = _definedSymbols[reloc.SymbolName];
+
+            // The virtual address of the relocation we are resolving
+            uint virtualRelocOffset = 0;
+            if (curSectionAsWebcil is not null)
+            {
+                virtualRelocOffset = webcilVirtualStart + (uint)reloc.Offset;
+                Debug.Assert(IsWithinSection(virtualRelocOffset, curSectionAsWebcil));
+            }
+
+            // The virtual address of the symbol this relocation refers to
+            uint virtualSymbolImageOffset = 0;
+            WebcilSection? symbolWebcilSection = null;
+
+            if (_sections[definedSymbol.SectionIndex] is WebcilSection targetSection)
+            {
+                symbolWebcilSection = targetSection;
+                virtualSymbolImageOffset = symbolWebcilSection.Header.VirtualAddress + (uint)definedSymbol.Value;
+                Debug.Assert(IsWithinSection(virtualSymbolImageOffset, symbolWebcilSection));
+            }
+
+            // We need a pinned raw pointer here for manipulation with Relocation.WriteValue
+            fixed (byte* pData = ReadRelocToDataSpan(reloc, relocScratchBuffer))
+            {
+                long addend = Relocation.ReadValue(reloc.Type, pData);
+                int relocLength = Relocation.GetSize(reloc.Type);
+                int? actualLength = null;
+
+                switch (reloc.Type)
+                {
+                    case RelocType.WASM_TYPE_INDEX_LEB:
+                    case RelocType.WASM_GLOBAL_INDEX_LEB:
+                    case RelocType.WASM_TABLE_INDEX_I32:
+                    case RelocType.WASM_TABLE_INDEX_I64:
+                    case RelocType.WASM_TABLE_INDEX_SLEB:
+                    case RelocType.WASM_TABLE_INDEX_REL_I32:
+                    case RelocType.WASM_FUNCTION_INDEX_LEB:
+                    {
+                        // These relocations reference a wasm structural index (function, type,
+                        // table entry, or well-known global). For R2R we self-resolve them here to
+                        // the index assigned when the symbol was registered into its index space.
+                        if (!_wasmSymbolManager.TryGetSymbol(reloc.SymbolName, out WasmSymbol symbol))
+                        {
+                            throw new InvalidOperationException($"Symbol '{reloc.SymbolName}' was not registered. Relocation type {reloc.Type}.");
+                        }
+                        if (Relocation.IsVariableLength(reloc.Type))
+                        {
+                            actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, symbol.Index + addend);
+                        }
+                        else
+                        {
+                            Relocation.WriteValue(reloc.Type, pData, symbol.Index + addend);
+                        }
+                        break;
+                    }
+
+                    case RelocType.IMAGE_REL_BASED_ABSOLUTE:
+                        // No action required
+                        break;
+
+                    case RelocType.IMAGE_REL_BASED_DIR64:
+                    case RelocType.IMAGE_REL_BASED_HIGHLOW:
+                        // This is an ImageBase-relative value in PE, but our image base
+                        // for Webcil is virtual address 0
+                        Debug.Assert(symbolWebcilSection != null);
+                        Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + 0 + addend);
+                        break;
+                    case RelocType.IMAGE_REL_BASED_ADDR32NB:
+                        Debug.Assert(symbolWebcilSection != null);
+                        Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                        break;
+                    case RelocType.IMAGE_REL_BASED_REL32:
+                    case RelocType.IMAGE_REL_BASED_RELPTR32:
+                        Debug.Assert(symbolWebcilSection != null);
+                        Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset - (virtualRelocOffset + relocLength) + addend);
+                        break;
+                    case RelocType.IMAGE_REL_FILE_ABSOLUTE:
+                        Debug.Assert(symbolWebcilSection != null);
+                        long fileOffset = symbolWebcilSection.Header.PointerToRawData + definedSymbol.Value;
+                        Relocation.WriteValue(reloc.Type, pData, fileOffset + addend);
+                        break;
+                    case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
+                    {
+                        // These relocs should be for cases of the form:
+                        //  global.get $imageBase
+                        //  i32.const <reloc>
+                        //  i32.add
+                        //  i32.load 0
+                        // So, the relocated address value should always represent an offset relative to image base.
+                        // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's
+                        // flag mapping
+                        if (symbolWebcilSection is null)
+                        {
+                            throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_SLEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
+                        }
+
+                        actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                        break;
+                    }
+                    case RelocType.WASM_MEMORY_ADDR_REL_LEB:
+                    {
+                        // These relocs should be for cases of the form:
+                        //  global.get $imageBase
+                        //  i32.load <reloc>
+                        // So, the relocated address value should always represent an offset relative to image base.
+                        // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's
+                        // flag mapping
+                        if (symbolWebcilSection is null)
+                        {
+                            throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_LEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
+                        }
+
+                        actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                        break;
+                    }
+                    case RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB:
+                    {
+                        WasmSymbol symbol = _wasmSymbolManager.GetSymbol(RtlRestoreContextTagName);
+                        Debug.Assert(symbol.IndexSpace == WasmIndexSpace.Tag);
+                        actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, symbol.Index + addend);
+                        break;
+                    }
+                    default:
+                        // TODO-WASM: add other cases as needed;
+                        // ignoring other reloc types for now
+                        throw new NotSupportedException($"Relocation type {reloc.Type} not yet implemented");
+                }
+
+                return WriteRelocFromDataSpan(reloc, pData, dstStream, actualLength ?? relocLength);
+            }
+
+            Span<byte> ReadRelocToDataSpan(SymbolicRelocation reloc, byte[] buffer)
             {
                 Span<byte> relocContents = buffer.AsSpan(0, Relocation.GetSize(reloc.Type));
-                sectionStream.Position = reloc.Offset + sectionStart;
+                sectionStream.Position = reloc.Offset;
                 sectionStream.ReadExactly(relocContents);
                 return relocContents;
             }
 
-            void WriteRelocFromDataSpan(SymbolicRelocation reloc, byte* pData, long sectionStart)
+            int WriteRelocFromDataSpan(SymbolicRelocation reloc, byte* pData, MemoryStream dstStream, int length)
             {
-                sectionStream.Position = reloc.Offset + sectionStart;
-                sectionStream.Write(new Span<byte>(pData, Relocation.GetSize(reloc.Type)));
+                if (destPos is  not null)
+                {
+                    dstStream.Position = (long)destPos;
+                }
+                dstStream.Write(new Span<byte>(pData, length));
+                return length;
             }
+        }
+
+        private record Segment(long Start, long End, SymbolicRelocation? Reloc);
+        private void ResolveRelocations(int sectionIndex, Stream sectionStream, MemoryStream dstStream, List<SymbolicRelocation> relocs, long sectionStart = 0)
+        {
+            if (relocs.Count == 0)
+            {
+                sectionStream.CopyTo(dstStream);
+                return;
+            }
+
+            if (_sections[sectionIndex] is WasmSection { Type: WasmSectionType.Code })
+            {
+                List<CodeBlob> blobs = ParseCodeBlobs(sectionStream);
+                sectionStream.Position = 0;
+                ResolveCodeRelocations(sectionIndex, sectionStream, dstStream, blobs, relocs);
+                return;
+            }
+
+            // Otherwise, we can resolve relocations on top of the copied in section stream, since the size and layout of the stream won't be changing.
+            long startPos = dstStream.Position;
+            sectionStream.CopyTo(dstStream);
+            foreach (SymbolicRelocation reloc in relocs)
+            {
+                long? destPos = sectionStart != 0 ? sectionStart + reloc.Offset : null;
+                ResolveReloc(sectionIndex, sectionStream, dstStream, reloc, destPos: destPos);
+            }
+            dstStream.Position = sectionStream.Length + startPos;
         }
 #nullable disable
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -701,7 +701,7 @@ namespace ILCompiler.ObjectWriter
                         MemoryStream destStream = new MemoryStream((int)originalStream.Length);
                         originalStream.Position = 0;
                         //originalStream.CopyTo(stream);
-                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0);
+                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0, shrink: false);
                         destStream.SetLength(destStream.Position);
                         section.Stream = destStream;
                         Console.WriteLine("Saved: {0} bytes of relocations in section {1}", originalStream.Length - destStream.Length, section.Name);
@@ -737,7 +737,7 @@ namespace ILCompiler.ObjectWriter
                     // We emit all Webcil sections into one stream, and copy data / resolve relocations directly into this combined stream.
                     // As a result, the real offsets that relocs in our list have need to be calculated based on the section's
                     // position within the Webcil segment
-                    ResolveRelocations(section.Index, section.Stream, webcilStream, relocations, sectionStart: (long)section.Header.PointerToRawData);
+                    ResolveRelocations(section.Index, section.Stream, webcilStream, relocations, sectionStart: (long)section.Header.PointerToRawData, shrink: false);
                 }
                 else
                 {
@@ -939,6 +939,7 @@ namespace ILCompiler.ObjectWriter
             //  write the temporary stream to the destination stream with the new size
             MemoryStream tempStream = new MemoryStream((int)maxBlobSize);
             byte[] copyBuffer = new byte[4096];
+            byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
             int[] blobShrink = new int[blobs.Count];
 
             blobs.Sort((a, b) => a.Start.CompareTo(b.Start));
@@ -969,7 +970,7 @@ namespace ILCompiler.ObjectWriter
                             nextReloc = blobRelocs[i + 1];
                         }
 
-                        int size = ResolveReloc(sectionIndex, sectionStream, tempStream, curReloc);
+                        int size = ResolveReloc(sectionIndex, sectionStream, tempStream, curReloc, relocScratchBuffer);
                         blobShrink[b] += (int)Relocation.GetSize(curReloc.Type) - size;
 
                         long nextStart = curReloc.Offset + Relocation.GetSize(curReloc.Type);
@@ -1009,10 +1010,8 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private unsafe int ResolveReloc(int sectionIndex, Stream sectionStream, MemoryStream dstStream, SymbolicRelocation reloc, long? destPos = null)
+        private unsafe int ResolveReloc(int sectionIndex, Stream sectionStream, MemoryStream dstStream, SymbolicRelocation reloc,  byte[] relocScratchBuffer, long? destPos = null, bool shrink = false)
         {
-            byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
-
             WebcilSection? curSectionAsWebcil = null;
             uint webcilVirtualStart = 0;
             if (_sections[sectionIndex] is WebcilSection curSection)
@@ -1072,7 +1071,8 @@ namespace ILCompiler.ObjectWriter
                         {
                             throw new InvalidOperationException($"Symbol '{reloc.SymbolName}' was not registered. Relocation type {reloc.Type}.");
                         }
-                        if (Relocation.IsVariableLength(reloc.Type))
+
+                        if (shrink && Relocation.IsVariableLength(reloc.Type))
                         {
                             actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, symbol.Index + addend);
                         }
@@ -1123,7 +1123,15 @@ namespace ILCompiler.ObjectWriter
                             throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_SLEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
                         }
 
-                        actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                        if (shrink)
+                        {
+                            actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                        }
+                        else
+                        {
+                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                        }
+
                         break;
                     }
                     case RelocType.WASM_MEMORY_ADDR_REL_LEB:
@@ -1139,14 +1147,29 @@ namespace ILCompiler.ObjectWriter
                             throw new InvalidDataException($"WASM_MEMORY_ADDR_REL_LEB: symbol '{reloc.SymbolName}' (sectionIndex {definedSymbol.SectionIndex}, section type {_sections[definedSymbol.SectionIndex]?.GetType().Name}) is not in a WebcilSection. Reloc in section {sectionIndex} ({_sections[sectionIndex]?.GetType().Name}), offset {reloc.Offset:X}.");
                         }
 
-                        actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                        if (shrink)
+                        {
+                            actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                        }
+                        else
+                        {
+                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                        }
+
                         break;
                     }
                     case RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB:
                     {
                         WasmSymbol symbol = _wasmSymbolManager.GetSymbol(RtlRestoreContextTagName);
                         Debug.Assert(symbol.IndexSpace == WasmIndexSpace.Tag);
-                        actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, symbol.Index + addend);
+                        if (shrink)
+                        {
+                            actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, symbol.Index + addend);
+                        }
+                        else
+                        {
+                            Relocation.WriteValue(reloc.Type, pData, symbol.Index + addend);
+                        }
                         break;
                     }
                     default:
@@ -1178,7 +1201,7 @@ namespace ILCompiler.ObjectWriter
         }
 
         private record Segment(long Start, long End, SymbolicRelocation? Reloc);
-        private void ResolveRelocations(int sectionIndex, Stream sectionStream, MemoryStream dstStream, List<SymbolicRelocation> relocs, long sectionStart = 0)
+        private void ResolveRelocations(int sectionIndex, Stream sectionStream, MemoryStream dstStream, List<SymbolicRelocation> relocs, long sectionStart = 0, bool shrink = false)
         {
             if (relocs.Count == 0)
             {
@@ -1186,7 +1209,7 @@ namespace ILCompiler.ObjectWriter
                 return;
             }
 
-            if (_sections[sectionIndex] is WasmSection { Type: WasmSectionType.Code })
+            if (shrink && _sections[sectionIndex] is WasmSection { Type: WasmSectionType.Code })
             {
                 List<CodeBlob> blobs = ParseCodeBlobs(sectionStream);
                 sectionStream.Position = 0;
@@ -1194,13 +1217,21 @@ namespace ILCompiler.ObjectWriter
                 return;
             }
 
+            byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
+
             // Otherwise, we can resolve relocations on top of the copied in section stream, since the size and layout of the stream won't be changing.
             long startPos = dstStream.Position;
             sectionStream.CopyTo(dstStream);
-            foreach (SymbolicRelocation reloc in relocs)
+            for (int i = 0; i < relocs.Count; i++)
             {
-                long? destPos = sectionStart != 0 ? sectionStart + reloc.Offset : null;
-                ResolveReloc(sectionIndex, sectionStream, dstStream, reloc, destPos: destPos);
+                if (i % 10000 == 0)
+                {
+                    Console.WriteLine("Resolving relocation {0}/{1} in section {2}", i, relocs.Count, sectionIndex);
+                }
+
+                SymbolicRelocation reloc = relocs[i];
+                long? destPos = sectionStart + reloc.Offset;
+                ResolveReloc(sectionIndex, sectionStream, dstStream, reloc, relocScratchBuffer, destPos: destPos);
             }
             dstStream.Position = sectionStream.Length + startPos;
         }

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -701,7 +701,7 @@ namespace ILCompiler.ObjectWriter
                         MemoryStream destStream = new MemoryStream((int)originalStream.Length);
                         originalStream.Position = 0;
                         //originalStream.CopyTo(stream);
-                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0, shrink: true);
+                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0, shrink: false);
                         section.Stream = destStream;
                         Console.WriteLine("Saved: {0} bytes of relocations in section {1}", originalStream.Length - destStream.Length, section.Name);
                         // originalStream may be disposed, section.Stream now points to resolved stream
@@ -928,7 +928,6 @@ namespace ILCompiler.ObjectWriter
             //  copy over the blob's contents to the temporary stream, resolving relocations in sorted order 
             //  write the temporary stream to the destination stream with the new size
             MemoryStream tempStream = new MemoryStream((int)maxBlobSize);
-            tempStream.SetLength(maxBlobSize);
             byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
             int[] blobShrink = new int[blobs.Count];
 
@@ -953,6 +952,7 @@ namespace ILCompiler.ObjectWriter
                 if (hasRelocs)
                 {
                     tempStream.Position = 0;
+                    tempStream.SetLength(blob.Size);
                     sectionStream.Position = blob.Start;
                     SymbolicRelocation firstReloc = relocs[relocCursor];
 
@@ -992,18 +992,18 @@ namespace ILCompiler.ObjectWriter
 
                     Debug.Assert(tempStream.Position <= blob.Size && blob.Size <= tempStream.Length, $"Temp stream position {tempStream.Position} exceeds blob size {blob.Size}");
 
-                    long tempStreamLength = tempStream.Position;
+                    tempStream.SetLength(tempStream.Position);
 
                     // Write the temp stream back into the original stream with a NEW length prefix, starting at writeCursor
-                    DwarfHelper.WriteULEB128(countBuffer, (ulong)tempStreamLength);
+                    DwarfHelper.WriteULEB128(countBuffer, (ulong)tempStream.Length);
                     sectionStream.Position = writeCursor;
-                    sectionStream.Write(countBuffer, 0, (int)DwarfHelper.SizeOfULEB128((ulong)tempStreamLength));
+                    sectionStream.Write(countBuffer, 0, (int)DwarfHelper.SizeOfULEB128((ulong)tempStream.Length));
                     writeCursor = sectionStream.Position; // set writeCursor to the position after the length prefix we just wrote
 
                     tempStream.Position = 0;
                     tempStream.CopyTo(sectionStream);
 
-                    writeCursor += tempStreamLength;
+                    writeCursor += tempStream.Length;
                 }
                 else
                 {
@@ -1226,9 +1226,12 @@ namespace ILCompiler.ObjectWriter
 
             if (shrink && _sections[sectionIndex] is WasmSection { Type: WasmSectionType.Code })
             {
-                List<CodeBlob> blobs = ParseCodeBlobs(sectionStream);
                 sectionStream.Position = 0;
                 sectionStream.CopyTo(dstStream);
+
+                dstStream.Position = 0;
+                List<CodeBlob> blobs = ParseCodeBlobs(dstStream);
+
                 dstStream.Position = 0;
                 ResolveCodeRelocations(sectionIndex, dstStream, blobs, relocs, shrink);
                 return;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -111,13 +111,14 @@ public class R2RTestSuites
             Assert.True(WasmR2RAssert.WasmIndexSpacesHaveExpectedEntries(webcilReader, out string indexDiagnostic), indexDiagnostic);
 
             // The wasm JIT references the ABI well-known globals via maximally padded WASM_GLOBAL_INDEX_LEB
-            // relocations that the R2R object writer must self-resolve back to the fixed global
-            // indices. Verify the emitted code contains a correctly self-resolved 'global.get' for the
+            // relocations that the R2R object writer must self-resolve to the fixed global
+            // indices and shrink down to their minimal size. Verify the emitted code contains a correctly self-resolved 'global.get' for the
             // image base (1, materialized by static-data reads in SumStaticData) and the table base
             // (2, materialized by the try/finally funclet path in SumWithFinally). Each pattern encodes
-            // the exact resolved index, so a regression in self-resolution changes it (or makes
-            // crossgen2 throw while emitting the method). The stack-pointer well-known global is passed to
-            // managed methods as a parameter in R2R, so it is not referenced via 'global.get' here.
+            // the exact resolved index in its minimal form, so a regression in self-resolution changes
+            // it (or makes crossgen2 throw while emitting the method). The stack-pointer well-known global
+            // is passed to managed methods as a parameter in R2R, so it is not referenced via
+            // 'global.get' here.
             const int ImageBaseGlobal = 1;
             const int TableBaseGlobal = 2;
             Assert.True(WasmR2RAssert.WasmImageContainsWellKnownGlobalGet(webcilReader, ImageBaseGlobal),

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
@@ -14,36 +14,26 @@ internal static class WasmR2RAssert
 {
     /// <summary>
     /// Returns true if any WASM function body in the image contains a <c>global.get</c> of the
-    /// given ABI well-known-global index, emitted as a maximally padded 5-byte
-    /// <c>WASM_GLOBAL_INDEX_LEB</c> reference (the <c>global.get</c> opcode <c>0x23</c> followed
-    /// by the 5-byte padded ULEB128 of the index).
+    /// given ABI well-known-global index (the <c>global.get</c> opcode <c>0x23</c> followed
+    /// by the minimally encoded ULEB128 index).
     /// </summary>
     /// <remarks>
     /// The wasm JIT references only the three ABI well-known globals (0 = stack pointer, 1 = image base,
-    /// 2 = table base) in this padded form; ordinary <c>global.get</c> instructions use the minimal
-    /// LEB128 encoding. The R2R object writer self-resolves the relocation in place, so after
-    /// compilation the padded slot holds the fixed index, e.g. image base -&gt;
-    /// <c>23 81 80 80 80 00</c> and table base -&gt; <c>23 82 80 80 80 00</c>. This is a regression
-    /// smoke check for that self-resolution: it scans raw instruction bytes and does not decode
-    /// wasm instruction boundaries.
+    /// 2 = table base) through padded relocations. The R2R object writer self-resolves and shrinks those
+    /// relocations, so after compilation the instruction contains the fixed index in its minimal form,
+    /// e.g. image base -&gt; <c>23 01</c> and table base -&gt; <c>23 02</c>. This is a regression smoke
+    /// check for that self-resolution: it scans raw instruction bytes and does not decode wasm
+    /// instruction boundaries.
     /// </remarks>
     public static bool WasmImageContainsWellKnownGlobalGet(WebcilImageReader reader, int wellKnownGlobalIndex)
     {
-        // The well-known globals are 0/1/2, which all fit in a single ULEB128 payload byte. The padded
-        // encoding below only writes that single payload byte, so it is correct for indices <= 0x7F.
+        // The well-known globals are 0/1/2, which all fit in a single ULEB128 byte.
         Debug.Assert((uint)wellKnownGlobalIndex <= 0x7F,
             $"Only single-byte well-known-global indices are supported; got {wellKnownGlobalIndex}.");
 
-        // global.get (0x23) followed by the 5-byte padded ULEB128 of wellKnownGlobalIndex. Padding sets
-        // the continuation bit on the first four bytes and clears the last, so a small index N
-        // encodes as (N | 0x80), 0x80, 0x80, 0x80, 0x00.
-        Span<byte> pattern = stackalloc byte[6];
+        Span<byte> pattern = stackalloc byte[2];
         pattern[0] = 0x23;
-        pattern[1] = (byte)((wellKnownGlobalIndex & 0x7F) | 0x80);
-        pattern[2] = 0x80;
-        pattern[3] = 0x80;
-        pattern[4] = 0x80;
-        pattern[5] = 0x00;
+        pattern[1] = (byte)wellKnownGlobalIndex;
 
         for (int functionIndex = 0; ; functionIndex++)
         {


### PR DESCRIPTION
This PR implements a relocation shrinking optimization in the WasmObjectWriter. All relocations in Wasm code emitted by the JIT are currently padded to the max 32-bit ULEB length of 5 bytes, but their resolved values may be much shorter. This PR keeps behavior the same for non-code sections which don't have variable length relocs, while implementing a shrinking procedure to re-write each relocation in the code section to its minimal length. The LEB lengths of each code blob are updated accordingly after shrinkage. 
## Impact
This yields around **5%** size savings for System.Private.CoreLib.