### PR TITLE
Fix CodeQL issues in PAL tests

### DIFF
--- a/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameA/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameA/test2/test2.cpp
@@ -90,7 +90,8 @@ PALTEST(file_io_GetFullPathNameA_test2_paltest_getfullpathnamea_test2, "file_io/
     if (CloseHandle(hFile) != TRUE)
     {
         Trace("ERROR :%ld: CloseHandle failed close hFile=0x%lx.\n",
-             GetLastError());
+             GetLastError(),
+             hFile);
         goto terminate;
     }
 
@@ -138,5 +139,4 @@ terminate:
     PAL_Terminate();
     return PASS;
 }
-
 

--- a/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameA/test3/test3.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameA/test3/test3.cpp
@@ -156,7 +156,8 @@ PALTEST(file_io_GetFullPathNameA_test3_paltest_getfullpathnamea_test3, "file_io/
     if (CloseHandle(hFile) != TRUE)
     {
         Trace("ERROR :%ld: CloseHandle failed close hFile=0x%lx.\n",
-              GetLastError());
+              GetLastError(),
+              hFile);
         bRetVal = FAIL;
         goto cleanUpThree;
     }

--- a/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameA/test4/test4.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameA/test4/test4.cpp
@@ -131,7 +131,8 @@ PALTEST(file_io_GetFullPathNameA_test4_paltest_getfullpathnamea_test4, "file_io/
     if (CloseHandle(hFile) != TRUE)
     {
         Trace("ERROR :%ld: CloseHandle failed close hFile=0x%lx.\n",
-              GetLastError());
+              GetLastError(),
+              hFile);
         bRetVal = FAIL;
         goto cleanUpTwo;
     }

--- a/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameW/test3/test3.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameW/test3/test3.cpp
@@ -159,7 +159,8 @@ PALTEST(file_io_GetFullPathNameW_test3_paltest_getfullpathnamew_test3, "file_io/
     if (CloseHandle(hFile) != TRUE)
     {
         Trace("ERROR :%ld: CloseHandle failed close hFile=0x%lx.\n",
-              GetLastError());
+              GetLastError(),
+              hFile);
         bRetVal = FAIL;
         goto cleanUpThree;
     }

--- a/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameW/test4/test4.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/GetFullPathNameW/test4/test4.cpp
@@ -131,7 +131,8 @@ PALTEST(file_io_GetFullPathNameW_test4_paltest_getfullpathnamew_test4, "file_io/
     if (CloseHandle(hFile) != TRUE)
     {
         Trace("ERROR :%ld: CloseHandle failed close hFile=0x%lx.\n",
-              GetLastError());
+              GetLastError(),
+              hFile);
         bRetVal = FAIL;
         goto cleanUpTwo;
     }

--- a/src/coreclr/pal/tests/palsuite/file_io/SetFilePointer/test2/SetFilePointer.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/SetFilePointer/test2/SetFilePointer.cpp
@@ -164,6 +164,7 @@ PALTEST(file_io_SetFilePointer_test2_paltest_setfilepointer_test2, "file_io/SetF
             PAL_TerminateEx(FAIL);
             return FAIL;
         }
+        szBuffer[dwByteCount] = '\0';
         szPtr = szText + 20;
         if (strcmp(szPtr, szBuffer) != 0)
         {

--- a/src/coreclr/pal/tests/palsuite/file_io/SetFilePointer/test3/SetFilePointer.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/SetFilePointer/test3/SetFilePointer.cpp
@@ -181,6 +181,7 @@ PALTEST(file_io_SetFilePointer_test3_paltest_setfilepointer_test3, "file_io/SetF
             PAL_TerminateEx(FAIL);
             return FAIL;
         }
+        szBuffer[dwByteCount] = '\0';
         szPtr = szText + 20;;
         if (strcmp(szPtr, szBuffer) != 0)
         {
@@ -263,6 +264,7 @@ PALTEST(file_io_SetFilePointer_test3_paltest_setfilepointer_test3, "file_io/SetF
             PAL_TerminateEx(FAIL);
             return FAIL;
         }
+        szBuffer[dwByteCount] = '\0';
         szPtr = szText + 42;
         if (strcmp(szPtr, szBuffer) != 0)
         {

--- a/src/coreclr/pal/tests/palsuite/file_io/WriteFile/test3/WriteFile.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/WriteFile/test3/WriteFile.cpp
@@ -47,6 +47,7 @@ BOOL validateResults_WriteFile_test3(const char* szString)
         return FALSE;
     }
 
+    szReadString[dwBytesRead] = '\0';
     if (strcmp(szReadString, szString))
     {
         Trace("read = %s  string = %s", szReadString, szString);

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test1/CreateFileMappingW.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test1/CreateFileMappingW.cpp
@@ -135,7 +135,7 @@ CleanUpThree:
         */
     if ( UnmapViewOfFile(lpMapViewAddress) == FALSE )
     {
-        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"%0x%lx\".\n",
+        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"0x%lx\".\n",
                 GetLastError(),
                 lpMapViewAddress);
         RetVal = FAIL;
@@ -170,4 +170,3 @@ CleanUpOne:
     PAL_TerminateEx(RetVal);
     return RetVal;
 }
-

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test3/CreateFileMappingW.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test3/CreateFileMappingW.cpp
@@ -117,7 +117,7 @@ CleanUpThree:
         */
     if ( UnmapViewOfFile(lpMapViewAddress) == FALSE )
     {
-        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"%0x%lx\".\n",
+        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"0x%lx\".\n",
                 GetLastError(),
                 lpMapViewAddress);
         RetVal = FAIL;
@@ -152,4 +152,3 @@ CleanUpOne:
     PAL_TerminateEx(RetVal);
     return RetVal;
 }
-

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test4/CreateFileMappingW.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test4/CreateFileMappingW.cpp
@@ -142,7 +142,7 @@ CleanUpThree:
         */
     if ( UnmapViewOfFile(lpMapViewAddress) == FALSE )
     {
-        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"%0x%lx\".\n",
+        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"0x%lx\".\n",
                 GetLastError(),
                 lpMapViewAddress);
         RetVal = FAIL;
@@ -177,5 +177,4 @@ CleanUpOne:
     PAL_TerminateEx(RetVal);
     return RetVal;
 }
-
 

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test5/CreateFileMappingW.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test5/CreateFileMappingW.cpp
@@ -141,7 +141,7 @@ CleanUpFour:
         */
     if ( UnmapViewOfFile(lpMapViewRO) == FALSE )
     {
-        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"%0x%lx\".\n",
+        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"0x%lx\".\n",
                 GetLastError(),
                 lpMapViewRO);
         RetVal = FAIL;
@@ -165,7 +165,7 @@ CleanUpTwo:
      */
     if ( UnmapViewOfFile(lpMapViewRW) == FALSE )
     {
-        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"%0x%lx\".\n",
+        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"0x%lx\".\n",
                 GetLastError(),
                 lpMapViewRW);
         RetVal = FAIL;
@@ -190,4 +190,3 @@ CleanUpOne:
     PAL_TerminateEx(RetVal);
     return RetVal;
 }
-

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test6/CreateFileMappingW.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test6/CreateFileMappingW.cpp
@@ -124,7 +124,7 @@ CleanUpThree:
      */
     if ( UnmapViewOfFile(lpMapViewRW2) == FALSE )
     {
-        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"%0x%lx\".\n",
+        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"0x%lx\".\n",
                 GetLastError(),
                 lpMapViewRW2);
         RetVal = FAIL;
@@ -136,7 +136,7 @@ CleanUpTwo:
      */
     if ( UnmapViewOfFile(lpMapViewRW) == FALSE )
     {
-        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"%0x%lx\".\n",
+        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"0x%lx\".\n",
                 GetLastError(),
                 lpMapViewRW);
         RetVal = FAIL;
@@ -161,4 +161,3 @@ CleanUpOne:
     PAL_TerminateEx(RetVal);
     return RetVal;
 }
-

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test7/createfilemapping.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/CreateFileMappingW/test7/createfilemapping.cpp
@@ -124,7 +124,7 @@ CleanUpThree:
      */
     if ( UnmapViewOfFile(lpMapViewRO) == FALSE )
     {
-        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"%0x%lx\".\n",
+        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"0x%lx\".\n",
                 GetLastError(),
                 lpMapViewRO);
         RetVal = FAIL;
@@ -136,7 +136,7 @@ CleanUpTwo:
      */
     if ( UnmapViewOfFile(lpMapViewRW) == FALSE )
     {
-        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"%0x%lx\".\n",
+        Trace("ERROR:%u: Failed to UnmapViewOfFile of \"0x%lx\".\n",
                 GetLastError(),
                 lpMapViewRW);
         RetVal = FAIL;
@@ -161,4 +161,3 @@ CleanUpOne:
     PAL_TerminateEx(RetVal);
     return RetVal;
 }
-

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/MapViewOfFile/test2/MapViewOfFile.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/MapViewOfFile/test2/MapViewOfFile.cpp
@@ -154,6 +154,7 @@ PALTEST(filemapping_memmgt_MapViewOfFile_test2_paltest_mapviewoffile_test2, "fil
         Fail("");
     }
 
+    readString[dwBytesRead] = '\0';
     if (memcmp(buf, readString, strlen(readString)) != 0)
     {
         CloseHandle(hFile);

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/MapViewOfFile/test3/MapViewOfFile.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/MapViewOfFile/test3/MapViewOfFile.cpp
@@ -158,6 +158,7 @@ PALTEST(filemapping_memmgt_MapViewOfFile_test3_paltest_mapviewoffile_test3, "fil
         Fail("");
     }
 
+    readString[dwBytesRead] = '\0';
     if (memcmp(ch, readString, strlen(readString)) != 0)
         {
         CloseHandle(hFile);

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/MapViewOfFile/test5/mapviewoffile.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/MapViewOfFile/test5/mapviewoffile.cpp
@@ -54,7 +54,8 @@ PALTEST(filemapping_memmgt_MapViewOfFile_test5_paltest_mapviewoffile_test5, "fil
     {
         Trace("ERROR:%u: Able to create a MapViewOfFile with "
               "hFileMapping=0x%lx.\n",
-              GetLastError());
+              GetLastError(),
+              hFileMapping);
         UnmapViewOfFile(lpMapViewAddress);
         Fail("");
     }
@@ -75,7 +76,8 @@ PALTEST(filemapping_memmgt_MapViewOfFile_test5_paltest_mapviewoffile_test5, "fil
     {
         Trace("ERROR:%u: Able to create a MapViewOfFile with "
               "hFileMapping=0x%lx.\n",
-              GetLastError());
+              GetLastError(),
+              hFileMapping);
         UnmapViewOfFile(lpMapViewAddress);
         Fail("");
     }

--- a/src/coreclr/pal/tests/palsuite/filemapping_memmgt/UnmapViewOfFile/test1/UnmapViewOfFile.cpp
+++ b/src/coreclr/pal/tests/palsuite/filemapping_memmgt/UnmapViewOfFile/test1/UnmapViewOfFile.cpp
@@ -128,6 +128,7 @@ PALTEST(filemapping_memmgt_UnmapViewOfFile_test1_paltest_unmapviewoffile_test1, 
         Fail("");
     }
 
+    readString[dwBytesRead] = '\0';
     if (memcmp(ch, readString, strlen(readString)) != 0)
         {
         Trace("ERROR: Read string from file \"%s\", is "

--- a/src/coreclr/pal/tests/palsuite/threading/CreateThread/test3/test3.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/CreateThread/test3/test3.cpp
@@ -59,7 +59,9 @@ PALTEST(threading_CreateThread_test3_paltest_createthread_test3, "threading/Crea
         if (0 == CloseHandle(hEvent_CreateThread_test3))
         {
             Trace("PALSUITE ERROR: Unable to execute CloseHandle(%p) during "
-                  "clean up.\nGetLastError returned '%u'.\n", hEvent_CreateThread_test3);
+                  "clean up.\nGetLastError returned '%u'.\n",
+                  hEvent_CreateThread_test3,
+                  GetLastError());
         }
         Fail("");
     } 
@@ -97,4 +99,3 @@ PALTEST(threading_CreateThread_test3_paltest_createthread_test3, "threading/Crea
     PAL_Terminate();
     return (PASS);
 }
-

--- a/src/coreclr/pal/tests/palsuite/threading/ResetEvent/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/ResetEvent/test1/test1.cpp
@@ -57,7 +57,7 @@ BOOL ResetEventTest()
 
                 if (dwRet != WAIT_TIMEOUT)
                 {
-                    Fail("ResetEventTest:WaitForSingleObject %s failed (%x)\n", GetLastError());
+                    Fail("ResetEventTest:WaitForSingleObject failed (%x)\n", GetLastError());
                 }
                 else
                 {

--- a/src/coreclr/pal/tests/palsuite/threading/ResetEvent/test3/test3.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/ResetEvent/test3/test3.cpp
@@ -72,7 +72,8 @@ PALTEST(threading_ResetEvent_test3_paltest_resetevent_test3, "threading/ResetEve
     {
         /* ERROR */
         Fail( "FAIL:ResetEvent() call failed on a closed event handle "
-                "but returned an unexpected error result %lu\n" );
+                "but returned an unexpected error result %lu\n",
+                GetLastError() );
     }
     
 

--- a/src/coreclr/pal/tests/palsuite/threading/SetEvent/test3/test3.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/SetEvent/test3/test3.cpp
@@ -71,7 +71,8 @@ PALTEST(threading_SetEvent_test3_paltest_setevent_test3, "threading/SetEvent/tes
     {
         /* ERROR */
         Fail( "FAIL:SetEvent() call failed on a closed event handle"
-                "but returned an unexpected error result %lu\n" );
+                "but returned an unexpected error result %lu\n",
+                GetLastError() );
     }
     
 

--- a/src/coreclr/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test1/test1.cpp
@@ -195,7 +195,8 @@ BOOL WaitMultipleDuplicateHandleTest_WFMOEx_test1()
     }
     else if (GetLastError() != ERROR_INVALID_PARAMETER)
     {
-        Trace("WaitMultipleDuplicateHandleTest:WaitAll failed: unexpected last error (%x)\n");
+        Trace("WaitMultipleDuplicateHandleTest:WaitAll failed: unexpected last error (%x)\n",
+              GetLastError());
         testResult = FALSE;
     }
 


### PR DESCRIPTION
Resolve incorrect printf-style argument counts and ensure buffers populated by file reads are explicitly null-terminated before string operations.

Mirrors fix made in the debugger fork of the PAL.