### PR TITLE
DispatchResolve: Avoid clobbering t1 in RhpInterfaceDispatch

### DIFF
--- a/src/coreclr/nativeaot/Runtime/riscv64/DispatchResolve.S
+++ b/src/coreclr/nativeaot/Runtime/riscv64/DispatchResolve.S
@@ -19,7 +19,9 @@ LEAF_ENTRY RhpInterfaceDispatch, _TEXT
         //  t1: parameter of the thunk's target
         PREPARE_EXTERNAL_VAR RhpCidResolve, t0
         mv      t1, t5
-        tail    C_FUNC(RhpUniversalTransitionTailCall)
+1:
+        auipc   t2, %pcrel_hi(C_FUNC(RhpUniversalTransitionTailCall))
+        jalr    x0, t2, %pcrel_lo(1b)
 
 LEAF_END RhpInterfaceDispatch, _TEXT
 


### PR DESCRIPTION
The `tail` pseudo-instruction expands to auipc t1 + jalr t1, which destroys the dispatch cell address just placed in t1 as the thunk target's parameter. Perform the tail jump manually through t2 instead, matching what RhpInterfaceDispatchSlow does in StubDispatch.S.