### PR TITLE
Fix JSON schema nullability for readonly properties

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
@@ -447,7 +447,8 @@ namespace System.Text.Json.Schema
 
                         if (propertyInfo is not null)
                         {
-                            return propertyInfo.IsGetNullable || propertyInfo.IsSetNullable;
+                            return (propertyInfo.Get is not null && propertyInfo.IsGetNullable) ||
+                                (propertyInfo.Set is not null && propertyInfo.IsSetNullable);
                         }
 
                         if (typeInfo.IsNullable)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
@@ -447,8 +447,17 @@ namespace System.Text.Json.Schema
 
                         if (propertyInfo is not null)
                         {
-                            return (propertyInfo.Get is not null && propertyInfo.IsGetNullable) ||
-                                (propertyInfo.Set is not null && propertyInfo.IsSetNullable);
+                            if (propertyInfo.Get is not null && propertyInfo.IsGetNullable)
+                            {
+                                return true;
+                            }
+
+                            if (propertyInfo.AssociatedParameter is not null)
+                            {
+                                return propertyInfo.AssociatedParameter.IsNullable;
+                            }
+
+                            return propertyInfo.Set is not null && propertyInfo.IsSetNullable;
                         }
 
                         if (typeInfo.IsNullable)

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -1137,6 +1137,25 @@ namespace System.Text.Json.Schema.Tests
                     }
                 """);
 
+            yield return new TestData<PocoWithGetOnlyProperties>(
+                Value: new(),
+                ExpectedJsonSchema: """
+                {
+                    "type": ["object", "null"],
+                    "properties": {
+                        "Values": {
+                            "type": "array",
+                            "items": { "type": ["string", "null"] }
+                        },
+                        "SingleValueGetOnly": { "type": "string" },
+                        "NullableGetOnly": { "type": ["string", "null"] },
+                        "SingleValueGetSet": { "type": "string" },
+                        "NonNullableReadonlyField": { "type": "string" },
+                        "NullableReadonlyField": { "type": ["string", "null"] }
+                    }
+                }
+                """);
+
             yield return new TestData<ClassWithComponentModelAttributes>(
                 Value: new("string", -1),
                 ExpectedJsonSchema: """

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -1667,6 +1667,21 @@ namespace System.Text.Json.Schema.Tests
             public PocoWithPolymorphism.DerivedPocoStringDiscriminator DerivedValue2 { get; set; } = new() { DerivedValue = "derived" };
         }
 
+        public sealed class PocoWithGetOnlyProperties
+        {
+            public IEnumerable<string> Values => [];
+            public string SingleValueGetOnly { get; } = "value";
+            public string? NullableGetOnly { get; }
+            public string SingleValueGetSet { get; set; } = "value";
+            [JsonInclude]
+            public readonly string NonNullableReadonlyField = "value";
+
+#pragma warning disable CS0649 // field never assigned to
+            [JsonInclude]
+            public readonly string? NullableReadonlyField;
+#pragma warning restore CS0649
+        }
+
         public class ClassWithComponentModelAttributes
         {
             public ClassWithComponentModelAttributes(string stringValue, [DefaultValue(42)] int intValue)

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -286,7 +286,7 @@ namespace System.Text.Json.Schema.Tests
 
         record PocoWithProperty(int Value);
 
-        public sealed class PocoWithGetOnlyProperties
+        sealed class PocoWithGetOnlyProperties
         {
             public IEnumerable<string> Values => [];
             public string SingleValueGetOnly { get; } = "value";

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -294,8 +294,11 @@ namespace System.Text.Json.Schema.Tests
             public string SingleValueGetSet { get; set; } = "value";
             [JsonInclude]
             public readonly string NonNullableReadonlyField = "value";
+
+#pragma warning disable CS0649 // field never assigned to
             [JsonInclude]
             public readonly string? NullableReadonlyField;
+#pragma warning restore CS0649
         }
 
         [JsonSerializable(typeof(PocoWithProperty))]

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -82,30 +82,6 @@ namespace System.Text.Json.Schema.Tests
             Assert.Equal(expectedType, (string)schema["type"]!);
         }
 
-        [Fact]
-        public void GetOnlyProperties_DoNotUseSetterNullabilityInSchema() 
-        {
-            JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(typeof(PocoWithGetOnlyProperties));
-            const string ExpectedJsonSchema = """
-                {
-                    "type": ["object", "null"],
-                    "properties": {
-                        "Values": {
-                            "type": "array",
-                            "items": { "type": ["string", "null"] }
-                        },
-                        "SingleValueGetOnly": { "type": "string" },
-                        "NullableGetOnly": { "type": ["string", "null"] },
-                        "SingleValueGetSet": { "type": "string" },
-                        "NonNullableReadonlyField": { "type": "string" },
-                        "NullableReadonlyField": { "type": ["string", "null"] }
-                    }
-                }
-                """;
-
-            AssertValidJsonSchema(typeof(PocoWithGetOnlyProperties), ExpectedJsonSchema, schema);
-        }
-
         [Theory]
         [InlineData(typeof(Type))]
         [InlineData(typeof(MethodInfo))]
@@ -285,21 +261,6 @@ namespace System.Text.Json.Schema.Tests
         }
 
         record PocoWithProperty(int Value);
-
-        sealed class PocoWithGetOnlyProperties
-        {
-            public IEnumerable<string> Values => [];
-            public string SingleValueGetOnly { get; } = "value";
-            public string? NullableGetOnly { get; }
-            public string SingleValueGetSet { get; set; } = "value";
-            [JsonInclude]
-            public readonly string NonNullableReadonlyField = "value";
-
-#pragma warning disable CS0649 // field never assigned to
-            [JsonInclude]
-            public readonly string? NullableReadonlyField;
-#pragma warning restore CS0649
-        }
 
         [JsonSerializable(typeof(PocoWithProperty))]
         partial class PocoWithPropertyContext : JsonSerializerContext;

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.cs
@@ -82,6 +82,30 @@ namespace System.Text.Json.Schema.Tests
             Assert.Equal(expectedType, (string)schema["type"]!);
         }
 
+        [Fact]
+        public void GetOnlyProperties_DoNotUseSetterNullabilityInSchema() 
+        {
+            JsonNode schema = Serializer.DefaultOptions.GetJsonSchemaAsNode(typeof(PocoWithGetOnlyProperties));
+            const string ExpectedJsonSchema = """
+                {
+                    "type": ["object", "null"],
+                    "properties": {
+                        "Values": {
+                            "type": "array",
+                            "items": { "type": ["string", "null"] }
+                        },
+                        "SingleValueGetOnly": { "type": "string" },
+                        "NullableGetOnly": { "type": ["string", "null"] },
+                        "SingleValueGetSet": { "type": "string" },
+                        "NonNullableReadonlyField": { "type": "string" },
+                        "NullableReadonlyField": { "type": ["string", "null"] }
+                    }
+                }
+                """;
+
+            AssertValidJsonSchema(typeof(PocoWithGetOnlyProperties), ExpectedJsonSchema, schema);
+        }
+
         [Theory]
         [InlineData(typeof(Type))]
         [InlineData(typeof(MethodInfo))]
@@ -261,6 +285,18 @@ namespace System.Text.Json.Schema.Tests
         }
 
         record PocoWithProperty(int Value);
+
+        public sealed class PocoWithGetOnlyProperties
+        {
+            public IEnumerable<string> Values => [];
+            public string SingleValueGetOnly { get; } = "value";
+            public string? NullableGetOnly { get; }
+            public string SingleValueGetSet { get; set; } = "value";
+            [JsonInclude]
+            public readonly string NonNullableReadonlyField = "value";
+            [JsonInclude]
+            public readonly string? NullableReadonlyField;
+        }
 
         [JsonSerializable(typeof(PocoWithProperty))]
         partial class PocoWithPropertyContext : JsonSerializerContext;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
@@ -118,6 +118,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(PocoWithNullableAnnotationAttributesOnConstructorParams))]
         [JsonSerializable(typeof(PocoWithNullableConstructorParameter))]
         [JsonSerializable(typeof(PocoWithOptionalConstructorParams))]
+        [JsonSerializable(typeof(PocoWithStructFollowedByNullableStruct))]
         [JsonSerializable(typeof(GenericPocoWithNullableConstructorParameter<string>))]
         [JsonSerializable(typeof(PocoWithPolymorphism))]
         [JsonSerializable(typeof(DiscriminatedUnion))]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/JsonSchemaExporterTests.cs
@@ -118,7 +118,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(PocoWithNullableAnnotationAttributesOnConstructorParams))]
         [JsonSerializable(typeof(PocoWithNullableConstructorParameter))]
         [JsonSerializable(typeof(PocoWithOptionalConstructorParams))]
-        [JsonSerializable(typeof(PocoWithStructFollowedByNullableStruct))]
+        [JsonSerializable(typeof(PocoWithGetOnlyProperties))]
         [JsonSerializable(typeof(GenericPocoWithNullableConstructorParameter<string>))]
         [JsonSerializable(typeof(PocoWithPolymorphism))]
         [JsonSerializable(typeof(DiscriminatedUnion))]


### PR DESCRIPTION
This a simpler fix for https://github.com/dotnet/runtime/issues/131602 that is specific in JsonSchemaExporter.

Long-term, I think we would need to fix the underlying values of `IsGetNullable` and `IsSetNullable`. So this is more of a workaround to take in RC1, and hence keeping the linked issue open.