### PR TITLE
[FileSystemGlobbing] Use the compiled Touki matcher on .NET 8+

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1697,3 +1697,29 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+License notice for Touki
+------------------------
+
+https://github.com/JeremyKuhne/touki/tree/74f6739ce8e70b760814e792c79a83fd5065c9d7
+
+MIT License
+
+Copyright (c) 2025 Jeremy W. Kuhne and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/ref/Microsoft.Extensions.FileSystemGlobbing.csproj
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/ref/Microsoft.Extensions.FileSystemGlobbing.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <_Net8TargetFramework Condition="'$(NetCoreAppCurrent)' != 'net8.0' and '$(NetCoreAppPrevious)' != 'net8.0' and '$(NetCoreAppMinimum)' != 'net8.0'">net8.0;</_Net8TargetFramework>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);$(_Net8TargetFramework)netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
             _isParentPath = isParentPath;
         }
 
+    #if USE_TOUKI_GLOBBING
+        internal DirectoryInfo DirectoryInfo => _directoryInfo;
+    #endif
+
         /// <inheritdoc />
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
         {

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinear.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/PatternContexts/PatternContextLinear.cs
@@ -52,7 +52,11 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts
             {
                 // Determine this frame's contribution to the stem (if any)
                 IPathSegment segment = Pattern.Segments[Frame.SegmentIndex];
+#if USE_TOUKI_GLOBBING
+                if (TrackStem && (frame.InStem || segment.CanProduceStem))
+#else
                 if (frame.InStem || segment.CanProduceStem)
+#endif
                 {
                     frame.InStem = true;
                     frame.StemItems.Add(directory.Name);
@@ -92,6 +96,10 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts
         }
 
         protected ILinearPattern Pattern { get; }
+
+    #if USE_TOUKI_GLOBBING
+        internal bool TrackStem { get; set; } = true;
+    #endif
 
         protected bool IsLastSegment()
         {

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRagged.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/PatternContexts/PatternContextRagged.cs
@@ -75,7 +75,11 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts
                 frame.BacktrackAvailable += 1;
             }
 
+#if USE_TOUKI_GLOBBING
+            if (TrackStem && frame.InStem)
+#else
             if (frame.InStem)
+#endif
             {
                 frame.StemItems.Add(directory.Name);
                 frame.AddedStemItem = true;
@@ -139,6 +143,10 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts
         }
 
         protected IRaggedPattern Pattern { get; }
+
+    #if USE_TOUKI_GLOBBING
+        internal bool TrackStem { get; set; } = true;
+    #endif
 
         protected bool IsStartingGroup()
         {

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/GlobalUsings.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/GlobalUsings.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+global using System;
+global using System.Buffers;
+global using System.Collections.Generic;
+global using System.Diagnostics;
+global using System.Diagnostics.CodeAnalysis;
+global using System.IO;
+global using System.Runtime.CompilerServices;
+global using System.Text;

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/ExclusionWinsPatternMatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/ExclusionWinsPatternMatcher.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+using Microsoft.Extensions.FileSystemGlobbing.Internal;
+
+internal sealed class ExclusionWinsPatternMatcher
+{
+    private readonly ToukiPattern[] _includes;
+    private readonly ToukiPattern[] _excludes;
+
+    public ExclusionWinsPatternMatcher(ToukiPattern[] includes, ToukiPattern[] excludes)
+    {
+        _includes = includes;
+        _excludes = excludes;
+    }
+
+    internal bool TryMatchFile(
+        ReadOnlySpan<char> currentDirectory,
+        ReadOnlySpan<char> fileName,
+        [NotNullWhen(true)] out ToukiPattern? matchingInclude)
+    {
+        matchingInclude = null;
+        foreach (ToukiPattern matcher in _includes)
+        {
+            if (matcher.MatchesFile(currentDirectory, fileName))
+            {
+                matchingInclude = matcher;
+                break;
+            }
+        }
+
+        if (matchingInclude is null)
+        {
+            return false;
+        }
+
+        foreach (ToukiPattern matcher in _excludes)
+        {
+            if (matcher.MatchesFile(currentDirectory, fileName))
+            {
+                matchingInclude = null;
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/AnyGlobStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/AnyGlobStrategy.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  Matches any input. Used for a single-segment <c>*</c> and whole-pattern
+//  recursive <c>**</c> after the factory has applied the appropriate root scope.
+// </summary>
+internal sealed class AnyGlobStrategy : GlobStrategy
+{
+    public AnyGlobStrategy()
+        : base(ignoreCase: false)
+    {
+    }
+
+    // <inheritdoc/>
+    internal override bool MatchCore(
+        ReadOnlySpan<char> directoryPrefix,
+        ReadOnlySpan<char> fileName)
+        => true;
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/CompiledGlobStrategy.BacktrackState.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/CompiledGlobStrategy.BacktrackState.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+internal sealed partial class CompiledGlobStrategy
+{
+    // <summary>
+    //  Mutable matcher state passed by reference into <see cref="Backtrack"/> instead of
+    //  individual <c>ref int</c> parameters. Cuts <see cref="Backtrack"/>'s argument list
+    //  from ten to three, which on net481 RyuJIT measurably reduces call-site overhead and
+    //  improves inlining behavior. Holds the active program/input cursors plus both
+    //  savepoint slots (AnyRun and GlobStar) and the per-GlobStar invariants.
+    // </summary>
+    private ref struct BacktrackState
+    {
+        public int ProgramIndex;
+        public int InputIndex;
+        public int AnyRunProgramIndex;
+        public int AnyRunInputIndex;
+        public int GlobStarProgramIndex;
+        public int GlobStarInputIndex;
+        public int GlobStarInitialInput;
+        public int GlobStarFlags;
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/CompiledGlobStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/CompiledGlobStrategy.cs
@@ -1,0 +1,704 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  General-purpose glob matcher used for patterns that don't fit a specialized shape.
+//  The pattern is encoded into a single program string interpreted at match time;
+//  matching is allocation-free.
+// </summary>
+// <remarks>
+//  <para>
+//   Program encoding (see <see cref="GlobOpCodes"/>):
+//  </para>
+//  <para>
+//   - <c>AnyRun</c>: matches zero or more characters.<br/>
+//   - <c>Literal</c> followed by <c>&lt;len&gt;&lt;chars&gt;</c>: matches the literal run.<br/>
+//   - <c>GlobStar</c> followed by its flags: matches zero or more path segments.
+//  </para>
+//  <para>
+//   Matching backtracks over the most recent <c>AnyRun</c> and <c>GlobStar</c>
+//   savepoints. The ordinal and ignore-case paths are compiled into separate static
+//   methods so the case branch is hoisted out of the hot loop.
+//  </para>
+// </remarks>
+internal sealed partial class CompiledGlobStrategy : GlobStrategy
+{
+    private readonly string _program;
+    private readonly int _nfaProgramLength;
+    private readonly int _tailStart;
+    private readonly int _tailLength;
+
+    // <summary>
+    //  Compile-time globstar presence, used to select the smaller single-wildcard
+    //  loop when recursive matching is unnecessary.
+    // </summary>
+    private readonly bool _hasGlobStar;
+
+    // <summary>
+    //  Constructs a matcher with a trailing-literal anchor. <paramref name="nfaProgramLength"/>
+    //  is the length of the program portion run by the NFA (excludes the trailing Literal
+    //  op header and payload); <paramref name="tailStart"/> and <paramref name="tailLength"/>
+    //  identify the tail characters within <paramref name="program"/>.
+    //  <paramref name="hasGlobStar"/> records whether the program contains globstar.
+    // </summary>
+    public CompiledGlobStrategy(
+        string program,
+        int nfaProgramLength,
+        int tailStart,
+        int tailLength,
+        bool hasGlobStar,
+        bool ignoreCase)
+        : base(ignoreCase)
+    {
+        _program = program;
+        _nfaProgramLength = nfaProgramLength;
+        _tailStart = tailStart;
+        _tailLength = tailLength;
+        _hasGlobStar = hasGlobStar;
+    }
+
+    // <inheritdoc/>
+    // <remarks>
+    //  <para>
+    //   Walks the virtual concatenation <paramref name="directoryPrefix"/> +
+    //   <paramref name="fileName"/> without copying. Per-char access goes through an
+    //   inline branch; literal-segment comparisons go through
+    //   <see cref="LiteralMatchesAt"/>, which splits the literal at the span boundary
+    //   so each half uses the vectorized <see cref="MemoryExtensions"/>.<c>SequenceEqual</c>
+    //   on a contiguous slice. The caller hands in <paramref name="directoryPrefix"/>
+    //   already separator-translated and separator-terminated (per the
+    //   <see cref="GlobStrategy.MatchCore"/> contract), so the boundary at
+    //   <c>directoryPrefix.Length</c> lines up exactly with the directory/file-name
+    //   split in the bytecode program.
+    //  </para>
+    // </remarks>
+    internal override bool MatchCore(
+        ReadOnlySpan<char> directoryPrefix,
+        ReadOnlySpan<char> fileName)
+    {
+        ReadOnlySpan<char> first = directoryPrefix;
+        ReadOnlySpan<char> second = fileName;
+        int firstLength = first.Length;
+        int totalLength = firstLength + second.Length;
+
+        // Tail-anchor fast-fail. When the encoded program ends in a Literal op, the
+        // factory pre-extracts that literal so we can verify it with a single
+        // contiguous compare (vectorized when not straddling) before running the NFA.
+        //
+        // The Literal is the program's last opcode, so matching the tail also
+        // consumes it: trim the tail and run the bytecode loop on the prefix.
+        if (_tailLength > 0)
+        {
+            if (totalLength < _tailLength)
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> tail = _program.AsSpan(_tailStart, _tailLength);
+            int tailStart = totalLength - _tailLength;
+            if (!LiteralMatchesAt(first, second, tailStart, tail, IgnoreCase))
+            {
+                return false;
+            }
+
+            int trimmed = totalLength - _tailLength;
+            if (trimmed >= firstLength)
+            {
+                second = second[..(trimmed - firstLength)];
+            }
+            else
+            {
+                first = first[..trimmed];
+                second = default;
+            }
+
+        }
+
+        ReadOnlySpan<char> program = _program.AsSpan(0, _nfaProgramLength);
+
+        if (!IgnoreCase)
+        {
+            return _hasGlobStar
+                ? MatchOrdinal(first, second, program, Separator)
+                : MatchOrdinalSimple(first, second, program, Separator);
+        }
+
+        return _hasGlobStar
+            ? MatchIgnoreCase(first, second, program, Separator)
+            : MatchIgnoreCaseSimple(first, second, program, Separator);
+    }
+
+    // <summary>
+    //  Compares the virtual <paramref name="first"/> + <paramref name="second"/> slice
+    //  starting at <paramref name="inputIndex"/> against <paramref name="literal"/> under
+    //  the matcher's case-fold rule. Splits the literal at the span boundary so each
+    //  half stays contiguous on its source span and uses vectorized routines.
+    // </summary>
+    private static bool LiteralMatchesAt(
+        ReadOnlySpan<char> first,
+        ReadOnlySpan<char> second,
+        int inputIndex,
+        ReadOnlySpan<char> literal,
+        bool ignoreCase)
+    {
+        int firstLength = first.Length;
+        int literalLength = literal.Length;
+
+        if (inputIndex + literalLength <= firstLength)
+        {
+            return LiteralMatch(first.Slice(inputIndex, literalLength), literal, ignoreCase);
+        }
+
+        if (inputIndex >= firstLength)
+        {
+            return LiteralMatch(second.Slice(inputIndex - firstLength, literalLength), literal, ignoreCase);
+        }
+
+        int leftLength = firstLength - inputIndex;
+        return LiteralMatch(first.Slice(inputIndex, leftLength), literal[..leftLength], ignoreCase)
+            && LiteralMatch(second[..(literalLength - leftLength)], literal[leftLength..], ignoreCase);
+    }
+
+    // <summary>
+    //  Ordinal match path for programs without <see cref="GlobOpCodes.GlobStar"/>.
+    //  Single AnyRun savepoint, no shared backtrack helper - keeps the JIT happy and
+    //  avoids the two-slot backtrack overhead of <see cref="MatchOrdinal"/> on the
+    //  globstar-free common case. Walks the virtual
+    //  <paramref name="first"/> + <paramref name="second"/> concatenation.
+    // </summary>
+    private static bool MatchOrdinalSimple(
+        ReadOnlySpan<char> first,
+        ReadOnlySpan<char> second,
+        ReadOnlySpan<char> program,
+        char separator)
+    {
+        int firstLength = first.Length;
+        int totalLength = firstLength + second.Length;
+        int programIndex = 0;
+        int inputIndex = 0;
+        int anyRunProgramIndex = -1;
+        int anyRunInputIndex = 0;
+
+        while (inputIndex < totalLength)
+        {
+            if (programIndex < program.Length)
+            {
+                char opcode = program[programIndex];
+
+                if (opcode == GlobOpCodes.AnyRun)
+                {
+                    anyRunProgramIndex = programIndex;
+                    anyRunInputIndex = inputIndex;
+                    programIndex++;
+                    continue;
+                }
+
+                if (opcode == GlobOpCodes.Literal)
+                {
+                    int literalLength = program[programIndex + 1];
+                    if (inputIndex + literalLength <= totalLength
+                        && LiteralMatchesAt(first, second, inputIndex, program.Slice(programIndex + 2, literalLength), ignoreCase: false))
+                    {
+                        inputIndex += literalLength;
+                        programIndex += 2 + literalLength;
+                        continue;
+                    }
+                }
+            }
+
+            if (anyRunProgramIndex >= 0)
+            {
+                // Path-aware AnyRun cannot extend across the separator.
+                if (separator != '\0' && anyRunInputIndex < totalLength)
+                {
+                    char anyRunChar = anyRunInputIndex < firstLength
+                        ? first[anyRunInputIndex]
+                        : second[anyRunInputIndex - firstLength];
+                    if (anyRunChar == separator)
+                    {
+                        return false;
+                    }
+                }
+
+                programIndex = anyRunProgramIndex + 1;
+                anyRunInputIndex++;
+                inputIndex = anyRunInputIndex;
+                continue;
+            }
+
+            return false;
+        }
+
+        while (programIndex < program.Length && program[programIndex] == GlobOpCodes.AnyRun)
+        {
+            programIndex++;
+        }
+
+        return programIndex == program.Length;
+    }
+
+    // <summary>
+    //  Ignore-case companion to <see cref="MatchOrdinalSimple"/>.
+    // </summary>
+    private static bool MatchIgnoreCaseSimple(
+        ReadOnlySpan<char> first,
+        ReadOnlySpan<char> second,
+        ReadOnlySpan<char> program,
+        char separator)
+    {
+        int firstLength = first.Length;
+        int totalLength = firstLength + second.Length;
+        int programIndex = 0;
+        int inputIndex = 0;
+        int anyRunProgramIndex = -1;
+        int anyRunInputIndex = 0;
+
+        while (inputIndex < totalLength)
+        {
+            if (programIndex < program.Length)
+            {
+                char opcode = program[programIndex];
+
+                if (opcode == GlobOpCodes.AnyRun)
+                {
+                    anyRunProgramIndex = programIndex;
+                    anyRunInputIndex = inputIndex;
+                    programIndex++;
+                    continue;
+                }
+
+                if (opcode == GlobOpCodes.Literal)
+                {
+                    int literalLength = program[programIndex + 1];
+                    if (inputIndex + literalLength <= totalLength
+                        && LiteralMatchesAt(first, second, inputIndex, program.Slice(programIndex + 2, literalLength), ignoreCase: true))
+                    {
+                        inputIndex += literalLength;
+                        programIndex += 2 + literalLength;
+                        continue;
+                    }
+                }
+            }
+
+            if (anyRunProgramIndex >= 0)
+            {
+                if (separator != '\0' && anyRunInputIndex < totalLength)
+                {
+                    char anyRunChar = anyRunInputIndex < firstLength
+                        ? first[anyRunInputIndex]
+                        : second[anyRunInputIndex - firstLength];
+                    if (anyRunChar == separator)
+                    {
+                        return false;
+                    }
+                }
+
+                programIndex = anyRunProgramIndex + 1;
+                anyRunInputIndex++;
+                inputIndex = anyRunInputIndex;
+                continue;
+            }
+
+            return false;
+        }
+
+        while (programIndex < program.Length && program[programIndex] == GlobOpCodes.AnyRun)
+        {
+            programIndex++;
+        }
+
+        return programIndex == program.Length;
+    }
+
+    // <summary>
+    //  Ordinal match path. Walks the virtual <paramref name="first"/> +
+    //  <paramref name="second"/> concatenation; uses <see cref="LiteralMatchesAt"/>
+    //  for literal runs (vectorized when not straddling the span boundary).
+    // </summary>
+    private static bool MatchOrdinal(
+        ReadOnlySpan<char> first,
+        ReadOnlySpan<char> second,
+        ReadOnlySpan<char> program,
+        char separator)
+    {
+        BacktrackState state = default;
+        state.AnyRunProgramIndex = -1;
+        state.GlobStarProgramIndex = -1;
+
+        int firstLength = first.Length;
+        int totalLength = firstLength + second.Length;
+
+        while (state.InputIndex < totalLength)
+        {
+            if (state.ProgramIndex < program.Length)
+            {
+                char opcode = program[state.ProgramIndex];
+
+                if (opcode == GlobOpCodes.AnyRun)
+                {
+                    state.AnyRunProgramIndex = state.ProgramIndex;
+                    state.AnyRunInputIndex = state.InputIndex;
+                    state.ProgramIndex++;
+                    continue;
+                }
+
+                if (opcode == GlobOpCodes.GlobStar)
+                {
+                    int flags = program[state.ProgramIndex + 1];
+                    int absorbedLength = FirstValidGlobStarLength(first, second, state.InputIndex, flags, separator);
+                    if (absorbedLength >= 0)
+                    {
+                        if (state.AnyRunProgramIndex > state.ProgramIndex)
+                        {
+                            state.AnyRunProgramIndex = -1;
+                        }
+
+                        state.GlobStarProgramIndex = state.ProgramIndex;
+                        state.GlobStarInitialInput = state.InputIndex;
+                        state.GlobStarInputIndex = state.InputIndex + absorbedLength;
+                        state.GlobStarFlags = flags;
+                        state.ProgramIndex += 2;
+                        state.InputIndex = state.GlobStarInputIndex;
+                        continue;
+                    }
+                }
+                else
+                {
+                    if (opcode == GlobOpCodes.Literal)
+                    {
+                        int length = program[state.ProgramIndex + 1];
+                        if (state.InputIndex + length <= totalLength
+                            && LiteralMatchesAt(first, second, state.InputIndex, program.Slice(state.ProgramIndex + 2, length), ignoreCase: false))
+                        {
+                            state.InputIndex += length;
+                            state.ProgramIndex += 2 + length;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            if (!Backtrack(first, second, separator, ref state))
+            {
+                return false;
+            }
+        }
+
+        return ConsumeTrailingEmpty(program, state.ProgramIndex);
+    }
+
+    // <summary>
+    //  Ordinal-ignore-case companion to <see cref="MatchOrdinal"/>.
+    // </summary>
+    private static bool MatchIgnoreCase(
+        ReadOnlySpan<char> first,
+        ReadOnlySpan<char> second,
+        ReadOnlySpan<char> program,
+        char separator)
+    {
+        BacktrackState state = default;
+        state.AnyRunProgramIndex = -1;
+        state.GlobStarProgramIndex = -1;
+
+        int firstLength = first.Length;
+        int totalLength = firstLength + second.Length;
+
+        while (state.InputIndex < totalLength)
+        {
+            if (state.ProgramIndex < program.Length)
+            {
+                char opcode = program[state.ProgramIndex];
+
+                if (opcode == GlobOpCodes.AnyRun)
+                {
+                    state.AnyRunProgramIndex = state.ProgramIndex;
+                    state.AnyRunInputIndex = state.InputIndex;
+                    state.ProgramIndex++;
+                    continue;
+                }
+
+                if (opcode == GlobOpCodes.GlobStar)
+                {
+                    int flags = program[state.ProgramIndex + 1];
+                    int absorbedLength = FirstValidGlobStarLength(first, second, state.InputIndex, flags, separator);
+                    if (absorbedLength >= 0)
+                    {
+                        if (state.AnyRunProgramIndex > state.ProgramIndex)
+                        {
+                            state.AnyRunProgramIndex = -1;
+                        }
+
+                        state.GlobStarProgramIndex = state.ProgramIndex;
+                        state.GlobStarInitialInput = state.InputIndex;
+                        state.GlobStarInputIndex = state.InputIndex + absorbedLength;
+                        state.GlobStarFlags = flags;
+                        state.ProgramIndex += 2;
+                        state.InputIndex = state.GlobStarInputIndex;
+                        continue;
+                    }
+                }
+                else
+                {
+                    if (opcode == GlobOpCodes.Literal)
+                    {
+                        int length = program[state.ProgramIndex + 1];
+                        if (state.InputIndex + length <= totalLength
+                            && LiteralMatchesAt(first, second, state.InputIndex, program.Slice(state.ProgramIndex + 2, length), ignoreCase: true))
+                        {
+                            state.InputIndex += length;
+                            state.ProgramIndex += 2 + length;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            if (!Backtrack(first, second, separator, ref state))
+            {
+                return false;
+            }
+        }
+
+        return ConsumeTrailingEmpty(program, state.ProgramIndex);
+    }
+
+    // <summary>
+    //  Consumes trailing ops whose empty match is valid (<see cref="GlobOpCodes.AnyRun"/>
+    //  and any <see cref="GlobOpCodes.GlobStar"/> that is not <c>GS_LT</c>). Returns
+    //  <see langword="true"/> iff the program is fully consumed.
+    // </summary>
+    private static bool ConsumeTrailingEmpty(ReadOnlySpan<char> program, int programIndex)
+    {
+        while (programIndex < program.Length)
+        {
+            char opcode = program[programIndex];
+            if (opcode == GlobOpCodes.AnyRun)
+            {
+                programIndex++;
+                continue;
+            }
+
+            if (opcode == GlobOpCodes.GlobStar)
+            {
+                int flags = program[programIndex + 1];
+                // GS_LT requires a non-empty absorbed slice; empty match invalid.
+                if ((flags & GlobOpCodes.GlobStarFlagLead) != 0
+                    && (flags & GlobOpCodes.GlobStarFlagTrail) != 0)
+                {
+                    return false;
+                }
+
+                programIndex += 2;
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    // <summary>
+    //  Backtracks to whichever savepoint (AnyRun or GlobStar) is more recent in
+    //  program flow; on exhaustion, falls through to the other. Returns
+    //  <see langword="false"/> when both slots are exhausted.
+    // </summary>
+    private static bool Backtrack(
+        ReadOnlySpan<char> first,
+        ReadOnlySpan<char> second,
+        char separator,
+        ref BacktrackState state)
+    {
+        int firstLength = first.Length;
+        int totalLength = firstLength + second.Length;
+
+        while (true)
+        {
+            bool tryGlobStar = state.GlobStarProgramIndex >= 0
+                && (state.AnyRunProgramIndex < 0 || state.GlobStarProgramIndex >= state.AnyRunProgramIndex);
+
+            if (tryGlobStar)
+            {
+                int currentAbsorbed = state.GlobStarInputIndex - state.GlobStarInitialInput;
+                int nextAbsorbed = NextValidGlobStarLength(
+                    first,
+                    second,
+                    state.GlobStarInitialInput,
+                    currentAbsorbed,
+                    state.GlobStarFlags,
+                    separator);
+                if (nextAbsorbed < 0)
+                {
+                    state.GlobStarProgramIndex = -1;
+                    continue;
+                }
+
+                state.GlobStarInputIndex = state.GlobStarInitialInput + nextAbsorbed;
+                state.ProgramIndex = state.GlobStarProgramIndex + 2;
+                state.InputIndex = state.GlobStarInputIndex;
+                return true;
+            }
+
+            if (state.AnyRunProgramIndex >= 0)
+            {
+                // Path-aware AnyRun cannot extend across the separator.
+                if (separator != '\0' && state.AnyRunInputIndex < totalLength)
+                {
+                    char anyRunChar = state.AnyRunInputIndex < firstLength
+                        ? first[state.AnyRunInputIndex]
+                        : second[state.AnyRunInputIndex - firstLength];
+                    if (anyRunChar == separator)
+                    {
+                        state.AnyRunProgramIndex = -1;
+                        continue;
+                    }
+                }
+
+                state.AnyRunInputIndex++;
+                if (state.AnyRunInputIndex > totalLength)
+                {
+                    state.AnyRunProgramIndex = -1;
+                    continue;
+                }
+
+                if (state.GlobStarProgramIndex > state.AnyRunProgramIndex)
+                {
+                    state.GlobStarProgramIndex = -1;
+                }
+
+                state.ProgramIndex = state.AnyRunProgramIndex + 1;
+                state.InputIndex = state.AnyRunInputIndex;
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    // <summary>
+    //  Returns the smallest valid absorbed length at which a
+    //  <see cref="GlobOpCodes.GlobStar"/> with the given flag bits may commit, given the
+    //  absorbed input slice <c>input[initial..initial+length]</c>. Returns <c>-1</c> when
+    //  no valid length exists (e.g., <c>GS_LT</c> at a position where the input character
+    //  at <c>initial</c> is not the separator).
+    // </summary>
+    private static int FirstValidGlobStarLength(
+        ReadOnlySpan<char> first,
+        ReadOnlySpan<char> second,
+        int initialInputIndex,
+        int flags,
+        char separator)
+    {
+        bool hasLead = (flags & GlobOpCodes.GlobStarFlagLead) != 0;
+        bool hasTrail = (flags & GlobOpCodes.GlobStarFlagTrail) != 0;
+        int firstLength = first.Length;
+        int totalLength = firstLength + second.Length;
+
+        if (hasLead && hasTrail)
+        {
+            if (initialInputIndex < totalLength)
+            {
+                char inputChar = initialInputIndex < firstLength
+                    ? first[initialInputIndex]
+                    : second[initialInputIndex - firstLength];
+                if (inputChar == separator)
+                {
+                    return 1;
+                }
+            }
+
+            return -1;
+        }
+
+        // GS_None / GS_R / GS_L: empty match (length 0) is always valid.
+        return 0;
+    }
+
+    // <summary>
+    //  Returns the smallest valid absorbed length greater than
+    //  <paramref name="currentAbsorbed"/> for a <see cref="GlobOpCodes.GlobStar"/>
+    //  backtrack, or <c>-1</c> when exhausted.
+    // </summary>
+    private static int NextValidGlobStarLength(
+        ReadOnlySpan<char> first,
+        ReadOnlySpan<char> second,
+        int initialInputIndex,
+        int currentAbsorbed,
+        int flags,
+        char separator)
+    {
+        bool hasLead = (flags & GlobOpCodes.GlobStarFlagLead) != 0;
+        bool hasTrail = (flags & GlobOpCodes.GlobStarFlagTrail) != 0;
+        int firstLength = first.Length;
+        int totalLength = firstLength + second.Length;
+        int maxAbsorbed = totalLength - initialInputIndex;
+
+        if (hasTrail)
+        {
+            // (GS_R or GS_LT.) Need length > currentAbsorbed with the input character at
+            // (initial + length - 1) equal to the separator. Scan upward.
+            for (int position = initialInputIndex + currentAbsorbed; position < totalLength; position++)
+            {
+                char inputChar = position < firstLength
+                    ? first[position]
+                    : second[position - firstLength];
+                if (inputChar == separator)
+                {
+                    return position - initialInputIndex + 1;
+                }
+            }
+
+            return -1;
+        }
+
+        if (hasLead)
+        {
+            // GS_L. Length 0 was the initial empty match; length >= 1 requires the input
+            // character at `initial` to be the separator. Beyond length 1, no further
+            // constraint.
+            int next = currentAbsorbed + 1;
+            if (next > maxAbsorbed)
+            {
+                return -1;
+            }
+
+            if (next == 1)
+            {
+                if (initialInputIndex < totalLength)
+                {
+                    char inputChar = initialInputIndex < firstLength
+                        ? first[initialInputIndex]
+                        : second[initialInputIndex - firstLength];
+                    if (inputChar == separator)
+                    {
+                        return 1;
+                    }
+                }
+
+                return -1;
+            }
+
+            return next;
+        }
+
+        // GS_None: no constraint.
+        {
+            int next = currentAbsorbed + 1;
+            return next > maxAbsorbed ? -1 : next;
+        }
+    }
+
+    // <summary>
+    //  Selects the literal-segment compare for the active case-folding mode.
+    //  Caller guarantees <c>a.Length == b.Length</c> (the NFA slices both sides to <c>length</c>).
+    // </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool LiteralMatch(ReadOnlySpan<char> a, ReadOnlySpan<char> b, bool ignoreCase) =>
+        ignoreCase ? a.Equals(b, StringComparison.OrdinalIgnoreCase) : a.SequenceEqual(b);
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/ContainsGlobStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/ContainsGlobStrategy.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  Matches inputs that contain a fixed literal substring (pattern of the form <c>*needle*</c>).
+// </summary>
+internal sealed class ContainsGlobStrategy : GlobStrategy
+{
+    private readonly string _needle;
+
+    public ContainsGlobStrategy(string needle, bool ignoreCase)
+        : base(ignoreCase)
+    {
+        _needle = needle;
+    }
+
+    // <inheritdoc/>
+    internal override bool MatchCore(
+        ReadOnlySpan<char> directoryPrefix,
+        ReadOnlySpan<char> fileName)
+    {
+        // ContainsGlobStrategy is only chosen for path-unaware dialects; the directory
+        // prefix is always empty by construction.
+        Debug.Assert(directoryPrefix.IsEmpty);
+        ReadOnlySpan<char> needle = _needle.AsSpan();
+
+        return IgnoreCase
+            ? fileName.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0
+            : fileName.IndexOf(needle) >= 0;
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobCompiler.Factory.LiteralCursor.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobCompiler.Factory.LiteralCursor.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+internal static partial class GlobCompiler
+{
+    private static partial class Factory
+    {
+        // <summary>
+        //  Records the in-progress position and length of the most recently emitted
+        //  <see cref="GlobOpCodes.Literal"/> opcode within the encoder's
+        //  <see cref="ValueStringBuilder"/>. <see cref="TryEncodeProgram"/> uses this so the
+        //  <see cref="GlobOpCodes.GlobStar"/> emitter can retroactively strip the trailing
+        //  separator from the prior Literal when a segment-bounded <c>**</c> absorbs it.
+        //  <see cref="None"/> represents "no Literal currently at the tail of the buffer"
+        //  (the most recent opcode is something else, or the buffer is empty).
+        // </summary>
+        private struct LiteralCursor
+        {
+            public int Start;
+            public int Length;
+
+            public static LiteralCursor None => new() { Start = -1, Length = 0 };
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobCompiler.Factory.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobCompiler.Factory.cs
@@ -1,0 +1,381 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+internal static partial class GlobCompiler
+{
+    private static partial class Factory
+    {
+        internal const int MaxOpcodeBodyLength = char.MaxValue;
+
+        public static bool TryCreate(
+            string pattern,
+            bool ignoreCase,
+            [NotNullWhen(true)] out GlobStrategy? result)
+        {
+            ReadOnlySpan<char> source = pattern;
+
+            if (source.IndexOf('*') < 0)
+            {
+                result = new LiteralGlobStrategy(source.ToString(), ignoreCase);
+                return true;
+            }
+
+            if (source.IndexOf('/') < 0
+                && TryCreateSegmentMatcher(source, ignoreCase, out result))
+            {
+                if (!source.SequenceEqual("**"))
+                {
+                    result = new RootFileNameStrategy(result);
+                }
+
+                return true;
+            }
+
+            if (TryCreateRecursiveDirectoryStrategy(source, ignoreCase, out result)
+                || TryCreateLiteralDirectoryStrategy(source, ignoreCase, out result))
+            {
+                return true;
+            }
+
+            if (TryCreateGlobStarFileNameStrategy(source, ignoreCase, out result))
+            {
+                return true;
+            }
+
+            if (!TryEncodeProgram(source, out string program, out bool hasGlobStar))
+            {
+                result = null;
+                return false;
+            }
+
+            FindTrailingLiteral(program, out int nfaProgramLength, out int tailStart, out int tailLength);
+            result = new CompiledGlobStrategy(
+                program,
+                nfaProgramLength,
+                tailStart,
+                tailLength,
+                hasGlobStar,
+                ignoreCase);
+            return true;
+        }
+
+        private static bool TryCreateRecursiveDirectoryStrategy(
+            ReadOnlySpan<char> pattern,
+            bool ignoreCase,
+            [NotNullWhen(true)] out GlobStrategy? result)
+        {
+            const string Prefix = "**/";
+            const string Suffix = "/*/**";
+
+            if (pattern.StartsWith(Prefix)
+                && pattern.EndsWith(Suffix)
+                && pattern.Length > Prefix.Length + Suffix.Length)
+            {
+                ReadOnlySpan<char> directoryPath = pattern[Prefix.Length..^Suffix.Length];
+                if (directoryPath.IndexOf('*') < 0)
+                {
+                    result = new RecursiveDirectoryPathStrategy(directoryPath.ToString(), ignoreCase);
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+
+        private static bool TryCreateLiteralDirectoryStrategy(
+            ReadOnlySpan<char> pattern,
+            bool ignoreCase,
+            [NotNullWhen(true)] out GlobStrategy? result)
+        {
+            int separator = pattern.LastIndexOf('/');
+            if (separator > 0
+                && pattern[..separator].IndexOf('*') < 0
+                && TryCreateSegmentMatcher(pattern[(separator + 1)..], ignoreCase, out GlobStrategy? fileMatcher))
+            {
+                result = new LiteralDirectoryPathStrategy(pattern[..(separator + 1)].ToString(), fileMatcher, ignoreCase);
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        private static bool TryCreateGlobStarFileNameStrategy(
+            ReadOnlySpan<char> pattern,
+            bool ignoreCase,
+            [NotNullWhen(true)] out GlobStrategy? result)
+        {
+            result = null;
+            if (pattern.Length < 4
+                || pattern[0] != '*'
+                || pattern[1] != '*'
+                || pattern[2] != '/')
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> segment = pattern[3..];
+            if (segment.IndexOf('/') >= 0
+                || !TryCreateSegmentMatcher(segment, ignoreCase, out GlobStrategy? segmentMatcher))
+            {
+                return false;
+            }
+
+            result = new GlobStarFileNameStrategy(segmentMatcher);
+            return true;
+        }
+
+        private static bool TryCreateSegmentMatcher(
+            ReadOnlySpan<char> segment,
+            bool ignoreCase,
+            [NotNullWhen(true)] out GlobStrategy? result)
+        {
+            int firstStar = segment.IndexOf('*');
+            if (firstStar < 0)
+            {
+                result = new LiteralGlobStrategy(segment.ToString(), ignoreCase);
+                return true;
+            }
+
+            int starCount = 0;
+            for (int index = firstStar; index < segment.Length; index++)
+            {
+                if (segment[index] == '*')
+                {
+                    starCount++;
+                }
+            }
+
+            if (starCount == segment.Length)
+            {
+                result = new AnyGlobStrategy();
+                return true;
+            }
+
+            if (starCount == 1)
+            {
+                if (firstStar == 0)
+                {
+                    result = new SuffixGlobStrategy(segment[1..].ToString(), ignoreCase);
+                }
+                else if (firstStar == segment.Length - 1)
+                {
+                    result = new PrefixGlobStrategy(segment[..firstStar].ToString(), ignoreCase);
+                }
+                else
+                {
+                    result = new PrefixSuffixGlobStrategy(
+                        segment[..firstStar].ToString(),
+                        segment[(firstStar + 1)..].ToString(),
+                        ignoreCase);
+                }
+
+                return true;
+            }
+
+            if (starCount == 2 && firstStar == 0 && segment[^1] == '*')
+            {
+                result = new ContainsGlobStrategy(segment[1..^1].ToString(), ignoreCase);
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        [SkipLocalsInit]
+        private static bool TryEncodeProgram(
+            ReadOnlySpan<char> pattern,
+            out string program,
+            out bool hasGlobStar)
+        {
+            ValueStringBuilder builder = new(stackalloc char[256]);
+            LiteralCursor lastLiteral = LiteralCursor.None;
+            hasGlobStar = false;
+            int overflowPosition = -1;
+
+            int index = 0;
+            while (index < pattern.Length)
+            {
+                if (pattern[index] == '*')
+                {
+                    int runEnd = index + 1;
+                    while (runEnd < pattern.Length && pattern[runEnd] == '*')
+                    {
+                        runEnd++;
+                    }
+
+                    if (TryEmitGlobStar(pattern, index, runEnd, ref builder, ref lastLiteral, out int next))
+                    {
+                        hasGlobStar = true;
+                        index = next;
+                        continue;
+                    }
+
+                    builder.Append(GlobOpCodes.AnyRun);
+                    lastLiteral = LiteralCursor.None;
+                    index = runEnd;
+                    continue;
+                }
+
+                int literalStart = index;
+                if (!TryEmitLiteralRun(pattern, ref index, ref builder, out lastLiteral))
+                {
+                    overflowPosition = literalStart;
+                    break;
+                }
+            }
+
+            if (overflowPosition >= 0)
+            {
+                builder.Dispose();
+                program = string.Empty;
+                return false;
+            }
+
+            program = builder.ToString();
+            return true;
+        }
+
+        private static bool TryEmitGlobStar(
+            ReadOnlySpan<char> pattern,
+            int index,
+            int runEnd,
+            ref ValueStringBuilder builder,
+            ref LiteralCursor lastLiteral,
+            out int next)
+        {
+            next = runEnd;
+            if (runEnd - index < 2
+                || (index != 0 && pattern[index - 1] != '/')
+                || (runEnd != pattern.Length && pattern[runEnd] != '/'))
+            {
+                return false;
+            }
+
+            int flags = 0;
+            if (index > 0)
+            {
+                flags |= GlobOpCodes.GlobStarFlagLead;
+            }
+
+            if (runEnd < pattern.Length)
+            {
+                flags |= GlobOpCodes.GlobStarFlagTrail;
+                next++;
+            }
+
+            if (index > 0)
+            {
+                StripTrailingSeparatorFromLastLiteral(ref builder, ref lastLiteral);
+            }
+
+            builder.Append(GlobOpCodes.GlobStar);
+            builder.Append((char)flags);
+            lastLiteral = LiteralCursor.None;
+            return true;
+        }
+
+        private static void StripTrailingSeparatorFromLastLiteral(
+            ref ValueStringBuilder builder,
+            ref LiteralCursor lastLiteral)
+        {
+            Debug.Assert(lastLiteral.Start >= 0 && lastLiteral.Length > 0);
+            Debug.Assert(builder[^1] == '/');
+
+            if (lastLiteral.Length == 1)
+            {
+                builder.Length = lastLiteral.Start;
+                lastLiteral = LiteralCursor.None;
+            }
+            else
+            {
+                builder.Length--;
+                lastLiteral.Length--;
+                builder[lastLiteral.Start + 1] = (char)lastLiteral.Length;
+            }
+        }
+
+        private static bool TryEmitLiteralRun(
+            ReadOnlySpan<char> pattern,
+            ref int index,
+            ref ValueStringBuilder builder,
+            out LiteralCursor lastLiteral)
+        {
+            int literalStart = builder.Length;
+            builder.Append(GlobOpCodes.Literal);
+            builder.Append('\0');
+            int literalLength = 0;
+
+            while (index < pattern.Length && pattern[index] != '*')
+            {
+                builder.Append(pattern[index]);
+                literalLength++;
+                index++;
+            }
+
+            if (literalLength > MaxOpcodeBodyLength)
+            {
+                lastLiteral = LiteralCursor.None;
+                return false;
+            }
+
+            builder[literalStart + 1] = (char)literalLength;
+            lastLiteral = new LiteralCursor { Start = literalStart, Length = literalLength };
+            return true;
+        }
+
+        private static void FindTrailingLiteral(
+            string program,
+            out int nfaProgramLength,
+            out int tailStart,
+            out int tailLength)
+        {
+            ReadOnlySpan<char> span = program;
+            int index = 0;
+            int lastOpcodeStart = -1;
+            char lastOpcode = '\0';
+            int lastOpcodeLength = 0;
+
+            while (index < span.Length)
+            {
+                lastOpcodeStart = index;
+                lastOpcode = span[index];
+                if (lastOpcode == GlobOpCodes.AnyRun)
+                {
+                    index++;
+                }
+                else if (lastOpcode == GlobOpCodes.GlobStar)
+                {
+                    index += 2;
+                }
+                else
+                {
+                    Debug.Assert(lastOpcode == GlobOpCodes.Literal);
+                    lastOpcodeLength = span[index + 1];
+                    index += 2 + lastOpcodeLength;
+                }
+            }
+
+            if (lastOpcode == GlobOpCodes.Literal)
+            {
+                nfaProgramLength = lastOpcodeStart;
+                tailStart = lastOpcodeStart + 2;
+                tailLength = lastOpcodeLength;
+            }
+            else
+            {
+                nfaProgramLength = program.Length;
+                tailStart = -1;
+                tailLength = 0;
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobCompiler.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobCompiler.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+internal static partial class GlobCompiler
+{
+    public static bool TryCompile(
+        string pattern,
+        bool ignoreCase,
+        [NotNullWhen(true)] out GlobStrategy? result) =>
+        Factory.TryCreate(pattern, ignoreCase, out result);
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobOpCodes.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobOpCodes.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  Opcode markers used by <see cref="CompiledGlobStrategy"/>'s bytecode-in-a-string
+//  encoding. Values are Unicode noncharacters, which are
+//  reserved by the Unicode standard for application-internal use and never appear
+//  in conforming text.
+// </summary>
+internal static class GlobOpCodes
+{
+    // <summary>Match zero or more characters (<c>*</c>). No payload.</summary>
+    public const char AnyRun = '\uFDD1';
+
+    // <summary>
+    //  Literal run. Followed by one length character and that many literal characters.
+    // </summary>
+    public const char Literal = '\uFDD2';
+
+    // <summary>
+    //  Globstar (<c>**</c>). Matches zero or more path segments (including the separators
+    //  between them). Followed by one
+    //  payload char whose low two bits encode which surrounding separators the scanner
+    //  absorbed into this opcode: bit 0 (<see cref="GlobStarFlagLead"/>) means the
+    //  pattern had a separator immediately before the <c>**</c> token; bit 1
+    //  (<see cref="GlobStarFlagTrail"/>) means a separator followed it. The two bits
+    //  together describe four shapes-whole-pattern <c>**</c> (neither),
+    //  leading <c>**/</c> (trail only), trailing <c>/**</c> (lead only), and middle
+    //  <c>/**/</c> (both)-each with their own validity constraints on the
+    //  absorbed input slice.
+    // </summary>
+    public const char GlobStar = '\uFDD5';
+
+    // <summary>
+    //  GlobStar payload bit: a path separator preceded the <c>**</c> in the source
+    //  pattern and was absorbed by this opcode. Equivalent to "the matched slice must
+    //  start with the separator (or be empty when paired with a non-set
+    //  <see cref="GlobStarFlagTrail"/>)".
+    // </summary>
+    public const int GlobStarFlagLead = 1;
+
+    // <summary>
+    //  GlobStar payload bit: a path separator followed the <c>**</c> in the source
+    //  pattern and was absorbed by this opcode. Equivalent to "the matched slice must
+    //  end with the separator (or be empty when paired with a non-set
+    //  <see cref="GlobStarFlagLead"/>)".
+    // </summary>
+    public const int GlobStarFlagTrail = 2;
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobStarFileNameStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobStarFileNameStrategy.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  Specialized matcher for the canonical <c>**/&lt;segment&gt;</c>
+//  shape (e.g. <c>**/*.cs</c>, <c>**/file.cs</c>, <c>**/foo*</c>) where the trailing
+//  segment contains no separators. The matcher delegates to an inner path-unaware
+//  segment matcher that already knows the cheapest implementation for the segment
+//  shape (literal / prefix / suffix / contains / prefix+suffix / any), bypassing the
+//  bytecode interpreter entirely. The two-span override ignores the directory prefix,
+//  so the per-file hot path is one delegated match against the file name span.
+// </summary>
+internal sealed class GlobStarFileNameStrategy : GlobStrategy
+{
+    private readonly GlobStrategy _segmentMatcher;
+
+    public GlobStarFileNameStrategy(GlobStrategy segmentMatcher)
+        : base(ignoreCase: false)
+    {
+        _segmentMatcher = segmentMatcher;
+    }
+
+    // <inheritdoc/>
+    // <remarks>
+    //  <para>
+    //   The directory prefix in <paramref name="directoryPrefix"/> is irrelevant for
+    //   <c>**/</c> globstar patterns: zero or more
+    //   directory segments are matched by the leading globstar, and the trailing
+    //   segment matches against the file name alone. The wrapper delegates straight
+    //   to the inner segment matcher with <paramref name="fileName"/>, bypassing the
+    //   bytecode interpreter and any path concatenation on the per-file hot path.
+    //  </para>
+    // </remarks>
+    internal override bool MatchCore(
+        ReadOnlySpan<char> directoryPrefix,
+        ReadOnlySpan<char> fileName)
+        => _segmentMatcher.MatchCore(default, fileName);
+
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/GlobStrategy.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  Immutable, root-independent FSG matching strategy.
+// </summary>
+// <remarks>
+//  <para>
+//   Strategies hold no per-enumeration state and can be matched concurrently.
+//  </para>
+// </remarks>
+internal abstract class GlobStrategy
+{
+    private protected GlobStrategy(bool ignoreCase)
+    {
+        IgnoreCase = ignoreCase;
+    }
+
+    // <summary>
+    //  The case-fold rule the strategy dispatches to when comparing characters.
+    // </summary>
+    internal bool IgnoreCase { get; }
+
+    // <summary>
+    //  The path separator character for path-aware matching, or <c>'\0'</c> when the
+    //  dialect is path-unaware.
+    // </summary>
+    protected const char Separator = '/';
+
+    // <summary>
+    //  Tests whether the logical concatenation
+    //  <paramref name="directoryPrefix"/> + <paramref name="fileName"/> matches the
+    //  compiled pattern. When <paramref name="directoryPrefix"/> is non-empty it
+    //  ends with <see cref="Separator"/>.
+    // </summary>
+    internal abstract bool MatchCore(
+        ReadOnlySpan<char> directoryPrefix,
+        ReadOnlySpan<char> fileName);
+
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/LiteralDirectoryPathStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/LiteralDirectoryPathStrategy.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Touki.Io.Globbing;
+
+internal sealed class LiteralDirectoryPathStrategy : GlobStrategy
+{
+    private readonly string _directoryPath;
+    private readonly GlobStrategy _fileMatcher;
+
+    public LiteralDirectoryPathStrategy(string directoryPath, GlobStrategy fileMatcher, bool ignoreCase)
+        : base(ignoreCase)
+    {
+        _directoryPath = directoryPath;
+        _fileMatcher = fileMatcher;
+    }
+
+    internal override bool MatchCore(ReadOnlySpan<char> directoryPrefix, ReadOnlySpan<char> fileName) =>
+        directoryPrefix.Equals(
+            _directoryPath,
+            IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)
+        && _fileMatcher.MatchCore(default, fileName);
+
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/LiteralGlobStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/LiteralGlobStrategy.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  Matches inputs that are byte-for-byte equal to a fixed literal.
+// </summary>
+internal sealed class LiteralGlobStrategy : GlobStrategy
+{
+    private readonly string _literal;
+
+    public LiteralGlobStrategy(string literal, bool ignoreCase)
+        : base(ignoreCase)
+    {
+        _literal = literal;
+    }
+
+    // <inheritdoc/>
+    // <remarks>
+    //  <para>
+    //   Compares the logical concatenation <paramref name="directoryPrefix"/> +
+    //   <paramref name="fileName"/> against the stored literal without copying either
+    //   span. The literal is split at <c>directoryPrefix.Length</c> so each half stays
+    //   contiguous on its source span and the inner comparisons use the same vectorized
+    //   routines as the path-unaware fast paths. Path-unaware matchers receive an
+    //   empty <paramref name="directoryPrefix"/> and the implementation collapses to a
+    //   single full-span equality. When <paramref name="directoryPrefix"/> is
+    //   non-empty the caller has appended <see cref="GlobStrategy.Separator"/> at
+    //   the end, so the split at <c>directoryPrefix.Length</c> aligns exactly with
+    //   the literal's directory / file-name boundary.
+    //  </para>
+    // </remarks>
+    internal override bool MatchCore(
+        ReadOnlySpan<char> directoryPrefix,
+        ReadOnlySpan<char> fileName)
+    {
+        int total = directoryPrefix.Length + fileName.Length;
+        if (total != _literal.Length)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> literal = _literal.AsSpan();
+        ReadOnlySpan<char> literalPrefix = literal[..directoryPrefix.Length];
+        ReadOnlySpan<char> literalFileName = literal[directoryPrefix.Length..];
+
+        return IgnoreCase
+            ? directoryPrefix.Equals(literalPrefix, StringComparison.OrdinalIgnoreCase)
+                && fileName.Equals(literalFileName, StringComparison.OrdinalIgnoreCase)
+            : directoryPrefix.SequenceEqual(literalPrefix)
+                && fileName.SequenceEqual(literalFileName);
+    }
+
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/PrefixGlobStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/PrefixGlobStrategy.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  Matches inputs that start with a fixed literal prefix (pattern of the form <c>prefix*</c>).
+// </summary>
+internal sealed class PrefixGlobStrategy : GlobStrategy
+{
+    private readonly string _prefix;
+
+    public PrefixGlobStrategy(string prefix, bool ignoreCase)
+        : base(ignoreCase)
+    {
+        _prefix = prefix;
+    }
+
+    // <inheritdoc/>
+    internal override bool MatchCore(
+        ReadOnlySpan<char> directoryPrefix,
+        ReadOnlySpan<char> fileName)
+    {
+        // PrefixGlobStrategy is only chosen for path-unaware dialects; the directory
+        // prefix is always empty by construction. The prefix is taken from the
+        // pattern; a literal '.' in the prefix correctly enforces the POSIX
+        // leading-dot rule by itself, so no extra check is required.
+        Debug.Assert(directoryPrefix.IsEmpty);
+        ReadOnlySpan<char> prefix = _prefix.AsSpan();
+        return IgnoreCase
+            ? fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            : fileName.StartsWith(prefix);
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/PrefixSuffixGlobStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/PrefixSuffixGlobStrategy.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  Matches inputs of the form <c>prefix*suffix</c> -- a single <c>*</c> bracketed by
+//  literal runs.
+// </summary>
+internal sealed class PrefixSuffixGlobStrategy : GlobStrategy
+{
+    private readonly string _prefix;
+    private readonly string _suffix;
+
+    public PrefixSuffixGlobStrategy(string prefix, string suffix, bool ignoreCase)
+        : base(ignoreCase)
+    {
+        _prefix = prefix;
+        _suffix = suffix;
+    }
+
+    // <inheritdoc/>
+    internal override bool MatchCore(
+        ReadOnlySpan<char> directoryPrefix,
+        ReadOnlySpan<char> fileName)
+    {
+        // PrefixSuffixGlobStrategy is only chosen for path-unaware dialects; the
+        // directory prefix is always empty by construction.
+        Debug.Assert(directoryPrefix.IsEmpty);
+        ReadOnlySpan<char> prefix = _prefix.AsSpan();
+        ReadOnlySpan<char> suffix = _suffix.AsSpan();
+        if (fileName.Length < prefix.Length + suffix.Length)
+        {
+            return false;
+        }
+
+        // The prefix is taken from the pattern and is not a wildcard, so it enforces the
+        // leading-dot rule by literal compare.
+        return IgnoreCase
+            ? fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                && fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            : fileName.StartsWith(prefix) && fileName.EndsWith(suffix);
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/RecursiveDirectoryPathStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/RecursiveDirectoryPathStrategy.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Touki.Io.Globbing;
+
+internal sealed class RecursiveDirectoryPathStrategy : GlobStrategy
+{
+    private readonly string _directoryPath;
+
+    public RecursiveDirectoryPathStrategy(string directoryPath, bool ignoreCase)
+        : base(ignoreCase)
+    {
+        _directoryPath = directoryPath + '/';
+    }
+
+    internal override bool MatchCore(ReadOnlySpan<char> directoryPrefix, ReadOnlySpan<char> fileName)
+    {
+        StringComparison comparison = IgnoreCase
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        ReadOnlySpan<char> remaining = directoryPrefix;
+
+        while (true)
+        {
+            int match = remaining.IndexOf(_directoryPath, comparison);
+            if (match < 0)
+            {
+                return false;
+            }
+
+            if (match == 0 || remaining[match - 1] == '/')
+            {
+                return true;
+            }
+
+            remaining = remaining[(match + 1)..];
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/RootFileNameStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/RootFileNameStrategy.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Touki.Io.Globbing;
+
+internal sealed class RootFileNameStrategy : GlobStrategy
+{
+    private readonly GlobStrategy _fileMatcher;
+
+    public RootFileNameStrategy(GlobStrategy fileMatcher)
+        : base(ignoreCase: false)
+    {
+        _fileMatcher = fileMatcher;
+    }
+
+    internal override bool MatchCore(ReadOnlySpan<char> directoryPrefix, ReadOnlySpan<char> fileName) =>
+        directoryPrefix.IsEmpty && _fileMatcher.MatchCore(default, fileName);
+
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/SuffixGlobStrategy.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/Globbing/SuffixGlobStrategy.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+// <summary>
+//  Matches inputs that end with a fixed literal suffix (pattern of the form <c>*suffix</c>).
+// </summary>
+internal sealed class SuffixGlobStrategy : GlobStrategy
+{
+    private readonly string _suffix;
+
+    public SuffixGlobStrategy(string suffix, bool ignoreCase)
+        : base(ignoreCase)
+    {
+        _suffix = suffix;
+    }
+
+    // <inheritdoc/>
+    internal override bool MatchCore(
+        ReadOnlySpan<char> directoryPrefix,
+        ReadOnlySpan<char> fileName)
+    {
+        // SuffixGlobStrategy is only chosen for path-unaware dialects; the directory
+        // prefix is always empty by construction.
+        Debug.Assert(directoryPrefix.IsEmpty);
+        ReadOnlySpan<char> suffix = _suffix.AsSpan();
+
+        return IgnoreCase
+            ? fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            : fileName.EndsWith(suffix);
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/OrderedPatternMatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/Io/OrderedPatternMatcher.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+using Microsoft.Extensions.FileSystemGlobbing.Internal;
+
+internal sealed class OrderedPatternMatcher
+{
+    private readonly IncludeOrExcludeValue<ToukiPattern>[] _rules;
+
+    public OrderedPatternMatcher(IncludeOrExcludeValue<ToukiPattern>[] rules)
+    {
+        _rules = rules;
+    }
+
+    internal bool TryMatchFile(
+        ReadOnlySpan<char> currentDirectory,
+        ReadOnlySpan<char> fileName,
+        [NotNullWhen(true)] out ToukiPattern? matchingInclude)
+    {
+        bool included = false;
+        matchingInclude = null;
+
+        foreach (IncludeOrExcludeValue<ToukiPattern> rule in _rules)
+        {
+            bool ruleIncludes = rule.IsInclude;
+            if (included == ruleIncludes)
+            {
+                continue;
+            }
+
+            if (rule.Value.MatchesFile(currentDirectory, fileName))
+            {
+                included = ruleIncludes;
+                matchingInclude = ruleIncludes ? rule.Value : null;
+            }
+        }
+
+        return included && matchingInclude is not null;
+    }
+
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/ToukiMatcherContext.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/ToukiMatcherContext.cs
@@ -1,0 +1,1023 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Enumeration;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
+using Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments;
+using Microsoft.Extensions.FileSystemGlobbing.Internal.PatternContexts;
+using Microsoft.Extensions.FileSystemGlobbing.Util;
+using Touki.Io;
+
+namespace Microsoft.Extensions.FileSystemGlobbing.Internal
+{
+    internal sealed class ToukiMatcherPlan
+    {
+        private ToukiMatcherPlan(
+            ToukiPattern[] includePatterns,
+            ToukiPattern[] excludePatterns,
+            DirectDirectoryExclusion[]? directDirectoryExclusions,
+            ExclusionWinsPatternMatcher exclusionWinsMatcher)
+        {
+            IncludePatterns = includePatterns;
+            ExcludePatterns = excludePatterns;
+            DirectDirectoryExclusions = directDirectoryExclusions;
+            ExclusionWinsMatcher = exclusionWinsMatcher;
+        }
+
+        private ToukiMatcherPlan(
+            IncludeOrExcludeValue<ToukiPattern>[] orderedPatterns,
+            OrderedPatternMatcher orderedMatcher)
+        {
+            OrderedPatterns = orderedPatterns;
+            OrderedMatcher = orderedMatcher;
+        }
+
+        public ToukiPattern[]? IncludePatterns { get; }
+
+        public ToukiPattern[]? ExcludePatterns { get; }
+
+        public IncludeOrExcludeValue<ToukiPattern>[]? OrderedPatterns { get; }
+
+        public DirectDirectoryExclusion[]? DirectDirectoryExclusions { get; }
+
+        public ExclusionWinsPatternMatcher? ExclusionWinsMatcher { get; }
+
+        public OrderedPatternMatcher? OrderedMatcher { get; }
+
+        public static bool TryCreate(
+            IReadOnlyList<IPattern> includePatterns,
+            IReadOnlyList<IPattern> excludePatterns,
+            StringComparison comparison,
+            [NotNullWhen(true)] out ToukiMatcherPlan? plan)
+        {
+            if (!TryGetPatterns(includePatterns, comparison, out ToukiPattern[]? includes)
+                || includes.Length == 0
+                || !TryGetPatterns(excludePatterns, comparison, out ToukiPattern[]? excludes))
+            {
+                plan = null;
+                return false;
+            }
+
+            var matcher = new ExclusionWinsPatternMatcher(includes, excludes);
+
+            DirectDirectoryExclusion[]? directDirectoryExclusions =
+                TryCreateDirectDirectoryExclusions(excludes, comparison, out DirectDirectoryExclusion[]? direct)
+                    ? direct
+                    : null;
+
+            plan = new ToukiMatcherPlan(includes, excludes, directDirectoryExclusions, matcher);
+            return true;
+        }
+
+        public static bool TryCreate(
+            IReadOnlyList<IncludeOrExcludeValue<IPattern>> orderedPatterns,
+            StringComparison comparison,
+            [NotNullWhen(true)] out ToukiMatcherPlan? plan)
+        {
+            var patterns = new IncludeOrExcludeValue<ToukiPattern>[orderedPatterns.Count];
+            bool hasInclude = false;
+
+            for (int index = 0; index < orderedPatterns.Count; index++)
+            {
+                IncludeOrExcludeValue<IPattern> item = orderedPatterns[index];
+                ToukiPattern pattern = ToukiPattern.Create(item.Value, comparison);
+                if (!pattern.TryCompile())
+                {
+                    plan = null;
+                    return false;
+                }
+
+                patterns[index] = new IncludeOrExcludeValue<ToukiPattern>
+                {
+                    IsInclude = item.IsInclude,
+                    Value = pattern
+                };
+
+                if (item.IsInclude)
+                {
+                    hasInclude = true;
+                }
+            }
+
+            if (!hasInclude)
+            {
+                plan = null;
+                return false;
+            }
+
+            plan = new ToukiMatcherPlan(patterns, new OrderedPatternMatcher(patterns));
+            return true;
+        }
+
+        public PatternMatchingResult Execute(DirectoryInfoBase directoryInfo, StringComparison comparison) =>
+            new ToukiMatcherContext(this, directoryInfo, comparison).Execute();
+
+        private static bool TryGetPatterns(
+            IReadOnlyList<IPattern> patterns,
+            StringComparison comparison,
+            [NotNullWhen(true)] out ToukiPattern[]? toukiPatterns)
+        {
+            var result = new ToukiPattern[patterns.Count];
+            for (int index = 0; index < patterns.Count; index++)
+            {
+                IPattern item = patterns[index];
+                ToukiPattern pattern = ToukiPattern.Create(item, comparison);
+                if (!pattern.TryCompile())
+                {
+                    toukiPatterns = null;
+                    return false;
+                }
+
+                result[index] = pattern;
+            }
+
+            toukiPatterns = result;
+            return true;
+        }
+
+        private static bool TryCreateDirectDirectoryExclusions(
+            ToukiPattern[] excludes,
+            StringComparison comparison,
+            [NotNullWhen(true)] out DirectDirectoryExclusion[]? directExcludes)
+        {
+            if (excludes.Length == 0)
+            {
+                directExcludes = [];
+                return true;
+            }
+
+            var result = new DirectDirectoryExclusion[excludes.Length];
+            for (int index = 0; index < excludes.Length; index++)
+            {
+                if (!DirectDirectoryExclusion.TryCreate(excludes[index], comparison, out result[index]))
+                {
+                    directExcludes = null;
+                    return false;
+                }
+            }
+
+            directExcludes = result;
+            return true;
+        }
+    }
+
+    internal readonly struct DirectDirectoryExclusion
+    {
+        private readonly ToukiPattern? _fileNamePattern;
+        private readonly string? _literalPath;
+        private readonly StringComparison _comparison;
+        private readonly bool _matchAll;
+        private readonly bool _pruneCandidate;
+
+        private DirectDirectoryExclusion(ToukiPattern fileNamePattern)
+        {
+            _fileNamePattern = fileNamePattern;
+        }
+
+        private DirectDirectoryExclusion(
+            string literalPath,
+            StringComparison comparison,
+            bool matchAll,
+            bool pruneCandidate)
+        {
+            _literalPath = literalPath;
+            _comparison = comparison;
+            _matchAll = matchAll;
+            _pruneCandidate = pruneCandidate;
+        }
+
+        public bool Matches(ReadOnlySpan<char> directoryPrefix, ReadOnlySpan<char> directoryName)
+        {
+            if (_fileNamePattern is not null)
+            {
+                return _fileNamePattern.MatchesFile(directoryPrefix, directoryName);
+            }
+
+            if (_matchAll)
+            {
+                return true;
+            }
+
+            if (!_pruneCandidate)
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> literalPath = _literalPath;
+            return directoryPrefix.Length + directoryName.Length == literalPath.Length
+                && directoryPrefix.Equals(literalPath[..directoryPrefix.Length], _comparison)
+                && directoryName.Equals(literalPath[directoryPrefix.Length..], _comparison);
+        }
+
+        public bool PrunesDescendants(ReadOnlySpan<char> directoryPrefix)
+        {
+            if (_fileNamePattern is not null || _matchAll || _pruneCandidate)
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> literalPath = _literalPath;
+            return directoryPrefix.Length == literalPath.Length + 1
+                && directoryPrefix[^1] == '/'
+                && directoryPrefix[..^1].Equals(literalPath, _comparison);
+        }
+
+        public static bool TryCreate(
+            ToukiPattern pattern,
+            StringComparison comparison,
+            out DirectDirectoryExclusion directExclude)
+        {
+            if (pattern.LegacyPattern is IRaggedPattern
+                {
+                    StartsWith.Count: 0,
+                    Contains.Count: 0,
+                    EndsWith.Count: 1,
+                    Segments.Count: > 1
+                } fileNamePattern
+                && fileNamePattern.Segments[0] is RecursiveWildcardSegment)
+            {
+                directExclude = new DirectDirectoryExclusion(pattern);
+                return true;
+            }
+
+            if (pattern.LegacyPattern is IRaggedPattern
+                {
+                    Contains.Count: 0,
+                    EndsWith.Count: 0,
+                    Segments.Count: > 0
+                } recursivePattern
+                && recursivePattern.Segments[^1] is RecursiveWildcardSegment)
+            {
+                string[] literalSegments = new string[recursivePattern.StartsWith.Count];
+                for (int index = 0; index < literalSegments.Length; index++)
+                {
+                    if (recursivePattern.StartsWith[index] is not LiteralPathSegment literal)
+                    {
+                        directExclude = default;
+                        return false;
+                    }
+
+                    literalSegments[index] = literal.Value;
+                }
+
+                directExclude = new DirectDirectoryExclusion(
+                    string.Join('/', literalSegments),
+                    comparison,
+                    matchAll: literalSegments.Length == 0,
+                    pruneCandidate: literalSegments.Length <= 1);
+                return true;
+            }
+
+            directExclude = default;
+            return false;
+        }
+    }
+
+    internal sealed class ToukiMatcherContext
+    {
+        private readonly DirectoryInfoBase _root;
+        private readonly IPatternContext? _directoryContext;
+        private readonly ExclusionWinsPatternMatcher? _exclusionWinsMatcher;
+        private readonly OrderedPatternMatcher? _orderedMatcher;
+        private readonly DirectDirectoryExclusion[]? _directDirectoryExclusions;
+        private readonly bool _hasParentPathSegment;
+        private readonly List<FilePatternMatch> _files = [];
+        private readonly StringComparer _comparer;
+        private HashSet<string>? _declaredLiteralFolderSegments;
+        private bool _declaredLiteralFileSegment;
+        private bool _declaredParentPathSegment;
+        private bool _declaredWildcardPathSegment;
+
+        public ToukiMatcherContext(
+            ToukiMatcherPlan plan,
+            DirectoryInfoBase directoryInfo,
+            StringComparison comparison)
+        {
+            _root = directoryInfo;
+            _comparer = StringComparisonHelper.GetStringComparer(comparison);
+            _exclusionWinsMatcher = plan.ExclusionWinsMatcher;
+            _orderedMatcher = plan.OrderedMatcher;
+            _directDirectoryExclusions = plan.DirectDirectoryExclusions;
+            _hasParentPathSegment = HasParentPathSegment(plan);
+
+            if (directoryInfo.GetType() == typeof(DirectoryInfoWrapper)
+                && !_hasParentPathSegment
+                && CanTraverseAllDirectories(plan))
+            {
+                _directoryContext = null;
+            }
+            else if (plan.OrderedPatterns is { } orderedPatterns)
+            {
+                var contexts = new IncludeOrExcludeValue<IPatternContext>[orderedPatterns.Length];
+                for (int index = 0; index < orderedPatterns.Length; index++)
+                {
+                    IncludeOrExcludeValue<ToukiPattern> item = orderedPatterns[index];
+                    contexts[index] = new IncludeOrExcludeValue<IPatternContext>
+                    {
+                        IsInclude = item.IsInclude,
+                        Value = CreateDirectoryPatternContext(item.Value, item.IsInclude)
+                    };
+                }
+
+                _directoryContext = new PreserveOrderCompositePatternContext(contexts);
+            }
+            else
+            {
+                ToukiPattern[] includePatterns = plan.IncludePatterns!;
+                var includeContexts = new IPatternContext[includePatterns.Length];
+                for (int index = 0; index < includePatterns.Length; index++)
+                {
+                    includeContexts[index] = CreateDirectoryPatternContext(
+                        includePatterns[index],
+                        isInclude: true);
+                }
+
+                ToukiPattern[] excludePatterns = plan.ExcludePatterns!;
+                var excludeContexts = new IPatternContext[excludePatterns.Length];
+                for (int index = 0; index < excludePatterns.Length; index++)
+                {
+                    excludeContexts[index] = CreateDirectoryPatternContext(
+                        excludePatterns[index],
+                        isInclude: false);
+                }
+
+                _directoryContext = new IncludesFirstCompositePatternContext(includeContexts, excludeContexts);
+            }
+        }
+
+        public PatternMatchingResult Execute()
+        {
+            Match(_root, parentRelativePath: null);
+            return new PatternMatchingResult(_files, _files.Count > 0);
+        }
+
+        private void Match(DirectoryInfoBase directory, string? parentRelativePath)
+        {
+            if (directory.GetType() == typeof(DirectoryInfoWrapper))
+            {
+                var wrapper = (DirectoryInfoWrapper)directory;
+                if (_hasParentPathSegment)
+                {
+                    Match(wrapper, parentRelativePath);
+                }
+                else
+                {
+                    DirectoryInfo wrappedDirectory = wrapper.DirectoryInfo;
+                    if (_directoryContext is null)
+                    {
+                        wrappedDirectory.Refresh();
+                        if (wrappedDirectory.Exists)
+                        {
+                            int rootPrefixLength = wrappedDirectory.FullName.Length
+                                + (Path.EndsInDirectorySeparator(wrappedDirectory.FullName) ? 0 : 1);
+                            MatchFileSystemPath(wrappedDirectory.FullName, rootPrefixLength);
+                        }
+                    }
+                    else
+                    {
+                        MatchFileSystemDirectory(wrapper, wrappedDirectory.FullName);
+                    }
+                }
+
+                return;
+            }
+
+            _directoryContext!.PushDirectory(directory);
+            Declare();
+
+            var entities = new List<FileSystemInfoBase?>();
+            if (_declaredWildcardPathSegment || _declaredLiteralFileSegment)
+            {
+                entities.AddRange(directory.EnumerateFileSystemInfos());
+            }
+            else
+            {
+                foreach (FileSystemInfoBase candidate in directory.EnumerateFileSystemInfos())
+                {
+                    if (candidate is DirectoryInfoBase
+                        && _declaredLiteralFolderSegments?.Contains(candidate.Name) == true)
+                    {
+                        entities.Add(candidate);
+                    }
+                }
+            }
+
+            if (_declaredParentPathSegment)
+            {
+                entities.Add(directory.GetDirectory(".."));
+            }
+
+            string directoryPrefix = parentRelativePath is null ? string.Empty : parentRelativePath + "/";
+            var subDirectories = new List<DirectoryInfoBase>();
+            foreach (FileSystemInfoBase? entity in entities)
+            {
+                if (entity is FileInfoBase fileInfo)
+                {
+                    PatternTestResult match = TestFile(directoryPrefix, fileInfo.Name);
+                    if (match.IsSuccessful)
+                    {
+                        _files.Add(new FilePatternMatch(
+                            MatcherContext.CombinePath(parentRelativePath, fileInfo.Name),
+                            match.Stem));
+                    }
+                }
+                else if (entity is DirectoryInfoBase directoryInfo && _directoryContext.Test(directoryInfo))
+                {
+                    subDirectories.Add(directoryInfo);
+                }
+            }
+
+            foreach (DirectoryInfoBase subDirectory in subDirectories)
+            {
+                Match(subDirectory, MatcherContext.CombinePath(parentRelativePath, subDirectory.Name));
+            }
+
+            _directoryContext.PopDirectory();
+        }
+
+        private void MatchFileSystemDirectory(
+            DirectoryInfoBase directory,
+            string physicalPath)
+        {
+            _directoryContext!.PushDirectory(directory);
+            Declare();
+            bool enumerateFiles = _declaredWildcardPathSegment || _declaredLiteralFileSegment;
+
+            FileSystemDirectoryInfo? firstSubDirectory = null;
+
+            bool exists;
+            if (directory is DirectoryInfoWrapper wrapper)
+            {
+                wrapper.DirectoryInfo.Refresh();
+                exists = wrapper.DirectoryInfo.Exists;
+            }
+            else
+            {
+                exists = Directory.Exists(physicalPath);
+            }
+
+            if (exists)
+            {
+                WrapperFileSystemEnumerator? enumerator = null;
+                try
+                {
+                    enumerator = new WrapperFileSystemEnumerator(
+                        this,
+                        physicalPath,
+                        directory,
+                        enumerateFiles);
+                }
+                catch (DirectoryNotFoundException)
+                {
+                }
+
+                if (enumerator is not null)
+                {
+                    using (enumerator)
+                    {
+                        while (enumerator.MoveNext())
+                        {
+                        }
+                    }
+
+                    firstSubDirectory = enumerator.FirstSubDirectory;
+                }
+            }
+
+            for (FileSystemDirectoryInfo? subDirectory = firstSubDirectory;
+                subDirectory is not null;
+                subDirectory = subDirectory.Next)
+            {
+                MatchFileSystemDirectory(
+                    subDirectory,
+                    subDirectory.FullName);
+            }
+
+            _directoryContext.PopDirectory();
+        }
+
+        private void MatchFileSystemPath(string physicalPath, int rootPrefixLength)
+        {
+            string[]? subDirectories = null;
+            int subDirectoryCount = 0;
+            WrapperFileSystemEnumerator? enumerator = null;
+            try
+            {
+                enumerator = new WrapperFileSystemEnumerator(this, physicalPath, rootPrefixLength);
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+
+            if (enumerator is not null)
+            {
+                using (enumerator)
+                {
+                    while (enumerator.MoveNext())
+                    {
+                    }
+
+                    enumerator.TakePathSubDirectories(out subDirectories, out subDirectoryCount);
+                }
+            }
+
+            if (subDirectories is null)
+            {
+                return;
+            }
+
+            try
+            {
+                for (int index = 0; index < subDirectoryCount; index++)
+                {
+                    MatchFileSystemPath(subDirectories[index], rootPrefixLength);
+                }
+            }
+            finally
+            {
+                ArrayPool<string>.Shared.Return(subDirectories, clearArray: true);
+            }
+        }
+
+        private void Match(DirectoryInfoWrapper directory, string? parentRelativePath)
+        {
+            _directoryContext!.PushDirectory(directory);
+            Declare();
+
+            bool enumerateFiles = _declaredWildcardPathSegment || _declaredLiteralFileSegment;
+            string directoryPrefix = parentRelativePath is null ? string.Empty : parentRelativePath + "/";
+            var subDirectories = new List<DirectoryInfoWrapper>();
+
+            DirectoryInfo wrappedDirectory = directory.DirectoryInfo;
+            wrappedDirectory.Refresh();
+            if (wrappedDirectory.Exists)
+            {
+                IEnumerable<FileSystemInfo> fileSystemInfos;
+                try
+                {
+                    fileSystemInfos = wrappedDirectory.EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly);
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    fileSystemInfos = [];
+                }
+
+                foreach (FileSystemInfo fileSystemInfo in fileSystemInfos)
+                {
+                    if (fileSystemInfo is DirectoryInfo childDirectory)
+                    {
+                        if (enumerateFiles || _declaredLiteralFolderSegments?.Contains(childDirectory.Name) == true)
+                        {
+                            var childWrapper = new DirectoryInfoWrapper(childDirectory);
+                            if (_directoryContext.Test(childWrapper))
+                            {
+                                subDirectories.Add(childWrapper);
+                            }
+                        }
+                    }
+                    else if (enumerateFiles)
+                    {
+                        PatternTestResult match = TestFile(directoryPrefix, fileSystemInfo.Name);
+                        if (match.IsSuccessful)
+                        {
+                            _files.Add(new FilePatternMatch(
+                                MatcherContext.CombinePath(parentRelativePath, fileSystemInfo.Name),
+                                match.Stem));
+                        }
+                    }
+                }
+            }
+
+            if (_declaredParentPathSegment
+                && directory.GetDirectory("..") is DirectoryInfoWrapper parentDirectory
+                && _directoryContext.Test(parentDirectory))
+            {
+                subDirectories.Add(parentDirectory);
+            }
+
+            foreach (DirectoryInfoWrapper subDirectory in subDirectories)
+            {
+                Match(subDirectory, MatcherContext.CombinePath(parentRelativePath, subDirectory.Name));
+            }
+
+            _directoryContext.PopDirectory();
+        }
+
+        private PatternTestResult TestFile(string directoryPrefix, string fileName)
+        {
+            if (!TryMatchFile(directoryPrefix, fileName, out ToukiPattern? pattern))
+            {
+                return PatternTestResult.Failed;
+            }
+
+            return PatternTestResult.Success(pattern.CalculateStem(directoryPrefix, fileName));
+        }
+
+        private bool TryMatchFile(
+            ReadOnlySpan<char> directoryPrefix,
+            ReadOnlySpan<char> fileName,
+            [NotNullWhen(true)] out ToukiPattern? pattern)
+        {
+            ToukiPattern? matchingInclude;
+            bool matched = _orderedMatcher is not null
+                ? _orderedMatcher.TryMatchFile(directoryPrefix, fileName, out matchingInclude)
+                : _exclusionWinsMatcher!.TryMatchFile(directoryPrefix, fileName, out matchingInclude);
+
+            pattern = matchingInclude;
+            return matched;
+        }
+
+        private bool IsDirectoryExcluded(
+            ReadOnlySpan<char> directoryPrefix,
+            ReadOnlySpan<char> directoryName)
+        {
+            foreach (DirectDirectoryExclusion exclude in _directDirectoryExclusions!)
+            {
+                if (exclude.Matches(directoryPrefix, directoryName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool ShouldPruneSubDirectories(ReadOnlySpan<char> directoryPrefix)
+        {
+            foreach (DirectDirectoryExclusion exclude in _directDirectoryExclusions!)
+            {
+                if (exclude.PrunesDescendants(directoryPrefix))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void Declare()
+        {
+            _declaredLiteralFileSegment = false;
+            _declaredLiteralFolderSegments?.Clear();
+            _declaredParentPathSegment = false;
+            _declaredWildcardPathSegment = false;
+            _directoryContext!.Declare(DeclareInclude);
+        }
+
+        private void DeclareInclude(IPathSegment patternSegment, bool isLastSegment)
+        {
+            if (patternSegment is LiteralPathSegment literalSegment)
+            {
+                if (isLastSegment)
+                {
+                    _declaredLiteralFileSegment = true;
+                }
+                else
+                {
+                    (_declaredLiteralFolderSegments ??= new HashSet<string>(_comparer)).Add(literalSegment.Value);
+                }
+            }
+            else if (patternSegment is ParentPathSegment)
+            {
+                _declaredParentPathSegment = true;
+            }
+            else if (patternSegment is WildcardPathSegment)
+            {
+                _declaredWildcardPathSegment = true;
+            }
+        }
+
+        private static bool HasParentPathSegment(ToukiMatcherPlan plan)
+        {
+            if (plan.OrderedPatterns is { } orderedPatterns)
+            {
+                foreach (IncludeOrExcludeValue<ToukiPattern> item in orderedPatterns)
+                {
+                    if (HasParentPathSegment(item.Value.LegacyPattern))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            foreach (ToukiPattern pattern in plan.IncludePatterns!)
+            {
+                if (HasParentPathSegment(pattern.LegacyPattern))
+                {
+                    return true;
+                }
+            }
+
+            foreach (ToukiPattern pattern in plan.ExcludePatterns!)
+            {
+                if (HasParentPathSegment(pattern.LegacyPattern))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IPatternContext CreateDirectoryPatternContext(
+            ToukiPattern pattern,
+            bool isInclude)
+        {
+            IPatternContext context = isInclude
+                ? pattern.LegacyPattern.CreatePatternContextForInclude()
+                : pattern.LegacyPattern.CreatePatternContextForExclude();
+
+            if (context is PatternContextLinear linearContext)
+            {
+                linearContext.TrackStem = false;
+            }
+            else if (context is PatternContextRagged raggedContext)
+            {
+                raggedContext.TrackStem = false;
+            }
+
+            return context;
+        }
+
+        private static bool CanTraverseAllDirectories(ToukiMatcherPlan plan)
+        {
+            if (plan.OrderedPatterns is not null || plan.DirectDirectoryExclusions is null)
+            {
+                return false;
+            }
+
+            foreach (ToukiPattern pattern in plan.IncludePatterns!)
+            {
+                if (pattern.LegacyPattern is IRaggedPattern { StartsWith.Count: 0 })
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasParentPathSegment(IPattern pattern)
+        {
+            IList<IPathSegment> segments = pattern switch
+            {
+                ILinearPattern linearPattern => linearPattern.Segments,
+                IRaggedPattern raggedPattern => raggedPattern.Segments,
+                _ => []
+            };
+
+            foreach (IPathSegment segment in segments)
+            {
+                if (segment is ParentPathSegment)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private sealed class WrapperFileSystemEnumerator : FileSystemEnumerator<bool>
+        {
+            private static readonly EnumerationOptions s_options = new()
+            {
+                AttributesToSkip = 0,
+                IgnoreInaccessible = false,
+                MatchType = MatchType.Win32
+            };
+
+            private readonly ToukiMatcherContext _context;
+            private readonly DirectoryInfoBase _directory;
+            private readonly bool _enumerateFiles;
+            private char[]? _directoryPrefixBuffer;
+            private readonly int _directoryPrefixLength;
+            private FileSystemDirectoryInfo? _lastSubDirectory;
+            private string[]? _pathSubDirectories;
+            private int _pathSubDirectoryCount;
+            private readonly bool _pruneSubDirectories;
+
+            public WrapperFileSystemEnumerator(
+                ToukiMatcherContext context,
+                string directory,
+                DirectoryInfoBase directoryInfo,
+                bool enumerateFiles)
+                : base(directory, s_options)
+            {
+                _context = context;
+                _directory = directoryInfo;
+                _enumerateFiles = enumerateFiles;
+
+                if (directoryInfo is FileSystemDirectoryInfo fileSystemDirectory)
+                {
+                    _directoryPrefixLength = fileSystemDirectory.RelativePrefixLength;
+                    _directoryPrefixBuffer = ArrayPool<char>.Shared.Rent(_directoryPrefixLength);
+                    BuildDirectoryPrefix(
+                        fileSystemDirectory,
+                        _directoryPrefixBuffer.AsSpan(0, _directoryPrefixLength));
+                }
+            }
+
+            public WrapperFileSystemEnumerator(
+                ToukiMatcherContext context,
+                string directory,
+                int rootPrefixLength)
+                : base(directory, s_options)
+            {
+                _context = context;
+                _directory = null!;
+                _enumerateFiles = true;
+
+                if (directory.Length >= rootPrefixLength)
+                {
+                    ReadOnlySpan<char> relativePath = directory.AsSpan(rootPrefixLength);
+                    _directoryPrefixLength = relativePath.Length + (relativePath.IsEmpty ? 0 : 1);
+                    if (_directoryPrefixLength != 0)
+                    {
+                        _directoryPrefixBuffer = ArrayPool<char>.Shared.Rent(_directoryPrefixLength);
+                        BuildDirectoryPrefix(
+                            relativePath,
+                            _directoryPrefixBuffer.AsSpan(0, _directoryPrefixLength));
+                    }
+                }
+
+                _pruneSubDirectories = _context.ShouldPruneSubDirectories(
+                    _directoryPrefixBuffer.AsSpan(0, _directoryPrefixLength));
+            }
+
+            public FileSystemDirectoryInfo? FirstSubDirectory { get; private set; }
+
+            public void TakePathSubDirectories(
+                out string[]? subDirectories,
+                out int count)
+            {
+                subDirectories = _pathSubDirectories;
+                count = _pathSubDirectoryCount;
+                _pathSubDirectories = null;
+                _pathSubDirectoryCount = 0;
+            }
+
+            protected override bool ShouldIncludeEntry(ref FileSystemEntry entry)
+            {
+                if (entry.IsDirectory)
+                {
+                    if (_directory is null)
+                    {
+                        if (_pruneSubDirectories)
+                        {
+                            return false;
+                        }
+
+                        ReadOnlySpan<char> directoryPrefix = _directoryPrefixBuffer.AsSpan(0, _directoryPrefixLength);
+                        if (_context.IsDirectoryExcluded(directoryPrefix, entry.FileName))
+                        {
+                            return false;
+                        }
+
+                        if (_pathSubDirectories is null)
+                        {
+                            _pathSubDirectories = ArrayPool<string>.Shared.Rent(4);
+                        }
+                        else if (_pathSubDirectoryCount == _pathSubDirectories.Length)
+                        {
+                            string[] replacement = ArrayPool<string>.Shared.Rent(_pathSubDirectories.Length * 2);
+                            Array.Copy(_pathSubDirectories, replacement, _pathSubDirectoryCount);
+                            ArrayPool<string>.Shared.Return(_pathSubDirectories, clearArray: true);
+                            _pathSubDirectories = replacement;
+                        }
+
+                        _pathSubDirectories[_pathSubDirectoryCount++] = entry.ToFullPath();
+                        return false;
+                    }
+
+                    string name = entry.FileName.ToString();
+                    if (_enumerateFiles || _context._declaredLiteralFolderSegments?.Contains(name) == true)
+                    {
+                        var directory = new FileSystemDirectoryInfo(entry.ToFullPath(), name, _directory);
+                        if (_context._directoryContext!.Test(directory))
+                        {
+                            if (_lastSubDirectory is null)
+                            {
+                                FirstSubDirectory = directory;
+                            }
+                            else
+                            {
+                                _lastSubDirectory.Next = directory;
+                            }
+
+                            _lastSubDirectory = directory;
+                        }
+                    }
+                }
+                else if (_enumerateFiles)
+                {
+                    ReadOnlySpan<char> directoryPrefix = _directoryPrefixBuffer.AsSpan(0, _directoryPrefixLength);
+                    if (_context.TryMatchFile(directoryPrefix, entry.FileName, out ToukiPattern? pattern))
+                    {
+                        string path = directoryPrefix.Length == 0
+                            ? entry.FileName.ToString()
+                            : string.Concat(directoryPrefix, entry.FileName);
+                        _context._files.Add(new FilePatternMatch(
+                            path,
+                            pattern.CalculateStem(directoryPrefix, entry.FileName, path)));
+                    }
+                }
+
+                return false;
+            }
+
+            protected override bool TransformEntry(ref FileSystemEntry entry) => false;
+
+            protected override void Dispose(bool disposing)
+            {
+                if (_directoryPrefixBuffer is { } buffer)
+                {
+                    _directoryPrefixBuffer = null;
+                    ArrayPool<char>.Shared.Return(buffer);
+                }
+
+                if (_pathSubDirectories is { } subDirectories)
+                {
+                    _pathSubDirectories = null;
+                    _pathSubDirectoryCount = 0;
+                    ArrayPool<string>.Shared.Return(subDirectories, clearArray: true);
+                }
+
+                base.Dispose(disposing);
+            }
+
+            private static void BuildDirectoryPrefix(
+                FileSystemDirectoryInfo directory,
+                Span<char> destination)
+            {
+                int offset = destination.Length;
+                for (FileSystemDirectoryInfo? current = directory;
+                    current is not null;
+                    current = current.ParentDirectory as FileSystemDirectoryInfo)
+                {
+                    destination[--offset] = '/';
+                    offset -= current.Name.Length;
+                    current.Name.CopyTo(destination[offset..]);
+                }
+
+                Debug.Assert(offset == 0);
+            }
+
+            private static void BuildDirectoryPrefix(
+                ReadOnlySpan<char> relativePath,
+                Span<char> destination)
+            {
+                for (int index = 0; index < relativePath.Length; index++)
+                {
+                    char value = relativePath[index];
+                    destination[index] = value == Path.DirectorySeparatorChar
+                        || value == Path.AltDirectorySeparatorChar
+                            ? '/'
+                            : value;
+                }
+
+                destination[^1] = '/';
+            }
+        }
+
+        private sealed class FileSystemDirectoryInfo : DirectoryInfoBase
+        {
+            public FileSystemDirectoryInfo(
+                string fullName,
+                string name,
+                DirectoryInfoBase parentDirectory)
+            {
+                FullName = fullName;
+                Name = name;
+                ParentDirectory = parentDirectory;
+                RelativePrefixLength = name.Length + 1
+                    + ((parentDirectory as FileSystemDirectoryInfo)?.RelativePrefixLength ?? 0);
+            }
+
+            public override string FullName { get; }
+
+            public override string Name { get; }
+
+            public override DirectoryInfoBase ParentDirectory { get; }
+
+            public FileSystemDirectoryInfo? Next { get; set; }
+
+            public int RelativePrefixLength { get; }
+
+            public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos() =>
+                throw new NotSupportedException();
+
+            public override DirectoryInfoBase GetDirectory(string path) =>
+                throw new NotSupportedException();
+
+            public override FileInfoBase GetFile(string path) =>
+                throw new NotSupportedException();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/ToukiPattern.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Internal/Touki/ToukiPattern.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Microsoft.Extensions.FileSystemGlobbing.Internal.PathSegments;
+using Touki.Io.Globbing;
+
+namespace Microsoft.Extensions.FileSystemGlobbing.Internal
+{
+    internal sealed class ToukiPattern
+    {
+        private readonly IPattern _legacyPattern;
+        private readonly bool _ignoreCase;
+        private readonly int _stemStartSegment;
+        private GlobStrategy? _strategy;
+        private bool _compileAttempted;
+
+        private ToukiPattern(IPattern legacyPattern, bool ignoreCase)
+        {
+            _legacyPattern = legacyPattern;
+            _ignoreCase = ignoreCase;
+            _stemStartSegment = GetStemStartSegment(legacyPattern);
+        }
+
+        public static ToukiPattern Create(IPattern legacyPattern, StringComparison comparisonType)
+        {
+            Debug.Assert(comparisonType is StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase);
+
+            return new ToukiPattern(legacyPattern, comparisonType == StringComparison.OrdinalIgnoreCase);
+        }
+
+        public IPattern LegacyPattern => _legacyPattern;
+
+        public bool MatchesFile(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> fileName) =>
+            (_strategy ?? GetStrategy()) is { } strategy
+            && strategy.MatchCore(currentDirectory, fileName);
+
+        public bool TryCompile() => GetStrategy() is not null;
+
+        public string CalculateStem(ReadOnlySpan<char> directoryPrefix, string fileName)
+            => CalculateStemCore(directoryPrefix, fileName, fileName, fullPath: null);
+
+        public string CalculateStem(
+            ReadOnlySpan<char> directoryPrefix,
+            ReadOnlySpan<char> fileName,
+            string fullPath)
+            => CalculateStemCore(directoryPrefix, fileName, materializedFileName: null, fullPath);
+
+        private string CalculateStemCore(
+            ReadOnlySpan<char> directoryPrefix,
+            ReadOnlySpan<char> fileName,
+            string? materializedFileName,
+            string? fullPath)
+        {
+            if (_stemStartSegment == int.MaxValue)
+            {
+                return directoryPrefix.IsEmpty && fullPath is not null
+                    ? fullPath
+                    : materializedFileName ?? fileName.ToString();
+            }
+
+            int offset = 0;
+            for (int segment = 0; segment < _stemStartSegment; segment++)
+            {
+                int separator = directoryPrefix[offset..].IndexOf('/');
+                if (separator < 0)
+                {
+                    return materializedFileName ?? fileName.ToString();
+                }
+
+                offset += separator + 1;
+            }
+
+            if (offset == 0 && fullPath is not null)
+            {
+                return fullPath;
+            }
+
+            return offset == directoryPrefix.Length
+                ? materializedFileName ?? fileName.ToString()
+                : string.Concat(directoryPrefix[offset..], fileName);
+        }
+
+        private GlobStrategy? GetStrategy()
+        {
+            if (Volatile.Read(ref _compileAttempted))
+            {
+                return _strategy;
+            }
+
+            lock (this)
+            {
+                if (!_compileAttempted)
+                {
+                    GlobCompiler.TryCompile(
+                        GetCompiledPattern(_legacyPattern),
+                        _ignoreCase,
+                        out _strategy);
+                    Volatile.Write(ref _compileAttempted, true);
+                }
+            }
+
+            return _strategy;
+        }
+
+        private static int GetStemStartSegment(IPattern pattern)
+        {
+            if (pattern is IRaggedPattern raggedPattern)
+            {
+                return raggedPattern.StartsWith.Count;
+            }
+
+            if (pattern is ILinearPattern linearPattern)
+            {
+                for (int index = 0; index < linearPattern.Segments.Count; index++)
+                {
+                    if (linearPattern.Segments[index].CanProduceStem)
+                    {
+                        return index;
+                    }
+                }
+            }
+
+            return int.MaxValue;
+        }
+
+        private static string GetCompiledPattern(IPattern pattern)
+        {
+            IList<IPathSegment> segments = pattern switch
+            {
+                ILinearPattern linearPattern => linearPattern.Segments,
+                IRaggedPattern raggedPattern => raggedPattern.Segments,
+                _ => throw new InvalidOperationException()
+            };
+
+            using ValueStringBuilder builder = new(stackalloc char[256]);
+            bool previousWasRecursive = false;
+            int emittedSegments = 0;
+            for (int index = 0; index < segments.Count; index++)
+            {
+                IPathSegment segment = segments[index];
+                bool isRecursive = segment is RecursiveWildcardSegment;
+                if (isRecursive && previousWasRecursive)
+                {
+                    continue;
+                }
+
+                if (isRecursive && emittedSegments != 0 && IsTrailingRecursiveRun(segments, index))
+                {
+                    builder.Append("/*");
+                    emittedSegments++;
+                }
+
+                if (emittedSegments != 0)
+                {
+                    builder.Append('/');
+                }
+
+                switch (segment)
+                {
+                    case LiteralPathSegment literal:
+                        builder.Append(literal.Value);
+                        break;
+                    case ParentPathSegment:
+                        builder.Append("..");
+                        break;
+                    case RecursiveWildcardSegment:
+                        builder.Append("**");
+                        break;
+                    case WildcardPathSegment wildcard:
+                        builder.Append(wildcard.BeginsWith);
+                        builder.Append('*');
+                        foreach (string contains in wildcard.Contains)
+                        {
+                            builder.Append(contains);
+                            builder.Append('*');
+                        }
+                        builder.Append(wildcard.EndsWith);
+                        break;
+                    default:
+                        throw new InvalidOperationException();
+                }
+
+                emittedSegments++;
+                previousWasRecursive = isRecursive;
+            }
+
+            return builder.ToString();
+
+            static bool IsTrailingRecursiveRun(IList<IPathSegment> segments, int start)
+            {
+                for (int index = start + 1; index < segments.Count; index++)
+                {
+                    if (segments[index] is not RecursiveWildcardSegment)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+
+}

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Matcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Matcher.cs
@@ -101,6 +101,10 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         private readonly List<IncludeOrExcludeValue<IPattern>>? _includeOrExcludePatterns;
         private readonly PatternBuilder _builder;
         private readonly bool _preserveFilterOrder;
+    #if USE_TOUKI_GLOBBING
+        private ToukiMatcherPlan? _toukiPlan;
+        private bool _toukiUnavailable;
+    #endif
 
         internal StringComparison ComparisonType { get; }
 
@@ -134,6 +138,9 @@ namespace Microsoft.Extensions.FileSystemGlobbing
             ComparisonType = comparisonType;
             _builder = new PatternBuilder(comparisonType);
             _preserveFilterOrder = preserveFilterOrder;
+#if USE_TOUKI_GLOBBING
+            _toukiUnavailable = comparisonType is not (StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase);
+#endif
 
             if (preserveFilterOrder)
             {
@@ -160,10 +167,15 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         /// <returns>The matcher</returns>
         public virtual Matcher AddInclude(string pattern)
         {
+            IPattern builtPattern = _builder.Build(pattern);
             if (_preserveFilterOrder)
-                _includeOrExcludePatterns!.Add(new IncludeOrExcludeValue<IPattern> { Value = _builder.Build(pattern), IsInclude = true });
+                _includeOrExcludePatterns!.Add(new IncludeOrExcludeValue<IPattern> { Value = builtPattern, IsInclude = true });
             else
-                _includePatterns!.Add(_builder.Build(pattern));
+                _includePatterns!.Add(builtPattern);
+
+#if USE_TOUKI_GLOBBING
+            _toukiPlan = null;
+#endif
 
             return this;
         }
@@ -182,10 +194,15 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         /// <returns>The matcher</returns>
         public virtual Matcher AddExclude(string pattern)
         {
+            IPattern builtPattern = _builder.Build(pattern);
             if (_preserveFilterOrder)
-                _includeOrExcludePatterns!.Add(new IncludeOrExcludeValue<IPattern> { Value = _builder.Build(pattern), IsInclude = false });
+                _includeOrExcludePatterns!.Add(new IncludeOrExcludeValue<IPattern> { Value = builtPattern, IsInclude = false });
             else
-                _excludePatterns!.Add(_builder.Build(pattern));
+                _excludePatterns!.Add(builtPattern);
+
+#if USE_TOUKI_GLOBBING
+            _toukiPlan = null;
+#endif
 
             return this;
         }
@@ -199,9 +216,46 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         {
             ArgumentNullException.ThrowIfNull(directoryInfo);
 
+#if USE_TOUKI_GLOBBING
+            bool hasInclude = _preserveFilterOrder
+                ? _includeOrExcludePatterns!.Exists(item => item.IsInclude)
+                : _includePatterns!.Count != 0;
+            if (!_toukiUnavailable && hasInclude)
+            {
+                ToukiMatcherPlan? plan = _toukiPlan;
+                if (plan is null)
+                {
+                    bool created = _preserveFilterOrder
+                        ? ToukiMatcherPlan.TryCreate(
+                            _includeOrExcludePatterns!,
+                            ComparisonType,
+                            out plan)
+                        : ToukiMatcherPlan.TryCreate(
+                            _includePatterns!,
+                            _excludePatterns!,
+                            ComparisonType,
+                            out plan);
+                    if (!created)
+                    {
+                        _toukiUnavailable = true;
+                    }
+                    else
+                    {
+                        _toukiPlan = plan;
+                    }
+                }
+
+                if (plan is not null)
+                {
+                    return plan.Execute(directoryInfo, ComparisonType);
+                }
+            }
+#endif
+
             return _preserveFilterOrder ?
                 new MatcherContext(_includeOrExcludePatterns!, directoryInfo, ComparisonType).Execute() :
                 new MatcherContext(_includePatterns!, _excludePatterns!, directoryInfo, ComparisonType).Execute();
         }
+
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Microsoft.Extensions.FileSystemGlobbing.csproj
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Microsoft.Extensions.FileSystemGlobbing.csproj
@@ -1,16 +1,39 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <_Net8TargetFramework Condition="'$(NetCoreAppCurrent)' != 'net8.0' and '$(NetCoreAppPrevious)' != 'net8.0' and '$(NetCoreAppMinimum)' != 'net8.0'">net8.0;</_Net8TargetFramework>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);$(_Net8TargetFramework)netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <IsPackable>true</IsPackable>
     <PackageDescription>File system globbing to find files matching a specified pattern.</PackageDescription>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <UseToukiGlobbing>true</UseToukiGlobbing>
+    <DefineConstants>$(DefineConstants);USE_TOUKI_GLOBBING</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="$(CoreLibSharedDir)\System\Numerics\Hashing\HashHelpers.cs"
              Link="System\Numerics\Hashing\HashHelpers.cs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Internal\Touki\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseToukiGlobbing)' == 'true'">
+    <Compile Include="Internal\Touki\**\*.cs" />
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
+             Link="Internal\Touki\Text\ValueStringBuilder.cs" />
+  </ItemGroup>
+
+  <Target Name="IncludeNet8PackageValidationBaseline" BeforeTargets="RunPackageValidation">
+    <ItemGroup>
+      <PackageValidationBaselineFrameworkToIgnore Remove="net8.0" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -691,7 +691,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         {
             RootDir_IsAbsolutePath_WithInMemory(rootDir, separator);
         }
-        
+
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
         [InlineData("C:\\src\\project", '\\')]
@@ -814,6 +814,98 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             AssertExtensions.CollectionEqual(expected, actual, StringComparer.OrdinalIgnoreCase);
         }
 
+        [Fact]
+        public void DerivedDirectoryInfoWrapperUsesVirtualEnumeration()
+        {
+            var directory = new TrackingDirectoryInfoWrapper(_context.DirectoryInfo!);
+            var matcher = new Matcher(StringComparison.Ordinal);
+            matcher.AddInclude("**/*.cs");
+
+            PatternMatchingResult result = matcher.Execute(directory);
+
+            Assert.True(directory.EnumerateCalled);
+            Assert.True(result.HasMatches);
+        }
+
+        [Fact]
+        public void DirectDirectoryExclusionsPreservePruningSemantics()
+        {
+            using var fileSystem = new DisposableFileSystem()
+                .CreateFiles(
+                    "bin/root.cs",
+                    "bin/Debug/debug.cs",
+                    "src/bin/nested.cs",
+                    "cache.user/hidden.cs",
+                    "src/keep.cs");
+            var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+            matcher.AddInclude("**/*.CS");
+            matcher.AddExclude("bin/Debug/**");
+            matcher.AddExclude("BIN/**");
+            matcher.AddExclude("**/*.USER");
+
+            PatternMatchingResult result = matcher.Execute(fileSystem.GetDirectoryInfoBase());
+
+            Assert.Equal(
+                ["src/bin/nested.cs", "src/keep.cs"],
+                result.Files.Select(match => match.Path).OrderBy(path => path));
+        }
+
+        [Theory]
+        [InlineData("bin/**", true)]
+        [InlineData("**/*.user", true)]
+        [InlineData("bin/Debug/**", true)]
+        [InlineData("**/bin/**", false)]
+#if NET
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+            "ReflectionAnalysis",
+            "IL2075",
+            Justification = "The test intentionally inspects a private implementation plan.")]
+#endif
+        public void DirectDirectoryExclusionsUseOnlyEquivalentShapes(
+            string exclude,
+            bool expected)
+        {
+            using var fileSystem = new DisposableFileSystem().CreateFiles("src/keep.cs");
+            var matcher = new Matcher(StringComparison.Ordinal);
+            matcher.AddInclude("**/*.cs");
+            matcher.AddExclude(exclude);
+
+            matcher.Execute(fileSystem.GetDirectoryInfoBase());
+
+            _ = expected;
+#if NET
+            System.Reflection.FieldInfo? field = typeof(Matcher).GetField(
+                "_toukiPlan",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            if (field is null)
+            {
+                return;
+            }
+
+            object? value = field.GetValue(matcher);
+            Assert.NotNull(value);
+            object plan = value;
+            object? directExclusions = plan.GetType()
+                .GetProperty("DirectDirectoryExclusions")!
+                .GetValue(plan);
+            Assert.Equal(expected, directExclusions is not null);
+#endif
+        }
+
+        [Fact]
+        public void DeepDirectDirectoryExclusionPreservesResults()
+        {
+            using var fileSystem = new DisposableFileSystem()
+                .CreateFiles("a/b/excluded.cs", "a/keep.cs");
+            var matcher = new Matcher(StringComparison.Ordinal);
+            matcher.AddInclude("**/*.cs");
+            matcher.AddExclude("a/b/**");
+
+            PatternMatchingResult result = matcher.Execute(fileSystem.GetDirectoryInfoBase());
+
+            Assert.Equal(["a/keep.cs"], result.Files.Select(match => match.Path));
+        }
+
         [Fact] // https://github.com/dotnet/runtime/issues/44767
         public void VerifyAbsolutePaths_HasMatches()
         {
@@ -826,7 +918,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
                 string fakeWindowsPath = "C:\\This\\is\\a\\nested\\windows-like\\path\\somefile.cs";
                 Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeWindowsPath), fakeWindowsPath).HasMatches);
             }
-            
+
             // Unix-like absolute paths are treated as relative paths on Windows.
             string fakeUnixPath = "/This/is/a/nested/unix-like/path/somefile.cs";
             Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeUnixPath), fakeUnixPath).HasMatches);
@@ -1021,6 +1113,22 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             Assert.True(result.HasMatches);
             Assert.Single(result.Files);
             Assert.Equal("../Folder2/File2.txt", result.Files.First().Path);
+        }
+
+        private sealed class TrackingDirectoryInfoWrapper : DirectoryInfoWrapper
+        {
+            public TrackingDirectoryInfoWrapper(DirectoryInfo directoryInfo)
+                : base(directoryInfo)
+            {
+            }
+
+            public bool EnumerateCalled { get; private set; }
+
+            public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
+            {
+                EnumerateCalled = true;
+                return base.EnumerateFileSystemInfos();
+            }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/OrderedPatternMatchingTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/OrderedPatternMatchingTests.cs
@@ -206,5 +206,20 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
                 "src/Internal/PatternContexts/PatternContext.cs"
             );
         }
+
+        [Fact]
+        public void ReIncludedFileUsesLatestIncludeStem()
+        {
+            var scenario = new FileSystemGlobbingTestContext(@"c:/project/", true)
+                .Include("src/**/*.cs")
+                .Exclude("src/generated/**")
+                .Include("src/generated/*.cs")
+                .Files("src/generated/Generated.cs")
+                .Execute();
+
+            Assert.Equal(
+                new FilePatternMatch("src/generated/Generated.cs", "Generated.cs"),
+                Assert.Single(scenario.Result.Files));
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/PatternMatchingTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/PatternMatchingTests.cs
@@ -1,7 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using Microsoft.Extensions.FileSystemGlobbing.Internal;
+using Microsoft.Extensions.FileSystemGlobbing.Internal.Patterns;
 using Microsoft.Extensions.FileSystemGlobbing.Tests.TestUtility;
 using Xunit;
 
@@ -434,6 +439,285 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
                 new FilePatternMatch(path: "../files/sub/one.txt", stem: "one.txt"),
                 new FilePatternMatch(path: "../files/sub/two.txt", stem: "two.txt")
             }, scenario.Result.Files.ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(SequentialSeparatorOracleData))]
+        public void SequentialSeparatorsMatchLegacyOracle(string pattern, string input)
+        {
+            AssertMatchesLegacy(pattern, input);
+        }
+
+        [Theory]
+        [MemberData(nameof(MultipleAsteriskOracleData))]
+        public void MultipleAsterisksMatchLegacyOracle(string pattern, string input)
+        {
+            AssertMatchesLegacy(pattern, input);
+        }
+
+        [Theory]
+        [MemberData(nameof(FileSystemGlobbingParityOracleData))]
+        public void CurrentToukiScenariosMatchLegacyOracle(string pattern, string input)
+        {
+            AssertMatchesLegacy(pattern, input);
+        }
+
+        [Theory]
+        [InlineData("a?b", "a?b")]
+        [InlineData("a?b", "axb")]
+        [InlineData("[abc].txt", "[abc].txt")]
+        [InlineData("[abc].txt", "a.txt")]
+        [InlineData("!important.txt", "!important.txt")]
+        public void UnsupportedGlobCharactersMatchLegacyOracle(string pattern, string input)
+        {
+            AssertMatchesLegacy(pattern, input);
+        }
+
+        [Fact]
+        public void MatcherCanExecuteRepeatedlyAndAddPatterns()
+        {
+            var matcher = new Matcher(StringComparison.Ordinal);
+
+            Assert.False(matcher.Match("src/Program.cs").HasMatches);
+
+            matcher.AddInclude("**/*.cs");
+
+            Assert.True(matcher.Match("src/Program.cs").HasMatches);
+            Assert.True(matcher.Match("src/Program.cs").HasMatches);
+
+            matcher.AddInclude("**/*.txt");
+
+            Assert.True(matcher.Match("docs/README.txt").HasMatches);
+            Assert.True(matcher.Match("src/Program.cs").HasMatches);
+        }
+
+        [Fact]
+        public void CultureComparisonLiteralRetainsLegacyBehavior()
+        {
+            var matcher = new Matcher(StringComparison.InvariantCultureIgnoreCase);
+            matcher.AddInclude("FILE.TXT");
+
+            Assert.True(matcher.Match("file.txt").HasMatches);
+        }
+
+        [Fact]
+        public void CultureComparisonWildcardRetainsLegacyException()
+        {
+            var matcher = new Matcher(StringComparison.InvariantCultureIgnoreCase);
+
+            Assert.Throws<InvalidOperationException>(() => matcher.AddInclude("*.txt"));
+        }
+
+        [Fact]
+        public void PatternBeyondToukiEncodingLimitFallsBackToLegacy()
+        {
+            string prefix = new('a', char.MaxValue + 1);
+            string fileName = "x/" + prefix + "/y";
+            var scenario = new FileSystemGlobbingTestContext(@"c:\files\", PreserveFilterOrder)
+                .Include("*/" + prefix + "/*")
+                .Files(fileName)
+                .Execute();
+
+            scenario.AssertExact(fileName);
+        }
+
+        [Theory]
+        [InlineData("*", "root.txt", "sub/leak.txt")]
+        [InlineData("*.txt", "root.txt", "sub/leak.txt")]
+        [InlineData("a*", "alpha", "sub/alpha")]
+        [InlineData("*a*", "alpha", "sub/alpha")]
+        [InlineData("a*b", "acb", "sub/acb")]
+        public void RootScopedPatternDoesNotMatchNestedFiles(string pattern, string rootMatch, string nestedMatch)
+        {
+            new FileSystemGlobbingTestContext(@"c:\files\", PreserveFilterOrder)
+                .Include(pattern, "sub/keep.cs")
+                .Files(rootMatch, nestedMatch, "sub/keep.cs")
+                .Execute()
+                .AssertExact(rootMatch, "sub/keep.cs");
+
+            FileSystemGlobbingTestContext excludeScenario = new FileSystemGlobbingTestContext(@"c:\files\", PreserveFilterOrder)
+                .Include("**")
+                .Exclude(pattern)
+                .Files(rootMatch, nestedMatch, "sub/keep.cs")
+                .Execute();
+
+            if (pattern == "*")
+            {
+                excludeScenario.AssertExact();
+            }
+            else
+            {
+                excludeScenario.AssertExact(nestedMatch, "sub/keep.cs");
+            }
+        }
+
+        [Fact]
+        public void DeterministicGeneratedPatternsMatchLegacyOracle()
+        {
+            string[] atoms = ["a", "b", "*", "*.cs", "a*b", "**", "?", "[x]", "***.cs", "**.cs"];
+            string[] files =
+            [
+                "a", "b", "x", "a.cs", "b.cs", "ab", "axb", "[x]",
+                "a/a", "a/b.cs", "a/x/ab", "b/a.cs", "x/a/b.cs", "x/y/a.cs"
+            ];
+            string root = Path.Combine(Directory.GetCurrentDirectory(), "generated-oracle-root");
+            var directory = new InMemoryDirectoryInfo(root, files);
+            var patterns = new List<string>(atoms.Length + (atoms.Length * atoms.Length * 3));
+
+            patterns.AddRange(atoms);
+            foreach (string first in atoms)
+            {
+                foreach (string last in atoms)
+                {
+                    patterns.Add(first + "/" + last);
+                    patterns.Add(first + "/**/" + last);
+                    patterns.Add(first + "/*/" + last);
+                }
+            }
+
+            foreach (string pattern in patterns)
+            {
+                var matcher = new Matcher(StringComparison.Ordinal, PreserveFilterOrder);
+                matcher.AddInclude(pattern);
+
+                PatternMatchingResult expected = MatchLegacy(directory, pattern);
+                PatternMatchingResult actual = matcher.Execute(directory);
+
+                Assert.True(
+                    expected.HasMatches == actual.HasMatches,
+                    $"HasMatches differed for '{pattern}'. Expected [{string.Join(", ", expected.Files.Select(file => file.Path))}], actual [{string.Join(", ", actual.Files.Select(file => file.Path))}].");
+                Assert.True(
+                    expected.Files.SequenceEqual(actual.Files),
+                    $"Files differed for '{pattern}'. Expected [{string.Join(", ", expected.Files.Select(file => file.Path))}], actual [{string.Join(", ", actual.Files.Select(file => file.Path))}].");
+            }
+        }
+
+        public static IEnumerable<object[]> SequentialSeparatorOracleData()
+        {
+            yield return new object[] { "a//b", "a/b" };
+            yield return new object[] { "a//b", "a//b" };
+            yield return new object[] { "a//b", "ab" };
+            yield return new object[] { "a//b", "a/x/b" };
+            yield return new object[] { "a///b", "a/b" };
+            yield return new object[] { "a///b", "a//b" };
+            yield return new object[] { "a////b", "a/b" };
+            yield return new object[] { "//a", "a" };
+            yield return new object[] { "//a", "/a" };
+            yield return new object[] { "a//", "a" };
+            yield return new object[] { "a//", "a/" };
+            yield return new object[] { "a//*", "a/b" };
+            yield return new object[] { "*//b", "a/b" };
+            yield return new object[] { "*//b", "x/b" };
+            yield return new object[] { "**//*.cs", "Foo.cs" };
+            yield return new object[] { "**//*.cs", "src/Foo.cs" };
+            yield return new object[] { "**//*.cs", "src/sub/Foo.cs" };
+            yield return new object[] { "a//**//b", "a/b" };
+            yield return new object[] { "a//**//b", "a/x/b" };
+            yield return new object[] { "a//**//b", "a/x/y/b" };
+            yield return new object[] { "a//.", "a/file.txt" };
+            yield return new object[] { ".//*a/*.*", ".hidden/a/A" };
+        }
+
+        public static IEnumerable<object[]> MultipleAsteriskOracleData()
+        {
+            yield return new object[] { "***", "" };
+            yield return new object[] { "***", "a" };
+            yield return new object[] { "***", "abc" };
+            yield return new object[] { "***", "a/b" };
+            yield return new object[] { "****", "a" };
+            yield return new object[] { "****", "a/b" };
+            yield return new object[] { "a***b", "ab" };
+            yield return new object[] { "a***b", "axb" };
+            yield return new object[] { "a***b", "axyzb" };
+            yield return new object[] { "a***b", "a/b" };
+            yield return new object[] { "a****b", "axyzb" };
+            yield return new object[] { "***.cs", "foo.cs" };
+            yield return new object[] { "***.cs", "a/foo.cs" };
+            yield return new object[] { "a***", "a" };
+            yield return new object[] { "a***", "abc" };
+            yield return new object[] { "***b", "b" };
+            yield return new object[] { "***b", "ab" };
+            yield return new object[] { "a/***", "a/" };
+            yield return new object[] { "a/***", "a/b" };
+            yield return new object[] { "a/***", "a/b/c" };
+            yield return new object[] { "***/foo", "foo" };
+            yield return new object[] { "***/foo", "a/foo" };
+            yield return new object[] { "***/foo", "a/b/foo" };
+            yield return new object[] { "a/***/b", "a/b" };
+            yield return new object[] { "a/***/b", "a/x/b" };
+            yield return new object[] { "a/***/b", "a/x/y/b" };
+        }
+
+        public static IEnumerable<object[]> FileSystemGlobbingParityOracleData()
+        {
+            yield return new object[] { "a?b", "a?b" };
+            yield return new object[] { "a?b", "axb" };
+            yield return new object[] { "a?b", "ab" };
+            yield return new object[] { "a/?/b", "a/?/b" };
+            yield return new object[] { "a/?/b", "a/x/b" };
+            yield return new object[] { "a/", "a/file.txt" };
+            yield return new object[] { "a/", "a/b/file.txt" };
+            yield return new object[] { "a/", "a" };
+            yield return new object[] { "a\\", "a/file.txt" };
+            yield return new object[] { "/", "file.txt" };
+            yield return new object[] { "/", "a/file.txt" };
+            yield return new object[] { "///", "file.txt" };
+            yield return new object[] { "///", "a/file.txt" };
+            yield return new object[] { "a///", "a/file.txt" };
+            yield return new object[] { "a///", "a" };
+            yield return new object[] { "**.cs", "file.cs" };
+            yield return new object[] { "**.cs", "dir/file.cs" };
+            yield return new object[] { "**.cs", "a/b/file.cs" };
+            yield return new object[] { "**.cs", "a/b/file.txt" };
+            yield return new object[] { "ab/**.suffix", "ab/file.suffix" };
+            yield return new object[] { "ab/**.suffix", "ab/x/file.suffix" };
+            yield return new object[] { "ab/**.suffix", "x/file.suffix" };
+            yield return new object[] { "src/**.*", "src/file.txt" };
+            yield return new object[] { "src/**.*", "src/a/file.txt" };
+            yield return new object[] { "**/a/b/*.cs", "a/a/b/source.cs" };
+            yield return new object[] { "**/a/a/*.cs", "a/a/a/source.cs" };
+            yield return new object[] { "**/a/**/a/*.cs", "a/a/source.cs" };
+            yield return new object[] { "**/a/**/a/*.cs", "x/a/x/y/a/source.cs" };
+        }
+
+        private void AssertMatchesLegacy(string pattern, string input)
+        {
+            string root = Path.Combine(Directory.GetCurrentDirectory(), "oracle-root");
+            var matcher = new Matcher(StringComparison.Ordinal, PreserveFilterOrder);
+            matcher.AddInclude(pattern);
+
+            PatternMatchingResult expected;
+            PatternMatchingResult actual;
+            if (input.IndexOf('?') >= 0)
+            {
+                const string mockRoot = @"c:\files\";
+                var directory = new MockDirectoryInfo(
+                    parentDirectory: null,
+                    fullName: mockRoot,
+                    name: ".",
+                    paths: input.Length == 0 ? Array.Empty<string>() : new[] { mockRoot + input });
+                expected = MatchLegacy(directory, pattern);
+                actual = matcher.Execute(directory);
+            }
+            else
+            {
+                expected = MatchLegacy(new InMemoryDirectoryInfo(root, new[] { input }), pattern);
+                actual = matcher.Match(root, input);
+            }
+
+            Assert.Equal(expected.HasMatches, actual.HasMatches);
+            Assert.Equal(expected.Files, actual.Files);
+        }
+
+        private PatternMatchingResult MatchLegacy(Abstractions.DirectoryInfoBase directory, string pattern)
+        {
+            IPattern legacyPattern = new PatternBuilder(StringComparison.Ordinal).Build(pattern);
+
+            return new MatcherContext(
+                new[] { legacyPattern },
+                Array.Empty<IPattern>(),
+                directory,
+                StringComparison.Ordinal).Execute();
         }
 
         // exclude: **/.*/**


### PR DESCRIPTION
## Summary

This change uses a focused, internal subset of Touki's compiled glob matcher for `Microsoft.Extensions.FileSystemGlobbing.Matcher` on .NET 8 and later. It also adds a `FileSystemEnumerator` fast path for the exact built-in `DirectoryInfoWrapper` type.

The existing implementation remains in place for `netstandard2.0`, .NET Framework, custom and derived directory wrappers, unsupported comparison modes, and patterns the focused compiler cannot represent.

No public API or package dependency is added. The reference API source is unchanged.

## Relationship To The System.IO Globbing Proposal

This is an optimization of the existing FileSystemGlobbing API, not an implementation of [#132060](https://github.com/dotnet/runtime/issues/132060). That proposal remains open and is not API-approved.

Current Touki models the proposal's separation between an immutable reusable matcher definition and independently owned root-bound sessions. This adaptation uses the same lifetime split internally:

| Proposed concept | This adaptation |
| --- | --- |
| Reusable matcher definition | Cached `ToukiMatcherPlan` |
| Per-enumeration mutable session | New `ToukiMatcherContext` per `Execute` |
| Reusable compiled pattern | Lazily compiled `ToukiPattern` |
| Compiled glob implementation | Internal `GlobCompiler` |

The proposed `IFileSystemMatcher` composition API returns only a Boolean file result. FileSystemGlobbing must additionally identify the winning include to produce `FilePatternMatch.Stem`. The local exclusion-wins and ordered matchers therefore return that winner without evaluating the pattern twice.

Proposal-only types such as `GlobSpecification`, `IFileSystemMatcher`, `DirectoryMatchType`, and `FileSystemPathEnumerator` are deliberately not imported or exposed here. Adding them would couple this package to an unapproved public design and add unused code.

The focused port originated from Touki commit `74f6739ce8e70b760814e792c79a83fd5065c9d7` and was revalidated against current Touki `256c9b73c9d9e1c138b4b1a54a639342b7cc851c`, including the FileSystemGlobbing parity work in [JeremyKuhne/touki#259](https://github.com/JeremyKuhne/touki/pull/259).

## Constraints Of The Existing API

The existing surface necessarily retains work that a purpose-built API can avoid:

- `PatternBuilder` remains the validation and normalization authority so exception timing, accepted syntax, parent traversal, and legacy edge cases do not change.
- `DirectoryInfoBase` is a public extensibility point. Only the exact built-in wrapper can use the physical `FileSystemEnumerator` path; derived and custom implementations must continue through virtual enumeration.
- `Matcher` is a mutable include/exclude builder. Pattern additions invalidate the cached plan, and each execution creates fresh traversal state.
- Results must preserve depth-first ordering and materialize `PatternMatchingResult`, relative paths, `FilePatternMatch` values, and stems.
- Ordered rules must preserve the latest include responsible for a matched file, not merely a Boolean result.
- Culture-based comparisons and compiler-limit cases fall back to the legacy implementation rather than changing behavior.
- The modern implementation is package-asset-specific. Downlevel targets keep the existing code.

These constraints are why the improvement here is smaller than Touki's direct compiled-matcher results: the inner predicate becomes inexpensive, but the public API still owns traversal compatibility and result construction.

## Adapted Performance Win

The unchanged public API benchmark shows lower allocation and flat-to-faster execution across the representative scenarios:

| Scenario | Baseline | Change | Allocation change |
| --- | ---: | ---: | ---: |
| Literal hit | 479.96 ns / 1,736 B | 420.93 ns / 1,408 B | -18.9% |
| Literal miss | 459.39 ns / 1,640 B | 400.09 ns / 1,312 B | -20.0% |
| `*.cs` hit | 465.98 ns / 1,624 B | 417.42 ns / 1,408 B | -13.3% |
| `**/*.cs`, deep input | 1,519.32 ns / 6,664 B | 1,449.34 ns / 6,424 B | -3.6% |
| Synthetic tree | 41.084 us / 117,304 B | 39.363 us / 113,280 B | -3.4% |
| Tree with excludes | 37.998 us / 99,792 B | 37.354 us / 96,784 B | -3.0% |
| Ordered rules | 43.363 us / 121,296 B | 41.904 us / 110,952 B | -8.5% |

For a 1,174-file physical Touki checkout, the specialized wrapper and retained overhead reductions changed the adapter's construct-and-execute path from 3.325 ms / 980.48 KB to 2.687 ms / 210.12 KB. A precompiled matcher measured 2.633 ms / 202.29 KB.

These local Windows BenchmarkDotNet runs are short and sequential, so timing changes should be treated directionally. The allocation reductions are stable.

## Headroom In A Purpose-Built API

The proposed API can expose compiled span matching directly and stream canonical paths from a matcher-aware enumerator. It does not need to build a virtual file system, calculate FSG stems, retain legacy pattern contexts, or materialize a `PatternMatchingResult`.

Current Touki measurements cited in #132060 show the difference in achievable scope:

- Reusable `GlobSpecification.IsMatch` cases run in roughly 8.5-75 ns with zero managed allocation, 13-89x faster than the closest public `Matcher.Match` scenarios. The operations return different result shapes, so this is not the expected speedup for this PR.
- Touki's native SDK-style enumeration benchmark measured 19.71 ms / 359.69 KB versus 24.98 ms / 5,589.55 KB for the existing FileSystemGlobbing path: 1.27x throughput and 93.6% less managed allocation for that workload.
- A proposed matcher session can return three-state directory proofs for generic pruning and can stream results without FSG-specific stem and result contracts.

This PR captures the compatible win available behind the current API. The API proposal represents the additional headroom available when callers can opt into an immutable compiled matcher and a purpose-built streaming enumeration contract.

## Compatibility And Packaging

The source and reference projects gain an explicit `net8.0` target. Without it, .NET 8 and .NET 9 consumers would select the `netstandard2.0` package asset and remain on the legacy engine.

| Consumer | Selected implementation |
| --- | --- |
| .NET Framework / `netstandard2.0` | Existing matcher |
| .NET 8 | Touki-backed `net8.0` asset |
| .NET 9 | Touki-backed `net8.0` asset |
| .NET 10+ | Touki-backed asset for that TFM |

All imported types are internal. The package contains no `Microsoft.IO.Redist` dependency. The pinned source and MIT license are recorded in source headers and `THIRD-PARTY-NOTICES.TXT`.

Compatibility coverage includes:

- 46 original Touki FileSystemGlobbing oracle rows.
- The 28-row current Touki parity matrix.
- A deterministic generated comparison against the legacy matcher.
- Literal unsupported syntax, root scoping, repeated execution, and plan invalidation.
- Ordered exclude/re-include winner and stem behavior.
- Derived-wrapper fallback and guarded direct-directory pruning.
- Legacy fallback for unsupported comparisons and compiler limits.

## Validation

- Required baseline: `build.cmd clr+libs -rc release`.
- All implementation/reference TFMs and APICompat: 0 warnings, 0 errors.
- `net11.0`: 626 passed, 0 failed.
- `net481`: 626 passed, 0 failed.
- Current Touki net10 suite: 7,130 passed, 0 failed, 119 platform skips.
- Fresh .NET 8 package consumer selected the `net8.0` asset and validated matching, stems, and internal-only Touki metadata.
- Fresh .NET 9 package consumer selected the `net8.0` asset.
- Shipping assets: `net8.0`, `net10.0`, `net11.0`, `netstandard2.0`, and `net462`; no new dependency groups.
- `git diff --check`, imported-source whitespace checks, and final independent Extensions review passed.

The current runtime test infrastructure cannot restore this test project for net8 because its current xUnit assertion package targets net10. The complete modern suite therefore runs on net11, while isolated consumers validate net8 and net9 package selection.

## Follow-Up Validation

- Run the full CI matrix across supported operating systems.
- Collect aligned Windows, Linux, and macOS measurements through the runtime performance workflow.
- Request packaging-owner review of the explicit net8 asset and legal review of the third-party notice.

> [!NOTE]
> This pull request description was drafted with GitHub Copilot assistance.
