### PR TITLE
[mono][wasm] Handle versioned OS platform P/Invoke attributes

### DIFF
--- a/src/tasks/WasmAppBuilder/mono/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/mono/PInvokeCollector.cs
@@ -290,7 +290,7 @@ internal sealed class PInvokeCollector {
             {
                 if (cattr.AttributeType.FullName == "System.Runtime.Versioning.UnsupportedOSPlatformAttribute" &&
                     cattr.ConstructorArguments.Count > 0 &&
-                    cattr.ConstructorArguments[0].Value?.ToString() == _targetOS)
+                    MatchesTargetOS(cattr.ConstructorArguments[0].Value?.ToString()))
                 {
                     return PlatformSupport.Unsupported;
                 }
@@ -298,7 +298,7 @@ internal sealed class PInvokeCollector {
                     cattr.ConstructorArguments.Count > 0)
                 {
                     hasSupportedOSPlatform = true;
-                    if (cattr.ConstructorArguments[0].Value?.ToString() == _targetOS)
+                    if (MatchesTargetOS(cattr.ConstructorArguments[0].Value?.ToString()))
                         hasSupportedTarget = true;
                 }
             }
@@ -312,6 +312,22 @@ internal sealed class PInvokeCollector {
             return hasSupportedTarget ? PlatformSupport.Supported : PlatformSupport.Unsupported;
 
         return PlatformSupport.Unknown;
+    }
+
+    private bool MatchesTargetOS(string? platformName)
+    {
+        if (string.Equals(platformName, _targetOS, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (platformName?.StartsWith(_targetOS, StringComparison.OrdinalIgnoreCase) != true)
+            return false;
+
+#if NETFRAMEWORK
+        string version = platformName.Substring(_targetOS.Length);
+#else
+        ReadOnlySpan<char> version = platformName.AsSpan(_targetOS.Length);
+#endif
+        return Version.TryParse(version, out _);
     }
 }
 


### PR DESCRIPTION
## Summary

- match versioned OS platform attributes against the Mono P/Invoke target OS
- keep valid `browser1.0` P/Invokes in the generated table

## Root cause

The Mono P/Invoke collector compared the complete platform attribute string
with `TargetOS`. Standard `net11.0-browser` libraries carry
`SupportedOSPlatform("browser1.0")`, while the build task receives
`TargetOS=browser`, so valid P/Invokes were silently filtered out.

The fix preserves the existing platform-only behavior while accepting a valid
optional `Version` suffix. It is intentionally limited to the Mono collector
where the regression was introduced.

Fixes #132297

## Validation

- built `WasmAppBuilder.csproj` in Release for both `net11.0` and `net472`
- no automated regression test is included; full workload validation is left
  to CI and the maintainers
