### PR TITLE
Enable hardware intrinsics for ExtractMostSignificantBits test

### DIFF
--- a/src/tests/JIT/opt/InstructionCombining/ExtractMostSignificantBits.csproj
+++ b/src/tests/JIT/opt/InstructionCombining/ExtractMostSignificantBits.csproj
@@ -13,5 +13,6 @@
     </Compile>
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
     <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_EnableHWIntrinsic" Value="1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Force `DOTNET_EnableHWIntrinsic=1` for the `ExtractMostSignificantBits` test. Its disasm assertions validate ARM64 hardware-intrinsic codegen and cannot be satisfied by the `jitstress_isas_nohwintrinsic` configuration.

Fixes #132106

> [!NOTE]
> This pull request was created with GitHub Copilot.