### PR TITLE
[mono][wasm][AOT] Pin `OP_MOVE` destinations in the GC pin area

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
@@ -1236,9 +1236,14 @@ namespace System.Tests
         private static void CollectAndScribble()
         {
             GC.Collect();
-            byte[] scribble = new byte[64];
-            scribble[0] = 1;
-            GC.KeepAlive(scribble);
+            // Reclaim and overwrite any just-freed slot with same-sized objects so that an
+            // object lost across the collection is observable (it reads a filler's Value = -1).
+            GcRootBox[] filler = new GcRootBox[64];
+            for (int j = 0; j < filler.Length; j++)
+            {
+                filler[j] = new GcRootBox(-1);
+            }
+            GC.KeepAlive(filler);
         }
 
         // Regression test for https://github.com/dotnet/runtime/issues/130592. On the Mono

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
@@ -1200,5 +1200,70 @@ namespace System.Tests
                 }
             }
         }
+
+        private sealed class GcRootBox
+        {
+            public int Value;
+            public GcRootBox Self;
+            public byte[] Payload;
+
+            public GcRootBox(int v)
+            {
+                Value = v;
+                Self = this;
+                Payload = new byte[16];
+                Payload[0] = (byte)v;
+            }
+
+            public bool IsIntact(int expected) =>
+                Value == expected && ReferenceEquals(Self, this) && Payload is not null && Payload[0] == (byte)expected;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static GcRootBox MakeGcRootBox(int v) => new GcRootBox(v);
+
+        // Taking the address forces the caller's local to be an address-taken variable.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void TouchGcRootBox(ref GcRootBox b)
+        {
+            if (b is null)
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void CollectAndScribble()
+        {
+            GC.Collect();
+            byte[] scribble = new byte[64];
+            scribble[0] = 1;
+            GC.KeepAlive(scribble);
+        }
+
+        // Regression test for https://github.com/dotnet/runtime/issues/130592. On the Mono
+        // wasm LLVM-AOT backend a ref OP_MOVE alias of an address-taken local could be left
+        // rooted nowhere once the local was reassigned, letting the aliased object be collected
+        // while a live local still referenced it. The invariant -- an object reachable through a
+        // live local survives a collection -- holds on every runtime, so this only has teeth on
+        // wasm AOT (it must be in the browser Mono smoke set to run there).
+        [Fact]
+        public static void MovedAliasOfAddressTakenLocalIsRootedAcrossGC()
+        {
+            GcRootBox cur = MakeGcRootBox(0);
+            TouchGcRootBox(ref cur);
+
+            for (int i = 1; i <= 128; i++)
+            {
+                GcRootBox alias = cur;      // ref MOVE; sole remaining reference to box (i - 1)
+                cur = MakeGcRootBox(i);     // overwrites cur's stack slot
+                TouchGcRootBox(ref cur);
+                CollectAndScribble();
+
+                Assert.True(alias.IsIntact(i - 1),
+                    $"object referenced by a live local was lost across GC at iteration {i} (read Value={alias.Value})");
+                GC.KeepAlive(alias);
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
@@ -1236,37 +1236,54 @@ namespace System.Tests
         private static void CollectAndScribble()
         {
             GC.Collect();
-            // Reclaim and overwrite any just-freed slot with same-sized objects so that an
-            // object lost across the collection is observable (it reads a filler's Value = -1).
-            GcRootBox[] filler = new GcRootBox[64];
-            for (int j = 0; j < filler.Length; j++)
-            {
-                filler[j] = new GcRootBox(-1);
-            }
-            GC.KeepAlive(filler);
+            // Refill the just-vacated nursery space so a stale reference reads different bytes.
+            byte[] scribble = new byte[64];
+            scribble[0] = 1;
+            GC.KeepAlive(scribble);
         }
 
-        // Regression test for https://github.com/dotnet/runtime/issues/130592. On the Mono
-        // wasm LLVM-AOT backend a ref OP_MOVE alias of an address-taken local could be left
-        // rooted nowhere once the local was reassigned, letting the aliased object be collected
-        // while a live local still referenced it. The invariant -- an object reachable through a
-        // live local survives a collection -- holds on every runtime, so this only has teeth on
-        // wasm AOT (it must be in the browser Mono smoke set to run there).
+        // Regression test for https://github.com/dotnet/runtime/issues/130592. On the Mono wasm
+        // LLVM-AOT backend a ref OP_MOVE alias of an address-taken local is not reported as a
+        // precise root, so when the GC relocates the object the alias keeps the pre-move address
+        // and silently reads whatever later reuses that memory. The invariant -- every live
+        // reference to an object denotes the same object after a collection -- holds on every
+        // runtime, so this only has teeth on wasm AOT (it must be in the browser Mono smoke set
+        // to run there).
         [Fact]
-        public static void MovedAliasOfAddressTakenLocalIsRootedAcrossGC()
+        public static async Task MovedAliasOfAddressTakenLocalIsRootedAcrossGC()
         {
+            // Resume on a shallow stack: under a deep caller frame a stale copy of the reference
+            // is often found by the conservative stack scan, which pins the object and hides the bug.
+            await Task.Yield();
+            RunMovedAliasLoop();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void RunMovedAliasLoop()
+        {
+            // A heap slot is always fixed up when the GC relocates the object, so it is the
+            // ground truth to compare the stack alias against.
+            GcRootBox[] witness = new GcRootBox[1];
+
             GcRootBox cur = MakeGcRootBox(0);
             TouchGcRootBox(ref cur);
 
             for (int i = 1; i <= 128; i++)
             {
-                GcRootBox alias = cur;      // ref MOVE; sole remaining reference to box (i - 1)
+                GcRootBox alias = cur;      // ref MOVE; sole remaining stack reference to box (i - 1)
+                witness[0] = cur;
                 cur = MakeGcRootBox(i);     // overwrites cur's stack slot
                 TouchGcRootBox(ref cur);
                 CollectAndScribble();
 
-                Assert.True(alias.IsIntact(i - 1),
-                    $"object referenced by a live local was lost across GC at iteration {i} (read Value={alias.Value})");
+                if (!ReferenceEquals(alias, witness[0]))
+                {
+                    Assert.Fail($"live local was not updated when the GC relocated the object at iteration {i}");
+                }
+                if (!alias.IsIntact(i - 1))
+                {
+                    Assert.Fail($"object referenced by a live local was lost across GC at iteration {i} (read Value={alias.Value})");
+                }
                 GC.KeepAlive(alias);
             }
         }

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -248,6 +248,8 @@ typedef struct {
 	int *gc_var_indexes;
 	int gc_var_indexes_len;
 	Address *gc_pin_area;
+	/* Saturating count (0-2) of definitions per vreg, used to decide if a ref move needs pinning */
+	guint8 *vreg_defcount;
 	LLVMValueRef il_state;
 	LLVMValueRef il_state_ret;
 } EmitContext;
@@ -4010,6 +4012,27 @@ emit_gc_pin (EmitContext *ctx, LLVMBuilderRef builder, int vreg)
 	LLVMValueRef addr = LLVMBuildGEP2 (builder, ctx->gc_pin_area->type, ctx->gc_pin_area->value, indexes, 2, "");
 	emit_store (builder, convert (ctx, ctx->values [vreg], IntPtrType ()), addr, TRUE);
 }
+
+/*
+ * A ref OP_MOVE aliases its source instead of producing a new value, so it only needs a pin
+ * slot of its own when the source can stop being rooted while the alias is still live. A vreg
+ * with a single definition keeps its pin slot for the rest of the method, but an address-taken
+ * variable has no pin slot at all: it lives in a stack slot which this method or a callee can
+ * overwrite at any point.
+ */
+static gboolean
+move_needs_gc_pin (EmitContext *ctx, MonoInst *ins)
+{
+	MonoCompile *cfg = ctx->cfg;
+	MonoInst *var;
+
+	if (!ctx->vreg_defcount || ins->sreg1 < 0 || (guint32)ins->sreg1 >= cfg->next_vreg)
+		return TRUE;
+	if (ctx->vreg_defcount [ins->sreg1] > 1)
+		return TRUE;
+	var = get_vreg_to_inst (cfg, ins->sreg1);
+	return var && (var->flags & (MONO_INST_VOLATILE | MONO_INST_INDIRECT | MONO_INST_IS_DEAD));
+}
 #endif
 
 /*
@@ -4057,6 +4080,17 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 	LLVMTypeRef pin_area_type = LLVMArrayType (IntPtrType (), ngc_vars);
 	LLVMValueRef gc_pin_area = build_alloca_llvm_type_name (ctx, pin_area_type, 0, "gc_pin");
 	ctx->gc_pin_area = create_address (ctx, gc_pin_area, pin_area_type);
+
+	/* Runs after the OP_LDADDR pass in emit_method_inner, so MONO_INST_INDIRECT is already set */
+	ctx->vreg_defcount = g_new0 (guint8, cfg->next_vreg);
+	for (MonoBasicBlock *dbb = cfg->bb_entry; dbb; dbb = dbb->next_bb) {
+		for (MonoInst *dins = dbb->code; dins; dins = dins->next) {
+			if (dins->dreg >= 0 && (guint32)dins->dreg < cfg->next_vreg &&
+				LLVM_INS_INFO (dins->opcode) [MONO_INST_DEST] != ' ' &&
+				ctx->vreg_defcount [dins->dreg] < 2)
+				ctx->vreg_defcount [dins->dreg] ++;
+		}
+	}
 #endif
 
 	/*
@@ -12752,7 +12786,18 @@ MONO_RESTORE_WARNING
 				emit_volatile_store (ctx, ins->dreg);
 #ifdef TARGET_WASM
 			//if (vreg_is_ref (cfg, ins->dreg) && ctx->values [ins->dreg])
-			if (vreg_is_ref (cfg, ins->dreg) && ctx->values [ins->dreg] && ins->opcode != OP_MOVE && ins->opcode != OP_AOTCONST)
+			/*
+			 * OP_MOVE dests need pinning too. A MOVE emits no LLVM instruction, so the dest is an SSA
+			 * alias of the source and used to rely on the source staying rooted. That fails when the
+			 * source is an address-taken variable: emit_gc_pin skips those (they live in their stack
+			 * slot instead), so overwriting the variable drops the only root and leaves the alias
+			 * holding an object rooted nowhere. See dotnet/runtime#130592.
+			 *
+			 * OP_AOTCONST stays excluded - those dests are GOT loads of ldstr literals and type/method
+			 * handles, already rooted by the loader's interned tables.
+			 */
+			if (vreg_is_ref (cfg, ins->dreg) && ctx->values [ins->dreg] && ins->opcode != OP_AOTCONST &&
+				(ins->opcode != OP_MOVE || move_needs_gc_pin (ctx, ins)))
 				emit_gc_pin (ctx, builder, ins->dreg);
 #endif
 		}
@@ -12913,6 +12958,7 @@ free_ctx (EmitContext *ctx)
 	g_free (ctx->is_dead);
 	g_free (ctx->unreachable);
 	g_free (ctx->gc_var_indexes);
+	g_free (ctx->vreg_defcount);
 	g_free (ctx->param_etypes);
 	g_ptr_array_free (ctx->phi_values, TRUE);
 	g_free (ctx->bblocks);

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -4014,11 +4014,34 @@ emit_gc_pin (EmitContext *ctx, LLVMBuilderRef builder, int vreg)
 }
 
 /*
+ * compute_vreg_defcounts:
+ *
+ *   Count the definitions of every vreg, saturating at 2, for move_needs_gc_pin ().
+ */
+static void
+compute_vreg_defcounts (EmitContext *ctx)
+{
+	MonoCompile *cfg = ctx->cfg;
+
+	ctx->vreg_defcount = g_new0 (guint8, cfg->next_vreg);
+	for (MonoBasicBlock *bb = cfg->bb_entry; bb; bb = bb->next_bb) {
+		for (MonoInst *ins = bb->code; ins; ins = ins->next) {
+			if (ins->dreg >= 0 && (guint32)ins->dreg < cfg->next_vreg &&
+				LLVM_INS_INFO (ins->opcode) [MONO_INST_DEST] != ' ' &&
+				ctx->vreg_defcount [ins->dreg] < 2)
+				ctx->vreg_defcount [ins->dreg] ++;
+		}
+	}
+}
+
+/*
  * A ref OP_MOVE aliases its source instead of producing a new value, so it only needs a pin
  * slot of its own when the source can stop being rooted while the alias is still live. A vreg
  * with a single definition keeps its pin slot for the rest of the method, but an address-taken
- * variable has no pin slot at all: it lives in a stack slot which this method or a callee can
- * overwrite at any point.
+ * variable is rooted through slots holding the variable's current value, which this method or
+ * a callee can overwrite at any point.
+ *
+ * Reads MONO_INST_INDIRECT, so it must run after the OP_LDADDR pass in emit_method_inner ().
  */
 static gboolean
 move_needs_gc_pin (EmitContext *ctx, MonoInst *ins)
@@ -4080,17 +4103,6 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 	LLVMTypeRef pin_area_type = LLVMArrayType (IntPtrType (), ngc_vars);
 	LLVMValueRef gc_pin_area = build_alloca_llvm_type_name (ctx, pin_area_type, 0, "gc_pin");
 	ctx->gc_pin_area = create_address (ctx, gc_pin_area, pin_area_type);
-
-	/* Runs after the OP_LDADDR pass in emit_method_inner, so MONO_INST_INDIRECT is already set */
-	ctx->vreg_defcount = g_new0 (guint8, cfg->next_vreg);
-	for (MonoBasicBlock *dbb = cfg->bb_entry; dbb; dbb = dbb->next_bb) {
-		for (MonoInst *dins = dbb->code; dins; dins = dins->next) {
-			if (dins->dreg >= 0 && (guint32)dins->dreg < cfg->next_vreg &&
-				LLVM_INS_INFO (dins->opcode) [MONO_INST_DEST] != ' ' &&
-				ctx->vreg_defcount [dins->dreg] < 2)
-				ctx->vreg_defcount [dins->dreg] ++;
-		}
-	}
 #endif
 
 	/*
@@ -13567,6 +13579,9 @@ emit_method_inner (EmitContext *ctx)
 	/*
 	 * Second pass: generate code.
 	 */
+#ifdef TARGET_WASM
+	compute_vreg_defcounts (ctx);
+#endif
 	// Emit entry point
 	entry_builder = create_builder (ctx);
 	entry_bb = get_bb (ctx, cfg->bb_entry);


### PR DESCRIPTION
Fixes the AOT codegen half of https://github.com/dotnet/runtime/issues/130592.
Related https://github.com/dotnet/runtime/pull/132180

Objects that are still referenced by a live local can be collected in Mono LLVM-AOT
browser-wasm code. The fix stops excluding `OP_MOVE` destinations from the GC pin area,
but only for the moves that actually need it, so the size cost is negligible
(**+0.15%** of AOT code, **+186 bytes** compressed).

```diff
-if (vreg_is_ref (cfg, ins->dreg) && ctx->values [ins->dreg] && ins->opcode != OP_MOVE && ins->opcode != OP_AOTCONST)
+if (vreg_is_ref (cfg, ins->dreg) && ctx->values [ins->dreg] && ins->opcode != OP_AOTCONST &&
+        (ins->opcode != OP_MOVE || move_needs_gc_pin (ctx, ins)))
         emit_gc_pin (ctx, builder, ins->dreg);
```

---

## Repro without the fix

[Log](https://helix.dot.net/api/2019-06-17/jobs/cc414616-7412-44f4-a7b0-621a04eabb73/workitems/WasmTestOnChrome-MONO-ST-System.Runtime.Tests/console)
```
[12:26:59] info: Starting:    System.Runtime.Tests.dll
[12:27:40] info: [FAIL] System.Tests.GCExtendedTests.MovedAliasOfAddressTakenLocalIsRootedAcrossGC
[12:27:40] info: live local was not updated when the GC relocated the object at iteration 1
[12:27:40] info:    at System.Tests.GCExtendedTests.MovedAliasOfAddressTakenLocalIsRootedAcrossGC()
[12:27:40] info: --- End of stack trace from previous location ---
[12:27:51] info: Finished:    System.Runtime.Tests.dll
```


## Background: how GC references stay alive in wasm AOT code

This part is unusual enough that the bug does not make sense without it.

On normal targets, SGen finds GC references by scanning the machine stack
conservatively: anything on the stack that looks like a heap pointer is treated as a
root, and the object it points to is pinned so the collector will not move it.

**WebAssembly has no addressable machine stack.** Local variables live in *wasm locals*
— slots in the VM's own execution state. They are not part of linear memory, so a
conservative scan of linear memory structurally cannot see them. A reference that lives
only in a wasm local is invisible to the GC.

Mono works around this with a **GC pin area**. For each method, the AOT compiler
allocates a small array in the method's linear-memory frame (`emit_entry_bb`), reserving
one slot per reference-typed virtual register. Every time a ref vreg is assigned, the
compiler emits a volatile store of that value into its slot (`emit_gc_pin`). Because the
pin area *is* in linear memory, the conservative scan finds it, and the objects are
pinned.

So on wasm the rule is: **a reference is only a GC root if something wrote it into the pin
area (or into some other linear-memory location).** If the compiler skips that store, the
value is invisible to the GC even though the program is still using it.

Two details matter later:

- `emit_gc_pin` and the slot allocation in `emit_entry_bb` both skip a variable only when
  it is `MONO_INST_VOLATILE` or `MONO_INST_IS_DEAD` — **not** when it is merely
  `MONO_INST_INDIRECT`. So an address-taken variable comes in two shapes: a volatile one
  has no pin slot at all and is rooted purely by its own linear-memory stack slot
  (`emit_volatile_store` writes it there), while an indirect-but-not-volatile one has both
  a pin slot and a stack slot. Either way its root is **overwritten when the variable is
  reassigned**, which is what matters below. Measured over an AOT compile of
  `System.Runtime.Tests`, the flag branch splits 61 584 volatile (no slot) to 7 668
  indirect-only (7 656 of them with a slot); `IS_DEAD` never occurred.
- An `OP_MOVE` in Mono's IR emits **no LLVM instruction**. `values[dreg] = values[sreg1]`
  simply makes the destination an SSA alias of the source. There is no new value, so the
  original code assumed there was no new root to record.

## The bug

`OP_MOVE` destinations were excluded from `emit_gc_pin`, on the assumption that the
*source* is already rooted, so the alias is covered.

That assumption breaks when the source is an **address-taken variable**:

1. The source's root is tied to the variable, not to the value: a volatile source has only
   its linear-memory stack slot, an indirect source has a stack slot and a pin slot. Both
   hold *the variable's current value*.
2. `alias = source` is an `OP_MOVE`, so under the old condition `alias` got **no pin store
   either**. `alias` exists only as a wasm local.
3. Reassigning the source (`source = something_else`) overwrites those slots — the
   **only** roots for the previous object.

The previous object is now referenced solely by `alias`, which lives in a wasm local that
the conservative scan cannot see. It is not pinned and not reachable, so the next
collection frees it (or moves it without updating the alias). The program then keeps using
a dangling reference.

That produces exactly the symptoms in #130592: reads returning garbage, `mono_class_get_flags:
unexpected GC filler class`, out-of-bounds accesses, and hangs inside a collection.

## Reproduction

`System.Tests.GCExtendedTests.MovedAliasOfAddressTakenLocalIsRootedAcrossGC` in
`src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs`.
`System.Runtime.Tests` is in the browser Mono smoke set, so this runs in the existing
`LibraryTests_Smoke_AOT` legs on both `browser_wasm` and `browser_wasm_win` with no
pipeline changes.

```csharp
await Task.Yield();             // resume on a shallow stack -- see below

GcRootBox[] witness = new GcRootBox[1];
GcRootBox cur = MakeGcRootBox(0);
TouchGcRootBox(ref cur);        // taking the address makes `cur` an address-taken variable

for (int i = 1; i <= 128; i++) {
    GcRootBox alias = cur;      // ref OP_MOVE; sole remaining stack reference to box (i - 1)
    witness[0] = cur;           // a heap slot, which the GC always fixes up
    cur = MakeGcRootBox(i);     // overwrites cur's stack slot
    TouchGcRootBox(ref cur);
    CollectAndScribble();       // GC.Collect() + a small allocation to reuse freed space

    if (!ReferenceEquals(alias, witness[0]))   // fails: alias still holds the pre-move address
        Assert.Fail(...);
    if (!alias.IsIntact(i - 1))
        Assert.Fail(...);
    GC.KeepAlive(alias);
}
```

The asserted invariant — *two live references to one object still denote the same object
after a collection* — holds on every runtime, so this test is safe to run everywhere. It
only has teeth on wasm AOT.

The failure mode is a **stale reference to a relocated object, not premature collection**:
a `WeakReference` to the aliased object stays alive across the collection. Two details are
what make the test detect it reliably:

- **Compare identity against a heap slot, not object contents.** A heap array element is
  always fixed up when the GC relocates the object, so it is ground truth for the stack
  alias. Checking the object's *bytes* instead only fails once the vacated nursery memory
  happens to be reused — that measured at 2 failures in 6 runs, hitting around iteration
  22-28. The witness comparison fails on the very first collection, every run.
- **`await Task.Yield()` before the loop.** Under a deep caller frame the conservative
  stack scan often finds a stale copy of the reference and pins the object, so it never
  moves and the bug hides. Resuming on a shallow stack removes that.

Measured on `browser-wasm`, `Release`, `RunAOTCompilation=true`,
`EnableAggressiveTrimming=true`, running the full `System.Runtime.Tests` suite in Chrome:

| build | result |
| --- | --- |
| baseline | **FAIL 3/3** — `live local was not updated when the GC relocated the object at iteration 1` |
| **this PR (conditional)** | **PASS 3/3** — 76 832 tests, 0 failed |
| flags-only variant | PASS 1/1 |
| baseline, interpreter (no AOT) | PASS — 76 885 tests, 0 failed |

It also reproduces in CI on the existing AOT leg —
[`WasmTestOnChrome-MONO-ST-System.Runtime.Tests`](https://helix.dot.net/api/2019-06-17/jobs/cc414616-7412-44f4-a7b0-621a04eabb73/workitems/WasmTestOnChrome-MONO-ST-System.Runtime.Tests/console).

## How common is the shape?

A temporary census in the AOT compiler over the five assemblies AOT'd by the sample
(including `System.Private.CoreLib`):

| | count |
| --- | --- |
| unique methods containing ref `OP_MOVE`s | 2,776 |
| ref `OP_MOVE`s total | 12,047 |
| ...with an address-taken/volatile source (**the hazard**) | **1,457, across 252 methods** |
| ...with a multi-definition source (the originally claimed shape) | 1,250, across 410 methods |

So the vulnerable pattern is not exotic; it appears in a few hundred CoreLib methods
alone. Whether a given site actually strands an object additionally depends on the object
being the sole reference across a collection, which is why it surfaces as rare, random
corruption rather than a consistent failure.

These two rows are also what the conditional rule targets: roughly 2,300 of the 12,047 ref
moves need a pin slot, and the other ~80% are provably covered by their source and are
skipped. That ratio is what produces the size numbers below.

## History of this code

Useful context, because the exclusion being removed was never a correctness decision.

| PR | change |
| --- | --- |
| [#59352](https://github.com/dotnet/runtime/pull/59352) (Sep 2021) | Introduced the design. Previously ref variables were marked volatile and reloaded on every access; this replaced that with the pin area, storing each ref vreg after assignment. Done for code size and speed. |
| [#69955](https://github.com/dotnet/runtime/pull/69955) (Jun 2022) | *"Wasm AOT micro optimizations."* Added three size optimizations on top, including **`!= OP_MOVE`**, described as *"Avoid storing arguments and results of moves into the gc_pin area."* No correctness argument was given. |
| — | That batch was reverted. |
| [#70465](https://github.com/dotnet/runtime/pull/70465) (Jun 2022) | *"Enable a subset of the gc_pin area optimizations."* Re-landed the `OP_MOVE` skip and the volatile/dead skip, but **not** the argument skip, with the note: **"The OP_ARG one causes random crashes."** |
| [#81179](https://github.com/dotnet/runtime/pull/81179) (Jan 2023) | Added `!= OP_AOTCONST`, which is genuinely safe — those are GOT loads of `ldstr` literals and type/method handles, already rooted by the loader's interned tables. |

In other words: the `OP_MOVE` exclusion came from a **size micro-optimization batch that was
already partially reverted for causing random crashes**, and the sibling exclusion from the
same batch was dropped for exactly the class of symptom seen here. This change removes the
remaining unsound member of that batch.

## The fix

Pin `OP_MOVE` destinations, but only when the source can stop being rooted while the alias
is still live. `OP_AOTCONST` keeps its blanket exclusion.

```c
static gboolean
move_needs_gc_pin (EmitContext *ctx, MonoInst *ins)
{
        MonoCompile *cfg = ctx->cfg;
        MonoInst *var;

        if (!ctx->vreg_defcount || ins->sreg1 < 0 || (guint32)ins->sreg1 >= cfg->next_vreg)
                return TRUE;
        if (ctx->vreg_defcount [ins->sreg1] > 1)
                return TRUE;
        var = get_vreg_to_inst (cfg, ins->sreg1);
        return var && (var->flags & (MONO_INST_VOLATILE | MONO_INST_INDIRECT | MONO_INST_IS_DEAD));
}
```

A move is skipped only when the source is provably rooted for the rest of the method:

- **Single definition** (`vreg_defcount <= 1`). Such a vreg's pin slot is written once and
  never overwritten, so the object stays pinned. `emit_entry_bb` counts definitions in one
  extra walk over the IR, saturating at 2; it runs after the `OP_LDADDR` pass, so
  `MONO_INST_INDIRECT` is already set by then. Arguments have zero IR definitions and are
  pinned in the prologue, so they fall into this bucket too.
- **Not address-taken**. `MONO_INST_VOLATILE`/`INDIRECT`/`IS_DEAD` variables are rooted
  through slots that hold the variable's *current* value — a stack slot, plus a pin slot
  for the indirect-only case — and this method *or a callee* can overwrite them through the
  escaped pointer, which is exactly the bug — so they are always pinned.

Everything else is pinned, so the rule is conservative by default: anything unknown
(no def-count array, out-of-range vreg) returns `TRUE`.

The rule is also transitively sound for chains of moves. `c = MOVE b; b = MOVE a` bottoms
out at a real definition: if `a` is single-def and not address-taken, its slot roots the
object for the whole method; if it is not, `b` gets pinned and — being single-def itself —
keeps *its* slot for the rest of the method, covering `c`.

Writing a MOVE destination's slot is safe by construction: `emit_entry_bb` already reserves
a pin slot for **every** non-volatile, non-dead ref vreg, using the same predicate
`emit_gc_pin` filters on. A MOVE destination therefore writes a slot that was already
allocated and left empty. It cannot collide with the source's slot, cannot grow the frame,
and cannot shift any other vreg's index.

### Why not just pin every ref move?

That was the first version of this change and it also fixes the bug, but it costs about
**9.5x more code size** for no additional correctness (see below). Both variants were built
and measured; the numbers for the unconditional variant are kept in the table for
comparison.

## Binary size impact

Measured on the `console-node` sample, `browser-wasm`, `Release`, `RunAOTCompilation=true`,
AOT'ing 5 assemblies including `System.Private.CoreLib`. All three configurations were built
from an identical tree with a full `mono+libs` rebuild and the identical app source; only the
pin condition differs. The baseline was reproduced twice, byte-identical.

**Final shipped artifact — `dotnet.native.wasm`:**

| | bytes | vs baseline |
| --- | ---: | ---: |
| baseline (today's code) | 7,727,862 | |
| **this PR (conditional)** | **7,745,349** | **+17,487 (+0.23%)** |
| unconditional variant | 7,872,152 | +144,290 (+1.87%) |
| baseline, brotli | 2,481,410 | |
| **this PR, brotli** | **2,481,596** | **+186 (+0.007%)** |
| unconditional variant, brotli | 2,510,062 | +28,652 (+1.15%) |

Brotli is what users actually download, and there the cost of this PR is **186 bytes** —
indistinguishable from noise.

**AOT-compiled managed code only (per-assembly object files), which isolates the codegen
change from the fixed runtime portion:**

| object | baseline | this PR | unconditional |
| --- | ---: | ---: | ---: |
| `aot-instances.dll.o` | 6,731,828 | +3,394 | +78,676 |
| `System.Private.CoreLib.dll.o` | 4,416,021 | +13,429 | +82,387 |
| `System.Runtime.InteropServices.JavaScript.dll.o` | 210,834 | +371 | +3,622 |
| `System.Console.dll.o` | 38,981 | +39 | +419 |
| `Wasm.Console.Node.Sample.dll.o` | 17,745 | +114 | +267 |
| **total** | **11,415,409** | **+17,347 (+0.15%)** | +165,371 (+1.45%) |

So the conditional rule costs **+0.15% of AOT code size** instead of +1.45%, a **9.5x
reduction**, while still fixing the bug (verified: the repro passes 2/2 with this version).
For reference, the original PR reported ~3.4 MB on a 65.5 MB application (~5%).

### Second measurement: a large app

The sample above AOTs 5 assemblies. Repeating the measurement on `System.Runtime.Tests`
(66 assemblies) gives a bigger relative cost, so the impact is app-dependent. These are
local unstripped builds with debug symbols on, i.e. a different basis from the shipped
numbers above, but all three configurations are identical apart from the pin condition:

| build | `dotnet.native.wasm` | vs baseline | pins added | tests |
| --- | ---: | ---: | ---: | --- |
| baseline | 53,768,636 | | 0 | FAIL |
| flags-only variant | 54,112,208 | +343,572 (+0.64%) | 97,247 | pass |
| **this PR (conditional)** | **54,368,645** | **+600,009 (+1.12%)** | **163,855** | pass |

A census over the same compile, one line per ref `OP_MOVE`, shows what the rule skips:

| outcome | count | share |
| --- | ---: | ---: |
| skipped, no pin | 625,164 | 79.2% |
| pinned: source has >1 definition | 66,608 | 8.4% |
| pinned: source is volatile/indirect/dead | 46,170 | 5.9% |
| pinned: both | 51,077 | 6.5% |
| **total ref `OP_MOVE`s** | **789,019** | |

Both derivations agree at ~3.7-3.9 bytes per pin store. The def-count clause accounts for
41% of the added pins and +0.47 percentage points of the size delta on its own; it is kept
for consistency, since a move whose source is redefined has the same hazard shape even
though no test was able to make that path fail.

> [!NOTE]
> Parts of this description were drafted with GitHub Copilot.

