### PR TITLE
Fix contract violation in CodeVersionManager::EnumerateClosedMethodDescs

### DIFF
--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -2099,7 +2099,16 @@ HRESULT CodeVersionManager::EnumerateClosedMethodDescs(
 
     if (redirectAsyncThunk && pMD->IsAsyncThunkMethod())
     {
-        pMD = pMD->GetAsyncVariantNoCreate();
+        EX_TRY
+        {
+            pMD = pMD->GetAsyncVariantNoCreate();
+        }
+        EX_CATCH_HRESULT(hr);
+
+        if (FAILED(hr))
+        {
+            return hr;
+        }
     }
     if (pMD == NULL)
     {


### PR DESCRIPTION
Fix contract violation by wrapping throwing method.