### PR TITLE
Fold installer build and test into CoreCLR jobs

### DIFF
--- a/eng/pipelines/installer/helix-queues-setup.yml
+++ b/eng/pipelines/installer/helix-queues-setup.yml
@@ -1,26 +1,23 @@
 parameters:
-  jobTemplate: ''
-  variables: []
+  archType: ''
+  condition: always()
+  creator: ''
+  includeAllPlatforms: false
+  isExtraPlatformsBuild: false
   osGroup: ''
   osSubgroup: ''
-  archType: ''
-  container: ''
-  pool: ''
   platform: ''
-  shouldContinueOnError: false
-  jobParameters: {}
+  useHelixMonitor: false
 
-jobs:
-- template: ${{ parameters.jobTemplate }}
+steps:
+- template: /eng/pipelines/installer/helix.yml
   parameters:
-    variables: ${{ parameters.variables }}
+    archType: ${{ parameters.archType }}
+    condition: ${{ parameters.condition }}
+    creator: ${{ parameters.creator }}
     osGroup: ${{ parameters.osGroup }}
     osSubgroup: ${{ parameters.osSubgroup }}
-    archType: ${{ parameters.archType }}
-    container: ${{ parameters.container }}
-    pool: ${{ parameters.pool }}
-    platform: ${{ parameters.platform }}
-    shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+    useHelixMonitor: ${{ parameters.useHelixMonitor }}
     helixQueues:
 
     # Linux arm
@@ -36,7 +33,7 @@ jobs:
       - (Alpine.324.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.24-helix-amd64@sha256:240788457ec91460a35f6aa8d70bc1aaa7d1347d211fc5f5c0b35f648a33d7bd
 
     # Linux musl arm64
-    - ${{ if and(eq(parameters.platform, 'linux_musl_arm64'), or(eq(parameters.jobParameters.isExtraPlatformsBuild, true), eq(parameters.jobParameters.includeAllPlatforms, true))) }}:
+    - ${{ if and(eq(parameters.platform, 'linux_musl_arm64'), or(eq(parameters.isExtraPlatformsBuild, true), eq(parameters.includeAllPlatforms, true))) }}:
       - (Alpine.324.Arm64.Open)AzureLinux.3.Arm64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.24-helix-arm64v8@sha256:c0651a184147638e54b2f6a3c8f040274b1bf2deb0bf3e5c4513824598497ae0
 
     # Linux x64
@@ -62,5 +59,3 @@ jobs:
     # windows arm64
     - ${{ if eq(parameters.platform, 'windows_arm64') }}:
       - Windows.11.Arm64.Open
-
-    ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/installer/helix.yml
+++ b/eng/pipelines/installer/helix.yml
@@ -4,6 +4,7 @@ parameters:
   osSubgroup: ''
   creator: ''
   helixQueues: ''
+  condition: always()
   useHelixMonitor: false
 
 steps:
@@ -38,3 +39,4 @@ steps:
         Creator: ${{ parameters.creator }}
         HelixTargetQueues: ${{ join('+', parameters.helixQueues) }}
       UseHelixMonitor: ${{ parameters.useHelixMonitor }}
+      condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -305,23 +305,18 @@ extends:
           variables:
             - name: librariesContainsChange
               value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+            - name: coreclrContainsChange
+              value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
+            - name: installerContainsChange
+              value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_installer.containsChange'] ]
           jobParameters:
-            nameSuffix: CoreCLR_Libraries
-            buildArgs: -s clr+libs+libs.tests -rc Release -c $(_BuildConfig) /p:ArchiveTests=true
-            timeoutInMinutes: 120
+            nameSuffix: CoreCLR_AllSubsets
+            buildArgs: -s clr+libs+libs.tests+host+packs -rc Release -c $(_BuildConfig) /p:ArchiveTests=true
+            timeoutInMinutes: 180
             preBuildSteps:
               - template: /eng/pipelines/coreclr/templates/setup-sccache.yml
             postBuildSteps:
               - template: /eng/pipelines/coreclr/templates/sccache-stats.yml
-              - template: /eng/pipelines/common/upload-artifact-step.yml
-                parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/bin
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-                  displayName: Build Assets
               - template: /eng/pipelines/libraries/helix.yml
                 parameters:
                   creator: dotnet-bot
@@ -331,6 +326,18 @@ extends:
                   condition: >-
                     or(
                       eq(variables['librariesContainsChange'], true),
+                      eq(variables['isRollingBuild'], true))
+              - template: /eng/pipelines/installer/helix-queues-setup.yml
+                parameters:
+                  creator: dotnet-bot
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+                  condition: >-
+                    or(
+                      eq(variables['installerContainsChange'], true),
+                      and(
+                        eq(variables['osGroup'], 'osx'),
+                        eq(variables['archType'], 'arm64'),
+                        eq(variables['coreclrContainsChange'], true)),
                       eq(variables['isRollingBuild'], true))
             condition: >-
               or(
@@ -348,20 +355,13 @@ extends:
           variables:
             - name: librariesContainsChange
               value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+            - name: installerContainsChange
+              value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_installer.containsChange'] ]
           jobParameters:
-            nameSuffix: CoreCLR_Libraries
-            buildArgs: -s clr+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
-            timeoutInMinutes: 120
+            nameSuffix: CoreCLR_AllSubsets
+            buildArgs: -s clr+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true
+            timeoutInMinutes: 180
             postBuildSteps:
-              - template: /eng/pipelines/common/upload-artifact-step.yml
-                parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/bin
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-                  displayName: Build Assets
               - template: /eng/pipelines/libraries/helix.yml
                 parameters:
                   helixBuildConfig: Release
@@ -372,6 +372,14 @@ extends:
                   condition: >-
                     or(
                       eq(variables['librariesContainsChange'], true),
+                      eq(variables['isRollingBuild'], true))
+              - template: /eng/pipelines/installer/helix-queues-setup.yml
+                parameters:
+                  creator: dotnet-bot
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+                  condition: >-
+                    or(
+                      eq(variables['installerContainsChange'], true),
                       eq(variables['isRollingBuild'], true))
             condition: >-
               or(
@@ -389,20 +397,22 @@ extends:
           buildConfig: release
           platforms:
           - osx_x64
+          variables:
+            - name: installerContainsChange
+              value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_installer.containsChange'] ]
           jobParameters:
-            nameSuffix: CoreCLR_Libraries
-            buildArgs: -s clr+libs -c $(_BuildConfig)
-            timeoutInMinutes: 120
+            nameSuffix: CoreCLR_AllSubsets
+            buildArgs: -s clr+libs+host+packs -c $(_BuildConfig)
+            timeoutInMinutes: 180
             postBuildSteps:
-              - template: /eng/pipelines/common/upload-artifact-step.yml
+              - template: /eng/pipelines/installer/helix-queues-setup.yml
                 parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/bin
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
-                  displayName: Build Assets
+                  creator: dotnet-bot
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+                  condition: >-
+                    or(
+                      eq(variables['installerContainsChange'], true),
+                      eq(variables['isRollingBuild'], true))
             condition: >-
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
@@ -1549,109 +1559,6 @@ extends:
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Installer Build and Test
-      # Only when installer-relevant paths change (or on rolling builds).
-      # osx_arm64 also runs on coreclr changes to catch single-file issues.
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-          platforms:
-            - windows_x86
-            - osx_x64
-          helixQueuesTemplate: /eng/pipelines/installer/helix-queues-setup.yml
-          jobParameters:
-            nameSuffix: Installer_Build_And_Test
-            buildArgs: -s host+packs -c $(_BuildConfig) -lc Release -rc Release
-            dependsOnGlobalBuilds:
-              - nameSuffix: CoreCLR_Libraries
-                buildConfig: release
-            preBuildSteps:
-              - template: /eng/pipelines/common/download-artifact-step.yml
-                parameters:
-                  artifactName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_Release
-                  artifactFileName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_Release$(archiveExtension)
-                  unpackFolder: $(Build.SourcesDirectory)/artifacts/bin
-                  displayName: 'unified artifacts'
-            timeoutInMinutes: 150
-            postBuildSteps:
-              - template: /eng/pipelines/installer/helix.yml
-                parameters:
-                  creator: dotnet-bot
-                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
-            condition:
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-            - windows_x64
-            - linux_x64
-            - linux_musl_x64
-          helixQueuesTemplate: /eng/pipelines/installer/helix-queues-setup.yml
-          jobParameters:
-            nameSuffix: Installer_Build_And_Test
-            buildArgs: -s host+packs -c $(_BuildConfig) -lc ${{ variables.debugOnPrReleaseOnRolling }} -rc Release
-            dependsOnGlobalBuilds:
-              - nameSuffix: CoreCLR_Libraries
-                buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            preBuildSteps:
-              - template: /eng/pipelines/common/download-artifact-step.yml
-                parameters:
-                  artifactName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(debugOnPrReleaseOnRolling)
-                  artifactFileName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(debugOnPrReleaseOnRolling)$(archiveExtension)
-                  unpackFolder: $(Build.SourcesDirectory)/artifacts/bin
-                  displayName: 'unified artifacts'
-            timeoutInMinutes: 150
-            postBuildSteps:
-              - template: /eng/pipelines/installer/helix.yml
-                parameters:
-                  creator: dotnet-bot
-                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
-            condition:
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      # osx_arm64 installer tests also run on coreclr changes to catch single-file issues
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-            - osx_arm64
-          helixQueuesTemplate: /eng/pipelines/installer/helix-queues-setup.yml
-          jobParameters:
-            nameSuffix: Installer_Build_And_Test
-            buildArgs: -s host+packs -c $(_BuildConfig) -lc ${{ variables.debugOnPrReleaseOnRolling }} -rc Release
-            dependsOnGlobalBuilds:
-              - nameSuffix: CoreCLR_Libraries
-                buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            preBuildSteps:
-              - template: /eng/pipelines/common/download-artifact-step.yml
-                parameters:
-                  artifactName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(debugOnPrReleaseOnRolling)
-                  artifactFileName: CoreCLR_Libraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(debugOnPrReleaseOnRolling)$(archiveExtension)
-                  unpackFolder: $(Build.SourcesDirectory)/artifacts/bin
-                  displayName: 'unified artifacts'
-            timeoutInMinutes: 150
-            postBuildSteps:
-              - template: /eng/pipelines/installer/helix.yml
-                parameters:
-                  creator: dotnet-bot
-                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
-            condition:
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
       #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -75,7 +75,7 @@ extends:
             allowNoHelixJobs: true
 
       #
-      # Build CoreCLR verticals where we don't run host tests
+      # Build CoreCLR verticals
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -289,8 +289,8 @@ extends:
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       #
-      # Build CoreCLR and Libraries with Libraries tests
-      # For running libraries tests and installer tests
+      # Build CoreCLR verticals
+      # Run libraries tests and installer tests
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -388,7 +388,7 @@ extends:
                 eq(variables['isRollingBuild'], true))
 
       #
-      # Build CoreCLR and Libraries
+      # Build CoreCLR verticals
       # For running installer tests
       #
       - template: /eng/pipelines/common/platform-matrix.yml


### PR DESCRIPTION
## Summary

The standalone Installer Build and Test jobs repeat work already performed by the CoreCLR and Libraries build jobs and require an artifact handoff between jobs. Fold that work into the existing producer jobs so each platform builds and submits its installer tests in one place.

- Rename the consolidated jobs to `CoreCLR_AllSubsets`.
- Add `host+packs` to the matching CoreCLR/Libraries build subsets.
- Submit installer tests as post-build steps while preserving installer-specific Helix queues and path conditions, including the macOS Arm64 CoreCLR trigger.
- Remove the standalone installer jobs and obsolete artifact uploads.
- Increase the combined job timeout and verify that all six platform/configuration job keys remain unique.

## Testing

Parsed the changed YAML files and checked the expanded platform/configuration/suffix keys for duplicates.

Fixes #131615

> [!NOTE]
> This pull request was prepared with GitHub Copilot.