### PR TITLE
Reset charsConsumed when BigInteger partial parsing fails

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
@@ -132,6 +132,11 @@ namespace System
                 else
                 {
                     ret = NumberToBigInteger(ref number, out result);
+
+                    if (ret != ParsingStatus.OK)
+                    {
+                        elementsConsumed = 0;
+                    }
                 }
             }
 

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
@@ -1482,6 +1482,11 @@ namespace System.Numerics.Tests
             // Only invalid characters (no valid number)
             yield return new object[] { "abc", NumberStyles.Integer, null };
             yield return new object[] { "xyz", NumberStyles.Integer, null };
+
+            // Values that scan successfully but aren't representable as a BigInteger
+            yield return new object[] { "1.5", NumberStyles.Float, null };
+            yield return new object[] { "3.14159abc", NumberStyles.Float, null };
+            yield return new object[] { "1E1000000000", NumberStyles.Float, null };
         }
 
         [Theory]

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
@@ -1484,9 +1484,9 @@ namespace System.Numerics.Tests
             yield return new object[] { "xyz", NumberStyles.Integer, null };
 
             // Values that scan successfully but aren't representable as a BigInteger
-            yield return new object[] { "1.5", NumberStyles.Float, null };
-            yield return new object[] { "3.14159abc", NumberStyles.Float, null };
-            yield return new object[] { "1E1000000000", NumberStyles.Float, null };
+            yield return new object[] { "1.5", NumberStyles.Float, CultureInfo.InvariantCulture };
+            yield return new object[] { "3.14159abc", NumberStyles.Float, CultureInfo.InvariantCulture };
+            yield return new object[] { "1E1000000000", NumberStyles.Float, CultureInfo.InvariantCulture };
         }
 
         [Theory]


### PR DESCRIPTION
`BigInteger.TryParsePartial` can scan an input successfully but later reject it during `NumberToBigInteger`, leaving `charsConsumed` non-zero even though the parse returned `false`. Reset the consumed count when that conversion fails so callers do not advance after an unsuccessful partial parse.

Add coverage for fractional inputs and an overflowing exponent, including trailing invalid characters.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.