### PR TITLE
Emit version 2 for NativeAOT managed data descriptor

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ManagedDataDescriptorNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ManagedDataDescriptorNode.cs
@@ -98,7 +98,7 @@ namespace ILCompiler.DependencyAnalysis
             using (var writer = new Utf8JsonWriter(stream))
             {
                 writer.WriteStartObject();
-                writer.WriteNumber("version", 0);
+                writer.WriteNumber("version", 2);
                 writer.WriteString("baseline", "empty");
 
                 writer.WriteStartObject("types");


### PR DESCRIPTION
## Summary

Update the ILC-generated NativeAOT managed type sub-descriptor to emit data descriptor version 2.

.NET 11 data contracts were frozen in #131858, which updated the reader to reject descriptors older than version 2. The separate NativeAOT managed descriptor writer was missed and continued emitting version 0. As a result, the matching DataContractReader packages reject NativeAOT binaries produced from the same build, preventing cDAC initialization.

## Testing

Internal cDAC dump and end-to-end tests exposed this issue across Windows and Linux architectures with:

`Unsupported data descriptor version '0'. Expected version 2.`

This change aligns the NativeAOT sub-descriptor with the frozen descriptor format.