### PR TITLE
Partition the ComWrappers RCW cache into per-processor buckets

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -1311,13 +1311,6 @@ namespace System.Runtime.InteropServices
             /// <summary>
             /// The most buckets to partition the cache into, regardless of how many processors there are.
             /// </summary>
-            /// <remarks>
-            /// Every bucket costs a lock and a dictionary for the lifetime of the <see cref="ComWrappers"/>
-            /// instance, so the count can't just track the processor count upwards. Past this point the added
-            /// buckets stop paying for themselves: going from 16 to 32 on a 32 processor machine only improves
-            /// a heavily contended lookup by about a fifth, while doubling what an instance costs and making
-            /// the uncontended lookup slower, as the buckets no longer sit as close together in memory.
-            /// </remarks>
             private const int MaxBucketCount = 16;
 
             private readonly Bucket[] _buckets;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -1308,14 +1308,26 @@ namespace System.Runtime.InteropServices
         /// </remarks>
         private readonly struct RcwCache
         {
+            /// <summary>
+            /// The most buckets to partition the cache into, regardless of how many processors there are.
+            /// </summary>
+            /// <remarks>
+            /// Every bucket costs a lock and a dictionary for the lifetime of the <see cref="ComWrappers"/>
+            /// instance, so the count can't just track the processor count upwards. Past this point the added
+            /// buckets stop paying for themselves: going from 16 to 32 on a 32 processor machine only improves
+            /// a heavily contended lookup by about a fifth, while doubling what an instance costs and making
+            /// the uncontended lookup slower, as the buckets no longer sit as close together in memory.
+            /// </remarks>
+            private const int MaxBucketCount = 16;
+
             private readonly Bucket[] _buckets;
 
             public RcwCache()
             {
                 // Use as many buckets as there are processors, matching the default concurrency level of
-                // 'ConcurrentDictionary'. The count is rounded up to a power of two so that the bucket for a
-                // given COM instance can be selected with a mask rather than a division.
-                uint bucketCount = BitOperations.RoundUpToPowerOf2((uint)Environment.ProcessorCount);
+                // 'ConcurrentDictionary', up to the cap above. The count is rounded up to a power of two so that
+                // the bucket for a given COM instance can be selected with a mask rather than a division.
+                uint bucketCount = BitOperations.RoundUpToPowerOf2((uint)Math.Min(Environment.ProcessorCount, MaxBucketCount));
                 Bucket[] buckets = new Bucket[bucketCount];
 
                 for (int i = 0; i < buckets.Length; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -1409,7 +1409,7 @@ namespace System.Runtime.InteropServices
             private readonly struct Bucket
             {
                 private readonly ReaderWriterLockSlim _lock;
-                private readonly Dictionary<IntPtr, GCHandle> _cache;
+                private readonly Dictionary<IntPtr, WeakGCHandle<NativeObjectWrapper>> _cache;
 
                 public Bucket()
                 {
@@ -1424,18 +1424,18 @@ namespace System.Runtime.InteropServices
                     try
                     {
                         Debug.Assert(wrapper.ProxyHandle.Target == comProxy);
-                        ref GCHandle rcwEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, comPointer, out bool exists);
+                        ref WeakGCHandle<NativeObjectWrapper> rcwEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, comPointer, out bool exists);
                         if (!exists)
                         {
                             // Someone else didn't beat us to adding the entry to the cache.
                             // Add our entry here.
-                            rcwEntry = GCHandle.Alloc(wrapper, GCHandleType.Weak);
+                            rcwEntry = new WeakGCHandle<NativeObjectWrapper>(wrapper);
                         }
-                        else if (rcwEntry.Target is not (NativeObjectWrapper cachedWrapper))
+                        else if (!rcwEntry.TryGetTarget(out NativeObjectWrapper? cachedWrapper))
                         {
                             Debug.Assert(rcwEntry.IsAllocated);
                             // The target was collected, so we need to update the cache entry.
-                            rcwEntry.Target = wrapper;
+                            rcwEntry.SetTarget(wrapper);
                         }
                         else
                         {
@@ -1449,7 +1449,7 @@ namespace System.Runtime.InteropServices
                             }
 
                             // The proxy object was collected, so we need to update the cache entry.
-                            rcwEntry.Target = wrapper;
+                            rcwEntry.SetTarget(wrapper);
                         }
 
                         // We either added an entry to the cache or updated an existing entry that was dead.
@@ -1468,12 +1468,13 @@ namespace System.Runtime.InteropServices
                     _lock.EnterReadLock();
                     try
                     {
-                        if (!_cache.TryGetValue(comPointer, out GCHandle existingHandle))
+                        if (!_cache.TryGetValue(comPointer, out WeakGCHandle<NativeObjectWrapper> existingHandle))
                         {
                             // No entry in the cache.
                             return null;
                         }
-                        if (existingHandle.Target is NativeObjectWrapper { ProxyHandle.Target: object cachedProxy })
+                        if (existingHandle.TryGetTarget(out NativeObjectWrapper? cachedWrapper)
+                            && cachedWrapper.ProxyHandle.Target is object cachedProxy)
                         {
                             // The target exists and is still alive. Return it.
                             return cachedProxy;
@@ -1493,13 +1494,13 @@ namespace System.Runtime.InteropServices
                     {
                         // Someone else could have removed the entry or added a new one in the time
                         // between us releasing the read lock and acquiring the write lock.
-                        if (_cache.TryGetValue(comPointer, out GCHandle existingHandle)
-                            && existingHandle.Target is null)
+                        if (_cache.TryGetValue(comPointer, out WeakGCHandle<NativeObjectWrapper> existingHandle)
+                            && !existingHandle.TryGetTarget(out _))
                         {
                             // There's still a dead entry in the cache,
                             // remove it.
                             _cache.Remove(comPointer);
-                            existingHandle.Free();
+                            existingHandle.Dispose();
                         }
                     }
                     finally
@@ -1521,12 +1522,12 @@ namespace System.Runtime.InteropServices
                         // NativeObjectWrapper finalizer ran.
                         // Only remove the entry if the target of the GC handle is the NativeObjectWrapper
                         // or is null (indicating that the corresponding NativeObjectWrapper has been scheduled for finalization).
-                        if (_cache.TryGetValue(comPointer, out GCHandle cachedRef)
-                            && (wrapper == cachedRef.Target
-                                || cachedRef.Target is null))
+                        if (_cache.TryGetValue(comPointer, out WeakGCHandle<NativeObjectWrapper> cachedRef)
+                            && (!cachedRef.TryGetTarget(out NativeObjectWrapper? cachedWrapper)
+                                || cachedWrapper == wrapper))
                         {
                             _cache.Remove(comPointer);
-                            cachedRef.Free();
+                            cachedRef.Dispose();
                         }
                     }
                     finally

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Threading;
@@ -1296,10 +1297,56 @@ namespace System.Runtime.InteropServices
             _rcwCache.RemoveAll(wrappers);
         }
 
-        private sealed class RcwCache
+        /// <summary>
+        /// The cache mapping COM instances to the <see cref="NativeObjectWrapper"/> objects tracking their RCWs.
+        /// </summary>
+        /// <remarks>
+        /// The cache is partitioned into several independent buckets, each with its own lock, so that operations on
+        /// COM instances that map to different buckets don't contend with one another. Reducing that contention is
+        /// important because the cache is consulted on essentially every transition from native to managed code, and
+        /// because the finalizer thread concurrently takes write locks to remove entries for collected RCWs.
+        /// </remarks>
+        private readonly struct RcwCache
         {
-            private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
-            private readonly Dictionary<IntPtr, GCHandle> _cache = [];
+            private readonly Bucket[] _buckets;
+
+            public RcwCache()
+            {
+                // Use as many buckets as there are processors, matching the default concurrency level of
+                // 'ConcurrentDictionary'. The count is rounded up to a power of two so that the bucket for a
+                // given COM instance can be selected with a mask rather than a division.
+                int bucketCount = (int)BitOperations.RoundUpToPowerOf2((uint)Environment.ProcessorCount);
+                Bucket[] buckets = new Bucket[bucketCount];
+
+                for (int i = 0; i < buckets.Length; i++)
+                {
+                    buckets[i] = new Bucket();
+                }
+
+                _buckets = buckets;
+            }
+
+            /// <summary>
+            /// Gets the bucket owning the entries for a given COM instance.
+            /// </summary>
+            /// <param name="comPointer">The com instance to get the bucket for.</param>
+            /// <returns>The bucket owning the entries for <paramref name="comPointer"/>.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private ref readonly Bucket GetBucket(IntPtr comPointer)
+            {
+                Bucket[] buckets = _buckets;
+
+                // COM instances are heap allocated, so they're always at least pointer aligned (and 16-byte aligned
+                // in practice). That means their low bits are constant and can't be used to select a bucket directly.
+                // Multiplying by a large odd constant (2^64 divided by the golden ratio) mixes every input bit into
+                // the high half of the product, which is then masked to produce the index. The whole sequence lowers
+                // to a multiply, a shift and a mask, which is negligible next to the lookup that follows.
+                ulong hash = (ulong)(nuint)comPointer * 0x9E3779B97F4A7C15;
+                uint index = (uint)(hash >> 32) & (uint)(buckets.Length - 1);
+
+                // Return the bucket by reference, so that it's addressed in place in the array rather than copied
+                return ref buckets[index];
+            }
 
             /// <summary>
             /// Gets the current RCW proxy object for <paramref name="comPointer"/> if it exists in the cache or inserts a new entry with <paramref name="comProxy"/>.
@@ -1310,139 +1357,182 @@ namespace System.Runtime.InteropServices
             /// <returns>The proxy object currently in the cache for <paramref name="comPointer"/> or the proxy object owned by <paramref name="wrapper"/> if no entry exists and the corresponding native wrapper.</returns>
             public (NativeObjectWrapper actualWrapper, object actualProxy) GetOrAddProxyForComInstance(IntPtr comPointer, NativeObjectWrapper wrapper, object comProxy)
             {
-                _lock.EnterWriteLock();
-                try
-                {
-                    Debug.Assert(wrapper.ProxyHandle.Target == comProxy);
-                    ref GCHandle rcwEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, comPointer, out bool exists);
-                    if (!exists)
-                    {
-                        // Someone else didn't beat us to adding the entry to the cache.
-                        // Add our entry here.
-                        rcwEntry = GCHandle.Alloc(wrapper, GCHandleType.Weak);
-                    }
-                    else if (rcwEntry.Target is not (NativeObjectWrapper cachedWrapper))
-                    {
-                        Debug.Assert(rcwEntry.IsAllocated);
-                        // The target was collected, so we need to update the cache entry.
-                        rcwEntry.Target = wrapper;
-                    }
-                    else
-                    {
-                        object? existingProxy = cachedWrapper.ProxyHandle.Target;
-                        // The target NativeObjectWrapper was not collected, but we need to make sure
-                        // that the proxy object is still alive.
-                        if (existingProxy is not null)
-                        {
-                            // The existing proxy object is still alive, we will use that.
-                            return (cachedWrapper, existingProxy);
-                        }
-
-                        // The proxy object was collected, so we need to update the cache entry.
-                        rcwEntry.Target = wrapper;
-                    }
-
-                    // We either added an entry to the cache or updated an existing entry that was dead.
-                    // Return our target object.
-                    return (wrapper, comProxy);
-                }
-                finally
-                {
-                    _lock.ExitWriteLock();
-                }
+                return GetBucket(comPointer).GetOrAddProxyForComInstance(comPointer, wrapper, comProxy);
             }
 
+            /// <summary>
+            /// Gets the current RCW proxy object for <paramref name="comPointer"/>, if it exists in the cache and is still alive.
+            /// </summary>
+            /// <param name="comPointer">The com instance we want to get the RCW for.</param>
+            /// <returns>The proxy object currently in the cache for <paramref name="comPointer"/>, if any.</returns>
             public object? FindProxyForComInstance(IntPtr comPointer)
             {
-                _lock.EnterReadLock();
-                try
-                {
-                    if (!_cache.TryGetValue(comPointer, out GCHandle existingHandle))
-                    {
-                        // No entry in the cache.
-                        return null;
-                    }
-                    if (existingHandle.Target is NativeObjectWrapper { ProxyHandle.Target: object cachedProxy })
-                    {
-                        // The target exists and is still alive. Return it.
-                        return cachedProxy;
-                    }
-                    // The target was collected, so we need to remove the entry from the cache.
-                    // We'll do this in a write lock after we exit the read lock.
-                    // We don't use an upgradeable lock here as only one thread can hold an upgradeable lock at a time,
-                    // effectively eliminating the benefit of using a reader-writer lock.
-                }
-                finally
-                {
-                    _lock.ExitReadLock();
-                }
-
-                _lock.EnterWriteLock();
-                try
-                {
-                    // Someone else could have removed the entry or added a new one in the time
-                    // between us releasing the read lock and acquiring the write lock.
-                    if (_cache.TryGetValue(comPointer, out GCHandle existingHandle)
-                        && existingHandle.Target is null)
-                    {
-                        // There's still a dead entry in the cache,
-                        // remove it.
-                        _cache.Remove(comPointer);
-                        existingHandle.Free();
-                    }
-                }
-                finally
-                {
-                    _lock.ExitWriteLock();
-                }
-
-                return null;
+                return GetBucket(comPointer).FindProxyForComInstance(comPointer);
             }
 
+            /// <summary>
+            /// Removes the entry associating <paramref name="comPointer"/> with <paramref name="wrapper"/>, if present.
+            /// </summary>
+            /// <param name="comPointer">The com instance to remove the entry for.</param>
+            /// <param name="wrapper">The <see cref="NativeObjectWrapper"/> that is expected to be in the cache.</param>
             public void Remove(IntPtr comPointer, NativeObjectWrapper wrapper)
             {
-                _lock.EnterWriteLock();
-                try
-                {
-                    Remove_Locked(comPointer, wrapper);
-                }
-                finally
-                {
-                    _lock.ExitWriteLock();
-                }
+                GetBucket(comPointer).Remove(comPointer, wrapper);
             }
 
+            /// <summary>
+            /// Removes the entries for all input <see cref="NativeObjectWrapper"/> objects, if present.
+            /// </summary>
+            /// <param name="wrappers">The <see cref="NativeObjectWrapper"/> objects to remove the entries for.</param>
             public void RemoveAll(IEnumerable<NativeObjectWrapper> wrappers)
             {
-                _lock.EnterWriteLock();
-                try
+                // The wrappers can span multiple buckets, so they're removed one at a time. This is only used when
+                // tearing down an apartment, so the extra lock acquisitions don't matter. Note that entries are not
+                // removed atomically as a batch anymore, but that was never something callers could rely on: the
+                // cache is only ever observed one entry at a time.
+                foreach (NativeObjectWrapper wrapper in wrappers)
                 {
-                    foreach (NativeObjectWrapper wrapper in wrappers)
-                    {
-                        Remove_Locked(wrapper.ExternalComObject, wrapper);
-                    }
-                }
-                finally
-                {
-                    _lock.ExitWriteLock();
+                    IntPtr comPointer = wrapper.ExternalComObject;
+
+                    GetBucket(comPointer).Remove(comPointer, wrapper);
                 }
             }
 
-            private void Remove_Locked(IntPtr comPointer, NativeObjectWrapper wrapper)
+            /// <summary>
+            /// A single partition of the RCW cache, holding the entries for all COM instances that map to it.
+            /// </summary>
+            /// <remarks>
+            /// This is a struct so that buckets are stored inline in the containing array. That saves a dereference
+            /// on each lookup, and lets several buckets share a cache line. There is no false sharing to worry about,
+            /// as the fields are only ever read: all mutable state lives in the referenced lock and dictionary.
+            /// </remarks>
+            private readonly struct Bucket
             {
-                Debug.Assert(_lock.IsWriteLockHeld);
-                // This method is used in a scenario where we already have a lock on the cache, so we can skip acquiring the lock again.
-                // TryGetOrCreateObjectForComInstanceInternal may have put a new entry into the cache
-                // in the time between the GC cleared the contents of the GC handle but before the
-                // NativeObjectWrapper finalizer ran.
-                // Only remove the entry if the target of the GC handle is the NativeObjectWrapper
-                // or is null (indicating that the corresponding NativeObjectWrapper has been scheduled for finalization).
-                if (_cache.TryGetValue(comPointer, out GCHandle cachedRef)
-                    && (wrapper == cachedRef.Target
-                        || cachedRef.Target is null))
+                private readonly ReaderWriterLockSlim _lock;
+                private readonly Dictionary<IntPtr, GCHandle> _cache;
+
+                public Bucket()
                 {
-                    _cache.Remove(comPointer);
-                    cachedRef.Free();
+                    _lock = new ReaderWriterLockSlim();
+                    _cache = [];
+                }
+
+                /// <inheritdoc cref="RcwCache.GetOrAddProxyForComInstance"/>
+                public (NativeObjectWrapper actualWrapper, object actualProxy) GetOrAddProxyForComInstance(IntPtr comPointer, NativeObjectWrapper wrapper, object comProxy)
+                {
+                    _lock.EnterWriteLock();
+                    try
+                    {
+                        Debug.Assert(wrapper.ProxyHandle.Target == comProxy);
+                        ref GCHandle rcwEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, comPointer, out bool exists);
+                        if (!exists)
+                        {
+                            // Someone else didn't beat us to adding the entry to the cache.
+                            // Add our entry here.
+                            rcwEntry = GCHandle.Alloc(wrapper, GCHandleType.Weak);
+                        }
+                        else if (rcwEntry.Target is not (NativeObjectWrapper cachedWrapper))
+                        {
+                            Debug.Assert(rcwEntry.IsAllocated);
+                            // The target was collected, so we need to update the cache entry.
+                            rcwEntry.Target = wrapper;
+                        }
+                        else
+                        {
+                            object? existingProxy = cachedWrapper.ProxyHandle.Target;
+                            // The target NativeObjectWrapper was not collected, but we need to make sure
+                            // that the proxy object is still alive.
+                            if (existingProxy is not null)
+                            {
+                                // The existing proxy object is still alive, we will use that.
+                                return (cachedWrapper, existingProxy);
+                            }
+
+                            // The proxy object was collected, so we need to update the cache entry.
+                            rcwEntry.Target = wrapper;
+                        }
+
+                        // We either added an entry to the cache or updated an existing entry that was dead.
+                        // Return our target object.
+                        return (wrapper, comProxy);
+                    }
+                    finally
+                    {
+                        _lock.ExitWriteLock();
+                    }
+                }
+
+                /// <inheritdoc cref="RcwCache.FindProxyForComInstance"/>
+                public object? FindProxyForComInstance(IntPtr comPointer)
+                {
+                    _lock.EnterReadLock();
+                    try
+                    {
+                        if (!_cache.TryGetValue(comPointer, out GCHandle existingHandle))
+                        {
+                            // No entry in the cache.
+                            return null;
+                        }
+                        if (existingHandle.Target is NativeObjectWrapper { ProxyHandle.Target: object cachedProxy })
+                        {
+                            // The target exists and is still alive. Return it.
+                            return cachedProxy;
+                        }
+                        // The target was collected, so we need to remove the entry from the cache.
+                        // We'll do this in a write lock after we exit the read lock.
+                        // We don't use an upgradeable lock here as only one thread can hold an upgradeable lock at a time,
+                        // effectively eliminating the benefit of using a reader-writer lock.
+                    }
+                    finally
+                    {
+                        _lock.ExitReadLock();
+                    }
+
+                    _lock.EnterWriteLock();
+                    try
+                    {
+                        // Someone else could have removed the entry or added a new one in the time
+                        // between us releasing the read lock and acquiring the write lock.
+                        if (_cache.TryGetValue(comPointer, out GCHandle existingHandle)
+                            && existingHandle.Target is null)
+                        {
+                            // There's still a dead entry in the cache,
+                            // remove it.
+                            _cache.Remove(comPointer);
+                            existingHandle.Free();
+                        }
+                    }
+                    finally
+                    {
+                        _lock.ExitWriteLock();
+                    }
+
+                    return null;
+                }
+
+                /// <inheritdoc cref="RcwCache.Remove"/>
+                public void Remove(IntPtr comPointer, NativeObjectWrapper wrapper)
+                {
+                    _lock.EnterWriteLock();
+                    try
+                    {
+                        // TryGetOrCreateObjectForComInstanceInternal may have put a new entry into the cache
+                        // in the time between the GC cleared the contents of the GC handle but before the
+                        // NativeObjectWrapper finalizer ran.
+                        // Only remove the entry if the target of the GC handle is the NativeObjectWrapper
+                        // or is null (indicating that the corresponding NativeObjectWrapper has been scheduled for finalization).
+                        if (_cache.TryGetValue(comPointer, out GCHandle cachedRef)
+                            && (wrapper == cachedRef.Target
+                                || cachedRef.Target is null))
+                        {
+                            _cache.Remove(comPointer);
+                            cachedRef.Free();
+                        }
+                    }
+                    finally
+                    {
+                        _lock.ExitWriteLock();
+                    }
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -1341,10 +1341,6 @@ namespace System.Runtime.InteropServices
                 // the golden ratio) mixes every input bit into the high half of the product, which is then masked
                 // to produce the index. The whole sequence lowers to a multiply, a shift and a mask, which is
                 // negligible next to the lookup that follows.
-                //
-                // The multiply is sized to the pointer width, so that a 32-bit process doesn't pay for a 64-bit
-                // multiply that the hardware has to emulate. Either way the high half leaves far more bits than
-                // the mask below consumes, as there is one bucket per processor.
                 uint hash = sizeof(nint) == 8
                     ? (uint)(((ulong)(nuint)comPointer * 0x9E3779B97F4A7C15) >> 32)
                     : ((uint)(nuint)comPointer * 0x9E3779B9) >> 16;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -1315,7 +1315,7 @@ namespace System.Runtime.InteropServices
                 // Use as many buckets as there are processors, matching the default concurrency level of
                 // 'ConcurrentDictionary'. The count is rounded up to a power of two so that the bucket for a
                 // given COM instance can be selected with a mask rather than a division.
-                int bucketCount = (int)BitOperations.RoundUpToPowerOf2((uint)Environment.ProcessorCount);
+                uint bucketCount = BitOperations.RoundUpToPowerOf2((uint)Environment.ProcessorCount);
                 Bucket[] buckets = new Bucket[bucketCount];
 
                 for (int i = 0; i < buckets.Length; i++)
@@ -1331,18 +1331,25 @@ namespace System.Runtime.InteropServices
             /// </summary>
             /// <param name="comPointer">The com instance to get the bucket for.</param>
             /// <returns>The bucket owning the entries for <paramref name="comPointer"/>.</returns>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private ref readonly Bucket GetBucket(IntPtr comPointer)
+            private unsafe ref readonly Bucket GetBucket(IntPtr comPointer)
             {
                 Bucket[] buckets = _buckets;
 
-                // COM instances are heap allocated, so they're always at least pointer aligned (and 16-byte aligned
-                // in practice). That means their low bits are constant and can't be used to select a bucket directly.
-                // Multiplying by a large odd constant (2^64 divided by the golden ratio) mixes every input bit into
-                // the high half of the product, which is then masked to produce the index. The whole sequence lowers
-                // to a multiply, a shift and a mask, which is negligible next to the lookup that follows.
-                ulong hash = (ulong)(nuint)comPointer * 0x9E3779B97F4A7C15;
-                uint index = (uint)(hash >> 32) & (uint)(buckets.Length - 1);
+                // COM instances are heap allocated, so they're always at least pointer aligned, and in practice
+                // more than that. Their low bits are therefore constant and can't be used to select a bucket
+                // directly. Multiplying by a large odd constant (2 raised to the width of a pointer, divided by
+                // the golden ratio) mixes every input bit into the high half of the product, which is then masked
+                // to produce the index. The whole sequence lowers to a multiply, a shift and a mask, which is
+                // negligible next to the lookup that follows.
+                //
+                // The multiply is sized to the pointer width, so that a 32-bit process doesn't pay for a 64-bit
+                // multiply that the hardware has to emulate. Either way the high half leaves far more bits than
+                // the mask below consumes, as there is one bucket per processor.
+                uint hash = sizeof(nint) == 8
+                    ? (uint)(((ulong)(nuint)comPointer * 0x9E3779B97F4A7C15) >> 32)
+                    : ((uint)(nuint)comPointer * 0x9E3779B9) >> 16;
+
+                uint index = hash & (uint)(buckets.Length - 1);
 
                 // Return the bucket by reference, so that it's addressed in place in the array rather than copied
                 return ref buckets[index];

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -1335,12 +1335,12 @@ namespace System.Runtime.InteropServices
             {
                 Bucket[] buckets = _buckets;
 
-                // COM instances are heap allocated, so they're always at least pointer aligned, and in practice
-                // more than that. Their low bits are therefore constant and can't be used to select a bucket
-                // directly. Multiplying by a large odd constant (2 raised to the width of a pointer, divided by
-                // the golden ratio) mixes every input bit into the high half of the product, which is then masked
-                // to produce the index. The whole sequence lowers to a multiply, a shift and a mask, which is
-                // negligible next to the lookup that follows.
+                // COM instances are always at least pointer aligned, and in practice more than that. Their low
+                // bits are therefore constant and can't be used to select a bucket directly. Multiplying by a
+                // large odd constant (2 raised to the width of a pointer, divided by the golden ratio) mixes
+                // every input bit into the high half of the product, which is then masked to produce the index.
+                // The whole sequence lowers to a multiply, a shift and a mask, which is negligible next to the
+                // lookup that follows.
                 uint hash = sizeof(nint) == 8
                     ? (uint)(((ulong)(nuint)comPointer * 0x9E3779B97F4A7C15) >> 32)
                     : ((uint)(nuint)comPointer * 0x9E3779B9) >> 16;

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -1125,9 +1125,7 @@ namespace ComWrappersTests
                     });
                     thread.Start();
 
-                    // The result is recorded and asserted by the caller, rather than asserted here, because this
-                    // callback is invoked from native code, and propagating a managed exception back out through a
-                    // native frame is only supported on CoreCLR on Windows (see PlatformDetection.IsExceptionInteropSupported).
+                    // The result is recorded and asserted by the caller.
                     NestedCallCompleted = thread.Join(TimeSpan.FromSeconds(20)); // 20 seconds should be more than long enough for the thread to complete
                 }
 

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -1083,43 +1083,51 @@ namespace ComWrappersTests
             Console.WriteLine($"Running {nameof(ComWrappersNoLockAroundQueryInterface)}...");
 
             var cw = new RecursiveSimpleComWrappers();
+            var managedObject = new RecursiveCrossThreadQI(cw);
 
-            IntPtr comObject = cw.GetOrCreateComInterfaceForObject(new RecursiveCrossThreadQI(cw), CreateComInterfaceFlags.None);
+            IntPtr comObject = cw.GetOrCreateComInterfaceForObject(managedObject, CreateComInterfaceFlags.None);
             try
             {
+                // The nested call has to use this same COM instance. The RCW cache is partitioned into buckets
+                // keyed off the COM instance, so using a different instance would only exercise the same lock by
+                // chance, and the test would no longer reliably catch a regression.
+                managedObject.NestedComObject = comObject;
+
                 _ = cw.GetOrCreateObjectForComInstance(comObject, CreateObjectFlags.TrackerObject);
             }
             finally
             {
                 Marshal.Release(comObject);
             }
+
+            Assert.True(managedObject.NestedCallCompleted);
         }
 
-        private class RecursiveCrossThreadQI(ComWrappers? wrappers) : ICustomQueryInterface
+        private class RecursiveCrossThreadQI(ComWrappers wrappers) : ICustomQueryInterface
         {
+            public IntPtr NestedComObject { get; set; }
+
+            public bool NestedCallCompleted { get; private set; }
+
             CustomQueryInterfaceResult ICustomQueryInterface.GetInterface(ref Guid iid, out IntPtr ppv)
             {
                 ppv = IntPtr.Zero;
-                if (iid == ComWrappersHelper.IID_IReferenceTracker && wrappers is not null)
+                if (iid == ComWrappersHelper.IID_IReferenceTracker)
                 {
                     Console.WriteLine("Attempting to create a new COM object on a different thread.");
+                    IntPtr nestedComObject = NestedComObject;
                     Thread thread = new Thread(() =>
                     {
-                        IntPtr comObject = wrappers.GetOrCreateComInterfaceForObject(new RecursiveCrossThreadQI(null), CreateComInterfaceFlags.None);
-                        try
-                        {
-                            // Make sure that ComWrappers isn't locking in GetOrCreateObjectForComInstance
-                            // around the QI call by calling it on a different thread from within a QI call to register a new managed wrapper
-                            // for a COM object representing "this".
-                            _ = wrappers.GetOrCreateObjectForComInstance(comObject, CreateObjectFlags.None);
-                        }
-                        finally
-                        {
-                            Marshal.Release(comObject);
-                        }
+                        // Make sure that ComWrappers isn't locking in GetOrCreateObjectForComInstance
+                        // around the QI call by calling it on a different thread from within a QI call to register a new managed wrapper
+                        // for a COM object representing "this".
+                        _ = wrappers.GetOrCreateObjectForComInstance(nestedComObject, CreateObjectFlags.None);
                     });
                     thread.Start();
-                    thread.Join(TimeSpan.FromSeconds(20)); // 20 seconds should be more than long enough for the thread to complete
+
+                    // The result is recorded and asserted by the caller, rather than asserted here, as this
+                    // callback is invoked through the COM ABI, which a managed exception can't propagate through.
+                    NestedCallCompleted = thread.Join(TimeSpan.FromSeconds(20)); // 20 seconds should be more than long enough for the thread to complete
                 }
 
                 return CustomQueryInterfaceResult.Failed;

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -1125,8 +1125,9 @@ namespace ComWrappersTests
                     });
                     thread.Start();
 
-                    // The result is recorded and asserted by the caller, rather than asserted here, as this
-                    // callback is invoked through the COM ABI, which a managed exception can't propagate through.
+                    // The result is recorded and asserted by the caller, rather than asserted here, because this
+                    // callback is invoked from native code, and propagating a managed exception back out through a
+                    // native frame is only supported on CoreCLR on Windows (see PlatformDetection.IsExceptionInteropSupported).
                     NestedCallCompleted = thread.Join(TimeSpan.FromSeconds(20)); // 20 seconds should be more than long enough for the thread to complete
                 }
 


### PR DESCRIPTION
## Motivation

`ComWrappers` keeps a per-instance RCW (Runtime Callable Wrapper) identity cache, mapping a COM identity pointer to the `NativeObjectWrapper` tracking the managed proxy for it. Until now that cache was a single `Dictionary<IntPtr, GCHandle>` behind a single `ReaderWriterLockSlim`.

That single lock is a process-wide serialization point on a very hot path:

- It is consulted on essentially **every** native-to-managed transition, via `TryGetOrCreateObjectForComInstanceInternal` → `FindProxyForComInstance`. In steady state this is a genuine cache **hit**, not a miss.
- At the same time, the **finalizer thread** takes **write** locks on it to remove entries for collected RCWs (`NativeObjectWrapper.Release` → `RcwCache.Remove`).

So application threads doing read lookups continuously contend with the finalizer thread doing writes. Profiling CsWinRT 3.0 on NativeAOT showed this as the single largest source of overhead in WinRT interop:

- `RhSpinWait` **19.1%** and `ntdll!RtlpEnterCriticalSectionContended` **11.4%** exclusive on the main thread — i.e. the main thread mostly *waiting*.
- `ReaderWriterLockSlim.TryEnterReadLockCore`/`ExitReadLock` **9.1%** combined and `RcwCache.FindProxyForComInstance` **6.4%** in another benchmark.

Even with no writers at all, `ReaderWriterLockSlim.EnterReadLock` still has to CAS a shared counter, so concurrent readers alone bounce a single cache line between cores.

## What this changes

**1. Partition the cache into buckets (`a50b8c7`)**

`RcwCache` becomes a thin facade over a `Bucket[]`, where each `Bucket` holds exactly the same `Dictionary` + `ReaderWriterLockSlim` + logic as the old single cache. The bucket for a given COM instance is chosen by hashing its pointer, so unrelated COM objects no longer contend.

The bucket count is `BitOperations.RoundUpToPowerOf2(Environment.ProcessorCount)` — matching the default concurrency level `ConcurrentDictionary` uses, and rounded to a power of two so the index is a mask rather than a division.

Some details worth calling out:

- **The hash matters.** COM instances are heap allocated and in practice at least 16-byte aligned, so their low bits are constant. Masking the pointer directly would put essentially *everything* in bucket 0. This uses multiply-shift ("Fibonacci") hashing — multiply by `0x9E3779B97F4A7C15` and take the high half — which lowers to a multiply, a shift and an `and`. Distribution was validated two ways over 200k keys, because the two input classes have different correct expectations:
  - **Aligned, sequentially allocated pointers** (16/32/64/96-byte strides, i.e. what an allocator actually produces). Bucket counts land within ±0.3% of `n/k` (χ² between 0.01 and 0.52 for k = 16/64/128). These keys are an arithmetic progression, not a random sample, so χ² ~ χ²(k−1) does *not* apply here — a multiply-shift hash stratifies an arithmetic progression almost perfectly, and χ² ≈ 0 is the desired outcome rather than a suspicious one. The contrast is the point: the exact same keys under raw masking give χ² ≈ 3×10⁶–1.3×10⁷, i.e. every object in one bucket.
  - **i.i.d. random pointers**, where χ² ~ χ²(k−1) *does* apply. Mean χ² over 20 trials was **13.95 / 61.22 / 125.64** for k = 16 / 64 / 128 against df = **15 / 63 / 127**, with p-values spread across the range (15–17 of 20 trials in [0.05, 0.95]). That is indistinguishable from a uniform hash.
- **Both `RcwCache` and `Bucket` are `readonly struct`s.** `RcwCache` is inlined into the `ComWrappers` object and `Bucket` instances live inline in the array, which avoids two pointer chases on the lookup path and lets several buckets share a cache line. `GetBucket` returns `ref readonly Bucket` so the 16-byte struct is never copied. There is no false sharing to worry about: the bucket fields are only ever written during construction, and all mutable state lives in the referenced lock and dictionary.
- **`RemoveAll` no longer removes as one atomic batch**, since wrappers can now span buckets. Its only caller is apartment/context teardown in `TrackerObjectManager`, and the cache is only ever observed one entry at a time, so nothing could depend on that atomicity.

**2. Use `WeakGCHandle<NativeObjectWrapper>` (`2074c0d`)**

The cached handles always point to a `NativeObjectWrapper`, so a strongly typed weak handle expresses that directly. It skips the type check on every read, allocates through `GCHandle.InternalAlloc` without revalidating the handle type, and reads the target once instead of twice when checking whether it was collected (which also removes a benign race where the two reads could disagree).

## Benchmark results

All numbers measured locally on a 32-core Windows x64 machine (Hyper-V), Release runtime, comparing `main` against this branch.

### Official CsWinRT benchmarks (`ProjectedConstructionPerf`)

Run against both CsWinRT 2.3.0-prerelease and 3.0.0-preview on the same runtime build, twice per configuration. Mean of 2 runs, in µs:

| Benchmark | 2.x main | 2.x PR | Δ | 3.0 main | 3.0 PR | Δ |
|---|---:|---:|---:|---:|---:|---:|
| ConstructProjectedClassWithInt | 1.318 | 1.220 | **−7.4%** | 1.251 | 1.150 | **−8.1%** |
| ConstructProjectedClassWithString | 5.073 | 5.009 | −1.3% | 5.125 | 5.003 | −2.4% |
| ConstructFastAbiProjectedClassWithInt | 1.310 | 1.184 | **−9.6%** | 1.261 | 1.167 | **−7.5%** |
| ConstructDerivedFastAbiProjectedClassWithInt | 1.303 | 1.220 | **−6.4%** | 1.210 | 1.204 | −0.5% |
| ConstructProjectedClassWithInterface | 1.672 | 1.497 | **−10.5%** | 1.442 | 1.373 | **−4.8%** |

Allocations are unchanged throughout. `WithString` barely moves because it is dominated by HSTRING marshalling.

### Sustained construction (10k instances per invocation)

A loop variant that constructs 10,000 projected objects per invocation, so RCWs from earlier iterations are being finalized while the loop is still running. The projected classes call `GC.AddMemoryPressure`, which makes the GC run frequently. This is the scenario the change targets most directly. Mean of 2 runs:

| | main | PR | Δ |
|---|---:|---:|---:|
| CsWinRT 2.x | 1.375 µs | 1.205 µs | **−12.4%** |
| CsWinRT 3.0 | 1.272 µs | 1.191 µs | **−6.3%** |

The GC counters show the mechanism. Gen2 collections per 1000 operations:

| | main | PR | Δ |
|---|---:|---:|---:|
| CsWinRT 2.x | 0.218 | 0.088 | **−60%** |
| CsWinRT 3.0 | 0.074 | 0.055 | **−26%** |

Gen0 and Gen1 track the same way. With a single lock, the finalizer thread stalls acquiring the write lock, so dead RCWs sit in the finalization queue long enough to be **promoted** instead of dying in gen0. Partitioning lets the finalizer drain faster, so fewer objects survive — a reduction in GC count on top of the reduction in lock waiting.

CsWinRT 3.0 benefits less here precisely because it already produces roughly 3x less GC pressure than 2.x (0.074 vs 0.218 gen2 collections), so there was less finalizer traffic to contend with in the first place.

### Microbenchmark: lookup throughput

Steady-state cache hits through `ComWrappers.GetOrCreateObjectForComInstance`, with rooted RCWs (source in the collapsed section below):

| Live RCWs | Uncontended (1 thread) | 32 threads |
|---:|---|---|
| 1 | 60.4 → 61.2 ns (1.01x) | 261.0 → 227.4 ns (**0.87x**) |
| 8 | 60.4 → 62.2 ns (1.03x) | 375.0 → 95.2 ns (**0.25x**) |
| 64 | 63.2 → 64.4 ns (1.02x) | 391.3 → 35.0 ns (**0.09x**) |
| 1024 | 63.9 → 70.8 ns (1.11x) | 267.9 → 19.6 ns (**0.07x**) |

Up to **13.6x faster** under contention. Note the ~60 ns floor is dominated by the `QueryInterface` transition in the harness, so the cache-specific deltas are understated in relative terms.

## Tradeoffs

Two costs, both intentional and called out explicitly:

**1. Slightly slower uncontended lookups with a large working set.** 1–3% for small working sets, growing to ~11% with 1024 live RCWs. This is cache footprint: each lookup now touches one of N locks and N dictionaries rather than always the same one. Reducing the bucket count would trade some of the contention win to shrink this.

**2. More memory per `ComWrappers` instance.** Measured 576 B → 6,536 B on a 32-core machine (one `ReaderWriterLockSlim` + one `Dictionary` per bucket, ~186 B/bucket). This scales with `ProcessorCount`, so it is larger on bigger machines. Most processes have very few `ComWrappers` instances, but that is worth confirming for this to be a good default. Allocating buckets lazily would avoid paying it for CCW-only or `UniqueInstance` usage that never touches the RCW cache, at the cost of a branch on the lookup path.

Both the bucket count and eager-vs-lazy allocation are easy to adjust — happy to tune based on feedback.

## Testing

- 3,461 interop tests pass (`System.Runtime.InteropServices.Tests` and `ComInterfaceGenerator.Tests`) against a **Checked** CoreLib, so `Debug.Assert` is active — including the assert in `RegisterWrapperForObject` that verifies the RCW cache maps the identity to the expected proxy, which directly validates bucket selection.
- `src/tests/Interop/COM/ComWrappers` runtime tests pass. Three `GlobalInstance` tests fail identically on `main` and on this branch in my environment (`8007007E`, COM class factory registration), so they are pre-existing and unrelated.
- **`ComWrappersNoLockAroundQueryInterface` was updated.** That test is a regression test asserting no cache lock is held across a `QueryInterface` callback. It made its nested cross-thread call using a *different* COM pointer, which with partitioning would only map to the same bucket by chance (~1/32), so it would have quietly stopped catching the regression it exists for. It now reuses the same identity pointer, which guarantees the same bucket, and additionally exercises the "lost the race" path in `RegisterObjectForComInstance`. It also now asserts the timed `Thread.Join` actually succeeded rather than ignoring the result (a timeout previously still passed). The join result is recorded and asserted by the caller rather than inside the callback, since that callback is invoked through the COM ABI and a managed exception cannot propagate through it.

<details>
<summary>Standalone benchmark source (no WinRT, runs cross-platform)</summary>

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Runtime.InteropServices;
using System.Runtime.InteropServices.Marshalling;
using System.Threading;
using System.Threading.Tasks;

BenchmarkSwitcher.FromAssembly(typeof(RcwCacheBenchmarks).Assembly).Run(args);

public class RcwCacheBenchmarks
{
    private const int ThreadCount = 32;
    private const int TotalOperations = 256_000;

    private static readonly StrategyBasedComWrappers ComWrappers = new();

    private nint[] _instances = [];
    private object[] _proxies = [];

    [Params(8, 1024)]
    public int InstanceCount { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        _instances = new nint[InstanceCount];
        _proxies = new object[InstanceCount];

        for (int i = 0; i < InstanceCount; i++)
        {
            _instances[i] = FakeComObject.Create();

            // Keep the RCWs rooted, so that every lookup below is a steady state cache hit
            _proxies[i] = ComWrappers.GetOrCreateObjectForComInstance(_instances[i], CreateObjectFlags.None);
        }
    }

    [Benchmark(OperationsPerInvoke = TotalOperations / ThreadCount)]
    public void Lookup()
    {
        nint[] instances = _instances;
        int mask = InstanceCount - 1;

        for (int i = 0; i < TotalOperations / ThreadCount; i++)
        {
            _ = ComWrappers.GetOrCreateObjectForComInstance(instances[i & mask], CreateObjectFlags.None);
        }
    }

    [Benchmark(OperationsPerInvoke = TotalOperations)]
    public void Lookup_Concurrent_T32()
    {
        const int OperationsPerThread = TotalOperations / ThreadCount;

        nint[] instances = _instances;
        int mask = InstanceCount - 1;

        Parallel.For(0, ThreadCount, new ParallelOptions { MaxDegreeOfParallelism = ThreadCount }, t =>
        {
            for (int i = 0; i < OperationsPerThread; i++)
            {
                _ = ComWrappers.GetOrCreateObjectForComInstance(instances[(i + (t * 37)) & mask], CreateObjectFlags.None);
            }
        });
    }
}

/// <summary>
/// A minimal native 'IUnknown' implementation, so the benchmark doesn't need any native code.
/// </summary>
internal static unsafe class FakeComObject
{
    private static readonly Guid IID_IUnknown = new(0x00000000, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46);

    public static nint Create()
    {
        nint* vtable = (nint*)NativeMemory.Alloc(3, (nuint)sizeof(nint));

        vtable[0] = (nint)(delegate* unmanaged<nint, Guid*, nint*, int>)&QueryInterface;
        vtable[1] = (nint)(delegate* unmanaged<nint, uint>)&AddRef;
        vtable[2] = (nint)(delegate* unmanaged<nint, uint>)&Release;

        // The instance is just the vtable pointer followed by a reference count
        nint* instance = (nint*)NativeMemory.Alloc(2, (nuint)sizeof(nint));

        instance[0] = (nint)vtable;
        instance[1] = 1;

        return (nint)instance;
    }

    private static ref int RefCount(nint thisPtr) => ref *(int*)(thisPtr + sizeof(nint));

    [UnmanagedCallersOnly]
    private static int QueryInterface(nint thisPtr, Guid* iid, nint* ppvObject)
    {
        if (*iid != IID_IUnknown)
        {
            *ppvObject = 0;

            return unchecked((int)0x80004002); // E_NOINTERFACE
        }

        *ppvObject = thisPtr;

        Interlocked.Increment(ref RefCount(thisPtr));

        return 0; // S_OK
    }

    [UnmanagedCallersOnly]
    private static uint AddRef(nint thisPtr) => (uint)Interlocked.Increment(ref RefCount(thisPtr));

    [UnmanagedCallersOnly]
    private static uint Release(nint thisPtr) => (uint)Interlocked.Decrement(ref RefCount(thisPtr));
}
```

</details>

> [!NOTE]
> Parts of this pull request description were generated with GitHub Copilot. All benchmark numbers in it were measured locally and are reproducible with the sources linked above.