### PR TITLE
[R2R] Handle missing virtual method signatures

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/MissingVirtualSignature/Dependency.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/MissingVirtualSignature/Dependency.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+public sealed class MissingSignatureType
+{
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/MissingVirtualSignature/Input.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/MissingVirtualSignature/Input.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public interface IMissingSignature<T>
+{
+    MissingSignatureType GetMissingType() => null;
+}
+
+public class MissingSignatureImplementation<T, U> : IMissingSignature<T>
+{
+}
+
+public class MissingSignatureFactory<T, U>
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public RuntimeTypeHandle GetTypeHandle() => typeof(MissingSignatureImplementation<T, U>).TypeHandle;
+}
+
+public static class EntryPoints
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static MissingSignatureFactory<T, U> CreateFactory<T, U>() => new MissingSignatureFactory<T, U>();
+
+    public static RuntimeTypeHandle GetTypeHandle() => CreateFactory<string, int>().GetTypeHandle();
+
+    public static int CompilableMethod() => 42;
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -1880,4 +1880,36 @@ public class R2RTestSuites
             Assert.True(R2RAssert.HasCompiledMethod(reader, "TestA`2<__Canon,int>", "TestMethod", out diag), diag);
         }
     }
+
+    [Fact]
+    public void MissingVirtualSignature()
+    {
+        var missingDependency = new CompiledAssembly
+        {
+            AssemblyName = nameof(MissingVirtualSignature) + "Dependency",
+            SourceResourceNames = ["MissingVirtualSignature/Dependency.cs"],
+        };
+        var input = new CompiledAssembly
+        {
+            AssemblyName = nameof(MissingVirtualSignature),
+            SourceResourceNames = ["MissingVirtualSignature/Input.cs"],
+            References = [missingDependency],
+        };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(MissingVirtualSignature),
+            [
+                new(nameof(MissingVirtualSignature), [new CrossgenAssembly(input)])
+                {
+                    AdditionalArgs = ["--parallelism", "1"],
+                    Validate = Validate,
+                },
+            ]));
+
+        static void Validate(ReadyToRunReader reader)
+        {
+            Assert.True(R2RAssert.HasCompiledMethod(reader, "EntryPoints", "CompilableMethod", out string diag), diag);
+            Assert.False(R2RAssert.HasCompiledMethod(reader, "IMissingSignature`1<__Canon>", "GetMissingType", out diag), diag);
+        }
+    }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestRunner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestRunner.cs
@@ -167,6 +167,10 @@ internal sealed class R2RTestCase(string name, List<CrossgenCompilation> compila
     public void SetOutputDir(string outputDir)
     {
         Compilations.ForEach(c => c.SetOutputDir(outputDir));
+        foreach (CompiledAssembly assembly in GetAssemblies())
+        {
+            assembly.SetOutputDir(outputDir);
+        }
     }
 }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
@@ -75,62 +75,68 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 result.Add(new CombinedDependencyListEntry(implNode, factory.VirtualMethodUse(decl), "Virtual method"));
             }
 
-            // Interface method path: for each interface implemented by this type,
-            // compile the implementation if the interface method slot is used.
-            DefType[] runtimeInterfaces = defType.RuntimeInterfaces;
-            DefType defTypeDefinition = (DefType)defType.GetTypeDefinition();
-            DefType[] definitionRuntimeInterfaces = defTypeDefinition.RuntimeInterfaces;
-
-            for (int interfaceIndex = 0; interfaceIndex < runtimeInterfaces.Length; interfaceIndex++)
+            try
             {
-                DefType interfaceType = runtimeInterfaces[interfaceIndex];
-                DefType definitionInterfaceType = definitionRuntimeInterfaces[interfaceIndex];
+                // Interface method path: for each interface implemented by this type,
+                // compile the implementation if the interface method slot is used.
+                DefType[] runtimeInterfaces = defType.RuntimeInterfaces;
+                DefType defTypeDefinition = (DefType)defType.GetTypeDefinition();
+                DefType[] definitionRuntimeInterfaces = defTypeDefinition.RuntimeInterfaces;
 
-                foreach (MethodDesc interfaceMethod in interfaceType.EnumAllVirtualSlots())
+                for (int interfaceIndex = 0; interfaceIndex < runtimeInterfaces.Length; interfaceIndex++)
                 {
-                    // GVMs handled in GVMDependenciesNode. SVMs handled at call site.
-                    if (interfaceMethod.HasInstantiation || interfaceMethod.Signature.IsStatic)
-                        continue;
+                    DefType interfaceType = runtimeInterfaces[interfaceIndex];
+                    DefType definitionInterfaceType = definitionRuntimeInterfaces[interfaceIndex];
 
-                    MethodDesc interfaceMethodDefinition = interfaceMethod;
-                    if (interfaceType != definitionInterfaceType)
-                        interfaceMethodDefinition = factory.TypeSystemContext.GetMethodForInstantiatedType(
-                            interfaceMethodDefinition.GetTypicalMethodDefinition(),
-                            (InstantiatedType)definitionInterfaceType);
-
-                    MethodDesc implMethod = defTypeDefinition.InstantiateAsOpen().ResolveInterfaceMethodTarget(interfaceMethodDefinition);
-                    if (implMethod is null)
+                    foreach (MethodDesc interfaceMethod in interfaceType.EnumAllVirtualSlots())
                     {
-                        // The method might be implemented through a default interface method
-                        var resolution = defTypeDefinition.InstantiateAsOpen().ResolveInterfaceMethodToDefaultImplementationOnType(interfaceMethodDefinition, out implMethod);
-                        if (resolution != DefaultInterfaceMethodResolution.DefaultImplementation)
-                        {
-                            implMethod = null;
-                        }
-                    }
+                        // GVMs handled in GVMDependenciesNode. SVMs handled at call site.
+                        if (interfaceMethod.HasInstantiation || interfaceMethod.Signature.IsStatic)
+                            continue;
 
-                    if (implMethod is not null)
-                    {
-                        implMethod = implMethod.InstantiateSignature(defType.Instantiation, Instantiation.Empty);
+                        MethodDesc interfaceMethodDefinition = interfaceMethod;
+                        if (interfaceType != definitionInterfaceType)
+                            interfaceMethodDefinition = factory.TypeSystemContext.GetMethodForInstantiatedType(
+                                interfaceMethodDefinition.GetTypicalMethodDefinition(),
+                                (InstantiatedType)definitionInterfaceType);
 
-                        if (implMethod.IsVirtual && !implMethod.IsFinal && !implMethod.OwningType.IsInterface)
+                        MethodDesc implMethod = defTypeDefinition.InstantiateAsOpen().ResolveInterfaceMethodTarget(interfaceMethodDefinition);
+                        if (implMethod is null)
                         {
-                            // The interface resolves to a virtual method that can be overridden.
-                            // Mark the class virtual slot as used so the class path compiles the
-                            // actual final target (which may be an override further down the hierarchy).
-                            result.Add(new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method"));
-                        }
-                        else
-                        {
-                            MethodDesc canonImpl = implMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                            DependencyNodeCore<NodeFactory> implNode = GetVirtualMethodImplNode(factory, canonImpl);
-                            if (implNode is not null)
+                            // The method might be implemented through a default interface method
+                            var resolution = defTypeDefinition.InstantiateAsOpen().ResolveInterfaceMethodToDefaultImplementationOnType(interfaceMethodDefinition, out implMethod);
+                            if (resolution != DefaultInterfaceMethodResolution.DefaultImplementation)
                             {
-                                result.Add(new CombinedDependencyListEntry(implNode, factory.VirtualMethodUse(interfaceMethod), "Interface method"));
+                                implMethod = null;
+                            }
+                        }
+
+                        if (implMethod is not null)
+                        {
+                            implMethod = implMethod.InstantiateSignature(defType.Instantiation, Instantiation.Empty);
+
+                            if (implMethod.IsVirtual && !implMethod.IsFinal && !implMethod.OwningType.IsInterface)
+                            {
+                                // The interface resolves to a virtual method that can be overridden.
+                                // Mark the class virtual slot as used so the class path compiles the
+                                // actual final target (which may be an override further down the hierarchy).
+                                result.Add(new CombinedDependencyListEntry(factory.VirtualMethodUse(implMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method"));
+                            }
+                            else
+                            {
+                                MethodDesc canonImpl = implMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                                DependencyNodeCore<NodeFactory> implNode = GetVirtualMethodImplNode(factory, canonImpl);
+                                if (implNode is not null)
+                                {
+                                    result.Add(new CombinedDependencyListEntry(implNode, factory.VirtualMethodUse(interfaceMethod), "Interface method"));
+                                }
                             }
                         }
                     }
                 }
+            }
+            catch (TypeSystemException)
+            {
             }
 
             return result;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
@@ -137,6 +137,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
             catch (TypeSystemException)
             {
+                // TODO: https://github.com/dotnet/runtime/issues/132338 - Gate this recovery on --resilient and report a warning.
             }
 
             return result;


### PR DESCRIPTION
## Summary

- catch `TypeSystemException` during inherited interface virtual dependency discovery
- preserve dependencies discovered before the resolution failure so affected code can fall back to runtime JIT
- add regression coverage for an interface signature that references a missing assembly

This intentionally keeps the change local to `InheritedVirtualMethodsNode`; broader resilient-mode policy and diagnostics will be handled separately.

## Testing

- verified the regression test fails before the fix at `InheritedVirtualMethodsNode.GetConditionalStaticDependencies`
- Debug `ILCompiler.ReadyToRun.Tests` build: 0 warnings, 0 errors
- `MissingVirtualSignature`: 1 passed, 0 failed

> [!NOTE]
> This pull request description was generated with GitHub Copilot.