### PR TITLE
[mono][wasm] Box gsharedvt Nullable<T> via a wrapper-free runtime helper

### DIFF
--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -203,6 +203,7 @@ MONO_JIT_ICALL (mono_get_native_calli_wrapper) \
 MONO_JIT_ICALL (mono_get_special_static_data) \
 MONO_JIT_ICALL (mono_gsharedvt_constrained_call) \
 MONO_JIT_ICALL (mono_gsharedvt_value_copy) \
+MONO_JIT_ICALL (mono_helper_box_nullable) \
 MONO_JIT_ICALL (mono_helper_compile_generic_method) \
 MONO_JIT_ICALL (mono_helper_ldstr) \
 MONO_JIT_ICALL (mono_helper_ldstr_mscorlib) \

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1169,6 +1169,15 @@ mono_helper_newobj_mscorlib (guint32 idx)
 	return obj;
 }
 
+MonoObject*
+mono_helper_box_nullable (gpointer vbuf, MonoClass *klass)
+{
+	ERROR_DECL (error);
+	MonoObject *result = mono_nullable_box (vbuf, klass, error);
+	mono_error_set_pending_exception (error);
+	return result;
+}
+
 /*
  * On some architectures, gdb doesn't like encountering the cpu breakpoint instructions
  * in generated code. So instead we emit a call to this function and place a gdb

--- a/src/mono/mono/mini/jit-icalls.h
+++ b/src/mono/mono/mini/jit-icalls.h
@@ -116,6 +116,8 @@ ICALL_EXPORT MonoString *mono_helper_ldstr_mscorlib (guint32 idx);
 
 ICALL_EXPORT MonoObject *mono_helper_newobj_mscorlib (guint32 idx);
 
+ICALL_EXPORT MonoObject *mono_helper_box_nullable (gpointer vbuf, MonoClass *klass);
+
 ICALL_EXPORT double mono_fsub (double a, double b);
 
 ICALL_EXPORT double mono_fadd (double a, double b);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -3404,6 +3404,26 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 }
 
 /*
+ * Box a gsharedvt Nullable<T> via a non-generic runtime helper, passing the value by
+ * address and the concrete class from the rgctx. This avoids a per-T box wrapper that
+ * cannot be emitted at AOT time when the consuming assembly runs interpreted.
+ */
+static MonoInst*
+mini_emit_nullable_box_helper (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_used)
+{
+	MonoInst *iargs [2], *addr, *var;
+
+	var = get_vreg_to_inst (cfg, val->dreg);
+	if (!var)
+		var = mono_compile_create_var_for_vreg (cfg, m_class_get_byval_arg (klass), OP_LOCAL, val->dreg);
+	EMIT_NEW_VARLOADA (cfg, addr, var, var->inst_vtype);
+
+	iargs [0] = addr;
+	iargs [1] = mini_emit_get_rgctx_klass (cfg, context_used, klass, MONO_RGCTX_INFO_KLASS);
+	return mono_emit_jit_icall (cfg, mono_helper_box_nullable, iargs);
+}
+
+/*
  * Returns NULL and set the cfg exception on error.
  */
 MonoInst*
@@ -3425,11 +3445,9 @@ mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_us
 				MonoInst *addr;
 				MonoMethodSignature *sig = mono_method_signature_internal (method);
 				if (mini_is_gsharedvt_klass (klass))
-					addr = mini_emit_get_gsharedvt_info_klass (cfg, klass,
-															   MONO_RGCTX_INFO_NULLABLE_CLASS_BOX);
-				else
-					addr = emit_get_rgctx_method (cfg, context_used, method,
-												  MONO_RGCTX_INFO_METHOD_FTNDESC);
+					return mini_emit_nullable_box_helper (cfg, val, klass, context_used);
+				addr = emit_get_rgctx_method (cfg, context_used, method,
+											  MONO_RGCTX_INFO_METHOD_FTNDESC);
 				cfg->interp_in_signatures = g_slist_prepend_mempool (cfg->mempool, cfg->interp_in_signatures, sig);
 				return mini_emit_llvmonly_calli (cfg, sig, &val, addr);
 			} else {
@@ -3495,9 +3513,14 @@ mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_us
 		/* Nullable case */
 		MONO_START_BB (cfg, is_nullable_bb);
 
-		{
+		if (cfg->llvm_only) {
+			MonoInst *box_call = mini_emit_nullable_box_helper (cfg, val, klass, context_used);
+			EMIT_NEW_UNALU (cfg, res, OP_MOVE, dreg, box_call->dreg);
+			res->type = STACK_OBJ;
+			res->klass = klass;
+		} else {
 			MonoInst *box_addr = mini_emit_get_gsharedvt_info_klass (cfg, klass,
-													MONO_RGCTX_INFO_NULLABLE_CLASS_BOX);
+										MONO_RGCTX_INFO_NULLABLE_CLASS_BOX);
 			MonoInst *box_call;
 			MonoMethodSignature *box_sig;
 
@@ -3510,10 +3533,7 @@ mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_us
 			box_sig->param_count = 1;
 			box_sig->params [0] = m_class_get_byval_arg (klass);
 
-			if (cfg->llvm_only)
-				box_call = mini_emit_llvmonly_calli (cfg, box_sig, &val, box_addr);
-			else
-				box_call = mini_emit_calli (cfg, box_sig, &val, box_addr, NULL, NULL);
+			box_call = mini_emit_calli (cfg, box_sig, &val, box_addr, NULL, NULL);
 			EMIT_NEW_UNALU (cfg, res, OP_MOVE, dreg, box_call->dreg);
 			res->type = STACK_OBJ;
 			res->klass = klass;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -5114,6 +5114,7 @@ register_icalls (void)
 	register_icall (mono_helper_ldstr, mono_icall_sig_object_ptr_int, FALSE);
 	register_icall (mono_helper_ldstr_mscorlib, mono_icall_sig_object_int, FALSE);
 	register_icall (mono_helper_newobj_mscorlib, mono_icall_sig_object_int, FALSE);
+	register_icall (mono_helper_box_nullable, mono_icall_sig_object_ptr_ptr, FALSE);
 	register_icall (mono_value_copy_internal, mono_icall_sig_void_ptr_ptr_ptr, FALSE);
 	register_icall (mono_object_castclass_unbox, mono_icall_sig_object_object_ptr, FALSE);
 	register_icall (mono_break, mono_icall_sig_void, TRUE);

--- a/src/tests/Loader/classloader/generics/regressions/131537/test131537.cs
+++ b/src/tests/Loader/classloader/generics/regressions/131537/test131537.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+// Regression test for https://github.com/dotnet/runtime/issues/131537
+// (WASM manifestation of https://github.com/dotnet/runtime/issues/66220).
+//
+// Constructing a non-generic Queue from a List<Nullable<T>> enumerates the list
+// through the non-generic IEnumerator, whose Current getter boxes each element
+// Nullable<T> -> object. On Mono WASM with an AOT'd corelib and this assembly
+// running in the interpreter (the WasmTestOnChrome-MONO-ST configuration), the
+// concrete Nullable<T> is never instantiated in the AOT'd corelib's TYPESPEC
+// table, so the required gsharedvt out-sig wrapper object(Nullable<T>) is not
+// emitted and the boxing call traps with "function signature mismatch".
+public class Test_131537
+{
+    [Fact]
+    public static void BoxNullableThroughNonGenericEnumerator()
+    {
+        RoundTrip(new List<Int128?> { 1, 2, 3 });
+        RoundTrip(new List<UInt128?> { 1, 2, 3 });
+        RoundTrip(new List<Half?> { (Half)1, (Half)2, (Half)3 });
+        RoundTrip(new List<decimal?> { 1m, 2m, 3m });
+        RoundTrip(new List<Guid?> { Guid.Empty, Guid.NewGuid() });
+        RoundTrip(new List<DateTime?> { DateTime.UnixEpoch, DateTime.MaxValue });
+        RoundTrip(new List<DateTimeOffset?> { DateTimeOffset.UnixEpoch, DateTimeOffset.MaxValue });
+        RoundTrip(new List<TimeSpan?> { TimeSpan.Zero, TimeSpan.FromSeconds(5) });
+    }
+
+    private static void RoundTrip<T>(List<T> source)
+    {
+        // Queue(ICollection) enumerates via the non-generic IEnumerator, boxing
+        // each element T -> object. This is the call that crashes when the
+        // object(Nullable<T>) gsharedvt out-sig wrapper is missing.
+        var queue = new Queue(source);
+        Assert.Equal(source.Count, queue.Count);
+
+        int i = 0;
+        foreach (object boxed in queue)
+        {
+            Assert.Equal(source[i], (T)boxed);
+            i++;
+        }
+    }
+}

--- a/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
+++ b/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test131537.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Reproduce the WasmTestOnChrome-MONO-ST configuration from #131537:
+         corelib is AOT'd but this test assembly runs in the interpreter, so the
+         object(Nullable<T>) gsharedvt out-sig wrapper is not emitted by AOT.
+         This item is ignored on non-wasm-AOT runtimes. -->
+    <_AOT_InternalForceInterpretAssemblies Include="test131537.dll" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## What

Under minimal gsharedvt (llvmonly / WASM), boxing a gsharedvt `Nullable<T>` resolves a per-`T` `Nullable<T>.Box` out-sig wrapper (`MONO_RGCTX_INFO_NULLABLE_CLASS_BOX`). When corelib is AOT'd but the consuming assembly runs **interpreted** (the `WasmTestOnChrome-MONO-ST` configuration), that per-`T` wrapper is absent and the boxing call traps with **`function signature mismatch`** — e.g. boxing a `Nullable<T>` element through the non-generic `IEnumerator.Current` (`new Queue(new List<Int128?> { ... })`).

## Fix

Emit a call to a new non-generic `mono_helper_box_nullable` icall — a thin wrapper over the existing `mono_nullable_box`, the same helper the interpreter uses (`MINT_BOX_NULLABLE_PTR`) — passing the value by address and the concrete `Nullable<T>` class from the rgctx. No per-`T` box wrapper is needed, so:

- the trap cannot occur, for corelib **and** value types defined in user assemblies, and
- the containing method stays fully AOT-compiled (nothing is dropped from the AOT image).

Only the `llvm_only` nullable-box paths in `mini_emit_box` are changed; other backends are untouched.

## Change

- `src/mono/mono/mini/jit-icalls.c` / `jit-icalls.h`, `src/mono/mono/metadata/jit-icall-reg.h`, `src/mono/mono/mini/mini-runtime.c`: add and register the `mono_helper_box_nullable(vbuf, klass)` JIT icall.
- `src/mono/mono/mini/method-to-ir.c`: new `mini_emit_nullable_box_helper`; both `llvm_only` `NULLABLE_CLASS_BOX` sites now route through it.
- `src/tests/Loader/classloader/generics/regressions/131537/`: regression test that boxes `Nullable<T>` through `Queue(ICollection)`. `_AOT_InternalForceInterpretAssemblies` reproduces the AOT-corelib + interpreted-assembly configuration on wasm-AOT lanes; it passes trivially elsewhere.

Fixes #131537.

## Background

This supersedes two earlier approaches explored on this issue:

- The fixed-list rooting in #131946 — only covered a hardcoded set of corelib value types, not `Nullable<UserStruct>`.
- @BrzVlad's suggestion to fail gsharedvt for `box` (mirroring `unbox.any`) — that cleared the trap but un-AOT'd whole methods, and CI surfaced a `null function` regression when an AOT'd caller reached a now-unemitted method (observed in the `Stream.CopyToAsync` / `BrowserHttp` async teardown on the `MONO-ST` Intrinsics lane).

Routing the nullable box through the wrapper-free icall keeps every method AOT-compiled, so it fixes the trap for **all** value types without that regression.

## Testing

Validated on **Release** Mono WASM AOT (AOT'd corelib + force-interpreted app — confirmed `System.Private.CoreLib` is in the AOT'd set while the app assembly is interpreted): boxing `Int128?` / `UInt128?` / `Half?` / `decimal?` / `Guid?` / `DateTime?` / `DateTimeOffset?` / `TimeSpan?` through `new Queue(List<T?>)` round-trips cleanly — no `function signature mismatch`, no `null function`. Full library-test coverage (`Number_AsCollectionElement_RoundTrip` on `WasmTestOnChrome-MONO`) runs in CI.

## Code size

Runtime binary: negligible (one small icall + a table entry). AOT'd app: roughly neutral — the per-`T` `object(Nullable<T>)` box out-sig wrappers are no longer needed for the gsharedvt path, offsetting the small per-call-site change, and it is much lighter than the rooting approach.

> [!NOTE]
> This pull request was prepared with GitHub Copilot.