### PR TITLE
Improve precision of double.LogP1 and float.LogP1

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -906,7 +906,32 @@ namespace System
         public static double Log(double x, double newBase) => Math.Log(x, newBase);
 
         /// <inheritdoc cref="ILogarithmicFunctions{TSelf}.LogP1(TSelf)" />
-        public static double LogP1(double x) => Math.Log(x + 1);
+        public static double LogP1(double x)
+        {
+            if (Math.Abs(x) >= 0.5)
+            {
+                return Math.Log(1.0 + x);
+            }
+
+            double onePlusX = 1.0 + x;
+
+            if (onePlusX == 1.0)
+            {
+                return x;
+            }
+
+            double result = Math.Log(onePlusX);
+
+            if (!IsFinite(result))
+            {
+                return result;
+            }
+
+            // Recover the low-order bits lost when onePlusX was rounded.
+            double roundingError = (onePlusX - 1.0) - x;
+
+            return roundingError == 0.0 ? result : result - (roundingError / onePlusX);
+        }
 
         /// <inheritdoc cref="ILogarithmicFunctions{TSelf}.Log2P1(TSelf)" />
         public static double Log2P1(double x) => Math.Log2(x + 1);

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -903,7 +903,32 @@ namespace System
         public static float Log(float x, float newBase) => MathF.Log(x, newBase);
 
         /// <inheritdoc cref="ILogarithmicFunctions{TSelf}.LogP1(TSelf)" />
-        public static float LogP1(float x) => MathF.Log(x + 1);
+        public static float LogP1(float x)
+        {
+            if (MathF.Abs(x) >= 0.5f)
+            {
+                return MathF.Log(1.0f + x);
+            }
+
+            float onePlusX = 1.0f + x;
+
+            if (onePlusX == 1.0f)
+            {
+                return x;
+            }
+
+            float result = MathF.Log(onePlusX);
+
+            if (!IsFinite(result))
+            {
+                return result;
+            }
+
+            // Recover the low-order bits lost when onePlusX was rounded.
+            float roundingError = (onePlusX - 1.0f) - x;
+
+            return roundingError == 0.0f ? result : result - (roundingError / onePlusX);
+        }
 
         /// <inheritdoc cref="ILogarithmicFunctions{TSelf}.Log10(TSelf)" />
         [Intrinsic]

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/NFloatTests.cs
@@ -1339,8 +1339,12 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData(-0.506931309f,           -0.707106781f,           CrossPlatformMachineEpsilon32)]       // expected: -(1 / sqrt(2))
         [InlineData(-0.5f,                   -0.693147181f,           CrossPlatformMachineEpsilon32)]       // expected: -(ln(2))
         [InlineData(-0.470922192f,           -0.636619772f,           CrossPlatformMachineEpsilon32)]       // expected: -(2 / pi)
-        [InlineData(-0.0f,                    0.0f,                   0.0f)]
+        [InlineData(-1.23e-8f,               -1.23e-8f,                0.0f)]
+        [InlineData(-float.Epsilon,          -float.Epsilon,           0.0f)]
+        [InlineData(-0.0f,                   -0.0f,                     0.0f)]
         [InlineData( 0.0f,                    0.0f,                   0.0f)]
+        [InlineData( float.Epsilon,           float.Epsilon,           0.0f)]
+        [InlineData( 1.23e-8f,                1.23e-8f,                 0.0f)]
         [InlineData( 0.374802227f,            0.318309886f,           CrossPlatformMachineEpsilon32)]       // expected:  (1 / pi)
         [InlineData( 0.543873444f,            0.434294482f,           CrossPlatformMachineEpsilon32)]       // expected:  (log10(e))
         [InlineData( 0.890081165f,            0.636619772f,           CrossPlatformMachineEpsilon32)]       // expected:  (2 / pi)
@@ -2015,8 +2019,13 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData(-0.50693130860476021,    -0.70710678118654752,      CrossPlatformMachineEpsilon64)]       // expected: -(1 / sqrt(2))
         [InlineData(-0.5,                    -0.69314718055994531,      CrossPlatformMachineEpsilon64)]       // expected: -(ln(2))
         [InlineData(-0.47092219173226465,    -0.63661977236758134,      CrossPlatformMachineEpsilon64)]       // expected: -(2 / pi)
-        [InlineData(-0.0,                     0.0,                      0.0)]
+        [InlineData(-1.23e-20,               -1.23e-20,                 0.0)]
+        [InlineData(-double.Epsilon,         -double.Epsilon,           0.0)]
+        [InlineData(-0.0,                    -0.0,                       0.0)]
         [InlineData( 0.0,                     0.0,                      0.0)]
+        [InlineData( double.Epsilon,          double.Epsilon,           0.0)]
+        [InlineData( 1.23e-20,                1.23e-20,                  0.0)]
+        [InlineData( 1.23e-15,                1.2299999999999993e-15,   1e-30)]
         [InlineData( 0.37480222743935863,     0.31830988618379067,      CrossPlatformMachineEpsilon64)]       // expected:  (1 / pi)
         [InlineData( 0.54387344397118114,     0.43429448190325183,      CrossPlatformMachineEpsilon64)]       // expected:  (log10(e))
         [InlineData( 0.89008116457222198,     0.63661977236758134,      CrossPlatformMachineEpsilon64)]       // expected:  (2 / pi)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.cs
@@ -1586,8 +1586,13 @@ namespace System.Tests
         [InlineData(-0.50693130860476021,    -0.70710678118654752,     CrossPlatformMachineEpsilon)]       // expected: -(1 / sqrt(2))
         [InlineData(-0.5,                    -0.69314718055994531,     CrossPlatformMachineEpsilon)]       // expected: -(ln(2))
         [InlineData(-0.47092219173226465,    -0.63661977236758134,     CrossPlatformMachineEpsilon)]       // expected: -(2 / pi)
-        [InlineData(-0.0,                     0.0,                     0.0)]
+        [InlineData(-1.23e-20,               -1.23e-20,                0.0)]
+        [InlineData(-double.Epsilon,         -double.Epsilon,          0.0)]
+        [InlineData(-0.0,                    -0.0,                      0.0)]
         [InlineData( 0.0,                     0.0,                     0.0)]
+        [InlineData( double.Epsilon,          double.Epsilon,          0.0)]
+        [InlineData( 1.23e-20,                1.23e-20,                 0.0)]
+        [InlineData( 1.23e-15,                1.2299999999999993e-15,  1e-30)]
         [InlineData( 0.37480222743935863,     0.31830988618379067,     CrossPlatformMachineEpsilon)]       // expected:  (1 / pi)
         [InlineData( 0.54387344397118114,     0.43429448190325183,     CrossPlatformMachineEpsilon)]       // expected:  (log10(e))
         [InlineData( 0.89008116457222198,     0.63661977236758134,     CrossPlatformMachineEpsilon)]       // expected:  (2 / pi)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
@@ -1876,7 +1876,7 @@ namespace System.Tests
             yield return new object[] { (Half)(-0.506931309f),  (Half)(-0.707106781f),  CrossPlatformMachineEpsilon };             // expected: -(1 / sqrt(2))
             yield return new object[] { (Half)(-0.5f),          (Half)(-0.693147181f),  CrossPlatformMachineEpsilon };             // expected: -(ln(2))
             yield return new object[] { (Half)(-0.470922192f),  (Half)(-0.636619772f),  CrossPlatformMachineEpsilon };             // expected: -(2 / pi)
-            yield return new object[] { (Half)(-0.0f),          (Half)( 0.0f),          0.0f };
+            yield return new object[] { (Half)(-0.0f),          (Half)(-0.0f),          0.0f };
             yield return new object[] { (Half)( 0.0f),          (Half)( 0.0f),          0.0f };
             yield return new object[] { (Half)( 0.374802227f),  (Half)( 0.318309886f),  CrossPlatformMachineEpsilon };             // expected:  (1 / pi)
             yield return new object[] { (Half)( 0.543873444f),  (Half)( 0.434294482f),  CrossPlatformMachineEpsilon };             // expected:  (log10(e))

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/BFloat16Tests.cs
@@ -1873,7 +1873,7 @@ namespace System.Numerics.Tests
             yield return new object[] { (BFloat16)(-0.5078f), (BFloat16)(-0.707f), CrossPlatformMachineEpsilon };             // expected: -(1 / sqrt(2))
             yield return new object[] { (BFloat16)(-0.5f), (BFloat16)(-0.6914f), CrossPlatformMachineEpsilon };             // expected: -(ln(2))
             yield return new object[] { (BFloat16)(-0.4707f), (BFloat16)(-0.6367f), CrossPlatformMachineEpsilon };             // expected: -(2 / pi)
-            yield return new object[] { (BFloat16)(-0f), (BFloat16)(0f), (BFloat16)0.0f };
+            yield return new object[] { (BFloat16)(-0f), (BFloat16)(-0f), (BFloat16)0.0f };
             yield return new object[] { (BFloat16)(0f), (BFloat16)(0f), (BFloat16)0.0f };
             yield return new object[] { (BFloat16)(0.375f), (BFloat16)(0.3184f), CrossPlatformMachineEpsilon };             // expected:  (1 / pi)
             yield return new object[] { (BFloat16)(0.543f), (BFloat16)(0.4336f), CrossPlatformMachineEpsilon };             // expected:  (log10(e))

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/SingleTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/SingleTests.cs
@@ -1336,8 +1336,12 @@ namespace System.Tests
         [InlineData(-0.506931309f,           -0.707106781f,           CrossPlatformMachineEpsilon)]       // expected: -(1 / sqrt(2))
         [InlineData(-0.5f,                   -0.693147181f,           CrossPlatformMachineEpsilon)]       // expected: -(ln(2))
         [InlineData(-0.470922192f,           -0.636619772f,           CrossPlatformMachineEpsilon)]       // expected: -(2 / pi)
-        [InlineData(-0.0f,                    0.0f,                   0.0f)]
+        [InlineData(-1.23e-8f,               -1.23e-8f,                0.0f)]
+        [InlineData(-float.Epsilon,          -float.Epsilon,           0.0f)]
+        [InlineData(-0.0f,                   -0.0f,                     0.0f)]
         [InlineData( 0.0f,                    0.0f,                   0.0f)]
+        [InlineData( float.Epsilon,           float.Epsilon,           0.0f)]
+        [InlineData( 1.23e-8f,                1.23e-8f,                 0.0f)]
         [InlineData( 0.374802227f,            0.318309886f,           CrossPlatformMachineEpsilon)]       // expected:  (1 / pi)
         [InlineData( 0.543873444f,            0.434294482f,           CrossPlatformMachineEpsilon)]       // expected:  (log10(e))
         [InlineData( 0.890081165f,            0.636619772f,           CrossPlatformMachineEpsilon)]       // expected:  (2 / pi)


### PR DESCRIPTION
Fixes #127508.

`double.LogP1` and `float.LogP1` currently evaluate `Log(1 + x)` directly. For values near zero, the addition rounds away some or all of `x` before the logarithm runs. For example:

- `double.LogP1(1.23e-15)` returns `1.332267629550187e-15` instead of approximately `1.23e-15`.
- `double.LogP1(1.23e-20)` returns `0`.
- Tiny negative values, subnormals, and negative zero lose their sign or become positive zero.

This change compensates for the rounding error when `|x| < 0.5`:

1. Compute the rounded `u = 1 + x`.
2. Recover its addition error with `(u - 1) - x`.
3. Correct `Log(u)` by subtracting `error / u`.
4. Return `x` directly when `1 + x` rounds to `1`.

The existing implementation remains unchanged for `|x| >= 0.5`, limiting behavioral and performance impact on normal inputs. The implementation is shared managed code, so CoreCLR, Mono, NativeAOT, and WASM receive the fix without introducing separate native `log1p` entry points.

Accuracy checks against a 400-digit oracle and platform `log1p`/`log1pf` found:

- Corrected `double` results within 1 ULP over a deterministic one-million-value sweep.
- Corrected `float` results within 2 ULP over a deterministic one-million-value sweep.
- Exact results for tiny values, minimum subnormals, and signed zero.

A local diagnostic microbenchmark on macOS arm64 measured approximately +0.5 ns per call for representative normal inputs and -0.7 ns per call for tiny inputs due to the early return.

Regression coverage was added for `double`, `float`, `NFloat`, `Half`, and `BFloat16`. The full `System.Runtime` and `System.Runtime.InteropServices` test suites pass.

`TensorPrimitives.LogP1` has a separate SIMD implementation based on `Log(x + 1)` and is intentionally left for follow-up work.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.