### PR TITLE
Remove obsolete WASM TypeScript definition cleanup logic

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -1292,7 +1292,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Prevent the wwwroot glob from picking up dotnet.d.ts copied by _EnsureDotnetTypeScriptDefinitions (https://github.com/dotnet/runtime/issues/124729) -->
   <ItemGroup Condition="'$(WasmEmitTypeScriptDefinitions)' == 'true'">
-    <Content Remove="wwwroot\dotnet.d.ts" />
     <Content Remove="wwwroot\_framework\dotnet.d.ts" />
   </ItemGroup>
 

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -1312,11 +1312,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_EnsureDotnetTypeScriptDefinitions"
-          DependsOnTargets="_ResolveDotnetTypeScriptDefinitionPaths"
+          DependsOnTargets="_ResolveWasmConfiguration;_ResolveDotnetTypeScriptDefinitionPaths"
           AfterTargets="PrepareForBuild"
           Inputs="$(_DotnetTypesSourcePath)"
           Outputs="$(_DotnetTypesDestPath)"
-          Condition="'$(WasmEmitTypeScriptDefinitions)' == 'true'">
+          Condition="'$(_WasmEmitTypeScriptDefinitions)' == 'true'">
 
     <MakeDir Directories="$(_DotnetTypesDestDir)"
              Condition="Exists('$(_DotnetTypesSourcePath)')" />

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -1312,11 +1312,11 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_EnsureDotnetTypeScriptDefinitions"
-          DependsOnTargets="_ResolveWasmConfiguration;_ResolveDotnetTypeScriptDefinitionPaths"
+          DependsOnTargets="_ResolveDotnetTypeScriptDefinitionPaths"
           AfterTargets="PrepareForBuild"
           Inputs="$(_DotnetTypesSourcePath)"
           Outputs="$(_DotnetTypesDestPath)"
-          Condition="'$(_WasmEmitTypeScriptDefinitions)' == 'true'">
+          Condition="'$(WasmEmitTypeScriptDefinitions)' == 'true'">
 
     <MakeDir Directories="$(_DotnetTypesDestDir)"
              Condition="Exists('$(_DotnetTypesSourcePath)')" />


### PR DESCRIPTION
Cleanup https://github.com/dotnet/runtime/pull/132122#discussion_r3765242857

The original change belonged to net11 previews so it's a subject to change, we don't need to provide a way to clean "wwwroot\dotnet.d.ts" on upgrade.