### PR TITLE
Enable GitHub MCP tools in CI evals

### DIFF
--- a/.github/workflows/ci-eval.yml
+++ b/.github/workflows/ci-eval.yml
@@ -299,6 +299,7 @@ jobs:
               secrets.COPILOT_GITHUB_TOKEN
             }}
           GH_TOKEN: ${{ github.token }}
+          # The GitHub MCP server reads this name from its Docker container.
           GITHUB_PERSONAL_ACCESS_TOKEN: ${{ github.token }}
           SPECS: ${{ steps.sel.outputs.specs }}
         run: |

--- a/.github/workflows/ci-eval.yml
+++ b/.github/workflows/ci-eval.yml
@@ -299,6 +299,7 @@ jobs:
               secrets.COPILOT_GITHUB_TOKEN
             }}
           GH_TOKEN: ${{ github.token }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ github.token }}
           SPECS: ${{ steps.sel.outputs.specs }}
         run: |
           workdir="$RUNNER_TEMP/vally"

--- a/.github/workflows/evals/README.md
+++ b/.github/workflows/evals/README.md
@@ -26,6 +26,10 @@ for conformance, behavior, and constructiveness. Every grader must pass.
 The workflow preserves the eval specs and installs Vally from the trusted base
 branch before it checks out the PR head. This lets it evaluate PR changes to the
 workflow prompts without allowing the PR to weaken its graders or toolchain.
+Each eval attaches a read-only GitHub MCP server with the `pull_requests`,
+`repos`, `issues`, and `search` toolsets. The `GITHUB_TOKEN` that the eval job
+supplies to that server has only the job's read permissions, allowing the
+scanner to use tools such as `github-mcp-server-search_issues`.
 
 These are format and behavior gates, not full ground-truth measurements. The
 second stage, a collector that scrapes the real failures and KBEs that actually
@@ -63,12 +67,13 @@ is failing at eval time.
 
 ## Run locally
 
-You need Node 22, a Copilot token for the agent and judges, and a GitHub token
-for the agent's `gh` calls.
+You need Node 22, Docker, a Copilot token for the agent and judges, and a
+GitHub token for the agent's `gh` calls and the GitHub MCP server.
 
 ```bash
 export COPILOT_GITHUB_TOKEN="$(gh auth token)"
 export GH_TOKEN="$(gh auth token)"
+export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token)"
 vally lint --eval-spec .github/workflows/evals/ci-failure-scan.eval.yaml --strict
 vally eval --eval-spec .github/workflows/evals/ci-failure-scan.eval.yaml \
   --skill-dir .github/workflows --workspace /tmp/ws --output-dir /tmp/out

--- a/.github/workflows/evals/README.md
+++ b/.github/workflows/evals/README.md
@@ -29,7 +29,7 @@ workflow prompts without allowing the PR to weaken its graders or toolchain.
 Each eval attaches a read-only GitHub MCP server with the `pull_requests`,
 `repos`, `issues`, and `search` toolsets. The `GITHUB_TOKEN` that the eval job
 supplies to that server has only the job's read permissions, allowing the
-scanner to use tools such as `github-mcp-server-search_issues`.
+scanner to use the `github` MCP server's `search_issues` tool.
 
 These are format and behavior gates, not full ground-truth measurements. The
 second stage, a collector that scrapes the real failures and KBEs that actually

--- a/.github/workflows/evals/ci-failure-fix.eval.yaml
+++ b/.github/workflows/evals/ci-failure-fix.eval.yaml
@@ -25,7 +25,7 @@ environment:
         - GITHUB_READ_ONLY=1
         - --env
         - GITHUB_TOOLSETS=pull_requests,repos,issues,search
-        - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
+        - ghcr.io/github/github-mcp-server:v1.5.0@sha256:e25564dccc9110a70a77b9df560cbde11aa392fcb5f08b9abe5c4ebc6d146ea4
 
 stimuli:
   - name: live-fix-or-engage-safe-output

--- a/.github/workflows/evals/ci-failure-fix.eval.yaml
+++ b/.github/workflows/evals/ci-failure-fix.eval.yaml
@@ -10,6 +10,23 @@ defaults:
 scoring:
   threshold: 1.0
 
+environment:
+  mcpServers:
+    github:
+      type: stdio
+      command: docker
+      args:
+        - run
+        - --interactive
+        - --rm
+        - --env
+        - GITHUB_PERSONAL_ACCESS_TOKEN
+        - --env
+        - GITHUB_READ_ONLY=1
+        - --env
+        - GITHUB_TOOLSETS=pull_requests,repos,issues,search
+        - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
+
 stimuli:
   - name: live-fix-or-engage-safe-output
     environment:

--- a/.github/workflows/evals/ci-failure-scan-feedback.eval.yaml
+++ b/.github/workflows/evals/ci-failure-scan-feedback.eval.yaml
@@ -25,7 +25,7 @@ environment:
         - GITHUB_READ_ONLY=1
         - --env
         - GITHUB_TOOLSETS=pull_requests,repos,issues,search
-        - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
+        - ghcr.io/github/github-mcp-server:v1.5.0@sha256:e25564dccc9110a70a77b9df560cbde11aa392fcb5f08b9abe5c4ebc6d146ea4
 
 stimuli:
   - name: live-constructive-feedback-safe-output

--- a/.github/workflows/evals/ci-failure-scan-feedback.eval.yaml
+++ b/.github/workflows/evals/ci-failure-scan-feedback.eval.yaml
@@ -10,6 +10,23 @@ defaults:
 scoring:
   threshold: 1.0
 
+environment:
+  mcpServers:
+    github:
+      type: stdio
+      command: docker
+      args:
+        - run
+        - --interactive
+        - --rm
+        - --env
+        - GITHUB_PERSONAL_ACCESS_TOKEN
+        - --env
+        - GITHUB_READ_ONLY=1
+        - --env
+        - GITHUB_TOOLSETS=pull_requests,repos,issues,search
+        - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
+
 stimuli:
   - name: live-constructive-feedback-safe-output
     environment:

--- a/.github/workflows/evals/ci-failure-scan.eval.yaml
+++ b/.github/workflows/evals/ci-failure-scan.eval.yaml
@@ -10,6 +10,23 @@ defaults:
 scoring:
   threshold: 1.0
 
+environment:
+  mcpServers:
+    github:
+      type: stdio
+      command: docker
+      args:
+        - run
+        - --interactive
+        - --rm
+        - --env
+        - GITHUB_PERSONAL_ACCESS_TOKEN
+        - --env
+        - GITHUB_READ_ONLY=1
+        - --env
+        - GITHUB_TOOLSETS=pull_requests,repos,issues,search
+        - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
+
 stimuli:
   - name: live-kbe-safe-output
     environment:

--- a/.github/workflows/evals/ci-failure-scan.eval.yaml
+++ b/.github/workflows/evals/ci-failure-scan.eval.yaml
@@ -25,7 +25,7 @@ environment:
         - GITHUB_READ_ONLY=1
         - --env
         - GITHUB_TOOLSETS=pull_requests,repos,issues,search
-        - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
+        - ghcr.io/github/github-mcp-server:v1.5.0@sha256:e25564dccc9110a70a77b9df560cbde11aa392fcb5f08b9abe5c4ebc6d146ea4
 
 stimuli:
   - name: live-kbe-safe-output


### PR DESCRIPTION
## Summary

- Enable the trusted Vally eval specs to attach the GitHub MCP server.
- Allow `/ci-scan eval` to use GitHub MCP issue search, making its duplicate-KBE lookup more robust.

## Validation

- `vally lint --eval-spec ... --strict` for all three CI eval specs.
- A live MCP query could not run locally because Docker is unavailable.

> [!NOTE]
> This pull request description was generated by GitHub Copilot.