### PR TITLE
Add Agent Merge CI guardrails to Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,7 +53,7 @@ For markdown (`.md`) files, ensure there is no trailing whitespace at the end of
 ### Agent Merge / CI check resolution
 
 - **Forbidden workflow action: rerunning failed CI as part of Agent Merge.** Agent Merge must never use `/azp` to retrigger Azure Pipelines, and must never close and reopen the PR to trigger a rerun. This is forbidden unless the user explicitly requests it.
-- **Never use reruns to determine whether a failure is unrelated to the PR.** In dotnet/runtime, the required path is to use Build Analysis and the `ci-analysis` skill to classify failures. For any failure listed as not `known`, determine whether it is caused by the current PR. If it is caused by the PR, fix it in the PR. If it is not caused by the PR, open or update a `Known Build Error` issue instead of retriggering CI.
+- **Never use reruns to determine whether a failure is unrelated to the PR.** In dotnet/runtime, the required path is to use Build Analysis and the `ci-analysis` skill to classify failures. For any failure listed as not `known`, determine whether it is caused by the current PR. If it is caused by the PR, fix it in the PR. If it is not caused by the PR, use the `create-kbe` skill to open or update a `Known Build Error` issue instead of retriggering CI.
 
 When NOT running under CCA, for commits and pushes:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,11 @@ For markdown (`.md`) files, ensure there is no trailing whitespace at the end of
 - **A push to an open PR re-runs its CI matrix** — dozens of jobs, over a hundred for broad changes. For anything non-trivial, validate locally rather than using CI to find out whether it builds, and batch fixes into one push. Branches with no PR trigger nothing, as do changes confined to `**.md`, `docs/*`, or `.github/*`.
 - **Treat review feedback as a sample, not a list.** A reviewer flags examples of a problem, not every instance. Grep for the rest of the class and fix it in the same push, and answer a whole round of comments at once rather than pushing per comment.
 
+### Agent Merge / CI check resolution
+
+- **Forbidden workflow action: rerunning failed CI as part of Agent Merge.** Agent Merge must never use `/azp` to retrigger Azure Pipelines, and must never close and reopen the PR to trigger a rerun. This is forbidden unless the user explicitly requests it.
+- **Never use reruns to determine whether a failure is unrelated to the PR.** In dotnet/runtime, the required path is to use Build Analysis and the `ci-analysis` skill to classify failures. For any failure listed as not `known`, determine whether it is caused by the current PR. If it is caused by the PR, fix it in the PR. If it is not caused by the PR, open or update a `Known Build Error` issue instead of retriggering CI.
+
 When NOT running under CCA, for commits and pushes:
 
 - Never squash and force push unless explicitly instructed. Always push incremental commits on top of previous PR changes.

--- a/.github/skills/create-kbe/SKILL.md
+++ b/.github/skills/create-kbe/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: create-kbe
+description: Create or update a Known Build Error issue in dotnet/runtime from a concrete CI failure. Use when a failure is actionable, a Build Analysis result is not yet known, or a workflow needs a repo-specific KBE issue for an outer-loop or PR-targeted failure.
+---
+
+# Create a Known Build Error for dotnet/runtime
+
+Use this skill when the workflow has a failure candidate that may need a `Known Build Error` issue in `dotnet/runtime`.
+
+This skill is the repo-specific entry point for KBE creation. It delegates to the shared logic in `.github/workflows/shared/create-kbe.instructions.md`, which owns the detailed search rules, body template, signature reasoning, verification steps, and duplicate detection.
+
+## When to use this skill
+
+- the scheduled outer-loop CI scanner identified a failure and needs to file a KBE
+- a PR-targeted scan found an actionable failure that Build Analysis has not already recognized as known
+- a workflow needs to decide whether a candidate should become a KBE, be skipped, or be deferred for human review
+
+## Required workflow
+
+Read and follow these in order:
+
+1. `.github/workflows/shared/create-kbe.instructions.md`
+2. the caller workflow or tool instructions that selected this failure and decided it is in scope
+3. any workflow-specific formatting or dry-run requirements for the current caller
+
+## Core rules
+
+- One failure shape = one KBE outcome.
+- Do not create duplicate KBEs.
+- Search existing open and recent closed KBEs before filing a new one.
+- If the failure is not caused by the PR, do not rerun CI; file or update a `Known Build Error` instead.
+- Do not comment on existing KBEs; Build Analysis tracks occurrence data in the issue body.
+- Only emit a KBE when the signature is stable and actionable.
+- If the issue is already known or effectively handled by existing triage, skip rather than filing a duplicate.

--- a/.github/workflows/ci-failure-scan.md
+++ b/.github/workflows/ci-failure-scan.md
@@ -109,8 +109,9 @@ Walk the steps in order. Do not skip. Stop at Step 6.
 
 Read once at start:
 
+- `.github/skills/create-kbe/SKILL.md` — the repo-level skill for creating a `Known Build Error` issue from an actionable failure
 - `.github/workflows/shared/create-kbe.instructions.md`
-- In that shared file, load these exact sections and apply them when referenced below:
+- In those instructions, load these exact sections and apply them when referenced below:
   - `<a id="shared-kbe-rules"></a>` / `## Shared rules`
   - `<a id="search-existing-kbe"></a>` / `## Search for an existing KBE`
   - `<a id="search-area-team-tracker"></a>` / `## Search for an area-team tracker`


### PR DESCRIPTION
## Summary
- add repo-specific Agent Merge guardrails to .github/copilot-instructions.md
- forbid /azp and PR reopen reruns for failed CI
- require Build Analysis + ci-analysis to classify non-known failures, fix PR-caused issues, and open/update a Known Build Error issue for unrelated failures

## Why
This keeps Agent Merge aligned with the dotnet/runtime workflow and prevents CI rerun churn from masking the original validation signal.

> [!NOTE]
> This PR description was generated with GitHub Copilot.