### PR TITLE
Add SslStream legacy path compatibility switch

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/LocalAppContextSwitches.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/LocalAppContextSwitches.cs
@@ -41,11 +41,11 @@ namespace System
             get => GetCachedSwitchValue("System.Net.Security.EnableServerOcspStaplingFromOnlyCertificateOnLinux", ref s_enableOcspStapling);
         }
 
-        private static int s_useLegacySslStream;
-        internal static bool UseLegacySslStream
+        private static int s_useLegacySslStreamHandshake;
+        internal static bool UseLegacySslStreamHandshake
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => GetCachedSwitchValue("System.Net.Security.UseLegacySslStream", "DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAM", ref s_useLegacySslStream);
+            get => GetCachedSwitchValue("System.Net.Security.UseLegacySslStreamHandshake", "DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAMHANDSHAKE", ref s_useLegacySslStreamHandshake);
         }
 
 #if !TARGET_WINDOWS

--- a/src/libraries/System.Net.Security/src/System/Net/Security/LocalAppContextSwitches.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/LocalAppContextSwitches.cs
@@ -41,6 +41,13 @@ namespace System
             get => GetCachedSwitchValue("System.Net.Security.EnableServerOcspStaplingFromOnlyCertificateOnLinux", ref s_enableOcspStapling);
         }
 
+        private static int s_useLegacySslStream;
+        internal static bool UseLegacySslStream
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue("System.Net.Security.UseLegacySslStream", "DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAM", ref s_useLegacySslStream);
+        }
+
 #if !TARGET_WINDOWS
         private static int s_useManagedNtlm;
         [FeatureSwitchDefinition("System.Net.Security.UseManagedNtlm")]

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -787,7 +787,8 @@ namespace System.Net.Security
         //
         internal ProtocolToken NextMessage(ReadOnlySpan<byte> incomingBuffer, out int consumed)
         {
-            if (TryNextMessageViaTlsSession(incomingBuffer, out ProtocolToken wedged, out consumed))
+            if (!LocalAppContextSwitches.UseLegacySslStream &&
+                TryNextMessageViaTlsSession(incomingBuffer, out ProtocolToken wedged, out consumed))
             {
                 if (NetEventSource.Log.IsEnabled() && wedged.Failed)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -787,7 +787,7 @@ namespace System.Net.Security
         //
         internal ProtocolToken NextMessage(ReadOnlySpan<byte> incomingBuffer, out int consumed)
         {
-            if (!LocalAppContextSwitches.UseLegacySslStream &&
+            if (!LocalAppContextSwitches.UseLegacySslStreamHandshake &&
                 TryNextMessageViaTlsSession(incomingBuffer, out ProtocolToken wedged, out consumed))
             {
                 if (NetEventSource.Log.IsEnabled() && wedged.Failed)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -34,12 +34,14 @@ namespace System.Net.Security.Tests
         [InlineData(null, false, false)]
         [InlineData(null, true, true)]
         [InlineData(false, true, false)]
+        [InlineData(true, false, true)]
         public async Task UseLegacySslStreamHandshake_SelectsExpectedHandshakePath(bool? appContextValue, bool? environmentValue, bool expectLegacyPath)
         {
             var psi = new ProcessStartInfo();
+            psi.Environment.Remove("DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAMHANDSHAKE");
             if (environmentValue.HasValue)
             {
-                psi.Environment.Add("DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAMHANDSHAKE", environmentValue.Value ? "1" : "0");
+                psi.Environment["DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAMHANDSHAKE"] = environmentValue.Value ? "1" : "0";
             }
 
             await RemoteExecutor.Invoke(async (switchValue, expectLegacyPathValue) =>

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Security;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
@@ -23,6 +24,60 @@ namespace System.Net.Security.Tests
         public SslStreamRemoteExecutorTests(ITestOutputHelper output)
         {
             _output = output;
+        }
+
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux | TestPlatforms.FreeBSD)]
+        [InlineData(null, null, false)]
+        [InlineData(false, null, false)]
+        [InlineData(true, null, true)]
+        [InlineData(null, false, false)]
+        [InlineData(null, true, true)]
+        [InlineData(false, true, false)]
+        public async Task UseLegacySslStream_SelectsExpectedHandshakePath(bool? appContextValue, bool? environmentValue, bool expectLegacyPath)
+        {
+            var psi = new ProcessStartInfo();
+            if (environmentValue.HasValue)
+            {
+                psi.Environment.Add("DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAM", environmentValue.Value ? "1" : "0");
+            }
+
+            await RemoteExecutor.Invoke(async (switchValue, expectLegacyPathValue) =>
+            {
+                if (bool.TryParse(switchValue, out bool value))
+                {
+                    AppContext.SetSwitch("System.Net.Security.UseLegacySslStream", value);
+                }
+
+                (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
+                using (clientStream)
+                using (serverStream)
+                using (var client = new SslStream(clientStream))
+                using (var server = new SslStream(serverStream))
+                using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+                {
+                    var clientOptions = new SslClientAuthenticationOptions
+                    {
+                        RemoteCertificateValidationCallback = delegate { return true; },
+                    };
+                    var serverOptions = new SslServerAuthenticationOptions
+                    {
+                        ServerCertificate = certificate,
+                    };
+
+                    await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                        client.AuthenticateAsClientAsync(clientOptions),
+                        server.AuthenticateAsServerAsync(serverOptions));
+
+                    FieldInfo tlsSessionField = typeof(SslStream).GetField("_tlsSession", BindingFlags.Instance | BindingFlags.NonPublic);
+                    Assert.NotNull(tlsSessionField);
+
+                    bool expectLegacy = bool.Parse(expectLegacyPathValue);
+                    Assert.Equal(expectLegacy, tlsSessionField.GetValue(client) is null);
+                    Assert.Equal(expectLegacy, tlsSessionField.GetValue(server) is null);
+                    await TestHelper.PingPong(client, server);
+                }
+            }, appContextValue.ToString(), expectLegacyPath.ToString(), new RemoteInvokeOptions { StartInfo = psi }).DisposeAsync();
         }
 
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -34,19 +34,19 @@ namespace System.Net.Security.Tests
         [InlineData(null, false, false)]
         [InlineData(null, true, true)]
         [InlineData(false, true, false)]
-        public async Task UseLegacySslStream_SelectsExpectedHandshakePath(bool? appContextValue, bool? environmentValue, bool expectLegacyPath)
+        public async Task UseLegacySslStreamHandshake_SelectsExpectedHandshakePath(bool? appContextValue, bool? environmentValue, bool expectLegacyPath)
         {
             var psi = new ProcessStartInfo();
             if (environmentValue.HasValue)
             {
-                psi.Environment.Add("DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAM", environmentValue.Value ? "1" : "0");
+                psi.Environment.Add("DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAMHANDSHAKE", environmentValue.Value ? "1" : "0");
             }
 
             await RemoteExecutor.Invoke(async (switchValue, expectLegacyPathValue) =>
             {
                 if (bool.TryParse(switchValue, out bool value))
                 {
-                    AppContext.SetSwitch("System.Net.Security.UseLegacySslStream", value);
+                    AppContext.SetSwitch("System.Net.Security.UseLegacySslStreamHandshake", value);
                 }
 
                 (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();


### PR DESCRIPTION
## Summary

Adds a compatibility switch that allows applications to temporarily restore the legacy `SslStream` handshake implementation instead of routing through the `TlsSession` wedge introduced by #130366.

The new switch is disabled by default, so existing behavior remains unchanged:

- AppContext: `System.Net.Security.UseLegacySslStreamHandshake`
- Environment variable: `DOTNET_SYSTEM_NET_SECURITY_USELEGACYSSLSTREAMHANDSHAKE`

When enabled, `SslStream` skips `TryNextMessageViaTlsSession` and uses its legacy `GenerateToken` path. This provides an operational rollback mechanism while the remaining work tracked by #131315 is completed.

Tests cover the default, explicit AppContext values, the environment variable, AppContext precedence in both directions, deterministic inherited-environment handling, both client and server path selection, and post-handshake data transfer.

## Testing

- Built `System.Net.Security` successfully with zero warnings.
- `SslStreamRemoteExecutorTests.UseLegacySslStreamHandshake_SelectsExpectedHandshakePath`: 7 passed.

Related to #131315.

> [!NOTE]
> This pull request description was created with GitHub Copilot.
