### PR TITLE
JIT: fold wasm local address frame offsets into store memargs

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1205,7 +1205,8 @@ protected:
     void genCodeForCpBlkUnroll(GenTreeBlk* cpBlkNode);
     void genCodeForPhysReg(GenTreePhysReg* tree);
 #ifdef TARGET_WASM
-    void genCodeForFrameSize(GenTree* tree);
+    void           genCodeForFrameSize(GenTree* tree);
+    cnsval_ssize_t genWasmMemargOffset(GenTree* addr);
 #endif // TARGET_WASM
 #ifdef SWIFT_SUPPORT
     void genCodeForSwiftErrorReg(GenTree* tree);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2715,7 +2715,11 @@ void CodeGen::genCodeForLclAddr(GenTreeLclFld* lclAddrNode)
     unsigned lclOffset = lclAddrNode->GetLclOffs();
 
     GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
-    if ((lclOffset != 0) || (m_compiler->lvaFrameAddress(lclNum, &FPBased) != 0))
+
+    // A folded address contributes its frame offset to the user's memarg instead.
+    //
+    if (((lclAddrNode->gtLIRFlags & LIR::Flags::FoldedAddr) == LIR::Flags::None) &&
+        ((lclOffset != 0) || (m_compiler->lvaFrameAddress(lclNum, &FPBased) != 0)))
     {
         GetEmitter()->emitIns_S(INS_I_const, EA_PTRSIZE, lclNum, lclOffset);
         GetEmitter()->emitIns(INS_I_add);
@@ -2936,6 +2940,35 @@ void CodeGen::genStoreIndTypeSimd12(GenTreeStoreInd* tree)
 }
 
 //------------------------------------------------------------------------
+// genWasmMemargOffset: Get the offset an indirection folds into its memarg.
+//
+// Arguments:
+//    addr - the address node of the indirection
+//
+// Return Value:
+//    The offset to encode in the memarg, or zero if the address carries no folded offset.
+//
+cnsval_ssize_t CodeGen::genWasmMemargOffset(GenTree* addr)
+{
+    if (addr->isContained() && addr->OperIs(GT_LEA))
+    {
+        return addr->AsAddrMode()->Offset();
+    }
+
+    if (addr->OperIs(GT_LCL_ADDR) && ((addr->gtLIRFlags & LIR::Flags::FoldedAddr) != LIR::Flags::None))
+    {
+        bool      FPBased;
+        const int offset = m_compiler->lvaFrameAddress(addr->AsLclFld()->GetLclNum(), &FPBased) +
+                           static_cast<int>(addr->AsLclFld()->GetLclOffs());
+        noway_assert(offset >= 0); // WASM address modes are unsigned.
+        assert(FPBased);
+        return offset;
+    }
+
+    return 0;
+}
+
+//------------------------------------------------------------------------
 // genCodeForIndir: Produce code for a GT_IND node.
 //
 // Arguments:
@@ -2959,13 +2992,7 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 
     // TODO-WASM: Memory barriers
 
-    if (addr->isContained() && addr->OperIs(GT_LEA))
-    {
-        // The contained address mode's offset folds into the memarg; its base is already pushed.
-        //
-        GetEmitter()->emitIns_I(ins_Load(type), emitActualTypeSize(type), addr->AsAddrMode()->Offset());
-    }
-    else if (addr->isContained())
+    if (addr->isContained() && !addr->OperIs(GT_LEA))
     {
         // A contained address constant folds into the memarg offset, so emit just the image base here.
         //
@@ -2981,7 +3008,9 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
     }
     else
     {
-        GetEmitter()->emitIns_I(ins_Load(type), emitActualTypeSize(type), 0);
+        // A contained address mode's offset or a folded local's frame offset supplies the memarg.
+        //
+        GetEmitter()->emitIns_I(ins_Load(type), emitActualTypeSize(type), genWasmMemargOffset(addr));
     }
 
     WasmProduceReg(tree);
@@ -2998,10 +3027,10 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GenTree* data = tree->Data();
     GenTree* addr = tree->Addr();
 
-    // Only a contained address mode is expected; its offset folds into the memarg below.
+    // A contained address mode's offset or a folded local's frame offset supplies the memarg.
     //
     assert(!addr->isContained() || addr->OperIs(GT_LEA));
-    const cnsval_ssize_t offset = addr->isContained() ? addr->AsAddrMode()->Offset() : 0;
+    const cnsval_ssize_t offset = genWasmMemargOffset(addr);
 
     // We must consume the operands in the proper execution order,
     // so that liveness is updated appropriately.

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -44,7 +44,11 @@ public:
 #ifdef TARGET_WASM
             MultiplyUsed = 0x08, // Set by lowering on nodes that the RA should allocate into
                                  // a dedicated register (WASM local), for multiple uses.
-#endif                           // TARGET_WASM
+
+            FoldedAddr = 0x10, // Set by lowering on a GT_LCL_ADDR whose frame offset is folded into
+                               // the memarg of the indirection using it. Codegen for such a node
+                               // emits just the frame pointer.
+#endif                         // TARGET_WASM
         };
     };
 

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -453,6 +453,7 @@ private:
 #ifdef TARGET_WASM
     static void      SetMultiplyUsed(GenTree* node DEBUGARG(const char* reason));
     GenTreeAddrMode* GetFoldableAddrMode(GenTreeIndir* indirNode);
+    void             TryFoldLclAddrOffset(GenTreeIndir* indirNode);
     GenTree*         LowerNeg(GenTreeOp* node);
     void             LowerIndexAddr(GenTreeIndexAddr* indexAddr);
     void             LowerCkfinite(GenTreeOp* node);

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -200,6 +200,38 @@ GenTreeAddrMode* Lowering::GetFoldableAddrMode(GenTreeIndir* indirNode)
 }
 
 //------------------------------------------------------------------------
+// TryFoldLclAddrOffset: Fold a local address's frame offset into its indirection's memarg.
+//
+// Arguments:
+//    indirNode - The indirection node of interest
+//
+// Notes:
+//    Codegen for GT_LCL_ADDR is "local.get $FP; i32.const <frame offset>; i32.add". Flagging the node makes
+//    it emit just the frame pointer, and the indirection supplies the frame offset as its memarg instead.
+//    The frame pointer plus a non-negative frame offset stays within the shadow stack, so the memarg's
+//    infinite-precision addition cannot differ from the "i32.add" it replaces.
+//
+//    SIMD12 indirections re-materialize the address for the trailing lane access, and a multiply-used
+//    address is read back from a wasm local that would no longer hold the full address, so neither folds.
+//
+//    Folding relies on the flagged node keeping its single use: because GT_LCL_ADDR is invariant, neither
+//    the stackifier ("CanMoveForward") nor "fgWasmSpillRefs" can replace it with a temporary.
+//
+void Lowering::TryFoldLclAddrOffset(GenTreeIndir* indirNode)
+{
+    GenTree* const addr = indirNode->Addr();
+
+    if (!indirNode->OperIs(GT_IND, GT_STOREIND) || !addr->OperIs(GT_LCL_ADDR) || indirNode->TypeIs(TYP_SIMD12) ||
+        ((addr->gtLIRFlags & LIR::Flags::MultiplyUsed) != LIR::Flags::None))
+    {
+        return;
+    }
+
+    assert(addr->IsInvariant());
+    addr->gtLIRFlags |= LIR::Flags::FoldedAddr;
+}
+
+//------------------------------------------------------------------------
 // LowerStoreIndir: Determine addressing mode for an indirection, and whether operands are contained.
 //
 // Arguments:
@@ -528,6 +560,10 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
     if (foldable != nullptr)
     {
         MakeSrcContained(indirNode, foldable);
+    }
+    else
+    {
+        TryFoldLclAddrOffset(indirNode);
     }
 
     // Contain a relocatable address constant so it folds into the load's memarg offset.

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -806,9 +806,6 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
     GenTree* value          = lclNode->Data();
     GenTree* insertionPoint = value->gtFirstNodeInOperandOrder();
 
-    // TODO-WASM-RA: figure out the address mode story here. Right now this will produce an address not folded
-    // into the store's address mode. We can utilize a contained LEA, but that will require some liveness work.
-
     var_types storeType = lclNode->TypeGet();
     // We can end up with a block copy operation storing a non-STRUCT into a STRUCT due to type erasure.
     if ((storeType == TYP_STRUCT) && lclNode->OperIsCopyBlkOp())


### PR DESCRIPTION
Stores to locals that are not register candidates are rewritten into STOREIND(GT_LCL_ADDR, value) by the wasm register allocator. Flag these during lowering when the indirection can handle the offset, so codegen emits just the frame pointer and the store adds the offset.

SPC R2R code section: 15,820,359 -> 14,953,402 bytes (-5.48%).