### PR TITLE
[QUIC] Fix receive race.

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -321,9 +321,10 @@ public sealed partial class QuicStream
             cancellationToken.ThrowIfCancellationRequested();
         }
 
-        // The following loop will repeat at most twice depending whether some data are readily available in the buffer (one iteration) or not.
-        // In which case, it'll wait on RECEIVE or any of PEER_SEND_(SHUTDOWN|ABORTED) event and attempt to copy data in the second iteration.
+        // Loop copying available data and/or waiting on RECEIVE or PEER_SEND_(SHUTDOWN|ABORTED) events.
+        // Keeps waiting while nothing was copied and the buffer is empty (and not final) to ignore stale wake-ups on _receiveTcs.
         int totalCopied = 0;
+        bool empty;
         do
         {
             // Concurrent call, this one lost the race.
@@ -333,7 +334,7 @@ public sealed partial class QuicStream
             }
 
             // Copy data from the buffer, reduce target and increment total.
-            int copied = _receiveBuffers.CopyTo(buffer, out bool complete, out bool empty);
+            int copied = _receiveBuffers.CopyTo(buffer, out bool complete, out empty);
             buffer = buffer.Slice(copied);
             totalCopied += copied;
 
@@ -357,7 +358,7 @@ public sealed partial class QuicStream
             {
                 break;
             }
-        } while (!buffer.IsEmpty && totalCopied == 0);  // Exit the loop if target buffer is full we at least copied something.
+        } while (totalCopied == 0 && empty);  // Keep waiting while we haven't copied anything and no data is available.
 
         if (totalCopied > 0 && Interlocked.CompareExchange(ref _receivedNeedsEnable, 0, 1) == 1)
         {


### PR DESCRIPTION
There's a race condition between `HandleEventReceive` and `ReadAsync` unblocking `_receiveTcs` twice. 
- `HandleEventReceive` will write data to the `_receiveBuffers`
- `ReadAsync` will read them and unblock `_receiveTcs` and return to the caller
- Another `ReadAsync` (with 0-byte read) will not copy anything and should wait for data
- But now the second part of the initial `HandleEventReceive` happens and unblocks the `_receiveTcs` for the data that were already returned to the user in the first `ReadAsync`
- Now the `ReadAsync` unblocks and returns and the caller interprets that we've received FIN and disposes the stream in good faith that the reading side is done, but it actually aborts instead

Fixes #121567, #109121

This was tested locally with sleep in `HandleEventReceive` that previously 100% reproduced the issue.