### PR TITLE
System.IO: Make CanSeek independent of SafeFileHandle.Type

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -336,10 +336,9 @@ namespace Microsoft.Win32.SafeHandles
         // GetNamedPipeInfo requires GENERIC_READ or GENERIC_WRITE and FILE_READ_ATTRIBUTES access.
         // There are valid scenarios like CreateNamedPipeW(PIPE_ACCESS_OUTBOUND) where GetNamedPipeInfo fails with ERROR_ACCESS_DENIED.
         // 3. Switching from GetNamedPipeInfo to getsockopt to distinguish pipes from sockets. It would add a dependency on ws2_32.dll, which is not desirable.
-        // That is why we use the cached file type (if available), and if not available, we use GetFileType to determine whether the file is seekable or not.
-        private bool GetCanSeekCore() => _cachedFileType != -1
-            ? (FileHandleType)_cachedFileType == FileHandleType.RegularFile
-            : Interop.Kernel32.GetFileType(this) == Interop.Kernel32.FileTypes.FILE_TYPE_DISK;
+        // That is why we use GetFileType directly. Using the cached Type value would make the result depend on whether Type was queried first:
+        // handles such as symbolic links are FILE_TYPE_DISK, but their refined type is not RegularFile.
+        private bool GetCanSeekCore() => Interop.Kernel32.GetFileType(this) == Interop.Kernel32.FileTypes.FILE_TYPE_DISK;
 
         internal FileHandleType GetFileTypeCore()
         {

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/SafeFileHandle/GetFileType.Windows.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/SafeFileHandle/GetFileType.Windows.cs
@@ -136,12 +136,14 @@ namespace System.IO.Tests
 
             using SafeFileHandle handleWithoutTypeAccess = OpenSymbolicLink(linkPath);
             using FileStream streamWithoutTypeAccess = new(handleWithoutTypeAccess, FileAccess.Read);
+            bool canSeekWithoutTypeAccess = streamWithoutTypeAccess.CanSeek;
+            Assert.True(canSeekWithoutTypeAccess);
 
             using SafeFileHandle handleWithTypeAccess = OpenSymbolicLink(linkPath);
             Assert.Equal(FileHandleType.SymbolicLink, handleWithTypeAccess.Type);
             using FileStream streamWithTypeAccess = new(handleWithTypeAccess, FileAccess.Read);
-
-            Assert.Equal(streamWithoutTypeAccess.CanSeek, streamWithTypeAccess.CanSeek);
+            bool canSeekWithTypeAccess = streamWithTypeAccess.CanSeek;
+            Assert.True(canSeekWithTypeAccess);
         }
 
         [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
@@ -154,10 +156,12 @@ namespace System.IO.Tests
 
             using SafeFileHandle handle = OpenSymbolicLink(linkPath);
             using FileStream stream = new(handle, FileAccess.Read);
-            bool canSeek = stream.CanSeek;
+            bool canSeekBeforeTypeAccess = stream.CanSeek;
+            Assert.True(canSeekBeforeTypeAccess);
 
             Assert.Equal(FileHandleType.SymbolicLink, handle.Type);
-            Assert.Equal(canSeek, stream.CanSeek);
+            bool canSeekAfterTypeAccess = stream.CanSeek;
+            Assert.True(canSeekAfterTypeAccess);
         }
 
         private static unsafe SafeFileHandle OpenSymbolicLink(string path)

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/SafeFileHandle/GetFileType.Windows.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/SafeFileHandle/GetFileType.Windows.cs
@@ -126,28 +126,10 @@ namespace System.IO.Tests
             }
         }
 
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        public unsafe void FileStream_SymbolicLink_CanSeek_IsNotAffectedByType()
-        {
-            string targetPath = GetTestFilePath();
-            string linkPath = GetTestFilePath();
-            File.WriteAllText(targetPath, "test");
-            File.CreateSymbolicLink(linkPath, targetPath);
-
-            using SafeFileHandle handleWithoutTypeAccess = OpenSymbolicLink(linkPath);
-            using FileStream streamWithoutTypeAccess = new(handleWithoutTypeAccess, FileAccess.Read);
-            bool canSeekWithoutTypeAccess = streamWithoutTypeAccess.CanSeek;
-            Assert.True(canSeekWithoutTypeAccess);
-
-            using SafeFileHandle handleWithTypeAccess = OpenSymbolicLink(linkPath);
-            Assert.Equal(FileHandleType.SymbolicLink, handleWithTypeAccess.Type);
-            using FileStream streamWithTypeAccess = new(handleWithTypeAccess, FileAccess.Read);
-            bool canSeekWithTypeAccess = streamWithTypeAccess.CanSeek;
-            Assert.True(canSeekWithTypeAccess);
-        }
-
-        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
-        public unsafe void FileStream_SymbolicLink_CanSeek_IsNotAffectedBySubsequentTypeAccess()
+        [ConditionalTheory(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public unsafe void FileStream_SymbolicLink_CanSeek_IsNotAffectedByType(bool accessTypeFirst)
         {
             string targetPath = GetTestFilePath();
             string linkPath = GetTestFilePath();
@@ -155,13 +137,15 @@ namespace System.IO.Tests
             File.CreateSymbolicLink(linkPath, targetPath);
 
             using SafeFileHandle handle = OpenSymbolicLink(linkPath);
-            using FileStream stream = new(handle, FileAccess.Read);
-            bool canSeekBeforeTypeAccess = stream.CanSeek;
-            Assert.True(canSeekBeforeTypeAccess);
+            if (accessTypeFirst)
+            {
+                Assert.Equal(FileHandleType.SymbolicLink, handle.Type);
+            }
 
+            using FileStream stream = new(handle, FileAccess.Read);
+            Assert.True(stream.CanSeek);
             Assert.Equal(FileHandleType.SymbolicLink, handle.Type);
-            bool canSeekAfterTypeAccess = stream.CanSeek;
-            Assert.True(canSeekAfterTypeAccess);
+            Assert.True(stream.CanSeek);
         }
 
         private static unsafe SafeFileHandle OpenSymbolicLink(string path)

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/SafeFileHandle/GetFileType.Windows.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/SafeFileHandle/GetFileType.Windows.cs
@@ -125,5 +125,54 @@ namespace System.IO.Tests
                 Assert.Equal(FileHandleType.SymbolicLink, handle.Type);
             }
         }
+
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        public unsafe void FileStream_SymbolicLink_CanSeek_IsNotAffectedByType()
+        {
+            string targetPath = GetTestFilePath();
+            string linkPath = GetTestFilePath();
+            File.WriteAllText(targetPath, "test");
+            File.CreateSymbolicLink(linkPath, targetPath);
+
+            using SafeFileHandle handleWithoutTypeAccess = OpenSymbolicLink(linkPath);
+            using FileStream streamWithoutTypeAccess = new(handleWithoutTypeAccess, FileAccess.Read);
+
+            using SafeFileHandle handleWithTypeAccess = OpenSymbolicLink(linkPath);
+            Assert.Equal(FileHandleType.SymbolicLink, handleWithTypeAccess.Type);
+            using FileStream streamWithTypeAccess = new(handleWithTypeAccess, FileAccess.Read);
+
+            Assert.Equal(streamWithoutTypeAccess.CanSeek, streamWithTypeAccess.CanSeek);
+        }
+
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
+        public unsafe void FileStream_SymbolicLink_CanSeek_IsNotAffectedBySubsequentTypeAccess()
+        {
+            string targetPath = GetTestFilePath();
+            string linkPath = GetTestFilePath();
+            File.WriteAllText(targetPath, "test");
+            File.CreateSymbolicLink(linkPath, targetPath);
+
+            using SafeFileHandle handle = OpenSymbolicLink(linkPath);
+            using FileStream stream = new(handle, FileAccess.Read);
+            bool canSeek = stream.CanSeek;
+
+            Assert.Equal(FileHandleType.SymbolicLink, handle.Type);
+            Assert.Equal(canSeek, stream.CanSeek);
+        }
+
+        private static unsafe SafeFileHandle OpenSymbolicLink(string path)
+        {
+            SafeFileHandle handle = Interop.Kernel32.CreateFile(
+                path,
+                Interop.Kernel32.GenericOperations.GENERIC_READ,
+                FileShare.ReadWrite,
+                null,
+                FileMode.Open,
+                Interop.Kernel32.FileOperations.FILE_FLAG_OPEN_REPARSE_POINT | Interop.Kernel32.FileOperations.FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
+
+            Assert.False(handle.IsInvalid);
+            return handle;
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #132077.

## Summary

- Determine Windows `SafeFileHandle.CanSeek` directly from the raw `GetFileType` result instead of the cached, refined `SafeFileHandle.Type` value.
- Add symbolic-link regression tests covering `Type` access both before and after `FileStream` evaluates `CanSeek`.

## Rationale

For handles opened on a symbolic link, Windows reports `FILE_TYPE_DISK`, while `SafeFileHandle.Type` refines that to `SymbolicLink`. As a result, #132077 could cache different `CanSeek` values depending on whether `Type` was queried before constructing the `FileStream`. Using the raw file type restores access-order-independent behavior while retaining the write-only named-pipe fix.

## Validation

- `.\build.cmd clr.corelib` — succeeded with 0 warnings and 0 errors.
- `FileStream_SymbolicLink_CanSeek_IsNotAffectedByType` — passed.
- `FileStream_WriteOnlyNamedPipe_CanSeek_IsAsync` — 2 cases passed.

No baseline build was run.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.