### PR TITLE
[Wasm RyuJIT] Mark SP/FP delta computation helpers as unused

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -4466,20 +4466,18 @@ int CodeGenInterface::genTotalFrameSize() const
 }
 
 //---------------------------------------------------------------------
-// genSPtoFPdelta - return the offset from SP to the frame pointer.
-// This number is going to be positive, since SP must be at the lowest
-// address.
+// genSPtoFPdelta - return the offset from the initial SP to the frame pointer in linear memory.
+// This number should be zero on wasm, since Initial SP = FP.
 //
 // There must be a frame pointer to call this function!
 int CodeGenInterface::genSPtoFPdelta() const
 {
     assert(isFramePointerUsed());
-    NYI_WASM("genSPtoFPdelta");
     return 0;
 }
 
 //---------------------------------------------------------------------
-// genCallerSPtoFPdelta - return the offset from Caller-SP to the frame pointer.
+// genCallerSPtoFPdelta - return the offset from Caller-SP to the frame pointer in linear memory.
 // This number is going to be negative, since the Caller-SP is at a higher
 // address than the frame pointer.
 //
@@ -4487,18 +4485,20 @@ int CodeGenInterface::genSPtoFPdelta() const
 int CodeGenInterface::genCallerSPtoFPdelta() const
 {
     assert(isFramePointerUsed());
-    NYI_WASM("genCallerSPtoFPdelta");
-    return 0;
+    int callerSPToFPDelta = genSPtoFPdelta() + genCallerSPtoInitialSPdelta();
+    assert(callerSPToFPDelta <= 0);
+    return callerSPToFPDelta;
 }
 
 //---------------------------------------------------------------------
-// genCallerSPtoInitialSPdelta - return the offset from Caller-SP to Initial SP.
+// genCallerSPtoInitialSPdelta - return the offset from Caller-SP to Initial SP in linear memory.
 //
 // This number will be negative.
 int CodeGenInterface::genCallerSPtoInitialSPdelta() const
 {
-    NYI_WASM("genCallerSPtoInitialSPdelta");
-    return 0;
+    int callerSPToInitialSPDelta = -genTotalFrameSize();
+    assert(callerSPToInitialSPDelta <= 0);
+    return callerSPToInitialSPDelta;
 }
 
 void RegSet::verifyRegUsed(regNumber reg)

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -4485,9 +4485,9 @@ int CodeGenInterface::genSPtoFPdelta() const
 int CodeGenInterface::genCallerSPtoFPdelta() const
 {
     assert(isFramePointerUsed());
-    int callerSPToFPDelta = genSPtoFPdelta() + genCallerSPtoInitialSPdelta();
-    assert(callerSPToFPDelta <= 0);
-    return callerSPToFPDelta;
+    int callerSPtoFPdelta = genCallerSPtoInitialSPdelta() + genSPtoFPdelta();
+    assert(callerSPtoFPdelta <= 0);
+    return callerSPtoFPdelta;
 }
 
 //---------------------------------------------------------------------
@@ -4496,9 +4496,9 @@ int CodeGenInterface::genCallerSPtoFPdelta() const
 // This number will be negative.
 int CodeGenInterface::genCallerSPtoInitialSPdelta() const
 {
-    int callerSPToInitialSPDelta = -genTotalFrameSize();
-    assert(callerSPToInitialSPDelta <= 0);
-    return callerSPToInitialSPDelta;
+    int callerSPtoInitialSPdelta = -genTotalFrameSize();
+    assert(callerSPtoInitialSPdelta <= 0);
+    return callerSPtoInitialSPdelta;
 }
 
 void RegSet::verifyRegUsed(regNumber reg)

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -4472,8 +4472,7 @@ int CodeGenInterface::genTotalFrameSize() const
 // There must be a frame pointer to call this function!
 int CodeGenInterface::genSPtoFPdelta() const
 {
-    assert(isFramePointerUsed());
-    return 0;
+    unreached();
 }
 
 //---------------------------------------------------------------------
@@ -4484,10 +4483,7 @@ int CodeGenInterface::genSPtoFPdelta() const
 // There must be a frame pointer to call this function!
 int CodeGenInterface::genCallerSPtoFPdelta() const
 {
-    assert(isFramePointerUsed());
-    int callerSPtoFPdelta = genCallerSPtoInitialSPdelta() + genSPtoFPdelta();
-    assert(callerSPtoFPdelta <= 0);
-    return callerSPtoFPdelta;
+    unreached();
 }
 
 //---------------------------------------------------------------------
@@ -4496,9 +4492,7 @@ int CodeGenInterface::genCallerSPtoFPdelta() const
 // This number will be negative.
 int CodeGenInterface::genCallerSPtoInitialSPdelta() const
 {
-    int callerSPtoInitialSPdelta = -genTotalFrameSize();
-    assert(callerSPtoInitialSPdelta <= 0);
-    return callerSPtoInitialSPdelta;
+    unreached();
 }
 
 void RegSet::verifyRegUsed(regNumber reg)


### PR DESCRIPTION
We do not expect to call these helpers, so we should be able to mark them as `unreached()`.