### PR TITLE
Disable DnsResolverTest.ResolveAddresses_NonExistent_ReturnsNxDomain on Windows Server 2025

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/DnsResolverTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/DnsResolverTest.cs
@@ -225,6 +225,7 @@ namespace System.Net.NameResolution.Tests
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/131188", typeof(PlatformDetection), nameof(PlatformDetection.IsWindowsServer2025))]
         public async Task ResolveAddresses_NonExistent_ReturnsNxDomain(bool async)
         {
             using DnsResolver r = new DnsResolver();


### PR DESCRIPTION
Disables `System.Net.NameResolution.Tests.DnsResolverTest.ResolveAddresses_NonExistent_ReturnsNxDomain` on Windows Server 2025, where the query returns `ServerFailure` instead of the expected `NxDomain` on CI machines.

The test is skipped only on Windows Server 2025 via `[ActiveIssue]` conditioned on `PlatformDetection.IsWindowsServer2025`, so it continues to run on all other Windows versions.

Contributes to #131188