### PR TITLE
[Wasm RyuJIT]: Remove more unreachable NYI_WASM entries

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -237,7 +237,9 @@ protected:
     void genEmitEndBlock(BasicBlock* block);
 
 public:
+#if HAS_FIXED_REGISTER_SET
     void genSpillVar(GenTree* tree);
+#endif // HAS_FIXED_REGISTER_SET
 
     void genEmitCallWithCurrentGC(EmitCallParams& callParams);
 
@@ -1671,6 +1673,7 @@ public:
 
     void instGen_MemoryBarrier(BarrierKind barrierKind = BARRIER_FULL);
 
+#ifdef HAS_FIXED_REGISTER_SET
     void instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg, insFlags flags = INS_FLAGS_DONT_CARE);
 
     void instGen_Set_Reg_To_Base_Plus_Imm(emitAttr  size,
@@ -1685,6 +1688,7 @@ public:
                                 ssize_t   imm,
                                 insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(size_t targetHandle = 0)
                                     DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
+#endif // HAS_FIXED_REGISTER_SET
 
 #if defined(TARGET_AMD64)
     void instGen_Push2Pop2Ppx(instruction ins, regNumber reg1, regNumber reg2);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -785,6 +785,23 @@ void CodeGenInterface::genUpdateLife(VARSET_VALARG_TP newLife)
     m_compiler->compUpdateLife</*ForCodeGen*/ true>(newLife);
 }
 
+//------------------------------------------------------------------------
+// genUpdateVarReg: Update the current register location for a multi-reg lclVar
+//
+// Arguments:
+//    varDsc   - the LclVarDsc for the lclVar
+//    tree     - the lclVar node
+//    regIndex - the index of the register in the node
+//
+// inline
+void CodeGenInterface::genUpdateVarReg(LclVarDsc* varDsc, GenTree* tree, int regIndex)
+{
+    // This should only be called for multireg lclVars.
+    assert(m_compiler->lvaEnregMultiRegVars);
+    assert(tree->IsMultiRegLclVar() || tree->OperIs(GT_COPY));
+    varDsc->SetRegNum(tree->GetRegByIndex(regIndex));
+}
+
 #ifndef TARGET_WASM
 // Return the register mask for the given register variable
 // inline

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -149,11 +149,13 @@ public:
     }
 #endif // TARGET_XARCH
 
+#if HAS_FIXED_REGISTER_SET
     // genSpillVar is called by compUpdateLifeVar.
     // TODO-Cleanup: We should handle the spill directly in CodeGen, rather than
     // calling it from compUpdateLifeVar.  Then this can be non-virtual.
 
     virtual void genSpillVar(GenTree* tree) = 0;
+#endif // HAS_FIXED_REGISTER_SET
 
     //-------------------------------------------------------------------------
     //  The following property indicates whether to align loops.

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -1009,7 +1009,7 @@ void CodeGen::genRecordAsyncResume(GenTreeVal* asyncResume)
     asyncResumeInfo->Locations()[index] = emitLocation(GetEmitter());
 }
 
-#ifndef TARGET_WASM
+#if HAS_FIXED_REGISTER_SET
 
 /*
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -1120,23 +1120,7 @@ void CodeGen::genSpillVar(GenTree* tree)
     }
 }
 
-//------------------------------------------------------------------------
-// genUpdateVarReg: Update the current register location for a multi-reg lclVar
-//
-// Arguments:
-//    varDsc   - the LclVarDsc for the lclVar
-//    tree     - the lclVar node
-//    regIndex - the index of the register in the node
-//
-// inline
-void CodeGenInterface::genUpdateVarReg(LclVarDsc* varDsc, GenTree* tree, int regIndex)
-{
-    // This should only be called for multireg lclVars.
-    assert(m_compiler->lvaEnregMultiRegVars);
-    assert(tree->IsMultiRegLclVar() || tree->OperIs(GT_COPY));
-    varDsc->SetRegNum(tree->GetRegByIndex(regIndex));
-}
-#endif // !TARGET_WASM
+#endif // HAS_FIXED_REGISTER_SET
 
 //------------------------------------------------------------------------
 // genUpdateVarReg: Update the current register location for a lclVar

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1522,10 +1522,9 @@ void CodeGen::genIntCastOverflowCheck(GenTreeCast* cast, const GenIntCastDesc& d
 //
 void CodeGen::genFloatToIntCast(GenTree* tree)
 {
-    if (tree->gtOverflow())
-    {
-        NYI_WASM("Overflow checks");
-    }
+    // Overflow checks for floating->integral should be handled on import
+    // by converting to helper calls like CORINFO_HELP_DBL2*_OVF (see fgCastRequiresHelper).
+    assert(!tree->gtOverflow());
 
     var_types   toType     = tree->TypeGet();
     var_types   fromType   = tree->AsCast()->CastOp()->TypeGet();
@@ -4039,11 +4038,6 @@ void CodeGen::genProfilingLeaveCallback(unsigned helper)
 }
 #endif
 
-void CodeGen::genSpillVar(GenTree* tree)
-{
-    NYI_WASM("Put all spillng to memory under '#if HAS_FIXED_REGISTER_SET'");
-}
-
 //------------------------------------------------------------------------
 // genLoadLocalIntoReg: set the register to "load(local on stack)".
 //
@@ -4494,11 +4488,6 @@ int CodeGenInterface::genCallerSPtoInitialSPdelta() const
 {
     NYI_WASM("genCallerSPtoInitialSPdelta");
     return 0;
-}
-
-void CodeGenInterface::genUpdateVarReg(LclVarDsc* varDsc, GenTree* tree, int regIndex)
-{
-    NYI_WASM("Move genUpdateVarReg from codegenlinear.cpp to codegencommon.cpp shared code");
 }
 
 void RegSet::verifyRegUsed(regNumber reg)

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2078,8 +2078,7 @@ instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*
             return INS_v128_load;
 #endif
         default:
-            NYI_WASM("ins_Load");
-            return INS_none;
+            unreached();
     }
 #endif // defined(TARGET_WASM)
 
@@ -2491,8 +2490,7 @@ instruction CodeGenInterface::ins_Store(var_types dstType, bool aligned /*=false
             return INS_v128_store;
 #endif
         default:
-            NYI_WASM("ins_Store");
-            return INS_none;
+            unreached();
     }
 #endif // defined(TARGET_WASM)
 
@@ -2931,6 +2929,7 @@ void CodeGen::instGen_Return(unsigned stkArgSize)
 #endif
 }
 
+#if HAS_FIXED_REGISTER_SET
 /*****************************************************************************
  *
  *  Machine independent way to move a Zero value into a register
@@ -2949,14 +2948,13 @@ void CodeGen::instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg, insFlags fla
     GetEmitter()->emitIns_R_R_I(INS_ori, size, reg, REG_R0, 0);
 #elif defined(TARGET_RISCV64)
     GetEmitter()->emitIns_R_R_I(INS_addi, size, reg, REG_R0, 0);
-#elif defined(TARGET_WASM)
-    NYI_WASM("instGen_Set_Reg_To_Zero");
 #else
 #error "Unknown TARGET"
 #endif
 
     regSet.verifyRegUsed(reg);
 }
+#endif // HAS_FIXED_REGISTER_SET
 
 #if defined(TARGET_AMD64)
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -182,6 +182,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree, GenTreeLclVarComm
             }
         }
 
+#if HAS_FIXED_REGISTER_SET
         if (ForCodeGen && ((lclVarTree->gtFlags & GTF_SPILL) != 0))
         {
             m_compiler->codeGen->genSpillVar(tree);
@@ -195,6 +196,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree, GenTreeLclVarComm
                 }
             }
         }
+#endif // HAS_FIXED_REGISTER_SET
     }
     else if (varDsc->lvPromoted)
     {


### PR DESCRIPTION
This also involves moving some `HAS_FIXED_REGISTER_SET` ifdefs around as well as moving the definition of `genUpdateVarReg` to codegencommon. 