### PR TITLE
Accept canonical NaN in BFloat16 explicit conversions on WASM

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
@@ -572,19 +572,6 @@ namespace System.Numerics.Tests
 
             foreach ((float original, BFloat16 expected) in data)
             {
-                // WASM on Mono lowers `float.Min` / `float.Max` through `f32.min` / `f32.max`
-                // (and `float.IsNaN(...)` branches through `f32.add`). The WebAssembly spec
-                // permits NaN-payload canonicalization on these ops but doesn't require it --
-                // arch-native targets (Arm64, xArch) don't canonicalize, at most stripping
-                // the signaling bit per IEEE 754. The V8 engine used by the CI Helix queues
-                // does canonicalize, so the bit-strict NaN cases in this theory don't round-
-                // trip through the software conversion path in that environment. Gated on
-                // Mono specifically since other WASM runtimes don't share this lowering.
-                // Tracked in https://github.com/dotnet/runtime/issues/103347; this filter can
-                // be removed once the conversion path either avoids the canonicalizing ops
-                // or the host engines start preserving NaN payloads.
-                if (PlatformDetection.IsMonoRuntime && PlatformDetection.IsWasm && float.IsNaN(original))
-                    continue;
                 yield return new object[] { original, expected };
             }
         }
@@ -594,6 +581,21 @@ namespace System.Numerics.Tests
         public static void ExplicitConversion_FromSingle(float f, BFloat16 expected) // Check the underlying bits for verifying NaNs
         {
             BFloat16 b16 = (BFloat16)f;
+
+            // The software `float`->`BFloat16` conversion routes the value through `f32.abs`/`f32.min`/
+            // `f32.max`/`f32.add`, and the WebAssembly spec permits (but doesn't require) host engines
+            // to canonicalize NaN payloads on those ops -- the V8 engine used on CI does. The sign is
+            // still carried through the integer ALU, so a canonicalized result is `sign | 0x7FC0`.
+            // Accept that as the expected value on WASM. See https://github.com/dotnet/runtime/issues/103347.
+            if (PlatformDetection.IsWasm && BFloat16.IsNaN(expected))
+            {
+                ushort canonical = (ushort)((BitConverter.BFloat16ToUInt16Bits(expected) & 0x8000) | 0x7FC0);
+                if (BitConverter.BFloat16ToUInt16Bits(b16) == canonical)
+                {
+                    expected = b16;
+                }
+            }
+
             AssertEqual(expected, b16);
         }
 
@@ -670,19 +672,6 @@ namespace System.Numerics.Tests
 
             foreach ((double original, BFloat16 expected) in data)
             {
-                // WASM on Mono lowers `double.Min` / `double.Max` through `f64.min` / `f64.max`
-                // (and `double.IsNaN(...)` branches through `f64.add`). The WebAssembly spec
-                // permits NaN-payload canonicalization on these ops but doesn't require it --
-                // arch-native targets (Arm64, xArch) don't canonicalize, at most stripping
-                // the signaling bit per IEEE 754. The V8 engine used by the CI Helix queues
-                // does canonicalize, so the bit-strict NaN cases in this theory don't round-
-                // trip through the software conversion path in that environment. Gated on
-                // Mono specifically since other WASM runtimes don't share this lowering.
-                // Tracked in https://github.com/dotnet/runtime/issues/103347; this filter can
-                // be removed once the conversion path either avoids the canonicalizing ops
-                // or the host engines start preserving NaN payloads.
-                if (PlatformDetection.IsMonoRuntime && PlatformDetection.IsWasm && double.IsNaN(original))
-                    continue;
                 yield return new object[] { original, expected };
             }
         }
@@ -692,6 +681,21 @@ namespace System.Numerics.Tests
         public static void ExplicitConversion_FromDouble(double d, BFloat16 expected) // Check the underlying bits for verifying NaNs
         {
             BFloat16 b16 = (BFloat16)d;
+
+            // The software `double`->`BFloat16` conversion routes the value through `f64.abs`/`f64.min`/
+            // `f64.max`/`f64.add`, and the WebAssembly spec permits (but doesn't require) host engines
+            // to canonicalize NaN payloads on those ops -- the V8 engine used on CI does. The sign is
+            // still carried through the integer ALU, so a canonicalized result is `sign | 0x7FC0`.
+            // Accept that as the expected value on WASM. See https://github.com/dotnet/runtime/issues/103347.
+            if (PlatformDetection.IsWasm && BFloat16.IsNaN(expected))
+            {
+                ushort canonical = (ushort)((BitConverter.BFloat16ToUInt16Bits(expected) & 0x8000) | 0x7FC0);
+                if (BitConverter.BFloat16ToUInt16Bits(b16) == canonical)
+                {
+                    expected = b16;
+                }
+            }
+
             AssertEqual(expected, b16);
         }
 


### PR DESCRIPTION
Applies the same fix as #130706 (which handled `HalfTests.ExplicitConversion_FromSingle`) to the two `BFloat16` explicit conversion tests: `ExplicitConversion_FromSingle` and `ExplicitConversion_FromDouble`.

The software `float`/`double` -> `BFloat16` conversions route the value through `abs`/`min`/`max`/`add` (`f32.*` / `f64.*` on WASM). The WebAssembly spec permits (but doesn't require) host engines to canonicalize NaN payloads on those ops, and the V8 engine used on the CI Helix queues does, so the bit-strict NaN cases don't round-trip there. Arch-native targets (and payload-preserving WASM engines) are unaffected.

Previously the NaN cases were skipped entirely via `if (PlatformDetection.IsMonoRuntime && PlatformDetection.IsWasm && ...) continue;`. That gate only fires on **Mono**, so once the browser CoreCLR work (#129634) started running these tests on CoreCLR+WASM they began failing on V8 with `Assert.Equal() ... Expected: NaN / Actual: NaN` (payloads differ). Dropping all NaN coverage on WASM also loses the sign-bit check, which *is* preserved (carried through the integer ALU).

Instead, this removes the skip and, on WASM only, accepts the canonical result (`sign | 0x7FC0` for `BFloat16`) in place of the exact expected payload:

* a canonicalizing run (V8 today) passes via the canonical value,
* a payload-preserving run (the IEEE 754 / WASM *recommended* behavior, and what arch-native targets do) still passes via the strict exact-bits check,
* a genuinely wrong payload (e.g. a dropped sign) still fails.

So the NaN cases now actually run on WASM for both Mono and CoreCLR, and the bit-strict `AssertEqual` stays in effect for all other targets.

Tracked in #103347.

> [!NOTE]
> This PR was prepared with the assistance of GitHub Copilot.
