### PR TITLE
Limit Helix job monitor to runtime pipeline

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -46,7 +46,7 @@ variables:
   value: ${{ notin(variables['Build.DefinitionName'], 'runtime-wasm', 'runtime-wasm-libtests', 'runtime-wasm-non-libtests', 'runtime-ioslike', 'runtime-ioslikesimulator', 'runtime-android', 'runtime-androidemulator', 'runtime-maccatalyst', 'runtime-linuxbionic') }}
 
 - name: enableHelixJobMonitor
-  value: true
+  value: false
 
 - name: debugOnPrReleaseOnRolling
   ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -49,6 +49,8 @@ pr:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:


### PR DESCRIPTION
## Summary

- default `enableHelixJobMonitor` to `false` in the shared pipeline variables
- explicitly enable it in `eng/pipelines/runtime.yml`
- preserve the standalone monitor job and fire-and-forget submissions only for the runtime pipeline

## Motivation

The original rollout in #129690 intended to enable the Helix Job Monitor only for the runtime pipeline. However, the switch was set to `true` in the shared variables template imported by other pipelines.

This caused standalone pipelines such as [`runtime-coreclr superpmi-collect` build 3043381](https://dev.azure.com/dnceng/internal/_build/results?buildId=3043381&view=results) to configure Helix submissions for out-of-band monitoring without adding a monitor job. Those submissions returned after submission rather than waiting for completion.

Defaulting the shared switch off and opting in from `runtime.yml` keeps the complete feature scoped to its intended pipeline.

## Validation

- `git diff --check`
- verified `enableHelixJobMonitor` is enabled only by `eng/pipelines/runtime.yml`

> [!NOTE]
> This pull request description was generated with GitHub Copilot.