### PR TITLE
Enable Helix job monitor across test pipelines

### DIFF
--- a/eng/pipelines/common/templates/wasi-wasm-coreclr-library-tests.yml
+++ b/eng/pipelines/common/templates/wasi-wasm-coreclr-library-tests.yml
@@ -9,6 +9,7 @@ parameters:
   scenarios: ['WasmTestOnWasmtime']
   shouldContinueOnError: false
   shouldRunSmokeOnly: false
+  useHelixMonitor: false
 
 jobs:
 
@@ -84,3 +85,4 @@ jobs:
             testRunNamePrefixSuffix: CoreCLR_WASI_$(_BuildConfig)
             extraHelixArguments: $(_wasmRunSmokeTestsOnlyArg) ${{ parameters.extraHelixArguments }}
             scenarios: ${{ parameters.scenarios }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}

--- a/eng/pipelines/common/templates/wasi-wasm-coreclr-runtime-tests.yml
+++ b/eng/pipelines/common/templates/wasi-wasm-coreclr-runtime-tests.yml
@@ -4,6 +4,7 @@ parameters:
   isWasmOnlyBuild: false
   platforms: []
   extraBuildArgs: ''
+  useHelixMonitor: false
 
 jobs:
 
@@ -53,6 +54,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_WASI_$(_BuildConfig)
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             # Curated test-tree subset -- expand as gates stabilize.
             testBuildArgs: >-
               -priority1

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -31,6 +31,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -39,6 +41,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       #
       # Debug builds
@@ -170,6 +177,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
@@ -186,6 +194,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
@@ -210,6 +219,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             readyToRun: true
             displayNameArgs: R2R_CG2

--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -2,6 +2,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -10,6 +12,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -66,6 +73,7 @@ extends:
           - windows_x64
           - windows_arm64
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: innerloop
             readyToRun: true
             compositeBuildMode: true
@@ -83,6 +91,7 @@ extends:
           - linux_x64
           - windows_x64
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: innerloop
             readyToRun: true
             compositeBuildMode: true

--- a/eng/pipelines/coreclr/crossgen2-gcstress.yml
+++ b/eng/pipelines/coreclr/crossgen2-gcstress.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -72,6 +79,7 @@ extends:
           - windows_x64
           - windows_arm64
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: gcstress-extra
             readyToRun: true
             compositeBuildMode: true

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -75,6 +82,7 @@ extends:
           - windows_x64
           - windows_arm64
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             readyToRun: true
             compositeBuildMode: true
@@ -92,6 +100,7 @@ extends:
           - linux_x64
           - windows_x64
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             readyToRun: true
             compositeBuildMode: true
@@ -116,6 +125,7 @@ extends:
           - windows_x64
           - windows_x86
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             readyToRun: true
             displayNameArgs: R2R

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -75,6 +82,7 @@ extends:
             displayNameArgs: R2R_CG2
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -98,6 +106,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: TestReadyToRun_$(_BuildConfig)
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Run pri0 tests with hot/cold splitting enabled (only supported on x64 at the moment)
       # TODO: test on arm64 once supported
@@ -117,3 +126,4 @@ extends:
             displayNameArgs: R2R_CG2_HotColdSplitting
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/coreclr/gc-longrunning.yml
+++ b/eng/pipelines/coreclr/gc-longrunning.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -68,6 +75,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: gc-longrunning
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)

--- a/eng/pipelines/coreclr/gc-simulator.yml
+++ b/eng/pipelines/coreclr/gc-simulator.yml
@@ -12,6 +12,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -20,6 +22,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -72,6 +79,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: gc-simulator
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)

--- a/eng/pipelines/coreclr/gc-standalone.yml
+++ b/eng/pipelines/coreclr/gc-standalone.yml
@@ -12,6 +12,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -20,6 +22,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -69,6 +76,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: gc-standalone
             displayNameArgs: GCStandAlone
             liveLibrariesBuildConfig: Release
@@ -86,6 +94,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: gc-standalone-server
             displayNameArgs: GCStandAloneServer
             liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/gcstress-extra.yml
+++ b/eng/pipelines/coreclr/gcstress-extra.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -67,6 +74,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: gcstress-extra
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)

--- a/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -67,6 +74,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: gcstress0x3-gcstress0xc
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)

--- a/eng/pipelines/coreclr/hardware-intrinsics-arm64.yml
+++ b/eng/pipelines/coreclr/hardware-intrinsics-arm64.yml
@@ -14,6 +14,8 @@ pr:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -23,8 +25,15 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/coreclr/templates/jit-hardware-intrinsics-common.yml
         parameters:
           platforms:
             - linux_arm64
           testBuildArgs: '-tree:JIT/HardwareIntrinsics'
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/coreclr/hardware-intrinsics.yml
+++ b/eng/pipelines/coreclr/hardware-intrinsics.yml
@@ -15,6 +15,8 @@ pr:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -24,12 +26,19 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/coreclr/templates/jit-hardware-intrinsics-common.yml
         parameters:
           platforms:
             - windows_x86
             - windows_x64
           testBuildArgs: 'tree JIT/HardwareIntrinsics'
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       - template: /eng/pipelines/coreclr/templates/jit-hardware-intrinsics-common.yml
         parameters:
@@ -38,3 +47,4 @@ extends:
             - linux_x64
             - osx_arm64
           testBuildArgs: '-tree:JIT/HardwareIntrinsics'
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/coreclr/interpreter.yml
+++ b/eng/pipelines/coreclr/interpreter.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       #
       # Checked builds
@@ -85,6 +92,7 @@ extends:
             - name: timeoutPerTestCollectionInMinutes
               value: 180
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             runInterpreter: true
             liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/libraries-gcstress-extra.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress-extra.yml
@@ -11,6 +11,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -19,6 +21,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -36,6 +43,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                     - heapverify1
                     - gcstress0xc_disabler2r

--- a/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
@@ -11,6 +11,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -25,6 +27,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -42,6 +49,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                     # Disable gcstress0x3 for now; it causes lots of test timeouts. Investigate this after
                     # gcstress0xc runs are clean. Tracking issue: https://github.com/dotnet/runtime/issues/38903.

--- a/eng/pipelines/coreclr/libraries-interpreter.yml
+++ b/eng/pipelines/coreclr/libraries-interpreter.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -37,5 +44,6 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                   - interpmode1

--- a/eng/pipelines/coreclr/libraries-jitstress-random.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress-random.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -41,6 +48,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                     - jitstress_random_1
                     - jitstress_random_2

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -41,6 +48,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                     - no_tiered_compilation
                     - jitminopts

--- a/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -41,6 +48,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                     - jitstress2_jitstressregs1
                     - jitstress2_jitstressregs2

--- a/eng/pipelines/coreclr/libraries-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstressregs.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -41,6 +48,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                     - jitstressregs1
                     - jitstressregs2

--- a/eng/pipelines/coreclr/libraries-pgo.yml
+++ b/eng/pipelines/coreclr/libraries-pgo.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -36,6 +43,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                     - defaultpgo
 
@@ -60,6 +68,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                     - defaultpgo
                     - fullpgo

--- a/eng/pipelines/coreclr/r2r-extra.yml
+++ b/eng/pipelines/coreclr/r2r-extra.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -67,6 +74,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: r2r-extra
             readyToRun: true
             displayNameArgs: R2R

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -12,6 +12,8 @@ pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -20,6 +22,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -75,6 +82,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             readyToRun: true
             displayNameArgs: R2R

--- a/eng/pipelines/coreclr/release-tests.yml
+++ b/eng/pipelines/coreclr/release-tests.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 720
+          allowNoHelixJobs: true
 
       #
       # Release CoreCLR and Library builds
@@ -76,6 +83,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
@@ -91,9 +99,9 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             liveLibrariesBuildConfig: Release
             readyToRun: true
             displayNameArgs: R2R
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-

--- a/eng/pipelines/coreclr/runincontext.yml
+++ b/eng/pipelines/coreclr/runincontext.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -65,6 +72,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             runInUnloadableContext: true
             displayNameArgs: RunInContext

--- a/eng/pipelines/coreclr/runtime-nativeaot-outerloop.yml
+++ b/eng/pipelines/coreclr/runtime-nativeaot-outerloop.yml
@@ -37,6 +37,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -45,6 +47,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       #
       # CoreCLR NativeAOT release build and libraries tests
@@ -79,6 +86,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       #
       # CoreCLR NativeAOT release build (checked runtime) and libraries tests
@@ -104,6 +112,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: NativeAOT_Checked_$(_BuildConfig)
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       #
       # CoreCLR NativeAOT release build (checked runtime) - SizeOpt and libraries tests
@@ -129,6 +138,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: NativeAOT_Checked_SizeOpt_$(_BuildConfig)
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       #
       # CoreCLR NativeAOT release build (checked runtime) - SpeedOpt and libraries tests
@@ -154,6 +164,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: NativeAOT_Checked_SpeedOpt_$(_BuildConfig)
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       #
       # CoreCLR NativeAOT checked build and Pri1 tests
@@ -184,6 +195,7 @@ extends:
                   creator: dotnet-bot
                   testBuildArgs: 'nativeaot /p:IlcUseServerGc=false'
                   liveLibrariesBuildConfig: Release
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testRunNamePrefixSuffix: NativeAOT_Pri1_$(_BuildConfig)
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
@@ -218,6 +230,7 @@ extends:
                   creator: dotnet-bot
                   testBuildArgs: 'nativeaot /p:IlcUseServerGc=false /p:ControlFlowGuard=Guard'
                   liveLibrariesBuildConfig: Release
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testRunNamePrefixSuffix: NativeAOT_Pri0_CET_CFG_$(_BuildConfig)
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
@@ -251,6 +264,7 @@ extends:
                   creator: dotnet-bot
                   testBuildArgs: 'nativeaot /p:IlcUseServerGc=false /p:ControlFlowGuard=Guard'
                   liveLibrariesBuildConfig: Release
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testRunNamePrefixSuffix: NativeAOT_Pri0_CFG_$(_BuildConfig)
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/eng/pipelines/coreclr/templates/jit-hardware-intrinsics-common.yml
+++ b/eng/pipelines/coreclr/templates/jit-hardware-intrinsics-common.yml
@@ -3,6 +3,9 @@ parameters:
     type: object
   - name: testBuildArgs
     type: string
+  - name: useHelixMonitor
+    type: boolean
+    default: false
 
 jobs:
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -30,6 +33,7 @@ jobs:
             creator: dotnet-bot
             testBuildArgs: ${{ parameters.testBuildArgs }}
             testRunNamePrefixSuffix: CoreCLR
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
           parameters:
@@ -61,6 +65,7 @@ jobs:
             testBuildArgs: nativeaot ${{ parameters.testBuildArgs }}
             testRunNamePrefixSuffix: NativeAOT
             nativeAotTest: true
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
           parameters:

--- a/eng/pipelines/coreclr/tieringtest.yml
+++ b/eng/pipelines/coreclr/tieringtest.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -65,6 +72,7 @@ extends:
           helixQueueGroup: ci
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: outerloop
             tieringTest: true
             displayNameArgs: TieringTest

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -41,6 +41,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
 #
 # Android arm64 devices and x64 emulators
@@ -72,3 +73,4 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -46,6 +46,7 @@ jobs:
             creator: dotnet-bot
             testBuildArgs: nativeaot tree nativeaot/SmokeTests /p:BuildNativeAOTRuntimePack=true
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
@@ -85,6 +86,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
 #
 # Android emulators
@@ -116,6 +118,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
 #
 # Android arm64 devices and x64 emulators
@@ -149,3 +152,4 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -41,6 +41,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -76,6 +77,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -119,6 +121,7 @@ jobs:
             creator: dotnet-bot
             testBuildArgs: /p:DevTeamProvisioning=- /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -154,4 +157,5 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -42,6 +42,7 @@ jobs:
             creator: dotnet-bot
             interpreter: true
             testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
 #
 # iOSSimulator
@@ -75,6 +76,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -111,6 +113,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -154,6 +157,7 @@ jobs:
             creator: dotnet-bot
             testBuildArgs: /p:DevTeamProvisioning=- /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -189,4 +193,5 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
@@ -42,6 +42,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -75,6 +76,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -111,6 +113,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -154,6 +157,7 @@ jobs:
             creator: dotnet-bot
             testBuildArgs: /p:DevTeamProvisioning=- /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -190,6 +194,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -225,4 +230,5 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -35,6 +35,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Libraries_Release_CoreCLR
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       condition: >-
         or(
@@ -59,6 +60,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NET481_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraHelixArguments: /p:BuildTargetFramework=net481
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       condition: >-
@@ -103,6 +105,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             condition: >-
               or(
               eq(variables['librariesContainsChange'], true),
@@ -146,6 +149,7 @@ jobs:
             creator: dotnet-bot
             llvmAotStepContainer: linux_x64
             testRunNamePrefixSuffix: Mono_Release
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
@@ -184,6 +188,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_Release
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
@@ -221,5 +226,6 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_Release
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -32,6 +32,7 @@ jobs:
       buildAOTOnHelix: false
       shouldRunSmokeOnly: true
       alwaysRun: true
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
   # AOT Library tests - wasi_wasm
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -56,6 +57,7 @@ jobs:
       buildAOTOnHelix: false
       runAOT: true
       alwaysRun: true
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
 #
 # ********** For !rolling builds, IOW - PR builds *************
@@ -73,6 +75,7 @@ jobs:
       extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
       scenarios:
         - WasmTestOnChrome
 
@@ -104,6 +107,7 @@ jobs:
       buildAOTOnHelix: false
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
   # AOT Library tests - browser_wasm
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -119,6 +123,7 @@ jobs:
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
   # AOT Library tests - wasi_wasm
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -147,6 +152,7 @@ jobs:
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
   # Wasi - run only smoke tests by default
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
@@ -222,6 +228,7 @@ jobs:
       # The CoreCLR build-only job above stages the CoreCLR runtime pack for the
       # wasm-tools workload install.
       includeCoreClrRuntimePack: true
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
   - template: /eng/pipelines/common/templates/simple-wasm-build-tests.yml
     parameters:
@@ -231,6 +238,7 @@ jobs:
       extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
   - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
     parameters:
@@ -239,6 +247,7 @@ jobs:
       extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
 - ${{ if and(ne(parameters.isRollingBuild, true), ne(parameters.excludeOptional, true)) }}:
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
@@ -252,5 +261,6 @@ jobs:
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
       scenarios:
         - WasmTestOnWasmtime

--- a/eng/pipelines/libraries/outerloop-mono.yml
+++ b/eng/pipelines/libraries/outerloop-mono.yml
@@ -10,6 +10,8 @@ schedules:
 
 variables:
   - template: variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -18,6 +20,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+        - template: /eng/common/core-templates/job/helix-job-monitor.yml
+          parameters:
+            helixAccessToken: $(HelixApiAccessToken)
+            timeoutInMinutes: 540
+            allowNoHelixJobs: true
 
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -47,6 +54,7 @@ extends:
                     testScope: outerloop
                     creator: dotnet-bot
                     testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                    useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -71,3 +79,4 @@ extends:
                     testScope: outerloop
                     creator: dotnet-bot
                     testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                    useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -11,6 +11,8 @@ schedules:
 
 variables:
   - template: variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -19,6 +21,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+        - template: /eng/common/core-templates/job/helix-job-monitor.yml
+          parameters:
+            helixAccessToken: $(HelixApiAccessToken)
+            timeoutInMinutes: 720
+            allowNoHelixJobs: true
 
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -53,6 +60,7 @@ extends:
                     testScope: outerloop
                     creator: dotnet-bot
                     testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+                    useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
         - ${{ if eq(variables['isRollingBuild'], false) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
@@ -82,6 +90,7 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+                      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
         - ${{ if eq(variables['includeWindowsOuterloop'], true) }}:
           - template: /eng/pipelines/common/platform-matrix.yml
@@ -107,6 +116,7 @@ extends:
                       testScope: outerloop
                       creator: dotnet-bot
                       extraHelixArguments: /p:BuildTargetFramework=net481
+                      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
         # WebAssembly CoreCLR - run the library test suites on Chrome with the slow
         # [OuterLoop] tests enabled. Uses -testscope all (not outerloop) on purpose:
@@ -151,3 +161,4 @@ extends:
                       creator: dotnet-bot
                       testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
                       extraHelixArguments: /p:BrowserHost=$(_hostedOs)
+                      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-android.yml
+++ b/eng/pipelines/runtime-android.yml
@@ -6,6 +6,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -13,6 +15,12 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-androidemulator.yml
+++ b/eng/pipelines/runtime-androidemulator.yml
@@ -7,6 +7,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -14,6 +16,12 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-cet.yml
+++ b/eng/pipelines/runtime-cet.yml
@@ -28,6 +28,8 @@ pr:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -36,6 +38,11 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       #
       # Build CoreCLR and Libraries
@@ -89,6 +96,7 @@ extends:
           helixQueueGroup: cet
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           jobParameters:
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             testGroup: innerloop
             liveLibrariesBuildConfig: release
             useCodeFlowEnforcement: true

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -35,6 +35,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -49,6 +51,12 @@ extends:
 
     - stage: Build
       jobs:
+      - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:
+        - template: /eng/common/core-templates/job/helix-job-monitor.yml
+          parameters:
+            helixAccessToken: $(HelixApiAccessToken)
+            timeoutInMinutes: 540
+            allowNoHelixJobs: true
 
       # Add wasm jobs only for rolling builds
       - ${{ if eq(variables.isRollingBuild, true) }}:

--- a/eng/pipelines/runtime-ioslike.yml
+++ b/eng/pipelines/runtime-ioslike.yml
@@ -6,6 +6,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -14,6 +16,12 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-ioslikesimulator.yml
+++ b/eng/pipelines/runtime-ioslikesimulator.yml
@@ -7,6 +7,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -15,6 +17,12 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-llvm.yml
+++ b/eng/pipelines/runtime-llvm.yml
@@ -55,6 +55,8 @@ pr:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -69,6 +71,12 @@ extends:
 
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       #
       # Build Mono and Installer on LLVMAOT mode
       #
@@ -142,6 +150,7 @@ extends:
                   creator: dotnet-bot
                   llvmAotStepContainer: linux_x64_llvmaot
                   testRunNamePrefixSuffix: Mono_Release
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
@@ -183,6 +192,7 @@ extends:
                   creator: dotnet-bot
                   llvmAotStepContainer: linux_x64_llvmaot
                   testRunNamePrefixSuffix: Mono_Release
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   testBuildArgs: >-
                     -tree:CoreMangLib -tree:Exceptions -tree:GC -tree:Interop -tree:Loader -tree:Regressions -tree:baseservices
                     -tree:ilverify -tree:managed -tree:profiler -tree:reflection -tree:tracing
@@ -230,6 +240,7 @@ extends:
                   creator: dotnet-bot
                   llvmAotStepContainer: linux_x64_llvmaot
                   testRunNamePrefixSuffix: Mono_Release
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   testBuildArgs: -tree:JIT/Intrinsics -tree:JIT/HardwareIntrinsics -tree:JIT/SIMD
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/eng/pipelines/runtime-maccatalyst.yml
+++ b/eng/pipelines/runtime-maccatalyst.yml
@@ -6,6 +6,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -14,6 +16,12 @@ extends:
     stages:
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-sanitized.yml
+++ b/eng/pipelines/runtime-sanitized.yml
@@ -11,6 +11,8 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:
@@ -19,6 +21,12 @@ extends:
     stages:
     - stage: AddressSanitizer
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       #
       # Build the whole product with CoreCLR and run runtime tests with AddressSanitizer
       #
@@ -45,6 +53,7 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
                   scenarios:
                     - normal
                     - no_tiered_compilation
@@ -80,6 +89,7 @@ extends:
                   creator: dotnet-bot
                   testBuildArgs: nativeaot tree nativeaot
                   liveLibrariesBuildConfig: Release
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
                 parameters:

--- a/eng/pipelines/runtime-wasm-dbgtests.yml
+++ b/eng/pipelines/runtime-wasm-dbgtests.yml
@@ -3,6 +3,8 @@ pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -16,6 +18,12 @@ extends:
 
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-wasm-libtests.yml
+++ b/eng/pipelines/runtime-wasm-libtests.yml
@@ -2,6 +2,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -15,6 +17,12 @@ extends:
 
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-wasm-non-libtests.yml
+++ b/eng/pipelines/runtime-wasm-non-libtests.yml
@@ -2,6 +2,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -15,6 +17,12 @@ extends:
 
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-wasm-optional.yml
+++ b/eng/pipelines/runtime-wasm-optional.yml
@@ -3,6 +3,8 @@ pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -16,6 +18,12 @@ extends:
 
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime-wasm.yml
+++ b/eng/pipelines/runtime-wasm.yml
@@ -6,6 +6,8 @@ trigger: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -19,6 +21,12 @@ extends:
 
     - stage: Build
       jobs:
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
+
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -171,6 +171,7 @@ extends:
           platforms:
           - wasi_wasm
           alwaysRun: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # CoreCLR library-test smoke leg run on wasmtime via Helix
       # (wasi_wasm queue). Starts with a single-library smoke set; see
@@ -181,6 +182,7 @@ extends:
           - wasi_wasm
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -39,6 +39,8 @@ pr:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
     - name: TeamName
@@ -50,6 +52,12 @@ extends:
     stages:
     - stage: Build
       jobs:
+        - template: /eng/common/core-templates/job/helix-job-monitor.yml
+          parameters:
+            helixAccessToken: $(HelixApiAccessToken)
+            timeoutInMinutes: 540
+            allowNoHelixJobs: true
+
         #
         # Build the whole product with Checked CoreCLR and run runtime tests
         #
@@ -69,6 +77,7 @@ extends:
                   parameters:
                     creator: dotnet-bot
                     testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+                    useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
               extraVariablesTemplates:
                 - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
@@ -91,6 +100,7 @@ extends:
                   parameters:
                     creator: dotnet-bot
                     testRunNamePrefixSuffix: Libraries_$(_BuildConfig)
+                    useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
               extraVariablesTemplates:
                 - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 


### PR DESCRIPTION
## Summary

- add the Helix Job Monitor to standard runtime test pipelines that submit gating work to Helix
- opt each supported submission into out-of-band monitoring through `useHelixMonitor`
- preserve shared-template compatibility by keeping monitor parameters disabled by default
- leave build-only and non-gating (`shouldContinueOnError`) submissions synchronous

## Motivation

#132084 scoped the monitor back to the main `runtime` pipeline because other pipelines inherited fire-and-forget submission without creating a monitor job. This change adds the complete pairing—monitor job plus opted-in submissions—to the other compatible pipelines.

Recent `dnceng-public/public` runs show agent time spent waiting synchronously for Helix across both long and short pipelines. Representative examples include:

- [`runtime-extra-platforms` build 1544136](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1544136): 36 Helix submission tasks, including waits over an hour
- [`runtime-coreclr gcstress-extra` build 1545563](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1545563): seven waits from roughly 50 minutes to 4 hours
- [`runtime-nativeaot-outerloop` build 1521226](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1521226): 22 Helix submission tasks
- [`runtime-libraries-coreclr outerloop` build 1531263](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1531263): multiple waits, including a 2 hour 56 minute WebAssembly leg

Moving that waiting to one generic monitor job releases the build agents after submission while retaining centralized result reporting and retry behavior.

## Scope

This covers pipelines using the standard monitor-capable runtime and libraries Helix templates. It intentionally excludes specialized submission flows such as diagnostics and SuperPMI, build-only legs, and submissions whose failures are explicitly non-gating.

## Validation

- parsed all 55 modified YAML files
- `git diff --check`

> [!NOTE]
> This pull request description was generated with GitHub Copilot.