### PR TITLE
JIT: fill two gaps in wasm codegen

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1197,7 +1197,8 @@ void CodeGen::genCodeForAsyncContinuation(GenTree* tree)
 // genReturnSuspend: Emit code for a GT_RETURN_SUSPEND node.
 //
 // Stores the continuation into the async global, then pushes a zero of the native return type
-// so the epilog's `return` is well-typed.
+// so the epilog's `return` is well-typed. Methods that return through a buffer lower to a wasm
+// function with no result, so there is nothing to push for those.
 //
 // Arguments:
 //    treeNode - The GT_RETURN_SUSPEND node.
@@ -1213,7 +1214,7 @@ void CodeGen::genReturnSuspend(GenTreeUnOp* treeNode)
     genStoreAsyncContinuationGlobal();
 
     var_types retNativeType = m_compiler->info.compRetNativeType;
-    if (retNativeType != TYP_VOID)
+    if ((retNativeType != TYP_VOID) && (m_compiler->info.compRetBuffArg == BAD_VAR_NUM))
     {
         emitter* emit = GetEmitter();
         switch (genActualType(retNativeType))
@@ -1232,6 +1233,16 @@ void CodeGen::genReturnSuspend(GenTreeUnOp* treeNode)
             case TYP_DOUBLE:
                 emit->emitIns_I(INS_f64_const, EA_8BYTE, 0);
                 break;
+#ifdef FEATURE_SIMD
+            case TYP_SIMD16:
+            {
+                // Vector128<T> is a wasm v128 returned by value.
+                //
+                uint8_t zero[16] = {};
+                emit->emitIns_V128Imm(INS_v128_const, zero);
+                break;
+            }
+#endif // FEATURE_SIMD
             default:
                 unreached();
         }
@@ -3313,6 +3324,16 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
         HELPER_SIG(CORINFO_HELP_THROWDIVZERO, MANAGED, CORINFO_WASM_TYPE_VOID /* retval */,
                    CORINFO_WASM_TYPE_I /* sp */, CORINFO_WASM_TYPE_I /* pep */);
         HELPER_SIG(CORINFO_HELP_THROWNULLREF, MANAGED, CORINFO_WASM_TYPE_VOID /* retval */,
+                   CORINFO_WASM_TYPE_I /* sp */, CORINFO_WASM_TYPE_I /* pep */);
+        HELPER_SIG(CORINFO_HELP_THROW_ARGUMENTEXCEPTION, MANAGED, CORINFO_WASM_TYPE_VOID /* retval */,
+                   CORINFO_WASM_TYPE_I /* sp */, CORINFO_WASM_TYPE_I /* pep */);
+        HELPER_SIG(CORINFO_HELP_THROW_ARGUMENTOUTOFRANGEEXCEPTION, MANAGED, CORINFO_WASM_TYPE_VOID /* retval */,
+                   CORINFO_WASM_TYPE_I /* sp */, CORINFO_WASM_TYPE_I /* pep */);
+        HELPER_SIG(CORINFO_HELP_THROW_NOT_IMPLEMENTED, MANAGED, CORINFO_WASM_TYPE_VOID /* retval */,
+                   CORINFO_WASM_TYPE_I /* sp */, CORINFO_WASM_TYPE_I /* pep */);
+        HELPER_SIG(CORINFO_HELP_THROW_PLATFORM_NOT_SUPPORTED, MANAGED, CORINFO_WASM_TYPE_VOID /* retval */,
+                   CORINFO_WASM_TYPE_I /* sp */, CORINFO_WASM_TYPE_I /* pep */);
+        HELPER_SIG(CORINFO_HELP_THROW_TYPE_NOT_SUPPORTED, MANAGED, CORINFO_WASM_TYPE_VOID /* retval */,
                    CORINFO_WASM_TYPE_I /* sp */, CORINFO_WASM_TYPE_I /* pep */);
         // RhpAssignRef
         HELPER_SIG(CORINFO_HELP_ASSIGN_REF, UNMANAGED, CORINFO_WASM_TYPE_VOID /* retval */, CORINFO_WASM_TYPE_I,


### PR DESCRIPTION
genReturnSuspend pushed a zero of the native return type to keep the epilog's return well typed. A method returning through a buffer lowers to a wasm function with no result, so there is nothing to push, and its compRetNativeType (TYP_STRUCT) fell into the default arm. Vector128 returns by value as a v128 and was missing too.

genEmitHelperCall only had signatures for four of the no-arg managed throw helpers. Add the rest; they are reachable from the unsupported intrinsic and out-of-range immediate paths.

Found crossgenning System.Private.Xml, whose XmlTextReaderImpl.ParseTextAsync returns a ValueTuple`4 by buffer.