### PR TITLE
Remove redundant / too-strict asserts in LoadAssembly

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -2336,18 +2336,6 @@ void AppDomain::LoadAssembly(Assembly *pAssembly,
 
 thread_local LoadLevelLimiter* LoadLevelLimiter::t_currentLoadLevelLimiter = nullptr;
 
-namespace
-{
-    FileLoadLevel GetCurrentFileLoadLevel()
-    {
-        WRAPPER_NO_CONTRACT;
-        if (LoadLevelLimiter::GetCurrent() == NULL)
-            return FILE_ACTIVE;
-        else
-            return (FileLoadLevel)(LoadLevelLimiter::GetCurrent()->GetLoadLevel()-1);
-    }
-}
-
 Assembly *AppDomain::LoadAssembly(AssemblySpec* pSpec,
                                   PEAssembly * pPEAssembly,
                                   FileLoadLevel targetLevel)

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -2504,9 +2504,6 @@ Assembly *AppDomain::LoadAssemblyInternal(AssemblySpec* pIdentity,
         GetAppDomain()->AddAssemblyToCache(pIdentity, result);
     }
 
-    _ASSERTE(result->GetLoadLevel() >= GetCurrentFileLoadLevel()
-        || result->GetLoadLevel() >= targetLevel);
-    _ASSERTE(result->CheckNoError(targetLevel));
     return result;
 } // AppDomain::LoadAssembly
 
@@ -2532,9 +2529,6 @@ Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel
 
         pAssembly->ThrowIfError(targetLevel);
 
-        _ASSERTE(pAssembly->CheckNoError(targetLevel));
-        _ASSERTE(pAssembly->GetLoadLevel() >= GetCurrentFileLoadLevel()
-            || pAssembly->GetLoadLevel() >= targetLevel);
         return pAssembly;
     }
 
@@ -2626,9 +2620,6 @@ Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel
     // specify the minimum load level acceptable and throw if not reached.)
 
     pAssembly->RequireLoadLevel((FileLoadLevel)(immediateTargetLevel-1));
-    _ASSERTE(pAssembly->GetLoadLevel() >= GetCurrentFileLoadLevel()
-        || pAssembly->GetLoadLevel() >= targetLevel);
-    _ASSERTE(pAssembly->CheckNoError(targetLevel));
     return pAssembly;
 }
 

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -408,12 +408,6 @@ public:
         LIMITED_METHOD_CONTRACT;
         m_currentLevel = level;
     }
-
-    static LoadLevelLimiter* GetCurrent()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return t_currentLoadLevelLimiter;
-    }
 };
 
 #define OVERRIDE_LOAD_LEVEL_LIMIT(newLimit)                    \


### PR DESCRIPTION
The assert of `pAssembly->GetLoadLevel() >= targetLevel` directly conflicted with the comment / expectation above it. It was too strict and could fire in exactly the scenario in the comment.
https://github.com/dotnet/runtime/blob/e83b5d502d68723c49b09fa0458102e4d6675a96/src/coreclr/vm/appdomain.cpp#L2614-L2618

Remove the asserts - they are already covered by previous calls to `ThrowIfError`, `RequiredLoadLevel`, and `EnsureLoadLevel`.

Fix https://github.com/dotnet/runtime/issues/132105

cc @dotnet/appmodel @AaronRobinsonMSFT 