### PR TITLE
Fix interpreter delegate calls through shuffle thunks

### DIFF
--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2408,12 +2408,11 @@ MethodDesc* NonVirtualEntry2MethodDesc(PCODE entryPoint)
         if (pPrecode == NULL)
             return NULL;
 #endif
-        StubCodeBlockKind codeBlockKind = pRS->_pRangeList->GetCodeBlockKind();
-        if (codeBlockKind == STUB_CODE_BLOCK_FIXUPPRECODE)
+        if (pRS->_pRangeList->GetCodeBlockKind() == STUB_CODE_BLOCK_FIXUPPRECODE)
         {
             return dac_cast<PTR_MethodDesc>(pPrecode->AsFixupPrecode()->GetMethodDesc());
         }
-        if (codeBlockKind == STUB_CODE_BLOCK_STUBPRECODE)
+        if (pRS->_pRangeList->GetCodeBlockKind() == STUB_CODE_BLOCK_STUBPRECODE)
         {
             return dac_cast<PTR_MethodDesc>(pPrecode->AsStubPrecode()->GetMethodDesc());
         }
@@ -2423,19 +2422,8 @@ MethodDesc* NonVirtualEntry2MethodDesc(PCODE entryPoint)
         MethodDesc* pMD;
         if (pRS->_pjit->JitCodeToMethodInfo(pRS, entryPoint, &pMD, NULL))
             return pMD;
-
-        // These stubs don't have a corresponding method by design
-        StubCodeBlockKind codeBlockKind = pRS->_pjit->GetStubCodeBlockKind(pRS, entryPoint);
-        if (codeBlockKind == STUB_CODE_BLOCK_WRAPPER_STUB ||
-            codeBlockKind == STUB_CODE_BLOCK_SHUFFLE_THUNK)
-        {
-            return NULL;
-        }
     }
 
-
-    // We should never get here
-    _ASSERTE(!"NonVirtualEntry2MethodDesc failed");
     return NULL;
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 }

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2408,11 +2408,12 @@ MethodDesc* NonVirtualEntry2MethodDesc(PCODE entryPoint)
         if (pPrecode == NULL)
             return NULL;
 #endif
-        if (pRS->_pRangeList->GetCodeBlockKind() == STUB_CODE_BLOCK_FIXUPPRECODE)
+        StubCodeBlockKind codeBlockKind = pRS->_pRangeList->GetCodeBlockKind();
+        if (codeBlockKind == STUB_CODE_BLOCK_FIXUPPRECODE)
         {
             return dac_cast<PTR_MethodDesc>(pPrecode->AsFixupPrecode()->GetMethodDesc());
         }
-        if (pRS->_pRangeList->GetCodeBlockKind() == STUB_CODE_BLOCK_STUBPRECODE)
+        if (codeBlockKind == STUB_CODE_BLOCK_STUBPRECODE)
         {
             return dac_cast<PTR_MethodDesc>(pPrecode->AsStubPrecode()->GetMethodDesc());
         }
@@ -2422,7 +2423,16 @@ MethodDesc* NonVirtualEntry2MethodDesc(PCODE entryPoint)
         MethodDesc* pMD;
         if (pRS->_pjit->JitCodeToMethodInfo(pRS, entryPoint, &pMD, NULL))
             return pMD;
+
+        // These stubs don't have a corresponding method by design
+        StubCodeBlockKind codeBlockKind = pRS->_pjit->GetStubCodeBlockKind(pRS, entryPoint);
+        if (codeBlockKind == STUB_CODE_BLOCK_WRAPPER_STUB ||
+            codeBlockKind == STUB_CODE_BLOCK_SHUFFLE_THUNK)
+        {
+            return NULL;
+        }
     }
+
 
     // We should never get here
     _ASSERTE(!"NonVirtualEntry2MethodDesc failed");


### PR DESCRIPTION
StubLinker-generated wrapper and shuffle stubs are now tracked by the JIT code manager. NonVirtualEntry2MethodDesc can therefore find their code ranges even though they do not map directly to managed method bodies. The assertion path was hit from the interpreter delegate dispatch, passing an address to a shuffle thunk. https://github.com/dotnet/runtime/blob/643b8962835e549e8f6c88fd8b19f6f79685fba0/src/coreclr/vm/interpexec.cpp#L3503

Recognize these stub block kinds and return null so callers use their existing non-method fallback path. Fixes assertions on the interpreter pipelines

```
ASSERT FAILED
	Expression: !"NonVirtualEntry2MethodDesc failed"
	Location:   /__w/1/s/src/coreclr/vm/method.cpp:2428
	Function:   NonVirtualEntry2MethodDesc
	Process:    90146
```

Regressed after https://github.com/dotnet/runtime/pull/131903