### PR TITLE
[testing] Run CoreCLR libraries on iOS for #131922

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -11,7 +11,7 @@ parameters:
 jobs:
 
 #
-# iOS
+# tvOS
 # Build the whole product using Native AOT and run libraries tests
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -23,7 +23,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      - tvos_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -79,7 +79,7 @@ jobs:
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
-# iOS
+# tvOS
 # Build the whole product using CoreCLR and run runtime tests
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -91,7 +91,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      - tvos_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource
@@ -122,7 +122,7 @@ jobs:
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
-# iOS
+# tvOS
 # Build the whole product using CoreCLR and run libraries smoke tests (Checked)
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -134,7 +134,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      - tvos_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -11,7 +11,7 @@ parameters:
 jobs:
 
 #
-# tvOS
+# iOS
 # Build the whole product using Native AOT and run libraries tests
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -23,7 +23,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - tvos_arm64
+      - ios_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -44,7 +44,7 @@ jobs:
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
-# tvOS
+# iOS
 # Build the whole product using CoreCLR and run libraries tests
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -56,7 +56,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - tvos_arm64
+      - ios_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -79,7 +79,7 @@ jobs:
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
-# tvOS
+# iOS
 # Build the whole product using CoreCLR and run runtime tests
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -91,7 +91,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - tvos_arm64
+      - ios_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource
@@ -122,7 +122,7 @@ jobs:
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
-# tvOS
+# iOS
 # Build the whole product using CoreCLR and run libraries smoke tests (Checked)
 #
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -134,7 +134,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - tvos_arm64
+      - ios_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -225,10 +225,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\tests\System.Reflection.MetadataLoadContext.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetOS)' == 'ios' and '$(RunDisablediOSTests)' != 'true'">
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetOS)' == 'tvos' and '$(RunDisablediOSTests)' != 'true'">
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.Emit\tests\System.Reflection.Emit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj" />


### PR DESCRIPTION
## Summary

- Switch the Release CoreCLR libraries leg in `runtime-extra-platforms-ioslike.yml` from physical tvOS arm64 to physical iOS arm64.
- Remove the broad physical-iOS library-test exclusion so the leg builds the normal library test set, including `System.Net.Security.Unit.Tests`. Existing Apple-mobile test-specific exclusions remain in effect.

The NativeAOT, runtime-test, and Checked smoke legs remain on tvOS.

This is a diagnostic draft and is not intended to merge as-is.

> [!NOTE]
> This draft PR was prepared with GitHub Copilot assistance.