### PR TITLE
Fix PerformanceCounterLib cache races

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -124,7 +124,8 @@ namespace System.Diagnostics
         {
             get
             {
-                if (_categoryTable == null)
+                Hashtable categoryTable = _categoryTable;
+                if (categoryTable == null)
                 {
                     lock (_categoryTableLock)
                     {
@@ -194,10 +195,12 @@ namespace System.Diagnostics
 
                             _categoryTable = tempCategoryTable;
                         }
+
+                        categoryTable = _categoryTable;
                     }
                 }
 
-                return _categoryTable;
+                return categoryTable;
             }
         }
 
@@ -205,15 +208,16 @@ namespace System.Diagnostics
         {
             get
             {
-                if (_helpTable == null)
+                Hashtable helpTable = _helpTable;
+                if (helpTable == null)
                 {
                     lock (_helpTableLock)
                     {
-                        _helpTable ??= GetStringTable(true);
+                        helpTable = _helpTable ??= GetStringTable(true);
                     }
                 }
 
-                return _helpTable;
+                return helpTable;
             }
         }
 
@@ -246,15 +250,16 @@ namespace System.Diagnostics
         {
             get
             {
-                if (_nameTable == null)
+                Hashtable nameTable = _nameTable;
+                if (nameTable == null)
                 {
                     lock (_nameTableLock)
                     {
-                        _nameTable ??= GetStringTable(false);
+                        nameTable = _nameTable ??= GetStringTable(false);
                     }
                 }
 
-                return _nameTable;
+                return nameTable;
             }
         }
 
@@ -329,10 +334,13 @@ namespace System.Diagnostics
 
         internal static void CloseAllTables()
         {
-            if (s_libraryTable != null)
+            lock (InternalSyncObject)
             {
-                foreach (PerformanceCounterLib library in s_libraryTable.Values)
-                    library.CloseTables();
+                if (s_libraryTable != null)
+                {
+                    foreach (PerformanceCounterLib library in s_libraryTable.Values)
+                        library.CloseTables();
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #90803.

## Root cause

`CloseAllTables` can clear a cache field after its getter has initialized it but before the getter rereads the field for its return value. That turns a successful initialization into a null return. Separately, `CloseAllTables` enumerates `s_libraryTable` without the lock used by `GetPerformanceCounterLib`, so concurrent library creation can mutate the `Hashtable` during enumeration.

## Changes

- Capture each initialized category, name, and help table in a local and return that stable snapshot.
- Take `InternalSyncObject` while enumerating and clearing the shared library table.

No public API or intended cache-invalidation behavior changes. A caller already using a cache may finish using that snapshot while invalidation causes subsequent callers to rebuild it.

## Validation

- `git diff --check` — passed.
- `./dotnet.sh build src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj -f net11.0-windows -c Release --no-restore` — passed with 0 warnings and 0 errors.

The runtime behavior and test suite are Windows-only, so they cannot execute on the macOS development host; the Windows-target implementation and its analyzers were compiled successfully. CI provides the Windows runtime coverage.

## Risk and rollback

Risk is limited to synchronization in the internal performance-counter cache. The additional lock reuses the lock already taken for every `s_libraryTable` mutation. Rollback is a single commit revert.

AI assistance was used for repository exploration and drafting; I reviewed the patch and validation results and will personally address review feedback.
