### PR TITLE
[object writer] Use binary search for seeking SectionData positions

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/SectionData.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/SectionData.cs
@@ -24,6 +24,7 @@ namespace ILCompiler.ObjectWriter
     {
         private readonly ArrayBufferWriter<byte> _appendBuffer = new();
         private readonly List<ReadOnlyMemory<byte>> _buffers = new();
+        private readonly List<long> _bufferOffsets = new();
         private long _length;
         private readonly byte[] _padding = new byte[16];
 
@@ -36,6 +37,7 @@ namespace ILCompiler.ObjectWriter
         {
             if (_appendBuffer.WrittenCount > 0)
             {
+                _bufferOffsets.Add(_length);
                 _buffers.Add(_appendBuffer.WrittenSpan.ToArray());
                 _length += _appendBuffer.WrittenCount;
                 _appendBuffer.Clear();
@@ -45,6 +47,7 @@ namespace ILCompiler.ObjectWriter
         public void AppendData(ReadOnlyMemory<byte> data)
         {
             FlushAppendBuffer();
+            _bufferOffsets.Add(_length);
             _buffers.Add(data);
             _length += data.Length;
         }
@@ -94,23 +97,31 @@ namespace ILCompiler.ObjectWriter
                     // Flush any non-appended data
                     _sectionData.FlushAppendBuffer();
 
-                    // Seek to the correct buffer
-                    _position = 0;
-                    _bufferIndex = 0;
+                    _position = Math.Clamp(value, 0, _sectionData._length);
+                    _bufferIndex = _sectionData._buffers.Count;
                     _bufferPosition = 0;
-                    while (_position < value && _bufferIndex < _sectionData._buffers.Count)
+
+                    if (_position < _sectionData._length)
                     {
-                        if (_sectionData._buffers[_bufferIndex].Length < value - _position)
+                        // Find the first buffer that starts after the requested position. The preceding
+                        // buffer contains the position; choosing the last duplicate offset skips empty buffers.
+                        int lower = 0;
+                        int upper = _sectionData._buffers.Count;
+                        while (lower < upper)
                         {
-                            _position += _sectionData._buffers[_bufferIndex].Length;
-                            _bufferIndex++;
+                            int middle = lower + ((upper - lower) / 2);
+                            if (_sectionData._bufferOffsets[middle] <= _position)
+                            {
+                                lower = middle + 1;
+                            }
+                            else
+                            {
+                                upper = middle;
+                            }
                         }
-                        else
-                        {
-                            _bufferPosition = (int)(value - _position);
-                            _position = value;
-                            break;
-                        }
+
+                        _bufferIndex = lower - 1;
+                        _bufferPosition = (int)(_position - _sectionData._bufferOffsets[_bufferIndex]);
                     }
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <Compile Include="DependencyGraphTests.cs" />
     <Compile Include="DevirtualizationTests.cs" />
+    <Compile Include="ObjectWriterTests.cs" />
     <Compile Include="SwiftLoweringTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ObjectWriterTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ObjectWriterTests.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ILCompiler.ObjectWriter;
+
+using Xunit;
+
+namespace ILCompiler.Compiler.Tests
+{
+    public class ObjectWriterTests
+    {
+        [Fact]
+        public void ReadStreamPositionFindsCorrectBuffer()
+        {
+            var sectionData = new SectionData();
+            var expected = new List<byte>();
+
+            for (int i = 0; i < 1_024; i++)
+            {
+                byte[] buffer = new byte[i % 5];
+                buffer.AsSpan().Fill((byte)i);
+                sectionData.AppendData(buffer);
+                expected.AddRange(buffer);
+            }
+
+            Span<byte> appendedData = sectionData.BufferWriter.GetSpan(3).Slice(0, 3);
+            appendedData.Fill(0xCC);
+            sectionData.BufferWriter.Advance(appendedData.Length);
+            expected.AddRange([0xCC, 0xCC, 0xCC]);
+
+            using Stream stream = sectionData.GetReadStream();
+
+            for (int position = 0; position < expected.Count; position++)
+            {
+                stream.Position = position;
+
+                Assert.Equal(position, stream.Position);
+                Assert.Equal(expected[position], stream.ReadByte());
+            }
+
+            stream.Position = stream.Length;
+            Assert.Equal(-1, stream.ReadByte());
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -26,6 +26,8 @@
     <ProjectReference Include="..\ILCompiler.MetadataTransform\ILCompiler.MetadataTransform.csproj" />
     <ProjectReference Include="..\ILCompiler.TypeSystem\ILCompiler.TypeSystem.csproj" />
 
+    <InternalsVisibleTo Include="ILCompiler.Compiler.Tests" />
+
     <PackageReference Condition="'$(DotNetBuildSourceOnly)' != 'true'" Include="StaticCs" Version="$(StaticCsVersion)">
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>contentfiles</ExcludeAssets> <!-- We include our own copy of the ClosedAttribute to work in source build -->


### PR DESCRIPTION
Store buffer offsets separately and use them to locate stream positions in logarithmic time in `ObjectWriter\SectionData.cs`. Note that from my testing this does add about 2.25 MB overhead working memory to a System.Private.CoreLib R2R compilation (out of 700+ total MB) but hugely reduces a perf trap that could be hit by random seeks over SectionData. This came up as part of my work on #132029; I definitely understand if we don't want the added overhead, but this wasn't too difficult to improve so I thought I'd put up a fix just in case.