### PR TITLE
[TEMP][DO NOT MERGE] Validate test131537 under Mono wasm-AOT on Chrome

### DIFF
--- a/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
+++ b/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
@@ -49,7 +49,9 @@ jobs:
             buildAllTestsAsStandalone: true
             # Scope the runtime-test build to just this one test, and AOT it locally
             # (RunAOTCompilation=true) so corelib is AOT'd in the produced wasm app.
-            testBuildArgs: tree Loader/classloader/generics/regressions/131537 /p:RunAOTCompilation=true /p:InstallV8ForTests=false
+            # _BuildAllTestGroupsForBrowser: this test is in group 3 (Pri0), and browser CI
+            # otherwise builds only group 1 (#114123); safe here since only one test is scoped.
+            testBuildArgs: tree Loader/classloader/generics/regressions/131537 /p:RunAOTCompilation=true /p:InstallV8ForTests=false /p:_BuildAllTestGroupsForBrowser=true
             scenarios:
               - WasmTestOnChrome
             useHelixMonitor: ${{ parameters.useHelixMonitor }}

--- a/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
+++ b/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
@@ -1,9 +1,8 @@
-# TEMP (wasm-aot-131537-validation): validate that the src/tests regression test
-# Loader/classloader/generics/regressions/131537 actually runs under the Mono
-# wasm-AOT configuration that reproduces #131537 (AOT'd corelib + force-interpreted
-# test assembly). Scoped to just that one test via `-tree`, AOT'd locally, run on
-# Chrome. Delete this file (and its reference in runtime-extra-platforms-wasm.yml)
-# before merging anything real.
+# TEMP (wasm-aot-131537-validation): validate that the WebAssembly functional test
+# FunctionalTests/WebAssembly/Browser/AOT_131537 reproduces #131537 under the Mono
+# wasm-AOT configuration (AOT'd corelib + force-interpreted test assembly). Scoped to
+# just that one test via `-tree`, AOT'd locally, run on Chrome. Delete this file (and
+# its reference in runtime-extra-platforms-wasm.yml) before merging anything real.
 
 parameters:
   alwaysRun: false
@@ -34,7 +33,7 @@ jobs:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       nameSuffix: AllSubsets_Mono_RuntimeTests_AOT_131537
       # No runtimeVariant (i.e. not monointerpreter): we want corelib AOT'd, and
-      # the test csproj force-interprets only test131537.dll via
+      # the functional test csproj force-interprets only its own assembly via
       # _AOT_InternalForceInterpretAssemblies — reproducing the failing config.
       buildArgs: -s mono+libs -c $(_BuildConfig) /p:MonoEnableAssertMessages=true /p:InstallV8ForTests=false ${{ parameters.extraBuildArgs }}
       timeoutInMinutes: 180
@@ -44,11 +43,11 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_$(_BuildConfig)_AOT_131537
-            # Scope the runtime-test build to just this one test, and AOT it locally
-            # (RunAOTCompilation=true) so corelib is AOT'd in the produced wasm app.
-            # _BuildAllTestGroupsForBrowser: this test is in group 3 (Pri0), and browser CI
-            # otherwise builds only group 1 (#114123); safe here since only one test is scoped.
-            testBuildArgs: tree Loader/classloader/generics/regressions/131537 /p:RunAOTCompilation=true /p:InstallV8ForTests=false /p:_BuildAllTestGroupsForBrowser=true
+            # Scope the runtime-test build to just this one functional test, and AOT it
+            # locally (the csproj sets RunAOTCompilation=true) so corelib is AOT'd in the
+            # produced wasm app. _BuildAllTestGroupsForBrowser: browser CI otherwise builds
+            # only test group 1 (#114123); safe here since only one test is scoped.
+            testBuildArgs: tree FunctionalTests/WebAssembly/Browser/AOT_131537 /p:RunAOTCompilation=true /p:InstallV8ForTests=false /p:_BuildAllTestGroupsForBrowser=true
             scenarios:
               - WasmTestOnChrome
             useHelixMonitor: ${{ parameters.useHelixMonitor }}

--- a/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
+++ b/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
@@ -44,6 +44,9 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_$(_BuildConfig)_AOT_131537
+            # Build the single scoped test as a standalone wasm app (not merged) so it
+            # yields its own Helix work item; merged mode drops a lone test (0 in group).
+            buildAllTestsAsStandalone: true
             # Scope the runtime-test build to just this one test, and AOT it locally
             # (RunAOTCompilation=true) so corelib is AOT'd in the produced wasm app.
             testBuildArgs: tree Loader/classloader/generics/regressions/131537 /p:RunAOTCompilation=true /p:InstallV8ForTests=false

--- a/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
+++ b/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
@@ -1,0 +1,54 @@
+# TEMP (wasm-aot-131537-validation): validate that the src/tests regression test
+# Loader/classloader/generics/regressions/131537 actually runs under the Mono
+# wasm-AOT configuration that reproduces #131537 (AOT'd corelib + force-interpreted
+# test assembly). Scoped to just that one test via `-tree`, AOT'd locally, run on
+# Chrome. Delete this file (and its reference in runtime-extra-platforms-wasm.yml)
+# before merging anything real.
+
+parameters:
+  alwaysRun: false
+  isExtraPlatformsBuild: false
+  isWasmOnlyBuild: false
+  platforms: []
+  extraBuildArgs: ''
+  useHelixMonitor: false
+
+jobs:
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    buildConfig: Release
+    runtimeFlavor: mono
+    platforms: ${{ parameters.platforms }}
+    variables:
+      - name: alwaysRunVar
+        value: ${{ parameters.alwaysRun }}
+      - name: timeoutPerTestInMinutes
+        value: 20
+      - name: timeoutPerTestCollectionInMinutes
+        value: 200
+    jobParameters:
+      testGroup: innerloop
+      isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
+      nameSuffix: AllSubsets_Mono_RuntimeTests_AOT_131537
+      # No runtimeVariant (i.e. not monointerpreter): we want corelib AOT'd, and
+      # the test csproj force-interprets only test131537.dll via
+      # _AOT_InternalForceInterpretAssemblies — reproducing the failing config.
+      buildArgs: -s mono+libs -c $(_BuildConfig) /p:MonoEnableAssertMessages=true /p:InstallV8ForTests=false ${{ parameters.extraBuildArgs }}
+      timeoutInMinutes: 180
+      condition: eq(variables['alwaysRunVar'], true)
+      postBuildSteps:
+        - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+          parameters:
+            creator: dotnet-bot
+            testRunNamePrefixSuffix: Mono_$(_BuildConfig)_AOT_131537
+            # Scope the runtime-test build to just this one test, and AOT it locally
+            # (RunAOTCompilation=true) so corelib is AOT'd in the produced wasm app.
+            testBuildArgs: tree Loader/classloader/generics/regressions/131537 /p:RunAOTCompilation=true /p:InstallV8ForTests=false
+            scenarios:
+              - WasmTestOnChrome
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
+      extraVariablesTemplates:
+        - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
+++ b/eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
@@ -44,9 +44,6 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_$(_BuildConfig)_AOT_131537
-            # Build the single scoped test as a standalone wasm app (not merged) so it
-            # yields its own Helix work item; merged mode drops a lone test (0 in group).
-            buildAllTestsAsStandalone: true
             # Scope the runtime-test build to just this one test, and AOT it locally
             # (RunAOTCompilation=true) so corelib is AOT'd in the produced wasm app.
             # _BuildAllTestGroupsForBrowser: this test is in group 3 (Pri0), and browser CI

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -249,8 +249,8 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
-  # TEMP (wasm-aot-131537-validation): Mono AOT + Chrome runtime-test lane scoped to
-  # Loader/classloader/generics/regressions/131537 only. Remove before merging.
+  # TEMP (wasm-aot-131537-validation): Mono AOT + Chrome functional-test lane scoped to
+  # FunctionalTests/WebAssembly/Browser/AOT_131537 only. Remove before merging.
   - template: /eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
     parameters:
       platforms:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -249,6 +249,18 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
+  # TEMP (wasm-aot-131537-validation): Mono AOT + Chrome runtime-test lane scoped to
+  # Loader/classloader/generics/regressions/131537 only. Remove before merging.
+  - template: /eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml
+    parameters:
+      platforms:
+        - browser_wasm
+      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+
 - ${{ if and(ne(parameters.isRollingBuild, true), ne(parameters.excludeOptional, true)) }}:
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
     parameters:

--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -203,7 +203,6 @@ MONO_JIT_ICALL (mono_get_native_calli_wrapper) \
 MONO_JIT_ICALL (mono_get_special_static_data) \
 MONO_JIT_ICALL (mono_gsharedvt_constrained_call) \
 MONO_JIT_ICALL (mono_gsharedvt_value_copy) \
-MONO_JIT_ICALL (mono_helper_box_nullable) \
 MONO_JIT_ICALL (mono_helper_compile_generic_method) \
 MONO_JIT_ICALL (mono_helper_ldstr) \
 MONO_JIT_ICALL (mono_helper_ldstr_mscorlib) \

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1169,15 +1169,6 @@ mono_helper_newobj_mscorlib (guint32 idx)
 	return obj;
 }
 
-MonoObject*
-mono_helper_box_nullable (gpointer vbuf, MonoClass *klass)
-{
-	ERROR_DECL (error);
-	MonoObject *result = mono_nullable_box (vbuf, klass, error);
-	mono_error_set_pending_exception (error);
-	return result;
-}
-
 /*
  * On some architectures, gdb doesn't like encountering the cpu breakpoint instructions
  * in generated code. So instead we emit a call to this function and place a gdb

--- a/src/mono/mono/mini/jit-icalls.h
+++ b/src/mono/mono/mini/jit-icalls.h
@@ -116,8 +116,6 @@ ICALL_EXPORT MonoString *mono_helper_ldstr_mscorlib (guint32 idx);
 
 ICALL_EXPORT MonoObject *mono_helper_newobj_mscorlib (guint32 idx);
 
-ICALL_EXPORT MonoObject *mono_helper_box_nullable (gpointer vbuf, MonoClass *klass);
-
 ICALL_EXPORT double mono_fsub (double a, double b);
 
 ICALL_EXPORT double mono_fadd (double a, double b);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -3404,26 +3404,6 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 }
 
 /*
- * Box a gsharedvt Nullable<T> via a non-generic runtime helper, passing the value by
- * address and the concrete class from the rgctx. This avoids a per-T box wrapper that
- * cannot be emitted at AOT time when the consuming assembly runs interpreted.
- */
-static MonoInst*
-mini_emit_nullable_box_helper (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_used)
-{
-	MonoInst *iargs [2], *addr, *var;
-
-	var = get_vreg_to_inst (cfg, val->dreg);
-	if (!var)
-		var = mono_compile_create_var_for_vreg (cfg, m_class_get_byval_arg (klass), OP_LOCAL, val->dreg);
-	EMIT_NEW_VARLOADA (cfg, addr, var, var->inst_vtype);
-
-	iargs [0] = addr;
-	iargs [1] = mini_emit_get_rgctx_klass (cfg, context_used, klass, MONO_RGCTX_INFO_KLASS);
-	return mono_emit_jit_icall (cfg, mono_helper_box_nullable, iargs);
-}
-
-/*
  * Returns NULL and set the cfg exception on error.
  */
 MonoInst*
@@ -3445,9 +3425,11 @@ mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_us
 				MonoInst *addr;
 				MonoMethodSignature *sig = mono_method_signature_internal (method);
 				if (mini_is_gsharedvt_klass (klass))
-					return mini_emit_nullable_box_helper (cfg, val, klass, context_used);
-				addr = emit_get_rgctx_method (cfg, context_used, method,
-											  MONO_RGCTX_INFO_METHOD_FTNDESC);
+					addr = mini_emit_get_gsharedvt_info_klass (cfg, klass,
+															   MONO_RGCTX_INFO_NULLABLE_CLASS_BOX);
+				else
+					addr = emit_get_rgctx_method (cfg, context_used, method,
+												  MONO_RGCTX_INFO_METHOD_FTNDESC);
 				cfg->interp_in_signatures = g_slist_prepend_mempool (cfg->mempool, cfg->interp_in_signatures, sig);
 				return mini_emit_llvmonly_calli (cfg, sig, &val, addr);
 			} else {
@@ -3513,14 +3495,9 @@ mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_us
 		/* Nullable case */
 		MONO_START_BB (cfg, is_nullable_bb);
 
-		if (cfg->llvm_only) {
-			MonoInst *box_call = mini_emit_nullable_box_helper (cfg, val, klass, context_used);
-			EMIT_NEW_UNALU (cfg, res, OP_MOVE, dreg, box_call->dreg);
-			res->type = STACK_OBJ;
-			res->klass = klass;
-		} else {
+		{
 			MonoInst *box_addr = mini_emit_get_gsharedvt_info_klass (cfg, klass,
-										MONO_RGCTX_INFO_NULLABLE_CLASS_BOX);
+													MONO_RGCTX_INFO_NULLABLE_CLASS_BOX);
 			MonoInst *box_call;
 			MonoMethodSignature *box_sig;
 
@@ -3533,7 +3510,10 @@ mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_us
 			box_sig->param_count = 1;
 			box_sig->params [0] = m_class_get_byval_arg (klass);
 
-			box_call = mini_emit_calli (cfg, box_sig, &val, box_addr, NULL, NULL);
+			if (cfg->llvm_only)
+				box_call = mini_emit_llvmonly_calli (cfg, box_sig, &val, box_addr);
+			else
+				box_call = mini_emit_calli (cfg, box_sig, &val, box_addr, NULL, NULL);
 			EMIT_NEW_UNALU (cfg, res, OP_MOVE, dreg, box_call->dreg);
 			res->type = STACK_OBJ;
 			res->klass = klass;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -5114,7 +5114,6 @@ register_icalls (void)
 	register_icall (mono_helper_ldstr, mono_icall_sig_object_ptr_int, FALSE);
 	register_icall (mono_helper_ldstr_mscorlib, mono_icall_sig_object_int, FALSE);
 	register_icall (mono_helper_newobj_mscorlib, mono_icall_sig_object_int, FALSE);
-	register_icall (mono_helper_box_nullable, mono_icall_sig_object_ptr_ptr, FALSE);
 	register_icall (mono_value_copy_internal, mono_icall_sig_void_ptr_ptr_ptr, FALSE);
 	register_icall (mono_object_castclass_unbox, mono_icall_sig_object_object_ptr, FALSE);
 	register_icall (mono_break, mono_icall_sig_void, TRUE);

--- a/src/tests/FunctionalTests/WebAssembly/Browser/AOT_131537/Program.cs
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/AOT_131537/Program.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Regression test for https://github.com/dotnet/runtime/issues/131537
+// (WASM manifestation of https://github.com/dotnet/runtime/issues/66220).
+//
+// Constructing a non-generic Queue from a List<Nullable<T>> enumerates the list
+// through the non-generic IEnumerator, whose Current getter boxes each element
+// Nullable<T> -> object. With corelib AOT'd and this assembly running in the
+// interpreter (see _AOT_InternalForceInterpretAssemblies in the csproj), the
+// concrete Nullable<T> is instantiated only in the interpreter, so the AOT
+// compiler never emits the required gsharedvt out-sig wrapper object(Nullable<T>)
+// and the boxing call traps with "function signature mismatch" (assertion in
+// mini-generic-sharing.c). The 16-byte payload types (Int128?/Guid?/decimal?)
+// are the ones that regress.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices.JavaScript;
+
+namespace Sample
+{
+    public partial class Test
+    {
+        public static void Main()
+        {
+            Console.WriteLine("Test_131537 loaded");
+        }
+
+        [JSExport]
+        public static int TestMeaning()
+        {
+            RoundTrip(new List<Int128?> { 1, 2, 3 });
+            RoundTrip(new List<UInt128?> { 1, 2, 3 });
+            RoundTrip(new List<Half?> { (Half)1, (Half)2, (Half)3 });
+            RoundTrip(new List<decimal?> { 1m, 2m, 3m });
+            RoundTrip(new List<Guid?> { Guid.Empty, Guid.NewGuid() });
+            RoundTrip(new List<DateTime?> { DateTime.UnixEpoch, DateTime.MaxValue });
+            RoundTrip(new List<DateTimeOffset?> { DateTimeOffset.UnixEpoch, DateTimeOffset.MaxValue });
+            RoundTrip(new List<TimeSpan?> { TimeSpan.Zero, TimeSpan.FromSeconds(5) });
+
+            // 42 == pass, per the WebAssembly functional test convention.
+            return 42;
+        }
+
+        private static void RoundTrip<T>(List<T> source)
+        {
+            // Queue(ICollection) enumerates via the non-generic IEnumerator, boxing
+            // each element T -> object. This is the call that crashes when the
+            // object(Nullable<T>) gsharedvt out-sig wrapper is missing.
+            var queue = new Queue(source);
+            if (queue.Count != source.Count)
+            {
+                throw new Exception($"count mismatch: {queue.Count} != {source.Count}");
+            }
+
+            int i = 0;
+            foreach (object boxed in queue)
+            {
+                if (!Equals(source[i], (T)boxed))
+                {
+                    throw new Exception($"element {i} mismatch");
+                }
+                i++;
+            }
+        }
+    }
+}

--- a/src/tests/FunctionalTests/WebAssembly/Browser/AOT_131537/WebAssembly.Browser.Aot_131537.Test.csproj
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/AOT_131537/WebAssembly.Browser.Aot_131537.Test.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Reproduces https://github.com/dotnet/runtime/issues/131537: corelib is AOT'd
+         while this app assembly runs in the interpreter, so the object(Nullable<T>)
+         gsharedvt out-sig wrapper is never emitted by AOT and boxing a 16-byte
+         Nullable<T> through the non-generic IEnumerator traps. -->
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <MonoForceInterpreter>false</MonoForceInterpreter>
+    <ExpectedExitCode>42</ExpectedExitCode>
+  </PropertyGroup>
+  <ItemGroup>
+    <WasmExtraFilesToDeploy Include="index.html" />
+    <WasmExtraFilesToDeploy Include="main.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Run this assembly interpreted while corelib stays AOT'd: this is the
+         WasmTestOnChrome-MONO configuration in which #131537 regresses. -->
+    <_AOT_InternalForceInterpretAssemblies Include="WebAssembly.Browser.Aot_131537.Test.dll" />
+  </ItemGroup>
+</Project>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/AOT_131537/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/AOT_131537/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!--  Licensed to the .NET Foundation under one or more agreements. -->
+<!-- The .NET Foundation licenses this file to you under the MIT license. -->
+<html>
+
+<head>
+  <title>131537 AOT nullable box test</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type='module' src="./main.js"></script>
+</head>
+
+<body>
+  <h3 id="header">131537 AOT nullable box test</h3>
+  Result: <span id="out"></span>
+</body>
+
+</html>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/AOT_131537/main.js
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/AOT_131537/main.js
@@ -1,0 +1,22 @@
+import { dotnet } from './_framework/dotnet.js'
+
+function wasm_exit(exit_code) {
+    var tests_done_elem = document.createElement("label");
+    tests_done_elem.id = "tests_done";
+    tests_done_elem.innerHTML = exit_code.toString();
+    document.body.appendChild(tests_done_elem);
+
+    console.log(`WASM EXIT ${exit_code}`);
+}
+
+try {
+    const { getAssemblyExports } = await dotnet.create();
+    const exports = await getAssemblyExports("WebAssembly.Browser.Aot_131537.Test.dll");
+    const ret = exports.Sample.Test.TestMeaning();
+    document.getElementById("out").innerHTML = `${ret}`;
+    console.debug(`ret: ${ret}`);
+    wasm_exit(ret);
+} catch (err) {
+    console.log(`WASM ERROR ${err}`);
+    wasm_exit(1);
+}

--- a/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
+++ b/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <!-- TEMP (wasm-aot-131537-validation): Pri0 so the innerloop wasm runtime-tests lanes include it. Revert to 1. -->
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- TEMP (wasm-aot-131537-validation): self-contained merged runner so it produces a wasm Helix work item
+         (non-merged Loader tests have no wasm work-item path). Mirrors GC/.../largearraytest.csproj. -->
+    <HasMergedInTests>true</HasMergedInTests>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test131537.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
   <ItemGroup>
     <!-- Reproduce the WasmTestOnChrome-MONO-ST configuration from #131537:
@@ -16,4 +16,6 @@
          This item is ignored on non-wasm-AOT runtimes. -->
     <_AOT_InternalForceInterpretAssemblies Include="test131537.dll" />
   </ItemGroup>
+
+  <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>

--- a/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
+++ b/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- TEMP (wasm-aot-131537-validation): Pri0 so the innerloop wasm runtime-tests lanes include it. Revert to 1. -->
-    <CLRTestPriority>0</CLRTestPriority>
-    <!-- TEMP (wasm-aot-131537-validation): self-contained merged runner so it produces a wasm Helix work item
-         (non-merged Loader tests have no wasm work-item path). Mirrors GC/.../largearraytest.csproj. -->
-    <HasMergedInTests>true</HasMergedInTests>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test131537.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
   <ItemGroup>
     <!-- Reproduce the WasmTestOnChrome-MONO-ST configuration from #131537:
@@ -16,6 +15,4 @@
          This item is ignored on non-wasm-AOT runtimes. -->
     <_AOT_InternalForceInterpretAssemblies Include="test131537.dll" />
   </ItemGroup>
-
-  <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>

--- a/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
+++ b/src/tests/Loader/classloader/generics/regressions/131537/test131537.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <CLRTestPriority>1</CLRTestPriority>
+    <!-- TEMP (wasm-aot-131537-validation): Pri0 so the innerloop wasm runtime-tests lanes include it. Revert to 1. -->
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test131537.cs" />

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -205,9 +205,10 @@
     <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="BuildManagedTestGroup" Properties="__TestGroupToBuild=1;__SkipRestorePackages=1" />
     <!-- ActiveIssue https://github.com/dotnet/runtime/issues/114123
     The groups 2..n are disabled for browser target because they get OOM kill in CI.
+    TEMP (wasm-aot-131537-validation): _BuildAllTestGroupsForBrowser opts a tree-scoped build back into groups 2..n on browser CI (safe because only one test is in scope).
     -->
     <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="BuildManagedTestGroup" Properties="__TestGroupToBuild=%(_GroupStartsWith.GroupNumber);__SkipRestorePackages=1"
-        Condition="'$(TargetOS)' != 'browser' or '$(ContinuousIntegrationBuild)' != 'true'"
+        Condition="'$(TargetOS)' != 'browser' or '$(ContinuousIntegrationBuild)' != 'true' or '$(_BuildAllTestGroupsForBrowser)' == 'true'"
     />
   </Target>
 


### PR DESCRIPTION
## Purpose (temporary — do not merge)

Validation-only PR to confirm that the `src/tests` regression test [`Loader/classloader/generics/regressions/131537`](https://github.com/dotnet/runtime/tree/main/src/tests/Loader/classloader/generics/regressions/131537) actually runs under the **Mono wasm-AOT** configuration that reproduces #131537 (AOT'd corelib + force-interpreted test assembly).

Background: on the merged fix (#132153) this `src/tests` case is **never executed under the failing config** in any pipeline — the only Mono wasm runtime-tests lane is hardcoded `testGroup: innerloop` (Pri0) **and** `runtimeVariant: monointerpreter` (no AOT). The test is `CLRTestPriority 1`, so it's excluded there; and even at Pri0 that lane is pure interpreter. The real CI guard is the library test `Number_AsCollectionElement_RoundTrip` on `WasmTestOnChrome-MONO`.

## Current branch state — expected RED

This branch has **two** temp commits:

1. Move test to Pri0 + add the scoped Mono AOT + Chrome runtime-test lane, wired into `runtime-wasm`.
2. **Revert of the #132153 runtime fix** (keeping the test) — so the AOT lane should show `test131537` **failing** with `function signature mismatch`, proving the lane exercises the #131537 repro.

**To see it go green:** drop commit 2 (the revert) and re-run — with the fix present the same lane should pass. That's the red→green demonstration.

## What the lane does (3 pipeline/test files)

- **Move the test to Pri0** so the innerloop wasm runtime-tests lanes include it (`test131537.csproj`).
- **Add a scoped Mono AOT + Chrome runtime-test lane** (`eng/pipelines/common/templates/wasm-aot-runtime-test-131537.yml`):
  - `-tree Loader/classloader/generics/regressions/131537` — builds **only** this test (keeps AOT cheap).
  - `/p:RunAOTCompilation=true` — AOT's corelib into the app; the csproj's `_AOT_InternalForceInterpretAssemblies` force-interprets `test131537.dll` → reproduces the failing mixed AOT+interp config.
  - `scenarios: [WasmTestOnChrome]`.
  - **No** `runtimeVariant: monointerpreter` (we want corelib AOT'd, not everything interpreted).
- **Wire it into the `runtime-wasm` pipeline** (`runtime-extra-platforms-wasm.yml`), gated to run only when triggered via `runtime-wasm` (`alwaysRun = isWasmOnlyBuild`).

## How to run

```
/azp run runtime-wasm
```

Look for the job `browser-wasm ... AllSubsets_Mono_RuntimeTests_AOT_131537`.

## Cleanup

All changes are temporary and marked `TEMP`. Revert the Pri0 change, drop the fix-revert commit, and delete the new template + its reference before merging anything real.

> [!NOTE]
> This pull request (and description) was prepared with GitHub Copilot.