### PR TITLE
ILVerify: Use case-insensitive comparer for assembly binding cache

### DIFF
--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -18,7 +18,7 @@ namespace ILVerify
 {
     internal sealed class Program : IResolver
     {
-        private readonly Dictionary<string, PEReader> _resolverCache = new();
+        private readonly Dictionary<string, PEReader> _resolverCache = new(StringComparer.InvariantCultureIgnoreCase);
         private readonly ILVerifyRootCommand _command;
         private readonly Dictionary<string, string> _inputFilePaths; // map of simple name to file path
         private readonly Dictionary<string, string> _referenceFilePaths; // map of simple name to file path

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -18,7 +18,7 @@ namespace ILVerify
 {
     internal sealed class Program : IResolver
     {
-        private readonly Dictionary<string, PEReader> _resolverCache = new(StringComparer.InvariantCultureIgnoreCase);
+        private readonly Dictionary<string, PEReader> _resolverCache = new(StringComparer.OrdinalIgnoreCase);
         private readonly ILVerifyRootCommand _command;
         private readonly Dictionary<string, string> _inputFilePaths; // map of simple name to file path
         private readonly Dictionary<string, string> _referenceFilePaths; // map of simple name to file path


### PR DESCRIPTION
ILVerify assembly binding should runtime assembly binding that is case-insensitive.

This is fixing a non-obvious failure mode caused by mismatched casing for `--system-module` ILVerify argument. We ended up loading the system module multiple times with different casing.