### PR TITLE
Disable Runtime_129681 CrossGen2 testing

### DIFF
--- a/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
+++ b/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
@@ -3,6 +3,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+    <!-- CrossGen2 reserves 6 GiB for regions which exceeds the 64 MiB hard limit - https://github.com/dotnet/runtime/issues/132062 -->
+    <CrossGenTest>false</CrossGenTest>
 
     <CLRTestBatchPreCommands><![CDATA[
       $(CLRTestBatchPreCommands)


### PR DESCRIPTION
`Runtime_129681` configures a 64 MiB GC heap hard limit, but CrossGen2 reserves 6 GiB for regions. Opt the test out of CrossGen2 so R2R jobs still execute the regression without failing during ahead-of-time compilation.

Fixes #132062
Fixes #132037

## Validation

- `build.cmd clr+libs -lc release -rc checked`: succeeded with 0 warnings and 0 errors.
- `src\tests\build.cmd -Test GC\Regressions\Github\Runtime_129681\Runtime_129681.csproj x64 checked -Priority 1`: succeeded with 0 warnings and 0 errors.
- Ran the generated wrapper with `RunCrossGen2=1`: the test passed (`Expected: 100`, `Actual: 100`), the script contained no Crossgen2 compiler or `IL-CG2` compilation commands, and no `IL-CG2` directory was created.

Replacing `DOTNET_GCStress=0xC` with `DOTNET_gcConcurrent=0` could be investigated separately because this regression only needs concurrent GC disabled. That may address the plain macOS startup failure in #132045; this PR does not claim to fix it.

> [!NOTE]
> This PR description was generated with GitHub Copilot.