### PR TITLE
Fix contract violation in AsyncThunkStubManager::TraceManager

### DIFF
--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -2220,17 +2220,10 @@ BOOL AsyncThunkStubManager::TraceManager(Thread *thread,
     MethodDesc* pMD = NonVirtualEntry2MethodDesc(stubIP);
     if (pMD->IsAsyncThunkMethod())
     {
-        MethodDesc* pOtherMD = pMD->GetOrdinaryVariantNoCreate();
-        _ASSERTE_MSG(pOtherMD != NULL, "ATSM::TraceManager: Async thunk does not have non-async variant");
-
-        // An ordinary variant may be a thunk in a rare case when we start from ReturnDroppingThunk.
-        // In such case the regular async variant must not be a thunk.
-        if (pOtherMD->IsAsyncThunkMethod())
-        {
-            pOtherMD = pMD->GetAsyncVariantNoCreate();
-            _ASSERTE_MSG(pOtherMD != NULL, "ATSM::TraceManager: Async thunk has no non-thunk variant to step through to");
-            _ASSERTE(!pOtherMD->IsAsyncThunkMethod());
-        }
+        MethodDesc* pOtherMD = pMD->IsReturnDroppingThunk()
+            ? pMD->GetAsyncVariantNoCreate()
+            : pMD->GetOrdinaryVariantNoCreate();
+        _ASSERTE_MSG(pOtherMD != NULL, "ATSM::TraceManager: Async thunk has no non-thunk variant to step through to");
 
         LOG((LF_CORDB, LL_INFO1000, "ATSM::TraceManager: Step through async thunk to target - %p\n", pOtherMD));
         PCODE target = GetStubTarget(pOtherMD);

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -2220,14 +2220,14 @@ BOOL AsyncThunkStubManager::TraceManager(Thread *thread,
     MethodDesc* pMD = NonVirtualEntry2MethodDesc(stubIP);
     if (pMD->IsAsyncThunkMethod())
     {
-        MethodDesc* pOtherMD = pMD->GetOrdinaryVariant();
+        MethodDesc* pOtherMD = pMD->GetOrdinaryVariantNoCreate();
         _ASSERTE_MSG(pOtherMD != NULL, "ATSM::TraceManager: Async thunk does not have non-async variant");
 
         // An ordinary variant may be a thunk in a rare case when we start from ReturnDroppingThunk.
         // In such case the regular async variant must not be a thunk.
         if (pOtherMD->IsAsyncThunkMethod())
         {
-            pOtherMD = pMD->GetAsyncVariant();
+            pOtherMD = pMD->GetAsyncVariantNoCreate();
             _ASSERTE_MSG(pOtherMD != NULL, "ATSM::TraceManager: Async thunk has no non-thunk variant to step through to");
             _ASSERTE(!pOtherMD->IsAsyncThunkMethod());
         }

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -2224,9 +2224,13 @@ BOOL AsyncThunkStubManager::TraceManager(Thread *thread,
             ? pMD->GetAsyncVariantNoCreate()
             : pMD->GetOrdinaryVariantNoCreate();
 
+        // An ordinary variant may be a thunk in a rare case when we start from ReturnDroppingThunk.
+        // In such case the regular async variant must not be a thunk.
         if (pOtherMD->IsAsyncThunkMethod())
         {
             pOtherMD = pMD->GetAsyncVariantNoCreate();
+            _ASSERTE_MSG(pOtherMD != NULL, "ATSM::TraceManager: Async thunk has no non-thunk variant to step through to");
+            _ASSERTE(!pOtherMD->IsAsyncThunkMethod());
         }
 
         LOG((LF_CORDB, LL_INFO1000, "ATSM::TraceManager: Step through async thunk to target - %p\n", pOtherMD));

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -2223,7 +2223,11 @@ BOOL AsyncThunkStubManager::TraceManager(Thread *thread,
         MethodDesc* pOtherMD = pMD->IsReturnDroppingThunk()
             ? pMD->GetAsyncVariantNoCreate()
             : pMD->GetOrdinaryVariantNoCreate();
-        _ASSERTE_MSG(pOtherMD != NULL, "ATSM::TraceManager: Async thunk has no non-thunk variant to step through to");
+
+        if (pOtherMD->IsAsyncThunkMethod())
+        {
+            pOtherMD = pMD->GetAsyncVariantNoCreate();
+        }
 
         LOG((LF_CORDB, LL_INFO1000, "ATSM::TraceManager: Step through async thunk to target - %p\n", pOtherMD));
         PCODE target = GetStubTarget(pOtherMD);


### PR DESCRIPTION
Use NoCreate version of async variant lookup, as we expect the variant to already exist.