### PR TITLE
Enable Azure Pipelines reporter in paltests.proj

### DIFF
--- a/src/coreclr/scripts/paltests.proj
+++ b/src/coreclr/scripts/paltests.proj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
   <PropertyGroup>
     <EnableXUnitReporter>true</EnableXUnitReporter>
+    <EnableAzurePipelinesReporter<true</EnableAzurePipelinesReporter>
     <Creator>$(_Creator)</Creator>
     <HelixAccessToken>$(_HelixAccessToken)</HelixAccessToken>
     <HelixBuild>$(_HelixBuild)</HelixBuild>

--- a/src/coreclr/scripts/paltests.proj
+++ b/src/coreclr/scripts/paltests.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
   <PropertyGroup>
     <EnableXUnitReporter>true</EnableXUnitReporter>
-    <EnableAzurePipelinesReporter<true</EnableAzurePipelinesReporter>
+    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
     <Creator>$(_Creator)</Creator>
     <HelixAccessToken>$(_HelixAccessToken)</HelixAccessToken>
     <HelixBuild>$(_HelixBuild)</HelixBuild>


### PR DESCRIPTION
Enables build analysis on the PALTests leg (see https://github.com/dotnet/runtime/issues/122345)