### PR TITLE
Restore BitArray array constructor performance

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
@@ -142,8 +142,15 @@ namespace System.Collections
         public BitArray(byte[] bytes)
         {
             ArgumentNullException.ThrowIfNull(bytes);
+            if (bytes.Length > int.MaxValue / BitsPerByte)
+            {
+                throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerByte), nameof(bytes));
+            }
 
-            _array = CreateArray(bytes, out _bitLength);
+            _bitLength = bytes.Length * BitsPerByte;
+            _array = AllocateByteArray(_bitLength);
+
+            Array.Copy(bytes, _array, bytes.Length);
         }
 
         /// <summary>
@@ -162,21 +169,15 @@ namespace System.Collections
         /// </remarks>
         public BitArray(ReadOnlySpan<byte> bytes)
         {
-            _array = CreateArray(bytes, out _bitLength);
-        }
-
-        private static byte[] CreateArray(ReadOnlySpan<byte> bytes, out int bitLength)
-        {
             if (bytes.Length > int.MaxValue / BitsPerByte)
             {
                 throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerByte), nameof(bytes));
             }
 
-            bitLength = bytes.Length * BitsPerByte;
-            byte[] array = AllocateByteArray(bitLength);
+            _bitLength = bytes.Length * BitsPerByte;
+            _array = AllocateByteArray(_bitLength);
 
-            bytes.CopyTo(array);
-            return array;
+            bytes.CopyTo(_array);
         }
 
         /// <summary>
@@ -192,26 +193,8 @@ namespace System.Collections
         {
             ArgumentNullException.ThrowIfNull(values);
 
-            _array = CreateArray(values, out _bitLength);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BitArray"/> class that contains bit values
-        /// copied from the specified read-only span of Booleans.
-        /// </summary>
-        /// <param name="values">A read-only span of Booleans to copy.</param>
-        /// <remarks>
-        /// This constructor is an <c>O(n)</c> operation, where <c>n</c> is the number of elements in <paramref name="values"/>.
-        /// </remarks>
-        public BitArray(ReadOnlySpan<bool> values)
-        {
-            _array = CreateArray(values, out _bitLength);
-        }
-
-        private static byte[] CreateArray(ReadOnlySpan<bool> values, out int bitLength)
-        {
-            bitLength = values.Length;
-            byte[] array = AllocateByteArray(bitLength);
+            _array = AllocateByteArray(values.Length);
+            _bitLength = values.Length;
 
             uint i = 0;
 
@@ -224,7 +207,90 @@ namespace System.Collections
             // (true for any non-zero values, false for 0) - any values between 2-255 will be interpreted as false.
             // Instead, we compare with zeroes (== false) then negate the result to ensure compatibility.
 
-            ref byte arrayRef = ref MemoryMarshal.GetArrayDataReference(array);
+            ref byte arrayRef = ref MemoryMarshal.GetArrayDataReference(_array);
+            ReadOnlySpan<byte> valuesAsBytes = MemoryMarshal.AsBytes(values.AsSpan());
+            if (Vector512.IsHardwareAccelerated)
+            {
+                while (valuesAsBytes.Length >= Vector512<byte>.Count)
+                {
+                    Vector512<byte> vector = Vector512.Create(valuesAsBytes);
+                    Vector512<byte> isFalse = Vector512.Equals(vector, Vector512<byte>.Zero);
+
+                    ulong result = isFalse.ExtractMostSignificantBits();
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(ulong) * (i / 64u)), ~result);
+                    i += (uint)Vector512<byte>.Count;
+                    valuesAsBytes = valuesAsBytes.Slice(Vector512<byte>.Count);
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated)
+            {
+                while (valuesAsBytes.Length >= Vector256<byte>.Count)
+                {
+                    Vector256<byte> vector = Vector256.Create(valuesAsBytes);
+                    Vector256<byte> isFalse = Vector256.Equals(vector, Vector256<byte>.Zero);
+
+                    uint result = isFalse.ExtractMostSignificantBits();
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32u)), ~result);
+                    i += (uint)Vector256<byte>.Count;
+                    valuesAsBytes = valuesAsBytes.Slice(Vector256<byte>.Count);
+                }
+            }
+            else if (Vector128.IsHardwareAccelerated)
+            {
+                while (valuesAsBytes.Length >= Vector128<byte>.Count * 2)
+                {
+                    Vector128<byte> lowerVector = Vector128.Create(valuesAsBytes);
+                    Vector128<byte> lowerIsFalse = Vector128.Equals(lowerVector, Vector128<byte>.Zero);
+                    uint lowerResult = lowerIsFalse.ExtractMostSignificantBits();
+
+                    Vector128<byte> upperVector = Vector128.Create(valuesAsBytes.Slice(Vector128<byte>.Count));
+                    Vector128<byte> upperIsFalse = Vector128.Equals(upperVector, Vector128<byte>.Zero);
+                    uint upperResult = upperIsFalse.ExtractMostSignificantBits();
+
+                    Unsafe.WriteUnaligned(
+                        ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32u)),
+                        ~((upperResult << 16) | lowerResult));
+                    i += (uint)Vector128<byte>.Count * 2u;
+                    valuesAsBytes = valuesAsBytes.Slice(Vector128<byte>.Count * 2);
+                }
+            }
+
+        Remainder:
+            for (; i < (uint)values.Length; i++)
+            {
+                if (values[i])
+                {
+                    (uint byteIndex, uint bitOffset) = Math.DivRem(i, BitsPerByte);
+                    _array[byteIndex] |= (byte)(1 << (int)bitOffset);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitArray"/> class that contains bit values
+        /// copied from the specified read-only span of Booleans.
+        /// </summary>
+        /// <param name="values">A read-only span of Booleans to copy.</param>
+        /// <remarks>
+        /// This constructor is an <c>O(n)</c> operation, where <c>n</c> is the number of elements in <paramref name="values"/>.
+        /// </remarks>
+        public BitArray(ReadOnlySpan<bool> values)
+        {
+            _array = AllocateByteArray(values.Length);
+            _bitLength = values.Length;
+
+            uint i = 0;
+
+            if (!BitConverter.IsLittleEndian || values.Length < Vector256<byte>.Count)
+            {
+                goto Remainder;
+            }
+
+            // Comparing with 1s would get rid of the final negation, however this would not work for some CLR bools
+            // (true for any non-zero values, false for 0) - any values between 2-255 will be interpreted as false.
+            // Instead, we compare with zeroes (== false) then negate the result to ensure compatibility.
+
+            ref byte arrayRef = ref MemoryMarshal.GetArrayDataReference(_array);
             ReadOnlySpan<byte> valuesAsBytes = MemoryMarshal.AsBytes(values);
             if (Vector512.IsHardwareAccelerated)
             {
@@ -278,11 +344,9 @@ namespace System.Collections
                 if (values[(int)i])
                 {
                     (uint byteIndex, uint bitOffset) = Math.DivRem(i, BitsPerByte);
-                    array[byteIndex] |= (byte)(1 << (int)bitOffset);
+                    _array[byteIndex] |= (byte)(1 << (int)bitOffset);
                 }
             }
-
-            return array;
         }
 
         /// <summary>
@@ -303,8 +367,22 @@ namespace System.Collections
         public BitArray(int[] values)
         {
             ArgumentNullException.ThrowIfNull(values);
+            if (values.Length > int.MaxValue / BitsPerInt32)
+            {
+                throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerInt32), nameof(values));
+            }
 
-            _array = CreateArray(values, out _bitLength);
+            _bitLength = values.Length * BitsPerInt32;
+            _array = AllocateByteArray(_bitLength);
+
+            if (BitConverter.IsLittleEndian)
+            {
+                MemoryMarshal.AsBytes(values).CopyTo(_array);
+            }
+            else
+            {
+                BinaryPrimitives.ReverseEndianness(values, MemoryMarshal.Cast<byte, int>((Span<byte>)_array));
+            }
         }
 
         /// <summary>
@@ -323,29 +401,22 @@ namespace System.Collections
         /// </remarks>
         public BitArray(ReadOnlySpan<int> values)
         {
-            _array = CreateArray(values, out _bitLength);
-        }
-
-        private static byte[] CreateArray(ReadOnlySpan<int> values, out int bitLength)
-        {
             if (values.Length > int.MaxValue / BitsPerInt32)
             {
                 throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerInt32), nameof(values));
             }
 
-            bitLength = values.Length * BitsPerInt32;
-            byte[] array = AllocateByteArray(bitLength);
+            _bitLength = values.Length * BitsPerInt32;
+            _array = AllocateByteArray(_bitLength);
 
             if (BitConverter.IsLittleEndian)
             {
-                MemoryMarshal.AsBytes(values).CopyTo(array);
+                MemoryMarshal.AsBytes(values).CopyTo(_array);
             }
             else
             {
-                BinaryPrimitives.ReverseEndianness(values, MemoryMarshal.Cast<byte, int>((Span<byte>)array));
+                BinaryPrimitives.ReverseEndianness(values, MemoryMarshal.Cast<byte, int>((Span<byte>)_array));
             }
-
-            return array;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- Restore the original `byte[]`, `bool[]`, and `int[]` constructor implementations.
- Keep the new `ReadOnlySpan<T>` constructors as separate implementations.
- Avoid helper-call regressions and forced-inlining code growth.

Fixes #131815.

## Motivation

After #131500 routed the existing array constructors through shared span helpers, Viper reported `BitArrayBoolArrayCtor(Size: 512)` increasing from 16.70 ns to 20.32 ns (+21.7%). [Bisection localized the sustained regression to #131500](https://github.com/dotnet/runtime/issues/131815#issuecomment-5181871434).

The x64 Boolean helper remains a real call:

| Implementation | Native code | Instructions |
|---|---:|---:|
| Original direct constructor | 242 bytes | 74 |
| Helper wrapper + `CreateArray` | 282 bytes | 86 |

A five-attempt Windows/x64 comparison with ReadyToRun and tiering disabled found duplication approximately 1.8% faster at size 4 and 3.2% faster at size 512, with separated confidence intervals in every attempt ([logs](https://bot.egorbo.com/api/jobs/683c2e48-6671-4532-af13-bf0a12409228/logs/full)).

## Alternatives investigated

- Removing `out bitLength` only moved work between the helper and caller; both versions generated 86 instructions.
- Changing the Boolean index from `uint` to `int` grew the helper from 192 bytes/60 instructions to 289 bytes/91 instructions and was about 19% slower at size 512.
- Forced and split inlining removed the call but expanded the ARM64 caller from 136 bytes to 408–504 bytes, without improving the default size-512 benchmark.

Restoring the duplicated array implementations is therefore the lowest-risk option. It restores the pre-#131500 code shape without depending on inlining heuristics or substantially increasing generated code size.

## Validation

- Checked `System.Private.CoreLib` build.
- Verified the array constructor bodies match their pre-#131500 implementations.
- Benchmarked the original helper and duplicated implementations on Windows/x64 and locally under multiple JIT/ReadyToRun configurations.

A Viper rerun is still required to confirm recovery on the original environment.

> [!NOTE]
> This pull request description was generated with GitHub Copilot and reviewed before publication.