### PR TITLE
Restore Windows Arm64 support for CPUs without LSE

### DIFF
--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -172,7 +172,7 @@ bool DetectCPUFeatures()
     {
 #if defined(HOST_X86) || defined(HOST_AMD64)
         PalPrintFatalError("\nThe current CPU is missing one or more of the following instruction sets: SSE, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, POPCNT\n");
-#elif defined(HOST_ARM64) && (defined(HOST_WINDOWS) || defined(HOST_OSX) || defined(HOST_MACCATALYST))
+#elif defined(HOST_ARM64) && (defined(HOST_OSX) || defined(HOST_MACCATALYST))
         PalPrintFatalError("\nThe current CPU is missing one or more of the following instruction sets: AdvSimd, LSE\n");
 #elif defined(HOST_ARM64)
         PalPrintFatalError("\nThe current CPU is missing one or more of the following instruction sets: AdvSimd\n");

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -87,12 +87,6 @@ namespace System.CommandLine
                 {
                     // We require armv8-a everywhere
                     instructionSetSupportBuilder.AddSupportedInstructionSet("armv8-a");
-
-                    if (targetOS == TargetOS.Windows)
-                    {
-                        // However, Windows also requires LSE
-                        instructionSetSupportBuilder.AddSupportedInstructionSet("lse");
-                    }
                 }
             }
             else if (targetArchitecture == TargetArchitecture.Wasm32)

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1402,7 +1402,7 @@ void EEJitManager::SetCpuInfo()
     {
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
         EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("\nThe current CPU is missing one or more of the following instruction sets: SSE, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, POPCNT\n"));
-#elif defined(TARGET_ARM64) && (defined(TARGET_WINDOWS) || defined(TARGET_OSX) || defined(TARGET_MACCATALYST))
+#elif defined(TARGET_ARM64) && (defined(TARGET_OSX) || defined(TARGET_MACCATALYST))
         EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("\nThe current CPU is missing one or more of the following instruction sets: AdvSimd, LSE\n"));
 #elif defined(TARGET_ARM64)
         EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("\nThe current CPU is missing one or more of the following instruction sets: AdvSimd\n"));

--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -677,13 +677,13 @@ int minipal_getcpufeatures(void)
 #endif // HOST_UNIX
 
 #if defined(HOST_WINDOWS)
-    if (!IsProcessorFeaturePresent(PF_ARM_V8_INSTRUCTIONS_AVAILABLE) ||
-        !IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE))
+    if (!IsProcessorFeaturePresent(PF_ARM_V8_INSTRUCTIONS_AVAILABLE))
     {
         // One of the baseline ISAs is not supported
         result |= IntrinsicConstants_Invalid;
     }
-    else
+
+    if (IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE))
     {
         result |= ARM64IntrinsicConstants_Atomics;
     }


### PR DESCRIPTION
Restore the Windows Arm64 JIT and NativeAOT minimum to Armv8-A by treating LSE as an optional CPU feature. Windows 10 IoT supports NXP i.MX 8 processors without LSE, but the current baseline rejects them during runtime startup.

The ReadyToRun baseline remains Armv8.2-A + RCPC. On affected hardware, R2R images are rejected and execution falls back to the JIT, preserving the existing R2R contract while allowing the process to run.

Fixes #132340

> [!NOTE]
> This pull request was created with GitHub Copilot.