### PR TITLE
[wasm][mono][AOT] `mini_get_underlying_signature` is not a fixed point on wasm, so gsharedvt out-sig wrappers are emitted under a signature the runtime never asks for

### DIFF
--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -1237,6 +1237,24 @@ get_wrapper_shared_vtype (MonoType *t)
 		if (m_class_is_byreflike (mono_class_from_mono_type_internal (ftype)))
 			/* Cannot inflate generic params with byreflike types */
 			return NULL;
+#ifdef TARGET_WASM
+		/*
+		 * Map unsigned integer fields to their signed counterparts, matching what the
+		 * size-based block below does to every slot. The two must agree because this
+		 * function's output is fed back into it: gsharedvt in/out sig wrappers store their
+		 * already-underlying signature, and the AOT method-ref decode path underlies it
+		 * again - so slot-type selection has to be idempotent, or the emitted wrapper's
+		 * signature differs from the one looked up at runtime and llvmonly fails at the
+		 * first interp->AOT call. An [InlineArray] field can otherwise flip the size gate
+		 * between the two applications, since such a class has one field but N times its
+		 * size. Signedness carries no ABI meaning here: these tuple instantiations exist
+		 * only to describe layout. See https://github.com/dotnet/runtime/issues/130592.
+		 */
+		if (ftype->type == MONO_TYPE_U4)
+			ftype = m_class_get_byval_arg (mono_get_int32_class ());
+		else if (ftype->type == MONO_TYPE_U8)
+			ftype = m_class_get_byval_arg (mono_get_int64_class ());
+#endif
 		if (!has_explicit_size) {
 			args [findex ++] = ftype;
 			if (findex >= 16)


### PR DESCRIPTION
On browser-wasm llvmonly, a partial-AOT (PGO-driven) publish of our app dies at boot, 10/10 deterministic, at `interp.c:2737`:

```
AOT: FOUND method System.Buffers.IndexOfAnyAsciiSearcher/AsciiState:.ctor (Vector128`1<byte>,BitVector256)
AOT NOT FOUND: (wrapper other) object:gsharedvt_out_sig (Mono.ValueTuple`2<long, long>&,Mono.ValueTuple`1<Mono.ValueTuple`1<uint>>&,intptr)
* Assertion at interp.c:2737 ...
```

The wrapper is **not missing from the image** — we traced it through all three AOT dedup phases (`out-add` → `dedup-collect` → compiled in `aot-instances` with `emit-extra-have-cfg`). The failure is the lookup round trip:

1. The AOT compiler builds the wrapper and stores its **already-underlying** signature in `WrapperInfo`; `encode_method_ref` writes that signature.
2. At runtime, `decode_method_ref_with_target` hands the decoded signature to `mini_get_gsharedvt_out_sig_wrapper`, which applies `mini_get_underlying_signature` a **second** time.
3. `mini_get_underlying_signature` is **not idempotent** on wasm. `get_wrapper_shared_vtype`'s size-gated canonicalisation (`if (!has_explicit_size && !has_fp) ... size <= 4 * 5`) is shut on the first pass for `BitVector256` (a 32-byte `[InlineArray]` of `uint` — field keeps `uint`), and open on the second pass (applied to the 4-byte `Mono.ValueTuple` the first pass produced → `int`):

```
stored:  ... (Mono.ValueTuple`2<long, long>&, Mono.ValueTuple`1<Mono.ValueTuple`1<uint>>&, intptr)
rebuilt: ... (Mono.ValueTuple`2<long, long>&, Mono.ValueTuple`1<Mono.ValueTuple`1<int>>&,  intptr)
```

So the image holds a wrapper under the pass-1 signature, the runtime asks under the pass-2 signature, and there is no JIT to fall back to. A probe that rebuilds each out-sig wrapper from its own stored signature found **6 signatures in one publish** where the rebuild lands on a different method.

## We have a fix that survives our full verification ladder

First, the instructive failure: iterating `mini_get_underlying_signature` to its fixed point clears the boot assert but **regresses full AOT** (our amplified GC-stress recipe goes 1/3 → 8/8 wedged with a new assert on an already-fixed-point signature) and uncovers a late boot stall — so the symptom-level fix is wrong.

The working fix goes one level down. The wasm block of `get_wrapper_shared_vtype` is a pure function of `(align, size)` — it's the *input* that is unstable: the field loop can change the size of the function's own output, because an `[InlineArray(N)]` class has exactly one field and N× its size. So pass 1 maps 32-byte `BitVector256` to a 4-byte `ValueTuple`1<uint>` with the size gate shut, and pass 2 sees 4 bytes, gate open, and rewrites `uint`→`int`. The fix normalizes `U4`→`I4` / `U8`→`I8` **inside the field loop** so the two producers of a slot type cannot disagree (one file, `mini-generic-sharing.c`, +37/−0 of which 33 lines are comment; no image/wire impact — only three wrapper method *names* move in our 121-assembly app).

Verification: the idempotency probe reads 6 → 0 non-idempotent signatures (a live zero — the probe logged 77,995 decisions in the zero arm); partial AOT goes from 2/2 boot-dead to 2/2 booting fully into the app; and the leg that condemned the naive fix — amplified full AOT ×8 — reads **0/8**. The late stall also vanished with the signature-preserving fix, confirming it was the naive iteration's own blast radius.

One deeper observation we deliberately did not act on, for your judgment: the field enumeration undercounts `[InlineArray]` layout generally — a 32-byte `InlineArray8<uint>` still *shares* as a 4-byte one-slot tuple after our fix, and the out-sig wrapper's `CEE_LDOBJ` reads through that shared type. We measured no present-day miscompile (both ends of the call agree on the collapsed type), but replicating the field `inlinearray_value` times in the enumeration — letting the existing `findex > 7` arm bail to unshareable — would fix the root rather than the spelling. We kept our change narrow because that alters which types are shareable at all.

Environment: dotnet/runtime `f7a6366c` (+ #131880 and #131946's head `605f9763` cherry-picked), .NET 11 nightly SDK `11.0.100-rc.1.26402.102`, Windows win-x64 cross, browser-wasm. Our compile-time trace patch (per-image, per-dedup-phase wrapper logging + the idempotency probe) is available on request.

Related: #130592 (our main thread; the GC corruption reported there is now root-caused separately — [PR HERE](https://github.com/dotnet/runtime/pull/132180)), #131946 (adjacent wrapper-coverage work; note the failing signature above is not `Nullable<T>`-shaped, and the wrapper exists — emission coverage is not the gap).

## Repro

Deterministic on our app (10/10 at boot, ~1 min per attempt) with `-p:AotFull=false` PGO partial AOT; we have not yet minimised to a standalone repro. The shape a minimal repro needs: an interpreted caller invoking an AOT'd method whose gsharedvt out-sig signature contains a struct that `get_wrapper_shared_vtype` canonicalises only on the second application — e.g. a small struct wrapping an `[InlineArray]`-backed 32-byte type, as `BitVector256` does. Ping us if you want the full 106-frame boot stack or the trace logs.
