### PR TITLE
Ensure BackgroundService invokes ExecuteAsync after start

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -41,11 +41,12 @@ namespace Microsoft.Extensions.Hosting
         {
             // Create linked token to allow cancelling executing task from provided token
             _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            CancellationToken stoppingToken = _stoppingCts.Token;
 
             // Execute all of ExecuteAsync asynchronously, and store the task we're executing so that we can wait for it later.
             _executeTask = cancellationToken.IsCancellationRequested
                 ? Task.FromCanceled(cancellationToken)
-                : Task.Run(() => ExecuteAsync(_stoppingCts.Token), CancellationToken.None);
+                : Task.Run(() => ExecuteAsync(stoppingToken), CancellationToken.None);
 
             // Always return a completed task.  Any result from ExecuteAsync will be handled by the Host.
             return Task.CompletedTask;

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -43,7 +43,9 @@ namespace Microsoft.Extensions.Hosting
             _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             // Execute all of ExecuteAsync asynchronously, and store the task we're executing so that we can wait for it later.
-            _executeTask = Task.Run(() => ExecuteAsync(_stoppingCts.Token), _stoppingCts.Token);
+            _executeTask = cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled(cancellationToken)
+                : Task.Run(() => ExecuteAsync(_stoppingCts.Token), CancellationToken.None);
 
             // Always return a completed task.  Any result from ExecuteAsync will be handled by the Host.
             return Task.CompletedTask;

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceTests.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Extensions.Hosting.Tests
 {
     public class BackgroundServiceTests
     {
+        public static bool IsThreadingAndRemoteExecutorSupported =>
+            PlatformDetection.IsMultithreadingSupported && RemoteExecutor.IsSupported;
+
         [Fact]
         public void StartReturnsCompletedTask()
         {
@@ -150,7 +153,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             await service.WaitForEndExecuteTask;
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ConditionalTheory(typeof(BackgroundServiceTests), nameof(IsThreadingAndRemoteExecutorSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public void ExecuteAsyncRunsWhenImmediatelyStoppedOrDisposed(bool dispose)

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace Microsoft.Extensions.Hosting.Tests
@@ -29,11 +30,14 @@ namespace Microsoft.Extensions.Hosting.Tests
         public async Task StartCancelledThrowsTaskCanceledException()
         {
             var ct = new CancellationToken(true);
-            var service = new WaitForCancelledTokenService();
+            var service = new TrackingBackgroundService();
 
-            await service.StartAsync(ct);
+            Task startTask = service.StartAsync(ct);
 
+            Assert.True(startTask.IsCompleted);
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.ExecuteTask);
+            Assert.True(service.ExecuteTask.IsCanceled);
+            Assert.False(service.ExecuteInvocation.IsCompleted);
         }
 
         [Fact]
@@ -144,6 +148,86 @@ namespace Microsoft.Extensions.Hosting.Tests
             tokenSource.Cancel();
 
             await service.WaitForEndExecuteTask;
+        }
+
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ExecuteAsyncRunsWhenImmediatelyStoppedOrDisposed(bool dispose)
+        {
+            var options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables["DOTNET_ThreadPool_UseWindowsThreadPool"] = "0";
+
+            using var _ = RemoteExecutor.Invoke((string disposeString) =>
+            {
+                ThreadPool.GetMinThreads(out int originalMinWorkerThreads, out int originalMinCompletionPortThreads);
+                ThreadPool.GetMaxThreads(out int originalMaxWorkerThreads, out int originalMaxCompletionPortThreads);
+                Assert.True(ThreadPool.SetMinThreads(1, originalMinCompletionPortThreads));
+                Assert.True(ThreadPool.SetMaxThreads(1, originalMaxCompletionPortThreads));
+
+                using var blockerEntered = new ManualResetEventSlim();
+                using var releaseBlocker = new ManualResetEventSlim();
+
+                try
+                {
+                    ThreadPool.QueueUserWorkItem(_ =>
+                    {
+                        blockerEntered.Set();
+                        releaseBlocker.Wait();
+                    });
+                    Assert.True(blockerEntered.Wait(RemoteExecutor.FailWaitTimeoutMilliseconds));
+
+                    int startThreadId = Environment.CurrentManagedThreadId;
+                    var service = new TrackingBackgroundService();
+                    service.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+                    Task stopTask;
+                    if (bool.Parse(disposeString))
+                    {
+                        service.Dispose();
+                        stopTask = service.ExecuteTask;
+                    }
+                    else
+                    {
+                        stopTask = service.StopAsync(CancellationToken.None);
+                    }
+
+                    releaseBlocker.Set();
+                    stopTask.GetAwaiter().GetResult();
+
+                    (int invocationCount, int threadId, bool isThreadPoolThread, bool isCancellationRequested) =
+                        service.ExecuteInvocation.GetAwaiter().GetResult();
+                    Assert.Equal(1, invocationCount);
+                    Assert.NotEqual(startThreadId, threadId);
+                    Assert.True(isThreadPoolThread);
+                    Assert.True(isCancellationRequested);
+                }
+                finally
+                {
+                    releaseBlocker.Set();
+                    ThreadPool.SetMaxThreads(originalMaxWorkerThreads, originalMaxCompletionPortThreads);
+                    ThreadPool.SetMinThreads(originalMinWorkerThreads, originalMinCompletionPortThreads);
+                }
+            }, dispose.ToString(), options);
+        }
+
+        private sealed class TrackingBackgroundService : BackgroundService
+        {
+            private readonly TaskCompletionSource<(int InvocationCount, int ThreadId, bool IsThreadPoolThread, bool IsCancellationRequested)> _executeInvocation =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private int _invocationCount;
+
+            public Task<(int InvocationCount, int ThreadId, bool IsThreadPoolThread, bool IsCancellationRequested)> ExecuteInvocation => _executeInvocation.Task;
+
+            protected override Task ExecuteAsync(CancellationToken stoppingToken)
+            {
+                _executeInvocation.SetResult((
+                    Interlocked.Increment(ref _invocationCount),
+                    Environment.CurrentManagedThreadId,
+                    Thread.CurrentThread.IsThreadPoolThread,
+                    stoppingToken.IsCancellationRequested));
+                return Task.CompletedTask;
+            }
         }
 
         private class WaitForCancelledTokenService : BackgroundService


### PR DESCRIPTION
Fixes #131249.

`BackgroundService.StartAsync` currently passes its stopping token to `Task.Run` as the scheduling token. If `StopAsync` or `Dispose` cancels that token before the queued delegate begins, the task transitions to `Canceled` without invoking `ExecuteAsync`.

This makes invocation timing-dependent: after a non-canceled start is accepted, `ExecuteAsync` may or may not run depending on whether the thread pool dequeues it before cancellation.

This change:

- Preserves the .NET 10 change that all `ExecuteAsync` work runs asynchronously on a thread-pool thread.
- Makes invocation deterministic after a non-canceled start is accepted by using `CancellationToken.None` as the `Task.Run` scheduling token.
- Passes the linked stopping token to `ExecuteAsync`, so an immediate stop or dispose invokes it with cancellation already requested.
- Preserves pre-canceled `StartAsync` behavior by explicitly assigning `Task.FromCanceled(cancellationToken)` to `ExecuteTask` without invoking `ExecuteAsync`.

Regression tests deterministically occupy the sole thread-pool worker and verify that immediate stop and dispose still invoke `ExecuteAsync` exactly once on a thread-pool thread with an already-canceled stopping token. Pre-canceled startup coverage verifies that `ExecuteTask` is canceled and `ExecuteAsync` is not invoked.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.