### PR TITLE
Add regression test for tuple swap with implicit indexer references

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -783,9 +783,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             }
 
             // Tuple-swapping elements accessed through an implicit indexer (using the
-            // System.Index '^' operator) used to crash the analyzer, because the
-            // implicit indexer reference is a deconstruction assignment target, which
-            // is a write that is not a byref.
+            // System.Index '^' operator) used to crash the analyzer, because Roslyn
+            // marks an implicit indexer reference that is a deconstruction assignment
+            // target as a write without also marking it as a reference.
             static void TestTupleSwap()
             {
                 Span<int> span = stackalloc int[4];

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/PropertyDataFlow.cs
@@ -782,6 +782,16 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 types[index].RequiresAll();
             }
 
+            // Tuple-swapping elements accessed through an implicit indexer (using the
+            // System.Index '^' operator) used to crash the analyzer, because the
+            // implicit indexer reference is a deconstruction assignment target, which
+            // is a write that is not a byref.
+            static void TestTupleSwap()
+            {
+                Span<int> span = stackalloc int[4];
+                (span[^1], span[^2]) = (span[^2], span[^1]);
+            }
+
             class IndexWithTypeWithDam
             {
                 class DamOnIndexOnly
@@ -925,6 +935,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 TestWrite();
                 TestNullCoalescingAssignment();
                 TestSpanIndexerAccess();
+                TestTupleSwap();
                 IndexWithTypeWithDam.Test();
             }
         }


### PR DESCRIPTION
## Summary

Adds a regression test for #117122, a crash (`Debug.Assert` failure in `VisitImplicitIndexerReference`) hit by the ILLink Roslyn analyzer when analyzing a tuple-swap deconstruction assignment involving `Span<T>` elements accessed via the `^` (Index) operator, e.g.:

```csharp
Span<int> span = stackalloc int[4];
(span[^1], span[^2]) = (span[^2], span[^1]);
```

## Root cause

`GetValueUsageInfo` returns `ValueUsageInfo.Write` (without `.Reference`) for operations on the left side of a deconstruction assignment. `VisitImplicitIndexerReference` previously asserted that any `Write`-flagged implicit indexer reference must also be `Reference`, an assumption that didn't hold for deconstruction-assignment targets.

This is already fixed on `main` by #131624 ("Add dataflow support for deconstruction assignments"), which added proper `VisitDeconstructionAssignment` handling that routes deconstruction targets through dedicated assignment-processing logic instead of the generic operation visitor that could trip the old assert. That change closes #123767, and as a side effect also fixes this crash — verified by testing with only that fix applied (no separate patch needed here).

## Testing

Folded the new test case (`TestTupleSwap`) into the existing `ImplicitIndexerAccess` nested test class in `PropertyDataFlow.cs`, since it already covers directly related `^`-indexer and `Span<T>` write scenarios. Verified the test:
- Reproduces the crash against code prior to #131624.
- Passes with #131624 applied.
- Passes across all three tools that share this test-case file: the Roslyn analyzer (`ILLink.RoslynAnalyzer.Tests`), the IL trimmer (`Mono.Linker.Tests`), and NativeAOT (`ILCompiler.Trimming.Tests`).

> [!NOTE]
> This content was created with assistance from AI.

Fixes https://github.com/dotnet/runtime/issues/117122