### PR TITLE
Create test for resurrection of RCW in COM Wrappers

### DIFF
--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -33,6 +33,8 @@ namespace ComWrappersTests
                 fpWrappedQueryInterface = MockReferenceTrackerRuntime.WrapQueryInterface(fpQueryInterface);
             }
 
+            public bool UseManualReleaseITestObjectWrapper { get; init; }
+
             protected unsafe override ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
             {
                 ComInterfaceEntry* entryRaw = null;
@@ -133,7 +135,14 @@ namespace ComWrappersTests
                 hr = Marshal.QueryInterface(externalComObject, typeof(ITest).GUID, out iTest);
                 if (hr == 0)
                 {
-                    return new ITestObjectWrapper(iTest);
+                    if (UseManualReleaseITestObjectWrapper)
+                    {
+                        return new ManualReleaseITestObjectWrapper(iTest);
+                    }
+                    else
+                    {
+                        return new ITestObjectWrapper(iTest);
+                    }
                 }
 
                 Assert.Fail("The COM object should support ITrackerObject or ITest for all tests in this test suite.");
@@ -418,9 +427,9 @@ namespace ComWrappersTests
         [MethodImpl(MethodImplOptions.NoInlining)]
         [ActiveIssue("Not supported on Mono", TestRuntimes.Mono)]
         [Fact]
-        public void ValidateResurrection()
+        public void ValidateManagedObjectWrapperResurrection()
         {
-            Console.WriteLine($"Running {nameof(ValidateResurrection)}...");
+            Console.WriteLine($"Running {nameof(ValidateManagedObjectWrapperResurrection)}...");
 
             var wrappers = new TestComWrappers();
 
@@ -619,6 +628,72 @@ namespace ComWrappersTests
             Assert.Equal(0, count);
             Marshal.Release(unmanagedObj);
             Marshal.Release(unmanagedObjIUnknown);
+        }
+
+        class Resurrecter()
+        {
+            public ManualReleaseITestObjectWrapper? UnmanagedWrapper;
+
+            ~Resurrecter()
+            {
+                if (UnmanagedWrapper != null)
+                {
+                    GC.ReRegisterForFinalize(this);
+                }
+            }
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [ActiveIssue("Not supported on Mono", TestRuntimes.Mono)]
+        [Fact]
+        public void ValidateNativeObjectWrapperResurrection()
+        {
+            Console.WriteLine($"Running {nameof(ValidateNativeObjectWrapperResurrection)}...");
+
+            var cw = new TestComWrappers()
+            {
+                UseManualReleaseITestObjectWrapper = true,
+            };
+
+            WeakGCHandle<Resurrecter> resurrecter;
+            nint unmanagedObj = AllocateWrapper(cw, out resurrecter);
+            Assert.Equal(0, Marshal.QueryInterface(unmanagedObj, IUnknownVtbl.IID_IUnknown, out IntPtr unmanagedObjIUnknown));
+            ForceGC();
+            AssertNativeObjectWrapperAlive(cw, resurrecter, unmanagedObjIUnknown);
+
+            resurrecter.Dispose();
+            Marshal.Release(unmanagedObjIUnknown);
+            Assert.Equal(0, Marshal.Release(unmanagedObj));
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static nint AllocateWrapper(ComWrappers cw, out WeakGCHandle<Resurrecter> handle)
+            {
+                Test test = new();
+                nint comWrapper = cw.GetOrCreateComInterfaceForObject(test, CreateComInterfaceFlags.None);
+                Assert.NotEqual(IntPtr.Zero, comWrapper);
+
+                var unmanagedWrapper = (ManualReleaseITestObjectWrapper)cw.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.UniqueInstance);
+                Resurrecter resurrecter = new()
+                {
+                    UnmanagedWrapper = unmanagedWrapper,
+                };
+                handle = new WeakGCHandle<Resurrecter>(resurrecter, true);
+                return comWrapper;
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void AssertNativeObjectWrapperAlive(ComWrappers cw, WeakGCHandle<Resurrecter> handle, IntPtr unmanagedObj)
+            {
+                Assert.True(handle.TryGetTarget(out Resurrecter resurrecter));
+                ManualReleaseITestObjectWrapper? unmanagedWrapper = resurrecter.UnmanagedWrapper;
+                Assert.NotNull(resurrecter);
+                Assert.True(ComWrappers.TryGetComInstance(unmanagedWrapper, out IntPtr unmanagedObjOther));
+                Assert.Equal(unmanagedObj, unmanagedObjOther);
+                resurrecter.UnmanagedWrapper = null;
+                Marshal.Release(unmanagedObjOther);
+                unmanagedWrapper.FinalRelease();
+            }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -94,13 +94,13 @@ namespace ComWrappersTests.Common
         }
     }
 
-    public class ITestObjectWrapper : ITest
+    public class ITestObjectWrapperBase : ITest
     {
         private readonly ITestVtbl._SetValue _setValue;
-        private readonly IntPtr _ptr;
-        private bool _released;
+        protected readonly IntPtr _ptr;
+        protected bool _released;
 
-        public ITestObjectWrapper(IntPtr ptr)
+        public ITestObjectWrapperBase(IntPtr ptr)
         {
             _ptr = ptr;
             VtblPtr inst = Marshal.PtrToStructure<VtblPtr>(ptr);
@@ -117,6 +117,24 @@ namespace ComWrappersTests.Common
             return count;
         }
 
+        public void SetValue(int i) => _setValue(_ptr, i);
+    }
+
+    public class ManualReleaseITestObjectWrapper : ITestObjectWrapperBase
+    {
+        public ManualReleaseITestObjectWrapper(IntPtr ptr)
+            : base(ptr)
+        {
+        }
+    }
+
+    public class ITestObjectWrapper : ITestObjectWrapperBase
+    {
+        public ITestObjectWrapper(IntPtr ptr)
+            : base(ptr)
+        {
+        }
+
         ~ITestObjectWrapper()
         {
             if (_ptr != IntPtr.Zero && !_released)
@@ -124,8 +142,6 @@ namespace ComWrappersTests.Common
                 Marshal.Release(_ptr);
             }
         }
-
-        public void SetValue(int i) => _setValue(_ptr, i);
     }
 
     //


### PR DESCRIPTION
#132040 made an assumption that runtime callable wrappers in COM Wrappers can only be resurrected when have a finalizer. This test shows that it is possible to resurrects such an object and tests that the `ComWrappers.TryGetComInstance` still works with the resurrected object. This test passes on main and fails on #132040. This new test is similar to the [existing test](https://github.com/dotnet/runtime/blob/14b601ec5edfeecbc70368890e8676fe5c29da83/src/tests/Interop/COM/ComWrappers/API/Program.cs#L421-L472) that validates managed object wrappers still work after being resurrected.