### PR TITLE
Remove and clarify `PEAssembly` constructor parameters

### DIFF
--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -211,12 +211,6 @@ public:
         return GetPEAssembly()->GetSimpleName();
     }
 
-    BOOL IsStrongNamed()
-    {
-        WRAPPER_NO_CONTRACT;
-        return GetPEAssembly()->IsStrongNamed();
-    }
-
     const void *GetPublicKey(DWORD *pcbPK)
     {
         WRAPPER_NO_CONTRACT;

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -164,7 +164,7 @@ public:
     static Assembly *Create(PEAssembly *pPEAssembly, AllocMemTracker *pamTracker, LoaderAllocator *pLoaderAllocator);
     static void Initialize();
 
-    BOOL IsSystem() { WRAPPER_NO_CONTRACT; return m_pPEAssembly->IsSystem(); }
+    bool IsSystem() { WRAPPER_NO_CONTRACT; return m_pPEAssembly->IsSystem(); }
 
     static Assembly* CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNameParts* pAssemblyNameParts, INT32 hashAlgorithm, INT32 access, LOADERALLOCATORREF* pKeepAlive);
 

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -181,7 +181,7 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pIma
         }
     }
 
-    PEAssemblyHolder pPEAssembly(PEAssembly::Open(pAssembly->GetPEImage(), pAssembly));
+    PEAssemblyHolder pPEAssembly(PEAssembly::Open(pAssembly));
     bindOperation.SetResult(pPEAssembly);
 
     return pCurDomain->LoadAssembly(&spec, pPEAssembly, FILE_LOADED);

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -923,7 +923,7 @@ protected:
 #endif
 
     BOOL IsReflectionEmit() const { WRAPPER_NO_CONTRACT; SUPPORTS_DAC; return (m_dwTransientFlags & IS_REFLECTION_EMIT) != 0; }
-    BOOL IsSystem() { WRAPPER_NO_CONTRACT; SUPPORTS_DAC; return m_pPEAssembly->IsSystem(); }
+    bool IsSystem() { WRAPPER_NO_CONTRACT; SUPPORTS_DAC; return m_pPEAssembly->IsSystem(); }
 
     virtual BOOL IsEditAndContinueCapable() const { return FALSE; }
 

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -639,17 +639,14 @@ ULONG PEAssembly::GetPEImageTimeDateStamp()
 #ifndef DACCESS_COMPILE
 
 PEAssembly::PEAssembly(
-                BINDER_SPACE::Assembly* pBindResultInfo,
+                BINDER_SPACE::Assembly* pBoundAssembly,
                 IMetaDataEmit* pEmit,
                 BOOL isSystem,
-                AssemblyBinder* pDynamicAssemblyBinder /*= NULL*/,
-                PEImage * pPEImage /*= NULL*/,
-                BINDER_SPACE::Assembly * pHostAssembly /*= NULL*/)
+                AssemblyBinder* pDynamicAssemblyBinder /*= NULL*/)
 {
     CONTRACTL
     {
         PRECONDITION(CheckPointer(pEmit, NULL_OK));
-        PRECONDITION(pBindResultInfo == NULL || pPEImage == NULL);
         STANDARD_VM_CHECK;
     }
     CONTRACTL_END;
@@ -667,8 +664,8 @@ PEAssembly::PEAssembly(
     m_pHostAssembly = nullptr;
     m_pAssemblyBinder = nullptr;
 
-    pPEImage = pBindResultInfo ? pBindResultInfo->GetPEImage() : pPEImage;
-    if (pPEImage)
+    PEImage* pPEImage = pBoundAssembly ? pBoundAssembly->GetPEImage() : NULL;
+    if (pPEImage != NULL)
     {
         _ASSERTE(pPEImage->CheckUniqueInstance());
         pPEImage->AddRef();
@@ -704,21 +701,9 @@ PEAssembly::PEAssembly(
 
     // Set the host assembly and binding context as the AssemblySpec initialization
     // for CoreCLR will expect to have it set.
-    if (pHostAssembly != nullptr)
+    if (pBoundAssembly != nullptr)
     {
-        m_pHostAssembly = clr::SafeAddRef(pHostAssembly);
-    }
-
-    if(pBindResultInfo != nullptr)
-    {
-        // Cannot have both pHostAssembly and a coreclr based bind
-        _ASSERTE(pHostAssembly == nullptr);
-        pBindResultInfo = clr::SafeAddRef(pBindResultInfo);
-        m_pHostAssembly = pBindResultInfo;
-    }
-
-    if (m_pHostAssembly != nullptr)
-    {
+        m_pHostAssembly = clr::SafeAddRef(pBoundAssembly);
         m_pAssemblyBinder = m_pHostAssembly->GetBinder();
     }
     else
@@ -732,24 +717,6 @@ PEAssembly::PEAssembly(
 #endif // LOGGING
 }
 #endif // !DACCESS_COMPILE
-
-
-PEAssembly *PEAssembly::Open(
-    PEImage *          pPEImageIL,
-    BINDER_SPACE::Assembly * pHostAssembly)
-{
-    STANDARD_VM_CONTRACT;
-
-    PEAssembly * pPEAssembly = new PEAssembly(
-        nullptr,        // BindResult
-        nullptr,        // IMetaDataEmit
-        FALSE,          // isSystem
-        nullptr,        // DynamicAssemblyBinder
-        pPEImageIL,
-        pHostAssembly);
-
-    return pPEAssembly;
-}
 
 
 PEAssembly::~PEAssembly()
@@ -831,9 +798,9 @@ PEAssembly *PEAssembly::DoOpenSystem()
     return new PEAssembly(pBoundAssembly, NULL, TRUE);
 }
 
-PEAssembly* PEAssembly::Open(BINDER_SPACE::Assembly* pBindResult)
+PEAssembly* PEAssembly::Open(BINDER_SPACE::Assembly* pBoundAssembly)
 {
-    return new PEAssembly(pBindResult,NULL,/*isSystem*/ false);
+    return new PEAssembly(pBoundAssembly, NULL, /*isSystem*/ false);
 };
 
 /* static */

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -641,28 +641,33 @@ ULONG PEAssembly::GetPEImageTimeDateStamp()
 PEAssembly::PEAssembly(
                 BINDER_SPACE::Assembly* pBoundAssembly,
                 IMetaDataEmit* pEmit,
-                BOOL isSystem,
+                bool isSystem,
                 AssemblyBinder* pDynamicAssemblyBinder /*= NULL*/)
+    :
+#ifdef LOGGING
+      m_pDebugName{NULL},
+#endif // LOGGING
+      m_PEImage{NULL}
+    , m_MDImportIsRW_Debugger_Use_Only{FALSE}
+    , m_pMDImport{NULL}
+    , m_pImporter{NULL}
+    , m_pEmitter{NULL}
+    , m_refCount{1}
+    , m_isSystem{isSystem}
+    , m_pHostAssembly{nullptr}
+    , m_pAssemblyBinder{nullptr}
 {
     CONTRACTL
     {
-        PRECONDITION(CheckPointer(pEmit, NULL_OK));
+        // A PEAssembly is either bound by an AssemblyBinder or dynamic (reflection emit)
+        PRECONDITION((pBoundAssembly == NULL) != (pEmit == NULL));
+        // Only a bound assembly can be System.Private.CoreLib.
+        PRECONDITION(pEmit == NULL || !isSystem);
+        // A bound assembly takes its binder from the bind result, not from a caller.
+        PRECONDITION(pBoundAssembly == NULL || pDynamicAssemblyBinder == NULL);
         STANDARD_VM_CHECK;
     }
     CONTRACTL_END;
-
-#ifdef LOGGING
-    m_pDebugName = NULL;
-#endif // LOGGING
-    m_PEImage = NULL;
-    m_MDImportIsRW_Debugger_Use_Only = FALSE;
-    m_pMDImport = NULL;
-    m_pImporter = NULL;
-    m_pEmitter = NULL;
-    m_refCount = 1;
-    m_isSystem = isSystem;
-    m_pHostAssembly = nullptr;
-    m_pAssemblyBinder = nullptr;
 
     PEImage* pPEImage = pBoundAssembly ? pBoundAssembly->GetPEImage() : NULL;
     if (pPEImage != NULL)
@@ -795,7 +800,7 @@ PEAssembly *PEAssembly::DoOpenSystem()
     ReleaseHolder<BINDER_SPACE::Assembly> pBoundAssembly;
     IfFailThrow(GetAppDomain()->GetDefaultBinder()->BindToSystem(&pBoundAssembly));
 
-    return new PEAssembly(pBoundAssembly, NULL, TRUE);
+    return new PEAssembly(pBoundAssembly, NULL, /*isSystem*/ true);
 }
 
 PEAssembly* PEAssembly::Open(BINDER_SPACE::Assembly* pBoundAssembly)
@@ -817,7 +822,7 @@ PEAssembly *PEAssembly::Create(IMetaDataAssemblyEmit *pAssemblyEmit, AssemblyBin
     // we have.)
     ReleaseHolder<IMetaDataEmit> pEmit;
     pAssemblyEmit->QueryInterface(IID_IMetaDataEmit, (void **)&pEmit);
-    return new PEAssembly(NULL, pEmit, FALSE, pDynamicAssemblyBinder);
+    return new PEAssembly(NULL, pEmit, /*isSystem*/ false, pDynamicAssemblyBinder);
 }
 
 #endif // #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -641,7 +641,6 @@ ULONG PEAssembly::GetPEImageTimeDateStamp()
 PEAssembly::PEAssembly(
                 BINDER_SPACE::Assembly* pBoundAssembly,
                 IMetaDataEmit* pEmit,
-                bool isSystem,
                 AssemblyBinder* pDynamicAssemblyBinder /*= NULL*/)
     :
 #ifdef LOGGING
@@ -653,7 +652,6 @@ PEAssembly::PEAssembly(
     , m_pImporter{NULL}
     , m_pEmitter{NULL}
     , m_refCount{1}
-    , m_isSystem{isSystem}
     , m_pHostAssembly{nullptr}
     , m_pAssemblyBinder{nullptr}
 {
@@ -661,8 +659,6 @@ PEAssembly::PEAssembly(
     {
         // A PEAssembly is either bound by an AssemblyBinder or dynamic (reflection emit)
         PRECONDITION((pBoundAssembly == NULL) != (pEmit == NULL));
-        // Only a bound assembly can be System.Private.CoreLib.
-        PRECONDITION(pEmit == NULL || !isSystem);
         // A bound assembly takes its binder from the bind result, not from a caller.
         PRECONDITION(pBoundAssembly == NULL || pDynamicAssemblyBinder == NULL);
         STANDARD_VM_CHECK;
@@ -800,12 +796,12 @@ PEAssembly *PEAssembly::DoOpenSystem()
     ReleaseHolder<BINDER_SPACE::Assembly> pBoundAssembly;
     IfFailThrow(GetAppDomain()->GetDefaultBinder()->BindToSystem(&pBoundAssembly));
 
-    return new PEAssembly(pBoundAssembly, NULL, /*isSystem*/ true);
+    return new PEAssembly(pBoundAssembly, NULL);
 }
 
 PEAssembly* PEAssembly::Open(BINDER_SPACE::Assembly* pBoundAssembly)
 {
-    return new PEAssembly(pBoundAssembly, NULL, /*isSystem*/ false);
+    return new PEAssembly(pBoundAssembly, NULL);
 };
 
 /* static */
@@ -822,7 +818,7 @@ PEAssembly *PEAssembly::Create(IMetaDataAssemblyEmit *pAssemblyEmit, AssemblyBin
     // we have.)
     ReleaseHolder<IMetaDataEmit> pEmit;
     pAssemblyEmit->QueryInterface(IID_IMetaDataEmit, (void **)&pEmit);
-    return new PEAssembly(NULL, pEmit, /*isSystem*/ false, pDynamicAssemblyBinder);
+    return new PEAssembly(NULL, pEmit, pDynamicAssemblyBinder);
 }
 
 #endif // #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -50,9 +50,7 @@ typedef DPTR(PEAssembly) PTR_PEAssembly;
 // --------------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------------
-// A PEAssembly is an input to the CLR loader.  It is produced as a result of
-// binding, usually through fusion (although there are a few less common methods to
-// obtain one which do not go through fusion, e.g. IJW loads)
+// A PEAssembly is an input to the CLR loader. It is produced as a result of binding.
 //
 // Although a PEAssembly is usually a disk based PE file, it is not
 // always the case. Thus it is a conscious decision to not export access to the PE
@@ -151,7 +149,7 @@ public:
     // Classification
     // ------------------------------------------------------------
 
-    BOOL IsSystem() const;
+    bool IsSystem() const;
     BOOL IsReflectionEmit() const;
 
     // ------------------------------------------------------------
@@ -354,7 +352,7 @@ private:
     PEAssembly(
         BINDER_SPACE::Assembly* pBoundAssembly,
         IMetaDataEmit* pEmit,
-        BOOL isSystem,
+        bool isSystem,
         AssemblyBinder* pDynamicAssemblyBinder = NULL
     );
 

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -321,14 +321,10 @@ public:
     // Creation entry points
     // ------------------------------------------------------------
 
-    static PEAssembly* Open(
-        PEImage* pPEImageIL,
-        BINDER_SPACE::Assembly* pHostAssembly);
-
     // This opens the canonical System.Private.CoreLib.dll
     static PEAssembly* OpenSystem();
 
-    static PEAssembly* Open(BINDER_SPACE::Assembly* pBindResult);
+    static PEAssembly* Open(BINDER_SPACE::Assembly* pBoundAssembly);
 
     static PEAssembly* Create(IMetaDataAssemblyEmit* pEmit, AssemblyBinder* pDynamicAssemblyBinder);
 
@@ -356,12 +352,10 @@ private:
     PEAssembly() = default;
 #else
     PEAssembly(
-        BINDER_SPACE::Assembly* pBindResultInfo,
+        BINDER_SPACE::Assembly* pBoundAssembly,
         IMetaDataEmit* pEmit,
         BOOL isSystem,
-        AssemblyBinder* pDynamicAssemblyBinder = NULL,
-        PEImage* pPEImageIL = NULL,
-        BINDER_SPACE::Assembly* pHostAssembly = NULL
+        AssemblyBinder* pDynamicAssemblyBinder = NULL
     );
 
     ~PEAssembly();

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -325,7 +325,7 @@ private:
 
 #ifdef DACCESS_COMPILE
     // just to make the DAC and GCC happy.
-    ~PEAssembly() {};
+    ~PEAssembly() = default;
     PEAssembly() = default;
 #else
     PEAssembly(

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -19,17 +19,8 @@
 #include "sstring.h"
 #include "peimage.h"
 #include "metadata.h"
-#include "corhlpr.h"
-#include "utilcode.h"
-#include "loaderheap.h"
-#include "sstring.h"
-#include "ex.h"
-#include "assemblyspecbase.h"
+#include "../binder/inc/assembly.hpp"
 #include "eecontract.h"
-#include "stackwalktypes.h"
-#include <specstrings.h>
-#include "slist.h"
-#include "eventtrace.h"
 
 #include "assemblybinderutil.h"
 
@@ -164,7 +155,6 @@ public:
     void GetMVID(GUID* pMvid);
     ULONG GetHashAlgId();
     HRESULT GetVersion(USHORT* pMajor, USHORT* pMinor, USHORT* pBuild, USHORT* pRevision);
-    BOOL IsStrongNamed();
     LPCUTF8 GetSimpleName();
     HRESULT GetScopeName(LPCUTF8 * pszName);
     const void *GetPublicKey(DWORD *pcbPK);

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -37,17 +37,8 @@
 // Forward declared classes
 // --------------------------------------------------------------------------------
 
-class Module;
-class EditAndContinueModule;
-
 class PEAssembly;
-class SimpleRWLock;
-
 typedef DPTR(PEAssembly) PTR_PEAssembly;
-
-// --------------------------------------------------------------------------------
-// Types
-// --------------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------------
 // A PEAssembly is an input to the CLR loader. It is produced as a result of binding.
@@ -57,23 +48,21 @@ typedef DPTR(PEAssembly) PTR_PEAssembly;
 // file directly; rather the specific information required should be provided via
 // individual query API.
 //
-// There are multiple "flavors" of PEAssemblies:
+// A PEAssembly is one of two kinds, distinguished by IsReflectionEmit():
 //
-// 1. HMODULE - these PE Files are loaded in response to "spontaneous" OS callbacks.
-//    These should only occur for .exe main modules and IJW dlls loaded via LoadLibrary
-//    or static imports in umnanaged code.
-//    These get their PEImage loaded directly in PEImage::CreateFromHMODULE(HMODULE hMod)
+// 1. Bound to a PE image - the result of an AssemblyBinder bind
+//    It holds the BINDER_SPACE::Assembly that the binder produced, and takes
+//    both its PEImage and its metadata from that bind result.
 //
-// 2. Assemblies loaded directly or indirectly by the managed code - these are the most
-//    common case.  A path is obtained from assembly binding and the result is loaded
-//    via PEImage:
-//      a. Display name loads - these are metadata-based binds
-//      b. Path loads - these are loaded from an explicit path
+//    The PEImage may come from:
+//      - File on disk - loaded via binding to an assembly name or an explicit path
+//      - Byte array - via an API such as AssemblyLoadContext.LoadFromStream
+//      - HMODULE - IJW module already loaded into memory by the OS (Windows)
+//    The source of the PEImage does not change the PEAssembly itself.
 //
-// 3. Byte arrays - loaded explicitly by user code.  These also go through PEImage.
-//
-// 4. Dynamic - these are not actual PE images at all, but are placeholders
-//    for reflection-based modules.
+// 2. Dynamic - a reflection emit assembly
+//    It has no PEImage. Its metadata comes from an IMetaDataEmit and it uses the binder
+//    of the assembly that created it.
 //
 // See also file:..\inc\corhdr.h#ManagedHeader for more on the format of managed images.
 // --------------------------------------------------------------------------------

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -331,7 +331,6 @@ private:
     PEAssembly(
         BINDER_SPACE::Assembly* pBoundAssembly,
         IMetaDataEmit* pEmit,
-        bool isSystem,
         AssemblyBinder* pDynamicAssemblyBinder = NULL
     );
 
@@ -381,7 +380,6 @@ private:
     IMetaDataEmit* m_pEmitter;
 
     Volatile<LONG>           m_refCount;
-    bool                     m_isSystem;
 
     PTR_BINDER_SPACE_Assembly m_pHostAssembly;
     PTR_AssemblyBinder m_pAssemblyBinder;

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -751,22 +751,6 @@ inline LPCSTR PEAssembly::GetSimpleName()
     return name;
 }
 
-inline BOOL PEAssembly::IsStrongNamed()
-{
-    CONTRACTL
-    {
-        THROWS;
-        WRAPPER(GC_NOTRIGGER);
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    DWORD flags = 0;
-    IfFailThrow(GetMDImport()->GetAssemblyProps(TokenFromRid(1, mdtAssembly), NULL, NULL, NULL, NULL, NULL, &flags));
-    return (flags & afPublicKey) != 0;
-}
-
-
 //---------------------------------------------------------------------------------------
 //
 // Check to see if this assembly has had its strong name signature verified yet.

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -221,7 +221,7 @@ inline LPCUTF8 PEAssembly::GetDebugName()
 // Classification
 // ------------------------------------------------------------
 
-inline BOOL PEAssembly::IsSystem() const
+inline bool PEAssembly::IsSystem() const
 {
     LIMITED_METHOD_CONTRACT;
     SUPPORTS_DAC;

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -226,7 +226,7 @@ inline bool PEAssembly::IsSystem() const
     LIMITED_METHOD_CONTRACT;
     SUPPORTS_DAC;
 
-    return m_isSystem;
+    return this == SystemDomain::SystemPEAssembly();
 }
 
 inline BOOL PEAssembly::IsReflectionEmit() const


### PR DESCRIPTION
A PEAssembly is either bound by an `AssemblyBinder` or dynamic (reflection emit). This is pretty unclear from the way the class can be created and the way it is documented.

- Remove redundant `PEAssembly::Open` and constructor parameters for associated PE image and host assembly. These were only used in one case - and they were derived from a bound assembly - which was equivalent to just passing in the bound assembly.
- Add asserts to the constructor around how its parameters should recommend either bound or dynamic.

cc @dotnet/appmodel @AaronRobinsonMSFT 