### PR TITLE
[ARM64] Tune write barriers

### DIFF
--- a/src/coreclr/vm/arm64/patchedcode.S
+++ b/src/coreclr/vm/arm64/patchedcode.S
@@ -83,9 +83,7 @@ WRITE_BARRIER_ENTRY JIT_CheckedWriteBarrier
     ldr  x17,  LOCAL_LABEL(wbs_highest_address)
     cmp  x14,  x12
     ccmp x14,  x17, #0x2, hs
-    bhs  LOCAL_LABEL(NotInHeap)
-
-    b C_FUNC(JIT_WriteBarrier)
+    blo  C_FUNC(JIT_WriteBarrier)
 
 LOCAL_LABEL(NotInHeap):
     str  x15, [x14]
@@ -250,17 +248,15 @@ LOCAL_LABEL(WriteWatchForGCHeapEnd\@):
     // Calculate region generations
     ldr  x17, JIT_WriteBarrier_Offset_RegionToGeneration + FIXUP_LABEL(\start)
     ldr  w12, JIT_WriteBarrier_Offset_RegionShr + FIXUP_LABEL(\start)
-    lsr  x15, x15, x12
-    add  x15, x15, x17 // x15 = (RHS >> wbs_region_shr) + wbs_region_to_generation_table
-    lsr  x12, x14, x12
-    add  x12, x12, x17 // x12 = (LHS >> wbs_region_shr) + wbs_region_to_generation_table
+    lsr  x15, x15, x12 // x15 = RHS >> wbs_region_shr
+    lsr  x12, x14, x12 // x12 = LHS >> wbs_region_shr
 
     // Check whether the region we are storing into is gen 0 - nothing to do in this case
-    ldrb w12, [x12]
+    ldrb w12, [x17, x12]
     cbz  w12, LOCAL_LABEL(\exit)
 
     // Return if the new reference is not from old to young
-    ldrb w15, [x15]
+    ldrb w15, [x17, x15]
     cmp  w15, w12
     bhs  LOCAL_LABEL(\exit)
 .endm
@@ -268,10 +264,9 @@ LOCAL_LABEL(WriteWatchForGCHeapEnd\@):
 
 .macro WRITE_BARRIER_CHECK_BIT_REGIONS_CARD_TABLE_STUB start, exit
     // Check if we need to update the card table
-    lsr w17, w14, 8
-    and w17, w17, 7
+    ubfx w17, w14, #8, #3
     movz w15, 1
-    lsl w17, w15, w17  // w17 = 1 << (LHS >> 8 && 7)
+    lsl w17, w15, w17  // w17 = 1 << ((LHS >> 8) & 7)
     ldr  x12, JIT_WriteBarrier_Offset_CardTable + FIXUP_LABEL(\start)
     add  x15, x12, x14, lsr #11
     ldrb w12, [x15]  // w12 = [(LHS >> 11) + g_card_table]

--- a/src/coreclr/vm/arm64/patchedcode.asm
+++ b/src/coreclr/vm/arm64/patchedcode.asm
@@ -213,17 +213,15 @@ WriteWatchForGCHeapEnd$name
         ; Calculate region generations
             ldr  x17, JIT_WriteBarrier_Offset_RegionToGeneration + start$name
             ldr  w12, JIT_WriteBarrier_Offset_RegionShr + start$name
-            lsr  x15, x15, x12
-            add  x15, x15, x17 ; x15 = (RHS >> wbs_region_shr) + wbs_region_to_generation_table
-            lsr  x12, x14, x12
-            add  x12, x12, x17 ; x12 = (LHS >> wbs_region_shr) + wbs_region_to_generation_table
+            lsr  x15, x15, x12 ; x15 = RHS >> wbs_region_shr
+            lsr  x12, x14, x12 ; x12 = LHS >> wbs_region_shr
 
         ; Check whether the region we are storing into is gen 0 - nothing to do in this case
-            ldrb w12, [x12]
+            ldrb w12, [x17, x12]
             cbz  w12, exit$name
 
         ; Return if the new reference is not from old to young
-            ldrb w15, [x15]
+            ldrb w15, [x17, x15]
             cmp  w15, w12
             bhs  exit$name
     MEND
@@ -231,10 +229,9 @@ WriteWatchForGCHeapEnd$name
     MACRO
         WRITE_BARRIER_CHECK_BIT_REGIONS_CARD_TABLE_STUB $name
         ; Check if we need to update the card table
-            lsr w17, w14, 8
-            and w17, w17, 7
+            ubfx w17, w14, #8, #3
             movz w15, 1
-            lsl w17, w15, w17  ; w17 = 1 << (LHS >> 8 && 7)
+            lsl w17, w15, w17  ; w17 = 1 << ((LHS >> 8) & 7)
             ldr  x12, JIT_WriteBarrier_Offset_CardTable + start$name
             add  x15, x12, x14, lsr #11
             ldrb w12, [x15]  ; w12 = [(LHS >> 11) + g_card_table]

--- a/src/coreclr/vm/arm64/patchedcodeconstants.h
+++ b/src/coreclr/vm/arm64/patchedcodeconstants.h
@@ -14,11 +14,7 @@
 
 #define JIT_WriteBarrier_Size					   0x3a0
 
-#ifdef TARGET_WINDOWS
 #define JIT_WriteBarrier_Table_Offset              (0x3c + JIT_WriteBarrier_Size)
-#else
-#define JIT_WriteBarrier_Table_Offset              (0x38 + JIT_WriteBarrier_Size)
-#endif
 
 #define JIT_WriteBarrier_Offset_CardTable          (0x0  + JIT_WriteBarrier_Table_Offset)
 #define JIT_WriteBarrier_Offset_CardBundleTable    (0x8  + JIT_WriteBarrier_Table_Offset)


### PR DESCRIPTION
* Region check: index the region-to-generation table with register-offset addressing instead of materializing both addresses — drops 2 `add`s and shortens the `lsr`->`add`->`ldrb` dependency chain.
* Bit-region card check: `lsr`+`and` -> `ubfx`.
* Unix `JIT_CheckedWriteBarrier`: `bhs`+`b` -> a single `blo`, saving a branch on the in-heap path. Side effect: the Unix and Windows layouts become identical, so the `JIT_WriteBarrier_Table_Offset` `#ifdef` is gone.

`JIT_WriteBarrier_Bit_Region64`: 140 -> 128 bytes.

Validated by assembling `patchedcode.asm` (armasm64) and `patchedcode.S` (clang, `aarch64-linux` + `arm64-apple`) in Release and `WRITE_BARRIER_CHECK`, then checking symbol offsets: all four configs now place `JIT_WriteBarrier` at `0x24` and the table at `0x400` (64B aligned, delta `0x3DC` == `0x3c + JIT_WriteBarrier_Size`), with the patch-table field order unchanged from `main`. Not yet run on arm64 hardware.
