### PR TITLE
Skip GitHub_130545 on NativeAOT

### DIFF
--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_130545.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_130545.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using TestLibrary;
 using Xunit;
 
 // Regression test for https://github.com/dotnet/runtime/issues/130545
@@ -120,6 +121,7 @@ namespace GitHub_130545
 
     public class Test
     {
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/132030", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         [Fact]
         public static void DelegateOverStaticAbstractThroughGsharedvt()
         {

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_130545.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GitHub_130545.csproj
@@ -5,4 +5,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileName).cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Tracks #132030

The `GitHub_130545` regression test was added for Mono WASM AOT and relies on reflection to force the gsharedvt path. The exact reflected method and generic argument are statically known, but NativeAOT currently fails while resolving the generic constraint metadata with `TypeLoadException`.

Temporarily skip this test only under NativeAOT while preserving its CoreCLR and Mono coverage. The test project now references `TestLibrary` for the runtime detection condition. Issue #132030 remains open to track the underlying NativeAOT reflection-metadata bug.

Validation:

- `src/tests/build.sh -Test Loader/classloader/StaticVirtualMethods/Regression/GitHub_130545.csproj x64 Release`
- 1 test project built, 0 warnings, 0 errors

> [!NOTE]
> This PR description was generated with GitHub Copilot.