### PR TITLE
Fix for array's dimensions LowerBound verbose check in ILlink tool

### DIFF
--- a/src/tools/illink/src/linker/Linker/DocumentationSignatureGenerator.PartVisitor.cs
+++ b/src/tools/illink/src/linker/Linker/DocumentationSignatureGenerator.PartVisitor.cs
@@ -42,7 +42,7 @@ namespace Mono.Linker
                     builder.Append("[0:");
                     for (int i = 1; i < arrayType.Rank; i++)
                     {
-                        if (arrayType.Dimensions[0].LowerBound != 0)
+                        if (arrayType.Dimensions[i].LowerBound != 0)
                             throw new NotImplementedException();
                         builder.Append(",0:");
                     }


### PR DESCRIPTION
Stumbled upon this in code analysis. Looks like typical copy-paste issue with obvious fix.

Found by Linux Verification Center (linuxtesting.org) with SVACE.