### PR TITLE
Handle truncation errors in diagnostic IPC transport names

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -158,9 +158,12 @@ ds_rt_transport_get_default_name (
 	STATIC_CONTRACT_NOTHROW;
 
 #ifdef TARGET_UNIX
+	// PAL_GetTransportName returns void, but sets name[0] to '\0' when it fails to generate a name.
 	PAL_GetTransportName (name_len, name, prefix, id, group_id, suffix);
+	return name [0] != '\0';
+#else
+	return false;
 #endif
-	return true;
 }
 
 /*

--- a/src/native/eventpipe/ds-ipc-pal-socket.c
+++ b/src/native/eventpipe/ds-ipc-pal-socket.c
@@ -734,7 +734,8 @@ ipc_transport_get_default_name (
 		pd.m_Pid,
 		pd.m_ApplicationGroupId,
 		"socket");
-	return true;
+	// PAL_GetTransportName returns void, but sets name[0] to '\0' when it fails to generate a name.
+	return name [0] != '\0';
 #else
 	return false;
 #endif
@@ -813,7 +814,7 @@ ipc_alloc_uds_address (
 	EP_ASSERT (ipc != NULL);
 
 	struct sockaddr_un *server_address = ep_rt_object_alloc (struct sockaddr_un);
-	ep_return_null_if_nok (server_address != NULL);
+	ep_raise_error_if_nok (server_address != NULL);
 
 	server_address->sun_family = AF_UNIX;
 
@@ -823,20 +824,29 @@ ipc_alloc_uds_address (
 			sizeof (server_address->sun_path),
 			"%s",
 			ipc_name);
-		if (result <= 0 || result >= (int32_t)(sizeof (server_address->sun_path)))
-			server_address->sun_path [0] = '\0';
+		ep_raise_error_if_nok (result > 0 && result < (int32_t)(sizeof (server_address->sun_path)));
 	} else {
 		// generate the default socket name
-		ipc_transport_get_default_name (
+		ep_raise_error_if_nok (ipc_transport_get_default_name (
 			server_address->sun_path,
-			sizeof (server_address->sun_path));
+			sizeof (server_address->sun_path)));
 	}
+
+	// An empty sun_path would bind to the Linux abstract namespace, which is not supported.
+	ep_raise_error_if_nok (server_address->sun_path [0] != '\0');
 
 	ipc->server_address = (ds_ipc_socket_address_t *)server_address;
 	ipc->server_address_len = sizeof (struct sockaddr_un);
 	ipc->server_address_family = server_address->sun_family;
+	server_address = NULL;
 
+ep_on_exit:
 	return ipc;
+
+ep_on_error:
+	ep_rt_object_free (server_address);
+	ipc = NULL;
+	ep_exit_error_handler ();
 #else
 	return NULL;
 #endif


### PR DESCRIPTION
## Summary

Port the EventPipe diagnostic IPC transport fix from dotnet/dotnet#8241 (commit `90e1097e9e4ad09e4aa3da19bf7dd73ee0eaaa2a`) to `main`.

`PAL_GetTransportName` reports failure by leaving the output empty. Propagate that failure and reject truncated or empty Unix-domain socket paths instead of allowing an empty `sun_path` to bind in the Linux abstract namespace.

## Testing

- `build.cmd clr.runtime -rc checked`
- `build.cmd clr.corelib+clr.nativecorelib+libs.pretest -rc checked -lc release`
- `src\tests\build.cmd -Test tracing/eventpipe/diagnosticport/diagnosticport.csproj x64 Checked`
- `diagnosticport.cmd` with `DOTNET_TieredCompilation=0`

> [!NOTE]
> This pull request description was generated with GitHub Copilot.