### PR TITLE
Enable DnsResolver tests on all Unix platforms

### DIFF
--- a/src/libraries/System.Net.NameResolution/ref/System.Net.NameResolution.cs
+++ b/src/libraries/System.Net.NameResolution/ref/System.Net.NameResolution.cs
@@ -56,27 +56,65 @@ namespace System.Net
         public static string GetHostName() { throw null; }
         [System.ObsoleteAttribute("Resolve has been deprecated. Use GetHostEntry instead.")]
         public static System.Net.IPHostEntry Resolve(string hostName) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Net.DnsResult<System.Net.AddressRecord> ResolveAddresses(string name) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Net.DnsResult<System.Net.AddressRecord> ResolveAddresses(string name, System.Net.Sockets.AddressFamily addressFamily) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Threading.Tasks.Task<System.Net.DnsResult<System.Net.AddressRecord>> ResolveAddressesAsync(string name, System.Net.Sockets.AddressFamily addressFamily, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Threading.Tasks.Task<System.Net.DnsResult<System.Net.AddressRecord>> ResolveAddressesAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Net.DnsResult<System.Net.CNameRecord> ResolveCName(string name) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Threading.Tasks.Task<System.Net.DnsResult<System.Net.CNameRecord>> ResolveCNameAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Net.DnsResult<System.Net.MxRecord> ResolveMx(string name) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Threading.Tasks.Task<System.Net.DnsResult<System.Net.MxRecord>> ResolveMxAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Net.DnsResult<System.Net.NsRecord> ResolveNs(string name) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Threading.Tasks.Task<System.Net.DnsResult<System.Net.NsRecord>> ResolveNsAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Net.DnsResult<System.Net.PtrRecord> ResolvePtr(System.Net.IPAddress address) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Net.DnsResult<System.Net.PtrRecord> ResolvePtr(string name) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Threading.Tasks.Task<System.Net.DnsResult<System.Net.PtrRecord>> ResolvePtrAsync(System.Net.IPAddress address, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Threading.Tasks.Task<System.Net.DnsResult<System.Net.PtrRecord>> ResolvePtrAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Net.DnsResult<System.Net.SrvRecord> ResolveSrv(string name) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Threading.Tasks.Task<System.Net.DnsResult<System.Net.SrvRecord>> ResolveSrvAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Net.DnsResult<System.Net.TxtRecord> ResolveTxt(string name) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
         public static System.Threading.Tasks.Task<System.Net.DnsResult<System.Net.TxtRecord>> ResolveTxtAsync(string name, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatform("wasi")]
     public sealed partial class DnsResolver : System.IAsyncDisposable, System.IDisposable
     {
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public DnsResolver() { }
         public DnsResolver(System.Net.DnsResolverOptions options) { }
         public void Dispose() { }

--- a/src/libraries/System.Net.NameResolution/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.NameResolution/src/Resources/Strings.resx
@@ -90,6 +90,9 @@
   <data name="net_dns_servers_contains_null" xml:space="preserve">
     <value>The DNS server list must not contain null entries.</value>
   </data>
+  <data name="net_dns_system_servers_not_supported" xml:space="preserve">
+    <value>The system-configured DNS servers cannot be determined on this platform. Specify the servers explicitly using DnsResolverOptions.Servers.</value>
+  </data>
   <data name="net_dns_unsupported_address_family" xml:space="preserve">
     <value>Only the InterNetwork and InterNetworkV6 address families are supported.</value>
   </data>

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.Resolve.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.Resolve.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +14,8 @@ namespace System.Net
         // Uses the system-configured DNS servers. A benign race may construct more
         // than one instance, but only one is published; DnsResolver holds no
         // unmanaged state, so the extra instance is simply collected.
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         private static DnsResolver DefaultResolver => field ??= new();
 
         /// <summary>
@@ -22,6 +25,9 @@ namespace System.Net
         /// <returns>A <see cref="DnsResult{T}"/> containing the address records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static DnsResult<AddressRecord> ResolveAddresses(string name)
             => DefaultResolver.ResolveAddresses(name);
 
@@ -37,6 +43,9 @@ namespace System.Net
         /// <returns>A <see cref="DnsResult{T}"/> containing the address records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static DnsResult<AddressRecord> ResolveAddresses(string name, AddressFamily addressFamily)
             => DefaultResolver.ResolveAddresses(name, addressFamily);
 
@@ -48,6 +57,9 @@ namespace System.Net
         /// <returns>A task that completes with a <see cref="DnsResult{T}"/> containing the address records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static Task<DnsResult<AddressRecord>> ResolveAddressesAsync(string name, CancellationToken cancellationToken = default)
             => DefaultResolver.ResolveAddressesAsync(name, cancellationToken);
 
@@ -64,6 +76,9 @@ namespace System.Net
         /// <returns>A task that completes with a <see cref="DnsResult{T}"/> containing the address records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static Task<DnsResult<AddressRecord>> ResolveAddressesAsync(string name, AddressFamily addressFamily, CancellationToken cancellationToken = default)
             => DefaultResolver.ResolveAddressesAsync(name, addressFamily, cancellationToken);
 
@@ -74,6 +89,9 @@ namespace System.Net
         /// <returns>A <see cref="DnsResult{T}"/> containing the SRV records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static DnsResult<SrvRecord> ResolveSrv(string name)
             => DefaultResolver.ResolveSrv(name);
 
@@ -85,6 +103,9 @@ namespace System.Net
         /// <returns>A task that completes with a <see cref="DnsResult{T}"/> containing the SRV records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static Task<DnsResult<SrvRecord>> ResolveSrvAsync(string name, CancellationToken cancellationToken = default)
             => DefaultResolver.ResolveSrvAsync(name, cancellationToken);
 
@@ -95,6 +116,9 @@ namespace System.Net
         /// <returns>A <see cref="DnsResult{T}"/> containing the MX records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static DnsResult<MxRecord> ResolveMx(string name)
             => DefaultResolver.ResolveMx(name);
 
@@ -106,6 +130,9 @@ namespace System.Net
         /// <returns>A task that completes with a <see cref="DnsResult{T}"/> containing the MX records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static Task<DnsResult<MxRecord>> ResolveMxAsync(string name, CancellationToken cancellationToken = default)
             => DefaultResolver.ResolveMxAsync(name, cancellationToken);
 
@@ -116,6 +143,9 @@ namespace System.Net
         /// <returns>A <see cref="DnsResult{T}"/> containing the TXT records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static DnsResult<TxtRecord> ResolveTxt(string name)
             => DefaultResolver.ResolveTxt(name);
 
@@ -127,6 +157,9 @@ namespace System.Net
         /// <returns>A task that completes with a <see cref="DnsResult{T}"/> containing the TXT records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static Task<DnsResult<TxtRecord>> ResolveTxtAsync(string name, CancellationToken cancellationToken = default)
             => DefaultResolver.ResolveTxtAsync(name, cancellationToken);
 
@@ -137,6 +170,9 @@ namespace System.Net
         /// <returns>A <see cref="DnsResult{T}"/> containing the CNAME records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static DnsResult<CNameRecord> ResolveCName(string name)
             => DefaultResolver.ResolveCName(name);
 
@@ -148,6 +184,9 @@ namespace System.Net
         /// <returns>A task that completes with a <see cref="DnsResult{T}"/> containing the CNAME records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static Task<DnsResult<CNameRecord>> ResolveCNameAsync(string name, CancellationToken cancellationToken = default)
             => DefaultResolver.ResolveCNameAsync(name, cancellationToken);
 
@@ -158,6 +197,9 @@ namespace System.Net
         /// <returns>A <see cref="DnsResult{T}"/> containing the PTR records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static DnsResult<PtrRecord> ResolvePtr(string name)
             => DefaultResolver.ResolvePtr(name);
 
@@ -167,6 +209,9 @@ namespace System.Net
         /// <param name="address">The IP address to perform a reverse lookup for.</param>
         /// <returns>A <see cref="DnsResult{T}"/> containing the PTR records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="address"/> is <see langword="null"/>.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static DnsResult<PtrRecord> ResolvePtr(IPAddress address)
             => DefaultResolver.ResolvePtr(address);
 
@@ -178,6 +223,9 @@ namespace System.Net
         /// <returns>A task that completes with a <see cref="DnsResult{T}"/> containing the PTR records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static Task<DnsResult<PtrRecord>> ResolvePtrAsync(string name, CancellationToken cancellationToken = default)
             => DefaultResolver.ResolvePtrAsync(name, cancellationToken);
 
@@ -188,6 +236,9 @@ namespace System.Net
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task that completes with a <see cref="DnsResult{T}"/> containing the PTR records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="address"/> is <see langword="null"/>.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static Task<DnsResult<PtrRecord>> ResolvePtrAsync(IPAddress address, CancellationToken cancellationToken = default)
             => DefaultResolver.ResolvePtrAsync(address, cancellationToken);
 
@@ -198,6 +249,9 @@ namespace System.Net
         /// <returns>A <see cref="DnsResult{T}"/> containing the NS records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static DnsResult<NsRecord> ResolveNs(string name)
             => DefaultResolver.ResolveNs(name);
 
@@ -209,6 +263,9 @@ namespace System.Net
         /// <returns>A task that completes with a <see cref="DnsResult{T}"/> containing the NS records.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is empty.</exception>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("wasi")]
         public static Task<DnsResult<NsRecord>> ResolveNsAsync(string name, CancellationToken cancellationToken = default)
             => DefaultResolver.ResolveNsAsync(name, cancellationToken);
     }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/DnsResolver.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/DnsResolver.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Sockets;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,6 +21,7 @@ namespace System.Net
     /// and used to issue multiple concurrent resolutions.
     /// </para>
     /// </remarks>
+    [UnsupportedOSPlatform("wasi")]
     public sealed partial class DnsResolver : IAsyncDisposable, IDisposable
     {
         private readonly IPEndPoint[] _servers;
@@ -29,6 +31,8 @@ namespace System.Net
         /// Initializes a new instance of the <see cref="DnsResolver"/> class that uses the
         /// system-configured DNS servers.
         /// </summary>
+        /// <exception cref="PlatformNotSupportedException">The system-configured DNS servers cannot be determined on this platform.</exception>
+        [UnsupportedOSPlatform("android")]
         public DnsResolver() : this(new DnsResolverOptions()) { }
 
         /// <summary>

--- a/src/libraries/System.Net.NameResolution/src/System/Net/DnsResolverPal.Managed.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/DnsResolverPal.Managed.cs
@@ -51,6 +51,16 @@ namespace System.Net
         // (InterNetwork / InterNetworkV6) are supported.
         public static void ValidateServers(IPEndPoint[] servers)
         {
+            if (servers.Length == 0 && OperatingSystem.IsAndroid())
+            {
+                // With no explicit servers the resolver falls back to the system configuration,
+                // which on Android cannot be read: there is no accessible /etc/resolv.conf and
+                // IPInterfaceProperties.DnsAddresses is unsupported there for the same reason.
+                // Rather than silently querying an unreachable fallback address, reject the
+                // configuration up front. See https://github.com/dotnet/runtime/issues/132212.
+                throw new PlatformNotSupportedException(SR.net_dns_system_servers_not_supported);
+            }
+
             foreach (IPEndPoint server in servers)
             {
                 if (server.AddressFamily is not (AddressFamily.InterNetwork or AddressFamily.InterNetworkV6))

--- a/src/libraries/System.Net.NameResolution/src/System/Net/DnsResolverPal.Managed.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/DnsResolverPal.Managed.cs
@@ -864,6 +864,9 @@ namespace System.Net
                 return systemServers;
             }
 
+            // Matches glibc: resolv.conf(5) specifies that when the file is missing or contains
+            // no nameserver entries, the name server on the local machine is queried. Hosts
+            // running a local resolver (dnsmasq, unbound, a container sidecar) rely on this.
             return new IPEndPoint[] { new IPEndPoint(IPAddress.Loopback, ResolvConf.DefaultDnsPort) };
         }
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/DnsResolverPal.Unsupported.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/DnsResolverPal.Unsupported.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 
 namespace System.Net
 {
+    // DnsResolver is not implemented on Browser or WASI. Enabling the managed resolver on
+    // WASI is tracked by https://github.com/dotnet/runtime/issues/132215.
     internal static partial class DnsResolverPal
     {
         // No platform-specific server restrictions to enforce; resolution itself is

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/DnsResolverLoopbackTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/DnsResolverLoopbackTest.cs
@@ -109,7 +109,7 @@ namespace System.Net.NameResolution.Tests
 
         // ---- Address resolution ----
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_Unspecified_ReturnsBothV4AndV6(bool async)
@@ -126,7 +126,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Contains(result.Records, a => a.Address.ToString() == "fd00::1");
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_IPv4Only_ReturnsOnlyV4(bool async)
@@ -143,7 +143,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal("10.0.0.2", record.Address.ToString());
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_IPv6Only_ReturnsOnlyV6(bool async)
@@ -159,7 +159,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal("fd00::1", record.Address.ToString());
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_AddressFamilyV4_QueriesOnlyA(bool async)
@@ -174,7 +174,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal("192.0.2.7", record.Address.ToString());
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_HasTtl(bool async)
@@ -195,7 +195,7 @@ namespace System.Net.NameResolution.Tests
         // The following behaviors are specific to the managed resolver; the Windows PAL
         // delegates server failover and record validation to DnsQueryEx.
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_ServerFailure_FailsOverToNextServer(bool async)
@@ -219,7 +219,7 @@ namespace System.Net.NameResolution.Tests
             Assert.True(failing.RequestCount > 0, "The first (failing) server should have been queried.");
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_AllServersFail_ReturnsServerFailure(bool async)
@@ -234,7 +234,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Empty(result.Records);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_MalformedARecord_Throws(bool async)
@@ -248,7 +248,7 @@ namespace System.Net.NameResolution.Tests
         }
 #endif
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_Nxdomain_ReturnsNxDomain(bool async)
@@ -278,7 +278,7 @@ namespace System.Net.NameResolution.Tests
 #endif
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_NoData_ReturnsNoErrorWithEmptyRecords(bool async)
@@ -307,7 +307,7 @@ namespace System.Net.NameResolution.Tests
 #endif
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_NoData_And_Nxdomain_AreDistinguishable(bool async)
@@ -341,7 +341,7 @@ namespace System.Net.NameResolution.Tests
 
         // ---- SRV ----
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveSrv_ReturnsRecords(bool async)
@@ -366,7 +366,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal((ushort)20, s2.Priority);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveSrv_IncludesAdditionalAddresses(bool async)
@@ -391,7 +391,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal(2, s2.Addresses.Count);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveSrv_NoAdditionalAddresses(bool async)
@@ -409,7 +409,7 @@ namespace System.Net.NameResolution.Tests
 
         // ---- MX / TXT / CNAME / PTR / NS ----
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveMx_ReturnsRecords(bool async)
@@ -429,7 +429,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Single(result.Records, m => m.Exchange == "mail2.test" && m.Preference == 20);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveTxt_ReturnsValues(bool async)
@@ -447,7 +447,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Contains(result.Records, t => t.Values.Count == 2 && t.Values[0] == "part1" && t.Values[1] == "part2");
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveCName_ReturnsCanonicalName(bool async)
@@ -463,7 +463,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal("canonical.test", record.CanonicalName);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolvePtr_ReturnsName(bool async)
@@ -479,7 +479,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal("host.test", record.Name);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveNs_ReturnsRecords(bool async)
@@ -523,7 +523,7 @@ namespace System.Net.NameResolution.Tests
 
         // ---- Cancellation while a query is in flight ----
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         public async Task ResolveAddresses_CancellationInFlight_Throws()
         {
             using SemaphoreSlim queryReceived = new(0, 1);
@@ -554,7 +554,7 @@ namespace System.Net.NameResolution.Tests
 
         // ---- Telemetry ----
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ResolveAddresses_RecordsDurationMetric_CoversQueryTime(bool async)

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/DnsResolverTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/DnsResolverTest.cs
@@ -21,6 +21,16 @@ namespace System.Net.NameResolution.Tests
         private const string TestNsHost = "microsoft.com";
         private const string NonExistentHost = "this-name-definitely-does-not-exist.dotnet-test.invalid";
 
+        // DnsResolver has no implementation on Browser or WASI; every query throws
+        // PlatformNotSupportedException there.
+        public static bool IsDnsResolverUnsupported => PlatformDetection.IsBrowser || PlatformDetection.IsWasi;
+
+        // Android cannot report the system-configured DNS servers, so the parameterless
+        // constructor throws there. Tests that never send a query specify a server explicitly
+        // so that they remain platform independent.
+        private static DnsResolver CreateResolver() =>
+            new DnsResolver(new DnsResolverOptions { Servers = { new IPEndPoint(IPAddress.Loopback, 53) } });
+
         // ---- Cross-platform argument-validation tests ----
 
         [Fact]
@@ -29,17 +39,33 @@ namespace System.Net.NameResolution.Tests
             Assert.Throws<ArgumentNullException>(() => new DnsResolver(null!));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid))]
         public void DnsResolver_Construct_DefaultOptions_DoesNotThrow()
         {
             using DnsResolver r = new DnsResolver();
             Assert.NotNull(r);
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid))]
+        public void DnsResolver_Construct_DefaultOptions_ThrowsPlatformNotSupported()
+        {
+            // Android exposes no readable resolver configuration, so a resolver that would
+            // have to use the system-configured servers cannot be created.
+            Assert.Throws<PlatformNotSupportedException>(() => new DnsResolver());
+            Assert.Throws<PlatformNotSupportedException>(() => Dns.ResolveAddresses(TestHost));
+        }
+
+        [ConditionalFact(nameof(IsDnsResolverUnsupported))]
+        public async Task DnsResolver_UnsupportedPlatform_ThrowsPlatformNotSupported()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => Dns.ResolveAddresses(TestHost));
+            await Assert.ThrowsAsync<PlatformNotSupportedException>(() => Dns.ResolveAddressesAsync(TestHost));
+        }
+
         [Fact]
         public async Task DnsResolver_NullName_Throws()
         {
-            using DnsResolver r = new DnsResolver();
+            using DnsResolver r = CreateResolver();
             await Assert.ThrowsAsync<ArgumentNullException>(() => r.ResolveAddressesAsync(null!));
             await Assert.ThrowsAsync<ArgumentNullException>(() => r.ResolveSrvAsync(null!));
             await Assert.ThrowsAsync<ArgumentNullException>(() => r.ResolveMxAsync(null!));
@@ -53,7 +79,7 @@ namespace System.Net.NameResolution.Tests
         [Fact]
         public void DnsResolver_NullName_Throws_Sync()
         {
-            using DnsResolver r = new DnsResolver();
+            using DnsResolver r = CreateResolver();
             Assert.Throws<ArgumentNullException>(() => r.ResolveAddresses(null!));
             Assert.Throws<ArgumentNullException>(() => r.ResolveSrv(null!));
             Assert.Throws<ArgumentNullException>(() => r.ResolveMx(null!));
@@ -66,7 +92,7 @@ namespace System.Net.NameResolution.Tests
         [Fact]
         public async Task DnsResolver_EmptyName_Throws()
         {
-            using DnsResolver r = new DnsResolver();
+            using DnsResolver r = CreateResolver();
             await Assert.ThrowsAsync<ArgumentException>(() => r.ResolveAddressesAsync(string.Empty));
             Assert.Throws<ArgumentException>(() => r.ResolveAddresses(string.Empty));
         }
@@ -74,7 +100,7 @@ namespace System.Net.NameResolution.Tests
         [Fact]
         public async Task DnsResolver_Disposed_Throws()
         {
-            DnsResolver r = new DnsResolver();
+            DnsResolver r = CreateResolver();
             r.Dispose();
             await Assert.ThrowsAsync<ObjectDisposedException>(() => r.ResolveAddressesAsync(TestHost));
             await Assert.ThrowsAsync<ObjectDisposedException>(() => r.ResolveSrvAsync(TestSrv));
@@ -87,7 +113,7 @@ namespace System.Net.NameResolution.Tests
         [Fact]
         public async Task DnsResolver_DisposeAsync_ThrowsOnUse()
         {
-            DnsResolver r = new DnsResolver();
+            DnsResolver r = CreateResolver();
             await r.DisposeAsync();
             await Assert.ThrowsAsync<ObjectDisposedException>(() => r.ResolveAddressesAsync(TestHost));
         }
@@ -139,15 +165,22 @@ namespace System.Net.NameResolution.Tests
             };
         }
 
-        // ---- Windows network tests (require outbound DNS) ----
+        // ---- Network tests (require outbound DNS) ----
+        //
+        // DnsResolver is implemented on Windows (DnsQueryEx) and on all Unix-like platforms
+        // (the managed stub resolver); it is unsupported on Browser and WASI. These tests use
+        // the system-configured DNS servers, which the managed resolver reads from
+        // /etc/resolv.conf. Android has no readable resolver configuration (its
+        // IPInterfaceProperties.DnsAddresses throws PlatformNotSupportedException for the same
+        // reason), so it is excluded until the servers can be obtained from the platform.
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         public async Task DnsResolver_PreCanceledToken_ReturnsCanceled()
         {
             using DnsResolver r = new DnsResolver();
             CancellationTokenSource cts = new CancellationTokenSource();
             cts.Cancel();
-            await Assert.ThrowsAsync<TaskCanceledException>(() => r.ResolveAddressesAsync(TestHost, cts.Token));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => r.ResolveAddressesAsync(TestHost, cts.Token));
         }
 
         // Regression test for the Windows 10 DnsQueryEx bug where an asynchronous query
@@ -189,7 +222,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -206,7 +239,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -221,7 +254,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -234,7 +267,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Empty(result.Records);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -250,7 +283,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -266,7 +299,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -282,7 +315,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -298,7 +331,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -311,7 +344,7 @@ namespace System.Net.NameResolution.Tests
             Assert.False(string.IsNullOrEmpty(result.Records[0].Name));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -322,7 +355,7 @@ namespace System.Net.NameResolution.Tests
             Assert.NotEmpty(result.Records);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]
@@ -360,6 +393,19 @@ namespace System.Net.NameResolution.Tests
             Assert.Throws<PlatformNotSupportedException>(() => new DnsResolver(opts));
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        public void DnsResolver_CustomServer_NonStandardPort_IsAccepted()
+        {
+            // The managed resolver talks to each server endpoint directly, so a non-default
+            // port is supported.
+            DnsResolverOptions opts = new DnsResolverOptions
+            {
+                Servers = { new IPEndPoint(IPAddress.Loopback, 5353) }
+            };
+            using DnsResolver r = new DnsResolver(opts);
+            Assert.NotNull(r);
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
         public void DnsResolver_CustomServers_MixedAddressFamilies_ThrowsArgumentException()
         {
@@ -376,9 +422,26 @@ namespace System.Net.NameResolution.Tests
             Assert.Throws<ArgumentException>(() => new DnsResolver(opts));
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
+        public void DnsResolver_CustomServers_MixedAddressFamilies_IsAccepted()
+        {
+            // The managed resolver opens a socket matching each server's address family, so a
+            // mixed IPv4/IPv6 server list is supported.
+            DnsResolverOptions opts = new DnsResolverOptions
+            {
+                Servers =
+                {
+                    new IPEndPoint(IPAddress.Loopback, 53),
+                    new IPEndPoint(IPAddress.IPv6Loopback, 53),
+                }
+            };
+            using DnsResolver r = new DnsResolver(opts);
+            Assert.NotNull(r);
+        }
+
         // ---- Reverse-arpa name building (covers both IPv4 and IPv6 paths used by ResolvePtr(IPAddress)) ----
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroid), nameof(PlatformDetection.IsNotBrowser), nameof(PlatformDetection.IsNotWasi))]
         [InlineData(false)]
         [InlineData(true)]
         [OuterLoop]


### PR DESCRIPTION
Follow-up to #129846, which added `DnsResolver` with a managed stub resolver implementation.

That implementation is compiled through the shared `-unix` target framework, which is a catch-all for every Unix-family `TargetOS` that has no explicit entry in `TargetFrameworks`. `System.Net.NameResolution` lists only `windows;unix;browser;wasi`, so macOS, the BSDs, illumos, Haiku, iOS, tvOS, MacCatalyst and Android already compile the same managed resolver as Linux — no per-platform PAL work is needed to support them. The tests were the only thing still gated to Windows.

## Test gating

- `DnsResolverTest`: the network tests move from `IsWindows` to "everywhere the resolver is implemented" (that is, everything except Android, Browser and WASI). Three tests that exercise genuinely `DnsQueryEx`-specific behavior stay Windows-only, and two Unix counterparts were added for the constructor-validation ones — the managed resolver talks to each server endpoint directly, so it accepts non-standard ports and mixed IPv4/IPv6 server lists that `DnsQueryEx` rejects.
- `DnsResolverLoopbackTest`: drops `IsNotMobile`. These tests pass an explicit `Servers` list and talk to an in-process loopback server, so they never touch the system resolver configuration and can run on Android and Apple mobile.
- `DnsResolver_PreCanceledToken_ReturnsCanceled` now asserts `ThrowsAnyAsync<OperationCanceledException>`. The managed PAL cancels via `CancellationToken.ThrowIfCancellationRequested()`, which produces a plain `OperationCanceledException`, whereas the Windows PAL produces a `TaskCanceledException`.

## Android

Android is the one Unix platform that cannot use the system-configured servers. There is no accessible `/etc/resolv.conf`, and `IPInterfaceProperties.DnsAddresses` throws `PlatformNotSupportedException` there for the same reason, so `ResolvConf.GetNameServers()` comes back empty and `GetServers()` falls back to `127.0.0.1:53` — every query would silently time out against an unreachable address.

Rather than fail that way, `DnsResolverPal.Managed.ValidateServers` now rejects the configuration up front with `PlatformNotSupportedException`, and the affected surface is annotated:

- the parameterless `DnsResolver()` constructor
- all 18 `Dns.Resolve*` statics, which route through it

`DnsResolver(DnsResolverOptions)` with an explicit `Servers` list keeps working on Android, which is why the annotation cannot go on the type. Tracked by #132212.

## Browser and WASI

`DnsResolver` is unsupported on both — they compile `DnsResolverPal.Unsupported.cs` (and on Browser the whole assembly is a generated PNSE stub). Browser needs no per-member attribute because `Directory.Build.props` already sets `UnsupportedOSPlatforms=browser`, which emits an assembly-level attribute; WASI was not covered by anything, so `[UnsupportedOSPlatform("wasi")]` is applied to the `DnsResolver` type and the `Dns.Resolve*` statics, following the `Zstandard*` precedent in System.IO.Compression.

Reusing the managed resolver on WASI is possible in principle — WASI does have TCP and UDP sockets — but it has no resolver configuration to read and no threads, so the synchronous query path (which blocks on `IAsyncResult.AsyncWaitHandle.WaitOne` and blocking `Socket.Send`/`Receive`) would deadlock the only thread. Tracked by #132215.

A new test asserts the `PlatformNotSupportedException` contract on each of Android, Browser and WASI. The argument-validation tests were switched to a resolver built with an explicit (never-contacted) server so that they keep running on Android instead of being skipped there.

## API

No new API surface. The only `ref/` changes are `[UnsupportedOSPlatform]` attributes on API already approved and merged in #129846.

## Validation

Built and tested on Linux x64: `System.Net.NameResolution.Functional.Tests` — 201 total, 0 failed, 6 skipped. The library builds clean (0 warnings) across all five target frameworks, including `-browser` and `-wasi`, and cross-compiles clean for `TargetOS=android`, `osx` and `maccatalyst`.

The mobile, macOS, Browser and WASI legs could not be exercised locally, so CI is the first execution there.

> [!NOTE]
> This pull request was authored with GitHub Copilot.
