### PR TITLE
Handle exceptions from parallel ReadyToRun compilation

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -296,7 +296,6 @@ namespace ILCompiler
         private readonly bool _resilient;
 
         private readonly int _parallelism;
-        private readonly CorInfoImpl[] _corInfoImpls;
 
         private readonly bool _generateMapFile;
         private readonly bool _generateMapCsvFile;
@@ -371,7 +370,6 @@ namespace ILCompiler
             _computedFixedLayoutTypesUncached = IsLayoutFixedInCurrentVersionBubbleInternal;
             _resilient = resilient;
             _parallelism = parallelism;
-            _corInfoImpls = new CorInfoImpl[_parallelism];
             _generateMapFile = generateMapFile;
             _generateMapCsvFile = generateMapCsvFile;
             _generatePdbFile = generatePdbFile;
@@ -415,9 +413,8 @@ namespace ILCompiler
         {
             _dependencyGraph.ComputeMarkedNodes();
 
-            _doneAllCompiling = true;
-            Array.Clear(_corInfoImpls);
-            _compilationThreadSemaphore.Release(_parallelism);
+            // Release single-threaded JIT state before object emission to reduce peak memory usage.
+            _singleThreadedWorkerState = default;
 
             var nodes = _dependencyGraph.MarkedNodeList;
 
@@ -719,15 +716,16 @@ namespace ILCompiler
             }
         }
 
-        [ThreadStatic]
-        private static int s_methodsCompiledPerThread = 0;
+        private struct WorkerState
+        {
+            public CorInfoImpl CorInfoImpl;
+            public int MethodsCompiled;
+        }
 
-        private SemaphoreSlim _compilationThreadSemaphore = new(0);
-        private volatile IEnumerator<DependencyNodeCore<NodeFactory>> _currentCompilationMethodList;
-        private volatile bool _doneAllCompiling;
-        private int _finishedThreadCount;
-        private ManualResetEventSlim _compilationSessionComplete = new ManualResetEventSlim();
-        private bool _hasCreatedCompilationThreads = false;
+        // SuperPMI collection runs crossgen2 with parallelism 1 and requires ObjectToHandle
+        // handles to remain stable across compilation waves, so retain this state between calls.
+        private WorkerState _singleThreadedWorkerState;
+        private int _compilationSessionGeneratedColdCode;
         private bool _hasAddedAsyncReferences = false;
 
         protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)
@@ -775,7 +773,7 @@ namespace ILCompiler
 
                 ProcessMutableMethodBodiesList();
                 ResetILCache();
-                CompileMethodList(obj);
+                generatedColdCode |= CompileMethodList(obj);
 
                 while (_methodsToRecompile.Count > 0)
                 {
@@ -789,7 +787,7 @@ namespace ILCompiler
                     if (Logger.IsVerbose)
                         Logger.Writer.WriteLine($"Processing {methodsToRecompile.Length} recompiles");
 
-                    CompileMethodList(methodsToRecompile);
+                    generatedColdCode |= CompileMethodList(methodsToRecompile);
                 }
             }
 
@@ -863,162 +861,115 @@ namespace ILCompiler
                 if (_methodILCache.Count > 1000 || _methodILCache.ILProvider.Version != _methodILCache.ExpectedILProviderVersion)
                     _methodILCache = new ILCache(_methodILCache.ILProvider, NodeFactory.CompilationModuleGroup);
             }
+        }
 
-            void CompileMethodList(IEnumerable<DependencyNodeCore<NodeFactory>> methodList)
+        private bool CompileMethodList(IReadOnlyList<DependencyNodeCore<NodeFactory>> methodList)
+        {
+            _compilationSessionGeneratedColdCode = 0;
+
+            NodeFactory.ManifestMetadataTable._mutableModule.DisableNewTokens = true;
+            try
             {
-                // Disable generation of new tokens across the multi-threaded compile
-                NodeFactory.ManifestMetadataTable._mutableModule.DisableNewTokens = true;
-
                 if (_parallelism == 1)
                 {
-                    foreach (var dependency in methodList)
-                        CompileOneMethod(dependency, 0);
+                    foreach (DependencyNodeCore<NodeFactory> dependency in methodList)
+                    {
+                        CompileOneMethod(dependency, ref _singleThreadedWorkerState);
+                    }
                 }
                 else
                 {
-                    _currentCompilationMethodList = methodList.GetEnumerator();
-                    _finishedThreadCount = 0;
-                    _compilationSessionComplete.Reset();
-
-                    if (!_hasCreatedCompilationThreads)
-                    {
-                        for (int compilationThreadId = 1; compilationThreadId < _parallelism; compilationThreadId++)
-                        {
-                            new Thread(CompilationThread).Start((object)compilationThreadId);
-                        }
-                        _hasCreatedCompilationThreads = true;
-                    }
-
-                    _compilationThreadSemaphore.Release(_parallelism - 1);
-                    CompileOnThread(0);
-                    _compilationSessionComplete.Wait();
+                    Parallel.ForEach<DependencyNodeCore<NodeFactory>, WorkerState>(
+                        // Method compilation costs vary widely, so avoid buffering work into imbalanced partitions.
+                        Partitioner.Create(methodList, EnumerablePartitionerOptions.NoBuffering),
+                        new ParallelOptions { MaxDegreeOfParallelism = _parallelism },
+                        static () => default,
+                        CompileOneMethodInParallel,
+                        static _ => { });
                 }
 
-                // Re-enable generation of new tokens after the multi-threaded compile
+                return Volatile.Read(ref _compilationSessionGeneratedColdCode) != 0;
+            }
+            finally
+            {
                 NodeFactory.ManifestMetadataTable._mutableModule.DisableNewTokens = false;
             }
+        }
 
-            void CompilationThread(object objThreadId)
+        private WorkerState CompileOneMethodInParallel(
+            DependencyNodeCore<NodeFactory> dependency,
+            ParallelLoopState _,
+            WorkerState workerState)
+        {
+            CompileOneMethod(dependency, ref workerState);
+            return workerState;
+        }
+
+        private void CompileOneMethod(DependencyNodeCore<NodeFactory> dependency, ref WorkerState workerState)
+        {
+            MethodWithGCInfo methodCodeNodeNeedingCode = dependency as MethodWithGCInfo;
+            if (methodCodeNodeNeedingCode == null)
             {
-                while (true)
+                if (dependency is DeferredTillPhaseNode deferredPhaseNode)
                 {
-                    _compilationThreadSemaphore.Wait();
-                    lock (this)
-                    {
-                        if (_doneAllCompiling)
-                            return;
-                    }
-                    CompileOnThread((int)objThreadId);
+                    if (Logger.IsVerbose)
+                        _logger.Writer.WriteLine($"Moved to phase {_nodeFactory.CompilationCurrentPhase}");
+                    deferredPhaseNode.NotifyCurrentPhase(_nodeFactory.CompilationCurrentPhase);
+                    return;
                 }
             }
 
-            void CompileOnThread(int compilationThreadId)
+            Debug.Assert((_nodeFactory.CompilationCurrentPhase == 0) || ((_nodeFactory.CompilationCurrentPhase == 2) && !_finishedFirstCompilationRunInPhase2));
+
+            MethodDesc method = methodCodeNodeNeedingCode.Method;
+
+            if (Logger.IsVerbose)
             {
-                var compilationMethodList = _currentCompilationMethodList;
-                while (true)
-                {
-                    DependencyNodeCore<NodeFactory> dependency;
-                    lock (compilationMethodList)
-                    {
-                        if (!compilationMethodList.MoveNext())
-                        {
-                            if (Interlocked.Increment(ref _finishedThreadCount) == _parallelism)
-                                _compilationSessionComplete.Set();
-
-                            return;
-                        }
-                        dependency = compilationMethodList.Current;
-                    }
-
-                    CompileOneMethod(dependency, compilationThreadId);
-                }
+                string methodName = method.ToString();
+                Logger.Writer.WriteLine("Compiling " + methodName);
             }
 
-            void CompileOneMethod(DependencyNodeCore<NodeFactory> dependency, int compileThreadId)
+            if (_nodeFactory.OptimizationFlags.PrintReproArgs)
             {
-                MethodWithGCInfo methodCodeNodeNeedingCode = dependency as MethodWithGCInfo;
-                if (methodCodeNodeNeedingCode == null)
+                Logger.Writer.WriteLine($"Single method repro args:{GetReproInstructions(method)}");
+            }
+
+            try
+            {
+                using (PerfEventSource.StartStopEvents.JitMethodEvents())
                 {
-                    if (dependency is DeferredTillPhaseNode deferredPhaseNode)
+                    workerState.MethodsCompiled++;
+                    if (workerState.CorInfoImpl is null ||
+                        (_parallelism != 1 && (workerState.MethodsCompiled % 3000) == 0))
                     {
-                        if (Logger.IsVerbose)
-                            _logger.Writer.WriteLine($"Moved to phase {_nodeFactory.CompilationCurrentPhase}");
-                        deferredPhaseNode.NotifyCurrentPhase(_nodeFactory.CompilationCurrentPhase);
-                        return;
+                        // Periodically create a new CorInfoImpl to clear out stale caches. For single-threaded
+                        // compilation, reuse one instance so SuperPMI can rely on non-reuse of ObjectToHandle handles.
+                        workerState.CorInfoImpl = new CorInfoImpl(this);
+                    }
+
+                    CorInfoImpl corInfoImpl = workerState.CorInfoImpl;
+                    corInfoImpl.CompileMethod(methodCodeNodeNeedingCode, Logger);
+                    if (corInfoImpl.HasColdCode)
+                    {
+                        Volatile.Write(ref _compilationSessionGeneratedColdCode, 1);
                     }
                 }
-
-                Debug.Assert((_nodeFactory.CompilationCurrentPhase == 0) || ((_nodeFactory.CompilationCurrentPhase == 2) && !_finishedFirstCompilationRunInPhase2));
-
-                MethodDesc method = methodCodeNodeNeedingCode.Method;
-
+            }
+            catch (TypeSystemException ex)
+            {
+                // If compilation fails, don't emit code for this method. It will be Jitted at runtime
                 if (Logger.IsVerbose)
-                {
-                    string methodName = method.ToString();
-                    Logger.Writer.WriteLine("Compiling " + methodName);
-                }
-
-                if (_nodeFactory.OptimizationFlags.PrintReproArgs)
-                {
-                    Logger.Writer.WriteLine($"Single method repro args:{GetReproInstructions(method)}");
-                }
-
-                try
-                {
-                    using (PerfEventSource.StartStopEvents.JitMethodEvents())
-                    {
-                        s_methodsCompiledPerThread++;
-                        bool createNewCorInfoImpl = false;
-
-                        if (_corInfoImpls[compileThreadId] == null)
-                            createNewCorInfoImpl = true;
-                        else
-                        {
-                            if (_parallelism == 1)
-                            {
-                                // Create only 1 CorInfoImpl if not using parallelism
-                                // This allows SuperPMI to rely on non-reuse of handles in ObjectToHandle
-                            }
-                            else
-                            {
-                                // Periodically create a new CorInfoImpl to clear out stale caches
-                                // This is done as the CorInfoImpl holds a cache of data structures visible to the JIT
-                                // Those data structures include both structures which will last for the lifetime of the compilation
-                                // process, as well as various temporary structures that would really be better off with thread lifetime.
-                                if ((s_methodsCompiledPerThread % 3000) == 0)
-                                {
-                                    createNewCorInfoImpl = true;
-                                }
-                            }
-                        }
-
-                        if (createNewCorInfoImpl)
-                            _corInfoImpls[compileThreadId] = new CorInfoImpl(this);
-
-                        CorInfoImpl corInfoImpl = _corInfoImpls[compileThreadId];
-                        corInfoImpl.CompileMethod(methodCodeNodeNeedingCode, Logger);
-                        if (corInfoImpl.HasColdCode)
-                        {
-                            generatedColdCode = true;
-                        }
-                    }
-                }
-                catch (TypeSystemException ex)
-                {
-                    // If compilation fails, don't emit code for this method. It will be Jitted at runtime
-                    if (Logger.IsVerbose)
-                        Logger.Writer.WriteLine($"Warning: Method `{method}` was not compiled because: {ex.Message}");
-                }
-                catch (RequiresRuntimeJitException ex)
-                {
-                    if (Logger.IsVerbose)
-                        Logger.Writer.WriteLine($"Info: Method `{method}` was not compiled because `{ex.Message}` requires runtime JIT");
-                }
-                catch (CodeGenerationFailedException ex) when (_resilient)
-                {
-                    if (Logger.IsVerbose)
-                        Logger.Writer.WriteLine($"Warning: Method `{method}` was not compiled because `{ex.Message}` requires runtime JIT");
-                }
+                    Logger.Writer.WriteLine($"Warning: Method `{method}` was not compiled because: {ex.Message}");
+            }
+            catch (RequiresRuntimeJitException ex)
+            {
+                if (Logger.IsVerbose)
+                    Logger.Writer.WriteLine($"Info: Method `{method}` was not compiled because `{ex.Message}` requires runtime JIT");
+            }
+            catch (CodeGenerationFailedException ex) when (_resilient)
+            {
+                if (Logger.IsVerbose)
+                    Logger.Writer.WriteLine($"Warning: Method `{method}` was not compiled because `{ex.Message}` requires runtime JIT");
             }
         }
 
@@ -1115,6 +1066,8 @@ namespace ILCompiler
 
         public override void Dispose()
         {
+            _singleThreadedWorkerState = default;
+
             // Workaround for https://github.com/dotnet/runtime/issues/23103.
             // ManifestMetadataTable.Dispose() allows to break circular reference
             // ConcurrentBag<EcmaModule> -> EcmaModule -> EcmaAssembly -> ReadyToRunCompilerContext -> ... -> ConcurrentBag<EcmaModule>.

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 using ILCompiler.DependencyAnalysis;
@@ -23,13 +21,20 @@ namespace ILCompiler
 {
     public sealed class RyuJitCompilation : Compilation
     {
-        private readonly ConditionalWeakTable<Thread, CorInfoImpl> _corinfos = new ConditionalWeakTable<Thread, CorInfoImpl>();
         internal readonly RyuJitCompilationOptions _compilationOptions;
         private readonly ProfileDataManager _profileDataManager;
         private readonly FileLayoutOptimizer _fileLayoutOptimizer;
         private readonly MethodImportationErrorProvider _methodImportationErrorProvider;
         private readonly ReadOnlyFieldPolicy _readOnlyFieldPolicy;
         private readonly int _parallelism;
+
+        private struct WorkerState
+        {
+            public CorInfoImpl CorInfoImpl;
+            public int MethodsCompiled;
+        }
+
+        private WorkerState _singleThreadedWorkerState;
 
         public InstructionSetSupport InstructionSetSupport { get; }
 
@@ -164,18 +169,18 @@ namespace ILCompiler
                 Logger.LogMessage($"Compiling {methodsToCompile.Count} methods...");
             }
 
-            Parallel.ForEach(
+            Parallel.ForEach<MethodCodeNode, WorkerState>(
                 // Method compilation costs vary widely, so avoid buffering work into imbalanced partitions.
                 Partitioner.Create(methodsToCompile, EnumerablePartitionerOptions.NoBuffering),
                 new ParallelOptions { MaxDegreeOfParallelism = _parallelism },
-                CompileSingleMethod);
+                static () => default,
+                CompileSingleMethodInParallel,
+                static _ => { });
         }
 
 
         private void CompileSingleThreaded(List<MethodCodeNode> methodsToCompile)
         {
-            CorInfoImpl corInfo = _corinfos.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
-
             foreach (MethodCodeNode methodCodeNodeNeedingCode in methodsToCompile)
             {
                 if (Logger.IsVerbose)
@@ -183,14 +188,31 @@ namespace ILCompiler
                     Logger.LogMessage($"Compiling {methodCodeNodeNeedingCode.Method}...");
                 }
 
-                CompileSingleMethod(corInfo, methodCodeNodeNeedingCode);
+                CompileSingleMethod(methodCodeNodeNeedingCode, ref _singleThreadedWorkerState);
             }
         }
 
-        private void CompileSingleMethod(MethodCodeNode methodCodeNodeNeedingCode)
+        private WorkerState CompileSingleMethodInParallel(
+            MethodCodeNode methodCodeNodeNeedingCode,
+            ParallelLoopState _,
+            WorkerState workerState)
         {
-            CorInfoImpl corInfo = _corinfos.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
-            CompileSingleMethod(corInfo, methodCodeNodeNeedingCode);
+            CompileSingleMethod(methodCodeNodeNeedingCode, ref workerState);
+            return workerState;
+        }
+
+        private void CompileSingleMethod(MethodCodeNode methodCodeNodeNeedingCode, ref WorkerState workerState)
+        {
+            workerState.MethodsCompiled++;
+            if (workerState.CorInfoImpl is null ||
+                (_parallelism != 1 && (workerState.MethodsCompiled % 3000) == 0))
+            {
+                // Periodically create a new CorInfoImpl to clear out stale caches. For single-threaded
+                // compilation, reuse one instance across dependency computation waves.
+                workerState.CorInfoImpl = new CorInfoImpl(this);
+            }
+
+            CompileSingleMethod(workerState.CorInfoImpl, methodCodeNodeNeedingCode);
         }
 
         private void CompileSingleMethod(CorInfoImpl corInfo, MethodCodeNode methodCodeNodeNeedingCode)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -106,6 +106,10 @@ namespace ILCompiler
         protected override void CompileInternal(string outputFile, ObjectDumper dumper)
         {
             _dependencyGraph.ComputeMarkedNodes();
+
+            // Release single-threaded JIT state before object emission to reduce peak memory usage.
+            _singleThreadedWorkerState = default;
+
             var nodes = _dependencyGraph.MarkedNodeList;
 
             nodes = _fileLayoutOptimizer.ApplyProfilerGuidedMethodSort(nodes);

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -164,7 +165,8 @@ namespace ILCompiler
             }
 
             Parallel.ForEach(
-                methodsToCompile,
+                // Method compilation costs vary widely, so avoid buffering work into imbalanced partitions.
+                Partitioner.Create(methodsToCompile, EnumerablePartitionerOptions.NoBuffering),
                 new ParallelOptions { MaxDegreeOfParallelism = _parallelism },
                 CompileSingleMethod);
         }

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -378,7 +378,7 @@ namespace ILCompiler
 
             using (PerfEventSource.StartStopEvents.CompilationEvents())
             {
-                ICompilation compilation;
+                ReadyToRunCodegenCompilation compilation;
                 using (PerfEventSource.StartStopEvents.LoadingEvents())
                 {
                     List<EcmaModule> inputModules = new List<EcmaModule>();
@@ -720,18 +720,19 @@ namespace ILCompiler
 
                     builder.UsePrintReproInstructions(CreateReproArgumentString);
 
-                    compilation = builder.ToCompilation();
+                    compilation = (ReadyToRunCodegenCompilation)builder.ToCompilation();
 
                 }
-                compilation.Compile(outFile);
+                using (compilation)
+                {
+                    compilation.Compile(outFile);
 
-                if (dgmlLogFileName != null)
-                    compilation.WriteDependencyLog(dgmlLogFileName);
+                    if (dgmlLogFileName != null)
+                        compilation.WriteDependencyLog(dgmlLogFileName);
 
-                compilation.Dispose();
-
-                if (((ReadyToRunCodegenCompilation)compilation).DeterminismCheckFailed)
-                    throw new Exception("Determinism Check Failed");
+                    if (compilation.DeterminismCheckFailed)
+                        throw new Exception("Determinism Check Failed");
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- replace ReadyToRun's persistent raw-thread work list with `Parallel.ForEach`, relying on TPL to join active compilation work before returning or propagating an exception
- use a no-buffering dynamic partitioner in both ReadyToRun and NativeAOT because method compilation costs vary widely and buffered partitions can cause high-core load imbalance
- keep ReadyToRun's `CorInfoImpl` and recycling counter in partition-local state, bounding cache lifetime without tying large caches to ThreadPool threads
- retain one ReadyToRun `WorkerState` across single-threaded compilation waves because SuperPMI collection uses `--parallelism:1` and requires stable `ObjectToHandle` handles
- dispose the ReadyToRun compilation when `Compile` throws and release single-threaded JIT state before object emission

## Testing

- `./build.sh clr.jit+clr.hosts`: succeeded
- `ILCompiler.ReadyToRun` and `ILCompiler.RyuJit` builds: succeeded with 0 warnings and 0 errors
- `ILCompiler.ReadyToRun.Tests`: 34 passed, 11 skipped, 0 failed
- `ILCompiler.Compiler.Tests`: 22 passed, 0 failed
- ReadyToRun compiler output was byte-for-byte identical between the dedicated-thread and TPL implementations
- ReadyToRun CoreLib compilation performance was neutral: parallelism 4 median 22.26s vs. 22.76s; parallelism 24 median 10.03s vs. 9.94s
- NativeAOT compiling crossgen2 with ILC (five alternating samples after warmup on a 32-logical-core Intel Xeon Platinum 8370C): parallelism 4 median 58.46s -> 57.09s (2.3% faster); parallelism 24 median 41.49s -> 39.91s (3.8% faster)
- NativeAOT crossgen2 object output was byte-for-byte identical across both implementations and both parallelism settings; median peak RSS was comparable (p4: 1282 MiB -> 1244 MiB, p24: 1296 MiB -> 1316 MiB)

> [!NOTE]
> This pull request description was generated with GitHub Copilot.