### PR TITLE
Disable test using gc cover on interpreter

### DIFF
--- a/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
+++ b/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
@@ -3,6 +3,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+    <!-- Test enables GC cover which is not compatible with the interpreter -->
+    <InterpreterIncompatible>true</InterpreterIncompatible>
 
     <CLRTestBatchPreCommands><![CDATA[
       $(CLRTestBatchPreCommands)

--- a/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
+++ b/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
@@ -3,19 +3,15 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
-    <!-- Test enables GC cover which is not compatible with the interpreter -->
-    <InterpreterIncompatible>true</InterpreterIncompatible>
 
     <CLRTestBatchPreCommands><![CDATA[
       $(CLRTestBatchPreCommands)
-      set DOTNET_GCStress=0xC
       set DOTNET_GCHeapHardLimit=0x4000000
       set DOTNET_GCRegionRange=0x4000000
       set DOTNET_GCRegionSize=0x100000
       ]]></CLRTestBatchPreCommands>
     <CLRTestBashPreCommands><![CDATA[
       $(CLRTestBashPreCommands)
-      export DOTNET_GCStress=0xC
       export DOTNET_GCHeapHardLimit=0x4000000
       export DOTNET_GCRegionRange=0x4000000
       export DOTNET_GCRegionSize=0x100000

--- a/src/tests/JIT/Regression/JitBlue/GitHub_27924/GitHub_27924.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_27924/GitHub_27924.csproj
@@ -1,25 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CLRTestBatchEnvironmentVariable -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <!-- Test enables GC stress C which is not compatible with the interpreter -->
-    <InterpreterIncompatible>true</InterpreterIncompatible>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
-
-    <!-- This test requires GCStress to trigger the regression. Set DOTNET_GCStress here. However,
-         not all CI platforms support GCStress. In particular, macOS and Alpine do not (currently).
-         All Windows support GCStress. We don't have any way (currently) to determine if we're
-         running on a platform that supports GCStress. So, don't set GCStress for non-Windows (Bash).
-         The test will run under GCStress in normal, scheduled GCStress runs, when only the supported
-         platforms are run with GCStress.
-    -->
-    <CLRTestBatchEnvironmentVariable Include="DOTNET_GCStress" Value="0xc" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestLibraryProjectPath)" />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_45090/Runtime_45090.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_45090/Runtime_45090.csproj
@@ -1,16 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CLRTestBatchEnvironmentVariable -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <!-- Test uses GCStress C that is not compatible with the interpreter -->
-    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
-
-    <CLRTestBatchEnvironmentVariable Include="DOTNET_GCStress" Value="0xC" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
GC coverage (GCStress=4) only supports jitted code.

Test enabled in https://github.com/dotnet/runtime/pull/131881