### PR TITLE
[mono][wasm] emit_gc_pin: don't skip OP_MOVE dests

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -12752,7 +12752,24 @@ MONO_RESTORE_WARNING
 				emit_volatile_store (ctx, ins->dreg);
 #ifdef TARGET_WASM
 			//if (vreg_is_ref (cfg, ins->dreg) && ctx->values [ins->dreg])
-			if (vreg_is_ref (cfg, ins->dreg) && ctx->values [ins->dreg] && ins->opcode != OP_MOVE && ins->opcode != OP_AOTCONST)
+			/*
+			 * OP_MOVE is deliberately NOT excluded. A MOVE emits no LLVM instruction — the dest is an
+			 * SSA alias of the source — so it used to rely on the SOURCE's gc_pin slot. That is sound
+			 * only while the source vreg is defined ONCE. When the source is redefined, as a loop
+			 * does, the source's slot is overwritten with the new object and the alias still holding
+			 * the old one has no slot written anywhere; the old object is then live in a wasm
+			 * value-stack local across the next safepoint, where the conservative stack scan cannot
+			 * reach it. It is therefore neither pinned (so the collector may move it) nor updated
+			 * when it does. See dotnet/runtime#130592.
+			 *
+			 * emit_entry_bb already allocates a pin slot for EVERY vreg_is_ref vreg regardless of how
+			 * it is defined, so this writes a slot that was reserved and left empty and cannot collide
+			 * with the source's. Cost: one volatile store per ref MOVE.
+			 *
+			 * OP_AOTCONST keeps its exclusion — those dests are GOT loads of ldstr literals and
+			 * type/method handles, rooted for the process by the loader's interned tables.
+			 */
+			if (vreg_is_ref (cfg, ins->dreg) && ctx->values [ins->dreg] && ins->opcode != OP_AOTCONST)
 				emit_gc_pin (ctx, builder, ins->dreg);
 #endif
 		}

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -12762,9 +12762,9 @@ MONO_RESTORE_WARNING
 			 * reach it. It is therefore neither pinned (so the collector may move it) nor updated
 			 * when it does. See dotnet/runtime#130592.
 			 *
-			 * emit_entry_bb already allocates a pin slot for EVERY vreg_is_ref vreg regardless of how
-			 * it is defined, so this writes a slot that was reserved and left empty and cannot collide
-			 * with the source's. Cost: one volatile store per ref MOVE.
+			 * emit_entry_bb already allocates a pin slot for every non-volatile, non-dead ref vreg
+			 * regardless of how it is defined, so this writes a slot that was reserved and left empty
+			 * and cannot collide with the source's. Cost: one volatile store per ref MOVE.
 			 *
 			 * OP_AOTCONST keeps its exclusion — those dests are GOT loads of ldstr literals and
 			 * type/method handles, rooted for the process by the loader's interned tables.


### PR DESCRIPTION
### Problem

On `TARGET_WASM`, `mini-llvm.c` gives every method a `gc_pin` alloca in its linear-memory frame and volatile-stores each ref vreg into it after the vreg is written, so that SGen's conservative stack scan (`conservative_stack_mark` is unconditionally `TRUE` on this target) pins the objects. Values that live only in wasm value-stack locals are structurally invisible to that scan, so the pin store is the only thing that makes a reference scannable.

`emit_gc_pin` was skipped for `OP_MOVE` dests:

```c
if (vreg_is_ref (cfg, ins->dreg) && ctx->values [ins->dreg] && ins->opcode != OP_MOVE && ins->opcode != OP_AOTCONST)
        emit_gc_pin (ctx, builder, ins->dreg);
```

A `MOVE` emits no LLVM instruction — the dest is an SSA alias of the source, `values [dreg] = values [sreg1]` — so the dest was left to be covered by the **source's** pin slot.

That is sound only while the source vreg is defined **once**. When the source is redefined — which is what a loop does — `values [sreg1]` moves on and the source's `gc_pin` slot is overwritten with the new object, while the alias still holding the *old* object has no slot written anywhere. The old object is then live in a wasm value-stack local across the next safepoint, where the conservative scan cannot reach it. It is therefore neither **pinned** (the collector is free to move it) nor **updated** when it does.

Both halves of the observed corruption follow from that one skip: the object is promoted out of the nursery, its old space is handed back as free and filler-stamped, and the mutator later dispatches through the stale pre-promotion address. Symptoms seen, all from the same root:

- `class-accessors.c`, `condition '0' not met, function:mono_class_get_flags: unexpected GC filler class`
- `class-accessors.c`, `condition 'klass' not met`
- `memory access out of bounds`
- a silent hang inside a minor collection

### How common the shape is

A compile-time census over one large full-AOT browser-wasm application — 121 assemblies, 120,678 methods compiled:

| | |
|---|---|
| ref vregs | 2,573,587 |
| `OP_MOVE` with a ref dest | **353,952** |
| …whose **source vreg is redefined** | **49,322** (14%, across 9,895 distinct methods) |
| `OP_AOTCONST` ref dests (still skipped) | 81,975 |

It is not an exotic shape; it is what a `foreach` over a collection compiles to. In the application method that the runtime-side investigation independently identified as the one executing at the stranding collection — a `foreach (var (k, v) in dictionary)` that builds an `ImmutableDictionary` — the hazard occurs **seven times**, on two loop-carried source vregs each defined twice.

### Measurements

Every leg is 8 runs of one amplified recipe on one machine: a full-AOT browser-wasm application booted under `MONO_GC_DEBUG=collect-before-allocs=5000,clear-at-gc`, driven headless, with a DOM-silence watchdog. Amplifier liveness was verified **per run** (banner present, 199–202 `GC_MINOR: (collect-before-alloc-triggered)` collections per run), so a clean run is a completed amplified run and not a run that ended early.

| runtime | AOT cross compiler | fix | wedged |
|---|---|---|---|
| debug (assertions) | SDK release | no | **6 / 8** |
| debug (assertions) | locally built debug | no | **8 / 8** |
| debug (assertions) | locally built debug | **yes** | **0 / 16** |
| **release** | **release** | **yes** | **0 / 16** |

And on **.NET 10** (`release/10.0` @ `5eaa18a9`, where the same fix cherry-picks byte-cleanly — the three load-bearing regions of `mini-llvm.c` are identical between the branches):

| runtime config | cross | fix | wedge rate |
|---|---|---|---|
| **shipped 10.0.9 pack** (Microsoft binary, unmodified) | shipped 10.0.9 cross | no | **5 / 8** (3 runs painted no UI at all) |
| debug + release, amplified + natural, incl. partial AOT | locally built | **yes** | **0 / 24** |

The two arms of the controlled comparison differ in **one emitted volatile store per ref MOVE and in nothing else** — the compiler was held fixed and only the condition was changed. Fisher's exact two-tailed for 8/8 → 0/16 is p < 1e-5. Across the whole program and both major versions: **unfixed 58 faults in 66 runs; fixed 0 in 52.**

The release rows matter separately: release is the shipping configuration, where the assertions are compiled out and only the hang and out-of-bounds faces remain observable — 0/16 on main, 0/24 on `release/10.0`. The shipped-pack row means the defect is user-visible in released .NET 10 today, so this may be worth considering for servicing alongside main.

### Why the fix is safe

`emit_entry_bb` already allocates a pin slot for **every** `vreg_is_ref` vreg, regardless of how that vreg is defined:

```c
for (guint32 i = 0; i < cfg->next_vreg; ++i) {
        if (vreg_is_ref (cfg, i)) {
                MonoInst *var = get_vreg_to_inst (ctx->cfg, i);
                if (!(var && var->flags & (MONO_INST_VOLATILE|MONO_INST_IS_DEAD))) {
                        ctx->gc_var_indexes [i] = ngc_vars + 1;
                        ...
```

So a MOVE dest's slot is one that was **already reserved and left empty**. Writing it cannot collide with the source's slot, cannot grow the frame, and cannot change any other vreg's index. The cost is one volatile store per ref MOVE — measured at ~3.4 MB of added code in a 65.5 MB application bundle.

### Why `OP_AOTCONST` keeps its exclusion

`OP_AOTCONST` ref dests are GOT loads of `ldstr` literals and type/method handles. Those are rooted for the process by the loader's interned tables, so they are not collectable and pinning them buys nothing. Measured on one application assembly: 1,324 of 1,432 module-wide candidates are of exactly that shape. Removing this exclusion as well would add 81,975 more stores across the application for no reachability benefit.

### On a standalone repro

**A minimal standalone repro is not included.** What reproduces reliably is the amplifier recipe above, at roughly 5-in-6 on a large application; the failure needs a loop-carried reference alias to survive a collection that actually promotes, which the application's deserialization path produces naturally and a small program does not. **We can construct a minimal repro on request** — the ingredients are a loop-carried ref local aliased by a MOVE plus forced collections (`collect-before-allocs`) — and are happy to do so if that is wanted before merging.

### Ref

Investigation thread: https://github.com/dotnet/runtime/issues/130592