### PR TITLE
Add BMP fast path to StringBuilder Rune overloads

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1057,8 +1057,20 @@ namespace System.Text
         /// </summary>
         /// <param name="value">The UTF-32-encoded code unit to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        public unsafe StringBuilder Append(Rune value)
+        public StringBuilder Append(Rune value)
         {
+            if (value.IsBmp)
+            {
+                return Append((char)value.Value);
+            }
+
+            return AppendRune(value);
+        }
+
+        private unsafe StringBuilder AppendRune(Rune value)
+        {
+            Debug.Assert(!value.IsBmp);
+
             // Convert value to span
             ReadOnlySpan<char> valueChars = value.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
 
@@ -1372,8 +1384,20 @@ namespace System.Text
         /// <param name="index">The position in this instance where insertion begins.</param>
         /// <param name="value">The value to insert.</param>
         /// <returns>A reference to this instance after the insert operation has completed.</returns>
-        public unsafe StringBuilder Insert(int index, Rune value)
+        public StringBuilder Insert(int index, Rune value)
         {
+            if (value.IsBmp)
+            {
+                return Insert(index, (char)value.Value);
+            }
+
+            return InsertRune(index, value);
+        }
+
+        private unsafe StringBuilder InsertRune(int index, Rune value)
+        {
+            Debug.Assert(!value.IsBmp);
+
             // Convert value to span
             ReadOnlySpan<char> valueChars = value.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
 
@@ -2320,7 +2344,17 @@ namespace System.Text
         /// A reference to this instance with <paramref name="oldRune"/> replaced by <paramref name="newRune"/> in the range
         /// from <paramref name="startIndex"/> to <paramref name="startIndex"/> + <paramref name="count"/> - 1.
         /// </returns>
-        public unsafe StringBuilder Replace(Rune oldRune, Rune newRune, int startIndex, int count)
+        public StringBuilder Replace(Rune oldRune, Rune newRune, int startIndex, int count)
+        {
+            if (oldRune.IsBmp && newRune.IsBmp)
+            {
+                return Replace((char)oldRune.Value, (char)newRune.Value, startIndex, count);
+            }
+
+            return ReplaceRune(oldRune, newRune, startIndex, count);
+        }
+
+        private unsafe StringBuilder ReplaceRune(Rune oldRune, Rune newRune, int startIndex, int count)
         {
             // Convert oldRune to span
             ReadOnlySpan<char> oldChars = oldRune.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);


### PR DESCRIPTION
Add a fast path that calls `StringBuilder.Append`/`Insert`/`Replace(char)` when `Rune.IsBmp` holds.
Move the existing span path into a private method so that the stackalloc stays out of the fast path.
This follows the pattern used in #127939.

## Benchmark

| Method                     | Job        | Toolchain               | Mean      | Error     | StdDev    | Median    | Min       | Max       | Ratio | RatioSD | Allocated | Alloc Ratio |
|--------------------------- |----------- |------------------------ |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|----------:|------------:|
| Append_Rune_Bmp            | Job-QIDXWP | \main\corerun.exe       |  2.818 ns | 0.0166 ns | 0.0130 ns |  2.819 ns |  2.790 ns |  2.844 ns |  1.00 |    0.00 |         - |          NA |
| Append_Rune_Bmp            | Job-APEIBT | \pr\corerun.exe |  2.378 ns | 0.0672 ns | 0.0773 ns |  2.358 ns |  2.266 ns |  2.514 ns |  0.84 |    0.03 |         - |          NA |
|                            |            |                         |           |           |           |           |           |           |       |         |           |             |
| Append_Rune_Supplementary  | Job-QIDXWP | \main\corerun.exe       |  3.299 ns | 0.1453 ns | 0.1674 ns |  3.237 ns |  3.075 ns |  3.648 ns |  1.00 |    0.00 |         - |          NA |
| Append_Rune_Supplementary  | Job-APEIBT | \pr\corerun.exe |  3.092 ns | 0.0594 ns | 0.0526 ns |  3.088 ns |  3.012 ns |  3.201 ns |  0.94 |    0.05 |         - |          NA |
|                            |            |                         |           |           |           |           |           |           |       |         |           |             |
| Insert_Rune_Bmp            | Job-QIDXWP | \main\corerun.exe       |  5.885 ns | 0.1921 ns | 0.2212 ns |  5.800 ns |  5.629 ns |  6.302 ns |  1.00 |    0.00 |         - |          NA |
| Insert_Rune_Bmp            | Job-APEIBT | \pr\corerun.exe |  5.465 ns | 0.0894 ns | 0.0747 ns |  5.454 ns |  5.372 ns |  5.605 ns |  0.93 |    0.04 |         - |          NA |
|                            |            |                         |           |           |           |           |           |           |       |         |           |             |
| Insert_Rune_Supplementary  | Job-QIDXWP | \main\corerun.exe       |  7.564 ns | 0.1035 ns | 0.0864 ns |  7.530 ns |  7.421 ns |  7.704 ns |  1.00 |    0.00 |         - |          NA |
| Insert_Rune_Supplementary  | Job-APEIBT | \pr\corerun.exe |  7.802 ns | 0.1499 ns | 0.1539 ns |  7.796 ns |  7.499 ns |  8.132 ns |  1.03 |    0.02 |         - |          NA |
|                            |            |                         |           |           |           |           |           |           |       |         |           |             |
| Replace_Rune_Bmp           | Job-QIDXWP | \main\corerun.exe       | 19.057 ns | 0.2855 ns | 0.2384 ns | 18.997 ns | 18.794 ns | 19.642 ns |  1.00 |    0.00 |         - |          NA |
| Replace_Rune_Bmp           | Job-APEIBT | \pr\corerun.exe | 15.674 ns | 0.3009 ns | 0.2955 ns | 15.719 ns | 15.130 ns | 16.245 ns |  0.82 |    0.02 |         - |          NA |
|                            |            |                         |           |           |           |           |           |           |       |         |           |             |
| Replace_Rune_Supplementary | Job-QIDXWP | \main\corerun.exe       | 21.403 ns | 0.3263 ns | 0.2548 ns | 21.416 ns | 20.926 ns | 21.709 ns |  1.00 |    0.00 |         - |          NA |
| Replace_Rune_Supplementary | Job-APEIBT | \pr\corerun.exe | 21.162 ns | 0.4119 ns | 0.3440 ns | 21.135 ns | 20.591 ns | 21.723 ns |  0.99 |    0.02 |         - |          NA |

<details><summary>Benchmark source</summary>

```csharp
    [BenchmarkCategory(Categories.Libraries, Categories.Runtime)]
    public class Perf_RuneForStringBuilder
    {
        private Rune _bmp;
        private Rune _supplementary;

        private StringBuilder _appendTarget;
        private StringBuilder _insertTarget;
        private StringBuilder _replaceBmp;
        private StringBuilder _replaceSupplementary;

        [GlobalSetup]
        public void Setup()
        {
            _bmp = new Rune('A');
            _supplementary = new Rune(0x1F600); // 😀

            _appendTarget = new StringBuilder(16);
            _insertTarget = new StringBuilder(16);

            var source = new string('x', 100);
            _replaceBmp = new StringBuilder(source + _bmp.ToString(), source.Length);
            _replaceSupplementary = new StringBuilder(source + _supplementary.ToString(), source.Length);
        }

        [Benchmark]
        public StringBuilder Append_Rune_Bmp()
        {
            _appendTarget.Clear();
            return _appendTarget.Append(_bmp);
        }

        [Benchmark]
        public StringBuilder Append_Rune_Supplementary()
        {
            _appendTarget.Clear();
            return _appendTarget.Append(_supplementary);
        }

        [Benchmark]
        public StringBuilder Insert_Rune_Bmp()
        {
            _insertTarget.Clear();
            return _insertTarget.Insert(0, _bmp);
        }

        [Benchmark]
        public StringBuilder Insert_Rune_Supplementary()
        {
            _insertTarget.Clear();
            return _insertTarget.Insert(0, _supplementary);
        }

        [Benchmark]
        public StringBuilder Replace_Rune_Bmp() => _replaceBmp.Replace(_bmp, _bmp);

        [Benchmark]
        public StringBuilder Replace_Rune_Supplementary() => _replaceSupplementary.Replace(_supplementary, _supplementary);

    }
```

</details>