### PR TITLE
[Profiler] Fix DoStackSnapshot calls in ELT hooks

### DIFF
--- a/src/coreclr/vm/profilinghelper.h
+++ b/src/coreclr/vm/profilinghelper.h
@@ -136,4 +136,15 @@ private:
     DWORD      m_dwOriginalFullState;
 };
 
+class ProfilerELTContextHolder
+{
+public:
+    ProfilerELTContextHolder(T_CONTEXT *pContext);
+    ~ProfilerELTContextHolder();
+
+private:
+    Thread *   m_pThread;
+    T_CONTEXT *m_pOriginalContext;
+};
+
 #endif //__PROFILING_HELPER_H__

--- a/src/coreclr/vm/profilinghelper.inl
+++ b/src/coreclr/vm/profilinghelper.inl
@@ -46,6 +46,36 @@ FORCEINLINE SetCallbackStateFlagsHolder::~SetCallbackStateFlagsHolder()
     }
 }
 
+FORCEINLINE ProfilerELTContextHolder::ProfilerELTContextHolder(T_CONTEXT *pContext)
+{
+    m_pThread = (pContext != nullptr) ? GetThreadNULLOk() : nullptr;
+    if (m_pThread != nullptr)
+    {
+        m_pOriginalContext = m_pThread->GetProfilerELTContext();
+        m_pThread->SetProfilerELTContext(pContext);
+    }
+    else
+    {
+        m_pOriginalContext = nullptr;
+    }
+}
+
+FORCEINLINE ProfilerELTContextHolder::~ProfilerELTContextHolder()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    if (m_pThread != nullptr)
+    {
+        m_pThread->SetProfilerELTContext(m_pOriginalContext);
+    }
+}
+
 #ifdef ENABLE_CONTRACTS
 //---------------------------------------------------------------------------------------
 //

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -123,6 +123,7 @@
 #include "generics.h"
 #include "gcinfo.h"
 #include "safemath.h"
+#include "stacktrace.h"
 #include "threadsuspend.h"
 #include "inlinetracking.h"
 #include "frozenobjectheap.h"
@@ -8578,6 +8579,8 @@ HRESULT ProfToEEInterfaceImpl::DoStackSnapshot(ThreadID thread,
     CONTEXT ctxCurrent;
     memset(&ctxCurrent, 0, sizeof(ctxCurrent));
 
+    CONTEXT ctxELT;
+
     REGDISPLAY rd;
 
     PROFILER_STACK_WALK_DATA data;
@@ -8714,6 +8717,17 @@ HRESULT ProfToEEInterfaceImpl::DoStackSnapshot(ThreadID thread,
             goto Cleanup;
         }
 #endif // !PLATFORM_SUPPORTS_SAFE_THREADSUSPEND
+    }
+
+    if ((pctxSeed == nullptr) && (pThreadToSnapshot == pCurrentThread))
+    {
+        T_CONTEXT *pELTContext = pCurrentThread->GetProfilerELTContext();
+        if (pELTContext != nullptr)
+        {
+            CopyOSContext(&ctxELT, pELTContext);
+            Thread::VirtualUnwindToFirstManagedCallFrame(&ctxELT);
+            pctxSeed = &ctxELT;
+        }
     }
 
     // If target thread is in pre-emptive mode, the profiler's seed context is unnecessary
@@ -10694,6 +10708,21 @@ void __stdcall ProfilerUnmanagedToManagedTransitionMD(MethodDesc *pMD,
 // These do a lot of work for us, setting up Frames, gathering arg info and resolving generics.
   //*******************************************************************************************
 
+#ifdef PROFILING_SUPPORTED
+static void CaptureProfilerELTContext(T_CONTEXT *pContext)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_COOPERATIVE;
+    }
+    CONTRACTL_END;
+
+    ClrCaptureContext(pContext);
+}
+#endif // PROFILING_SUPPORTED
+
 HCIMPL2(EXTERN_C void, ProfileEnter, UINT_PTR clientData, void * platformSpecificHandle)
 {
     FCALL_CONTRACT;
@@ -10740,6 +10769,14 @@ HCIMPL2(EXTERN_C void, ProfileEnter, UINT_PTR clientData, void * platformSpecifi
     // This means that we cannot trigger a GC.
     SetCallbackStateFlagsHolder csf(
         COR_PRF_CALLBACKSTATE_INCALLBACK);
+
+    T_CONTEXT *pProfilerELTContext = nullptr;
+    if (CORProfilerStackSnapshotEnabled())
+    {
+        pProfilerELTContext = static_cast<T_CONTEXT *>(_alloca(sizeof(T_CONTEXT)));
+        CaptureProfilerELTContext(pProfilerELTContext);
+    }
+    ProfilerELTContextHolder contextHolder(pProfilerELTContext);
 
     COR_PRF_ELT_INFO_INTERNAL eltInfo;
     eltInfo.platformSpecificHandle = platformSpecificHandle;
@@ -10908,6 +10945,14 @@ HCIMPL2(EXTERN_C void, ProfileLeave, UINT_PTR clientData, void * platformSpecifi
     SetCallbackStateFlagsHolder csf(
         COR_PRF_CALLBACKSTATE_INCALLBACK);
 
+    T_CONTEXT *pProfilerELTContext = nullptr;
+    if (CORProfilerStackSnapshotEnabled())
+    {
+        pProfilerELTContext = static_cast<T_CONTEXT *>(_alloca(sizeof(T_CONTEXT)));
+        CaptureProfilerELTContext(pProfilerELTContext);
+    }
+    ProfilerELTContextHolder contextHolder(pProfilerELTContext);
+
     COR_PRF_ELT_INFO_INTERNAL eltInfo;
     eltInfo.platformSpecificHandle = platformSpecificHandle;
 
@@ -11032,6 +11077,14 @@ HCIMPL2(EXTERN_C void, ProfileTailcall, UINT_PTR clientData, void * platformSpec
     // This means that we cannot trigger a GC.
     SetCallbackStateFlagsHolder csf(
         COR_PRF_CALLBACKSTATE_INCALLBACK);
+
+    T_CONTEXT *pProfilerELTContext = nullptr;
+    if (CORProfilerStackSnapshotEnabled())
+    {
+        pProfilerELTContext = static_cast<T_CONTEXT *>(_alloca(sizeof(T_CONTEXT)));
+        CaptureProfilerELTContext(pProfilerELTContext);
+    }
+    ProfilerELTContextHolder contextHolder(pProfilerELTContext);
 
     COR_PRF_ELT_INFO_INTERNAL eltInfo;
     eltInfo.platformSpecificHandle = platformSpecificHandle;

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1283,6 +1283,7 @@ Thread::Thread()
     }
 
     m_pProfilerFilterContext = NULL;
+    m_pProfilerELTContext = nullptr;
 #endif // PROFILING_SUPPORTED
 
     m_CacheStackBase = 0;

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -2747,6 +2747,12 @@ private:
     T_CONTEXT *m_pProfilerFilterContext;
 
     //---------------------------------------------------------------
+    // Native context captured before invoking an ELT profiler callback.
+    // DoStackSnapshot may unwind it to seed a same-thread stack walk.
+    //---------------------------------------------------------------
+    T_CONTEXT *m_pProfilerELTContext;
+
+    //---------------------------------------------------------------
     // Bitmask to remember per-thread state useful for the profiler API.  See
     // COR_PRF_CALLBACKSTATE_* flags in clr\src\inc\ProfilePriv.h for bit values.
     //---------------------------------------------------------------
@@ -2834,6 +2840,20 @@ public:
         LIMITED_METHOD_CONTRACT;
 
         m_pProfilerFilterContext = pContext;
+    }
+
+    void SetProfilerELTContext(T_CONTEXT *pContext)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        m_pProfilerELTContext = pContext;
+    }
+
+    T_CONTEXT *GetProfilerELTContext()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_pProfilerELTContext;
     }
 
     FORCEINLINE DWORD GetProfilerEvacuationCounter(size_t slot)

--- a/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
+++ b/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
@@ -97,7 +97,8 @@ HRESULT SlowPathELTProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
     if (FAILED(hr = pCorProfilerInfo->SetEventMask2(COR_PRF_MONITOR_ENTERLEAVE
                                                     | COR_PRF_ENABLE_FUNCTION_ARGS
                                                     | COR_PRF_ENABLE_FUNCTION_RETVAL
-                                                    | COR_PRF_ENABLE_FRAME_INFO,
+                                                    | COR_PRF_ENABLE_FRAME_INFO
+                                                    | COR_PRF_ENABLE_STACK_SNAPSHOT,
                                                     0)))
     {
         wcout << L"FAIL: IpCorProfilerInfo::SetEventMask2() failed hr=0x" << std::hex << hr << endl;
@@ -163,6 +164,8 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::EnterCallback(FunctionIDOrClientI
     {
         return S_OK;
     }
+
+    TestHookRestrictions();
 
     COR_PRF_FRAME_INFO frameInfo;
     ULONG pcbArgumentInfo = 0;
@@ -422,12 +425,59 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::EnterCallback(FunctionIDOrClientI
     return hr;
 }
 
+HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::StackSnapshotCallback(
+    FunctionID functionId,
+    UINT_PTR instructionPointer,
+    COR_PRF_FRAME_INFO frameInfo,
+    ULONG32 contextSize,
+    BYTE context[],
+    void *clientData)
+{
+    bool *sawManagedFrame = reinterpret_cast<bool *>(clientData);
+    *sawManagedFrame |= functionId != 0;
+    return S_OK;
+}
+
+void SlowPathELTProfiler::TestHookRestrictions()
+{
+    if (_testedHookRestrictions.exchange(true))
+    {
+        return;
+    }
+
+#ifndef WIN32
+    bool sawManagedFrame = false;
+    HRESULT hr = pCorProfilerInfo->DoStackSnapshot(
+        0,
+        StackSnapshotCallback,
+        COR_PRF_SNAPSHOT_DEFAULT,
+        &sawManagedFrame,
+        nullptr,
+        0);
+    if (hr != S_OK || !sawManagedFrame)
+    {
+        wcout << L"DoStackSnapshot from ELT hook failed hr=0x" << std::hex << hr
+              << L" sawManagedFrame=" << sawManagedFrame << endl;
+        _failures++;
+    }
+#endif // WIN32
+
+    HRESULT forceGCHr = pCorProfilerInfo->ForceGC();
+    if (forceGCHr != CORPROF_E_UNSUPPORTED_CALL_SEQUENCE)
+    {
+        wcout << L"ForceGC from ELT hook returned unexpected hr=0x" << std::hex << forceGCHr << endl;
+        _failures++;
+    }
+}
+
 HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::LeaveCallback(FunctionIDOrClientID functionIdOrClientID, COR_PRF_ELT_INFO eltInfo)
 {
     if (_testType != TestType::LeaveHooks)
     {
         return S_OK;
     }
+
+    TestHookRestrictions();
 
     COR_PRF_FRAME_INFO frameInfo;
     COR_PRF_FUNCTION_ARGUMENT_RANGE * pRetvalRange = new COR_PRF_FUNCTION_ARGUMENT_RANGE;

--- a/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.h
+++ b/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.h
@@ -127,7 +127,7 @@ class SlowPathELTProfiler : public Profiler
 public:
     static std::shared_ptr<SlowPathELTProfiler> s_profiler;
 
-    SlowPathELTProfiler() : Profiler(), _failures(0), _testType(TestType::Unknown)
+    SlowPathELTProfiler() : Profiler(), _failures(0), _testedHookRestrictions(false), _testType(TestType::Unknown)
     {
         _sawFuncEnter[L"SimpleArgsFunc"] = false;
         _sawFuncEnter[L"MixedStructFunc"] = false;
@@ -185,11 +185,21 @@ private:
     };
 
     std::atomic<int> _failures;
+    std::atomic<bool> _testedHookRestrictions;
     std::unordered_map<std::wstring, bool> _sawFuncEnter;
     std::unordered_map<std::wstring, bool> _sawFuncLeave;
 
     TestType _testType;
 
+    static HRESULT STDMETHODCALLTYPE StackSnapshotCallback(
+        FunctionID functionId,
+        UINT_PTR instructionPointer,
+        COR_PRF_FRAME_INFO frameInfo,
+        ULONG32 contextSize,
+        BYTE context[],
+        void *clientData);
+
+    void TestHookRestrictions();
     void PrintBytes(const BYTE *bytes, size_t length);
 
     bool ValidateInt(UINT_PTR ptr, int expected);


### PR DESCRIPTION
Fixes #130220

## Platform scope

The reported Windows scenario returns `CORPROF_E_STACKSNAPSHOT_UNSAFE`, rather than the Linux regression's `E_FAIL`. That indicates a separate snapshot-safety boundary and is not changed by this fix. The new context is used only after the existing safety checks allow the walk.

## Problem

Same-thread `DoStackSnapshot` calls from slow enter, leave, and tailcall profiler hooks no longer have the managed machine state needed to begin a stack walk on Linux.

[#107152](https://github.com/dotnet/runtime/pull/107152) intentionally removed GC-trigger authorization from ELT hooks, but it also removed the `HelperMethodFrame` that supplied the managed-side machine state needed by an unseeded stack walk.

Without that frame, an unseeded `DoStackSnapshot` call from an ELT callback has no complete managed instruction pointer, stack pointer, and preserved-register state from which to start walking. On Linux x64, the issue reproduction consequently changed from 320 successful snapshots on the parent commit to 320 `E_FAIL` results after #107152.

A counterfactual build restored only the helper frame while leaving GC-trigger authorization removed. All 320 snapshots succeeded, showing that the missing stack-walk state caused the regression.

## Fix

When stack snapshots are enabled, the slow ELT helpers now:

1. Capture a native context before invoking arbitrary profiler code.
2. Publish it on the current `Thread` for the callback lifetime.
3. Restore the previous context after the callback, including for nested ELT callbacks.

For a same-thread `DoStackSnapshot` call without a profiler-supplied seed, CoreCLR copies that context, virtually unwinds it through the CoreCLR ELT helpers to the first managed frame, and uses the resulting managed context through the existing snapshot-seed path.

The ELT context is separate from `m_pProfilerFilterContext`, so ordinary runtime and GC stack walks do not observe it. This change does not add a public API, exported ABI, explicit runtime frame, GC poll, or trigger-scope authorization.

## Safety

ELT callback state remains `COR_PRF_CALLBACKSTATE_INCALLBACK`. GC-triggering profiler APIs therefore remain prohibited while the stack snapshot, which is `GC_NOTRIGGER`, receives the starting state it needs.

The profiler regression test verifies that `ForceGC` still returns `CORPROF_E_UNSUPPORTED_CALL_SEQUENCE`.

## Testing

- Checked CoreCLR build.
- Slow-path ELT enter and leave profiler tests.
- Demonstrated that the enter test fails with `E_FAIL` on the unfixed runtime.
- Original issue harness: ten runs with 32 of 32 successful snapshots per run, for 320 successes and no failures.

## Performance

Native virtual unwinding is deferred until `DoStackSnapshot` is called. ELT callbacks capture only the raw context.

The relative increase is large because the benchmark uses an intentionally empty hook with a roughly 49 ns baseline. The added absolute cost is approximately 36 ns and is paid only when stack snapshots are enabled.

Linux x64 BenchmarkDotNet results:

| Configuration | Baseline | Change | Ratio |
| --- | ---: | ---: | ---: |
| Slow ELT with stack-snapshot flag | 48.53 ns | 84.33 ns | 1.74x |
| Slow ELT without stack-snapshot flag | 47.65 ns | 48.59 ns | 1.02x |

The snapshot-enabled path adds approximately 36 ns per callback. The path without the snapshot flag remains within benchmark noise.
