### PR TITLE
[cDAC] Disable Helix job monitor on XPlat dump generation

### DIFF
--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -61,7 +61,7 @@ parameters:
 - name: cdacDumpTestMode
   displayName: cDAC Dump Test Mode
   type: string
-  default: single-leg
+  default: xplat
   values:
     - single-leg
     - xplat
@@ -326,7 +326,7 @@ extends:
             prepareParameters:
               cdacTestConfig: Debug
             sendDisplayName: 'Send cDAC Dump Gen to Helix'
-            sendParams: $(Build.SourcesDirectory)/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj /t:Test /p:DumpOnly=true /p:TargetOS=$(osGroup) /p:TargetArchitecture=$(archType) /p:HelixTargetQueues="$(CdacHelixQueue)" /p:TestHostPayload=$(TestHostPayloadDir) /p:DumpTestsPayload=$(Build.SourcesDirectory)/artifacts/helixPayload/cdac /bl:$(Build.SourcesDirectory)/artifacts/log/SendDumpGenToHelix.binlog
+            sendParams: $(Build.SourcesDirectory)/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj /t:Test /p:DumpOnly=true /p:EnableHelixJobMonitor=false /p:TargetOS=$(osGroup) /p:TargetArchitecture=$(archType) /p:HelixTargetQueues="$(CdacHelixQueue)" /p:TestHostPayload=$(TestHostPayloadDir) /p:DumpTestsPayload=$(Build.SourcesDirectory)/artifacts/helixPayload/cdac /bl:$(Build.SourcesDirectory)/artifacts/log/SendDumpGenToHelix.binlog
             failDisplayName: 'Fail on dump generation errors'
             failErrorMessage: 'One or more cDAC dump generation failures were detected. Failing the job.'
             publishDumpsArtifactName: CdacDumps_$(osGroup)_$(archType)

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -61,7 +61,7 @@ parameters:
 - name: cdacDumpTestMode
   displayName: cDAC Dump Test Mode
   type: string
-  default: xplat
+  default: single-leg
   values:
     - single-leg
     - xplat


### PR DESCRIPTION
## Summary

Disable the Helix Job Monitor for cDAC cross-platform dump generation.

This restores the previous synchronous behavior where the submitting job:

1. Waits for Helix work to complete.
2. Downloads `dumps.tar.gz` into `artifacts/helixresults`.
3. Publishes the dumps for the dependent cross-platform test jobs.

## Root cause

After #129690 enabled the Helix Job Monitor globally, `SendHelixJob` began returning immediately after submission. The cDAC dump-generation flow requires `DownloadFilesFromResults`, but the monitor does not download those artifacts for the submitting job.

Consequently, `Publish Dump Artifacts` runs before `artifacts/helixresults` exists, although the Helix work items later complete successfully.

Fixes  #131979 

> [!NOTE]
> This content was created with assistance from AI.
