### PR TITLE
Restore isolation for GC Collect tests

### DIFF
--- a/src/tests/GC/API/GC/Collect.csproj
+++ b/src/tests/GC/API/GC/Collect.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- This test requires uncontested process-wide GC state. -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/GC/API/GC/Collect0.csproj
+++ b/src/tests/GC/API/GC/Collect0.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- This test requires uncontested process-wide GC state. -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect1.csproj
+++ b/src/tests/GC/API/GC/Collect1.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- This test requires uncontested process-wide GC state. -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #131721
Fixes #131893

PR #126108 removed process isolation from `Collect`, `Collect0`, and `Collect1`, allowing their generation assertions to observe GC state accumulated by earlier tests in the merged runner. Restore isolation because these tests require uncontested process-wide GC state.

Local x86 Checked investigation reproduced all three failures by accumulating leaked pinned handles in a shared process. The same failures occurred under FullOpt, while target-only runs, runs excluding `AddrOfPinnedObject`, and pin-and-free controls completed 10,000 iterations without failure, so this change preserves JIT-mode coverage instead of marking the tests `JitOptimizationSensitive`.

Validation:
- Windows x64 and x86 Checked Core_Root and targeted GC test builds
- Individual `Collect`, `Collect0`, and `Collect1` wrappers
- Full merged GC runner with the restored out-of-process dispatch

> [!NOTE]
> This pull request description was prepared with GitHub Copilot.