### PR TITLE
Support deserializing read-only collections in XmlSerializer via [CollectionBuilder]

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Expected.SerializableAssembly.XmlSerializers.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Expected.SerializableAssembly.XmlSerializers.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
 
     public class XmlSerializationWriter1 : System.Xml.Serialization.XmlSerializationWriter {
 
-        public void Write126_TypeWithXmlElementProperty(object o) {
+        public void Write129_TypeWithXmlElementProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlElementProperty", @"");
@@ -16,7 +16,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write2_TypeWithXmlElementProperty(@"TypeWithXmlElementProperty", @"", ((global::TypeWithXmlElementProperty)o), true, false);
         }
 
-        public void Write127_TypeWithXmlDocumentProperty(object o) {
+        public void Write130_TypeWithXmlDocumentProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlDocumentProperty", @"");
@@ -26,7 +26,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write3_TypeWithXmlDocumentProperty(@"TypeWithXmlDocumentProperty", @"", ((global::TypeWithXmlDocumentProperty)o), true, false);
         }
 
-        public void Write128_TypeWithBinaryProperty(object o) {
+        public void Write131_TypeWithBinaryProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithBinaryProperty", @"");
@@ -36,7 +36,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write4_TypeWithBinaryProperty(@"TypeWithBinaryProperty", @"", ((global::TypeWithBinaryProperty)o), true, false);
         }
 
-        public void Write129_Item(object o) {
+        public void Write132_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDateTimeOffsetProperties", @"");
@@ -46,7 +46,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write5_Item(@"TypeWithDateTimeOffsetProperties", @"", ((global::TypeWithDateTimeOffsetProperties)o), true, false);
         }
 
-        public void Write130_Item(object o) {
+        public void Write133_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDateAndTimeOnlyProperties", @"");
@@ -56,7 +56,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write6_Item(@"TypeWithDateAndTimeOnlyProperties", @"", ((global::TypeWithDateAndTimeOnlyProperties)o), true, false);
         }
 
-        public void Write131_DateOnlyWrapper(object o) {
+        public void Write134_DateOnlyWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DateOnlyWrapper", @"");
@@ -66,7 +66,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write7_DateOnlyWrapper(@"DateOnlyWrapper", @"", ((global::DateOnlyWrapper)o), true, false);
         }
 
-        public void Write132_TimeOnlyWrapper(object o) {
+        public void Write135_TimeOnlyWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TimeOnlyWrapper", @"");
@@ -76,7 +76,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write8_TimeOnlyWrapper(@"TimeOnlyWrapper", @"", ((global::TimeOnlyWrapper)o), true, false);
         }
 
-        public void Write133_TimeOnlyAsXsdTimeWrapper(object o) {
+        public void Write136_TimeOnlyAsXsdTimeWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TimeOnlyAsXsdTimeWrapper", @"");
@@ -86,7 +86,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write9_TimeOnlyAsXsdTimeWrapper(@"TimeOnlyAsXsdTimeWrapper", @"", ((global::TimeOnlyAsXsdTimeWrapper)o), true, false);
         }
 
-        public void Write134_DateTimeDateWrapper(object o) {
+        public void Write137_DateTimeDateWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DateTimeDateWrapper", @"");
@@ -96,7 +96,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write10_DateTimeDateWrapper(@"DateTimeDateWrapper", @"", ((global::DateTimeDateWrapper)o), true, false);
         }
 
-        public void Write135_DateTimeTimeWrapper(object o) {
+        public void Write138_DateTimeTimeWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DateTimeTimeWrapper", @"");
@@ -106,7 +106,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write11_DateTimeTimeWrapper(@"DateTimeTimeWrapper", @"", ((global::DateTimeTimeWrapper)o), true, false);
         }
 
-        public void Write136_TypeWithTimeSpanProperty(object o) {
+        public void Write139_TypeWithTimeSpanProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithTimeSpanProperty", @"");
@@ -116,7 +116,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write12_TypeWithTimeSpanProperty(@"TypeWithTimeSpanProperty", @"", ((global::TypeWithTimeSpanProperty)o), true, false);
         }
 
-        public void Write137_Item(object o) {
+        public void Write140_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDefaultTimeSpanProperty", @"");
@@ -126,7 +126,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write13_Item(@"TypeWithDefaultTimeSpanProperty", @"", ((global::TypeWithDefaultTimeSpanProperty)o), true, false);
         }
 
-        public void Write138_TypeWithByteProperty(object o) {
+        public void Write141_TypeWithByteProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithByteProperty", @"");
@@ -136,7 +136,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write14_TypeWithByteProperty(@"TypeWithByteProperty", @"", ((global::TypeWithByteProperty)o), true, false);
         }
 
-        public void Write139_TypeWithXmlNodeArrayProperty(object o) {
+        public void Write142_TypeWithXmlNodeArrayProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlNodeArrayProperty", @"");
@@ -146,7 +146,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write15_TypeWithXmlNodeArrayProperty(@"TypeWithXmlNodeArrayProperty", @"", ((global::TypeWithXmlNodeArrayProperty)o), true, false);
         }
 
-        public void Write140_Animal(object o) {
+        public void Write143_Animal(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Animal", @"");
@@ -156,7 +156,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write16_Animal(@"Animal", @"", ((global::Animal)o), true, false);
         }
 
-        public void Write141_Dog(object o) {
+        public void Write144_Dog(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Dog", @"");
@@ -166,7 +166,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write18_Dog(@"Dog", @"", ((global::Dog)o), true, false);
         }
 
-        public void Write142_DogBreed(object o) {
+        public void Write145_DogBreed(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"DogBreed", @"");
@@ -175,7 +175,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteElementString(@"DogBreed", @"", Write17_DogBreed(((global::DogBreed)o)));
         }
 
-        public void Write143_Group(object o) {
+        public void Write146_Group(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Group", @"");
@@ -185,7 +185,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write20_Group(@"Group", @"", ((global::Group)o), true, false);
         }
 
-        public void Write144_Vehicle(object o) {
+        public void Write147_Vehicle(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Vehicle", @"");
@@ -195,7 +195,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write19_Vehicle(@"Vehicle", @"", ((global::Vehicle)o), true, false);
         }
 
-        public void Write145_Employee(object o) {
+        public void Write148_Employee(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Employee", @"");
@@ -205,7 +205,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write21_Employee(@"Employee", @"", ((global::Employee)o), true, false);
         }
 
-        public void Write146_BaseClass(object o) {
+        public void Write149_BaseClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseClass", @"");
@@ -215,7 +215,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write23_BaseClass(@"BaseClass", @"", ((global::BaseClass)o), true, false);
         }
 
-        public void Write147_DerivedClass(object o) {
+        public void Write150_DerivedClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedClass", @"");
@@ -225,7 +225,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write22_DerivedClass(@"DerivedClass", @"", ((global::DerivedClass)o), true, false);
         }
 
-        public void Write148_SimpleBaseClass(object o) {
+        public void Write151_SimpleBaseClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleBaseClass", @"");
@@ -235,7 +235,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write25_SimpleBaseClass(@"SimpleBaseClass", @"", ((global::SimpleBaseClass)o), true, false);
         }
 
-        public void Write149_SimpleDerivedClass(object o) {
+        public void Write152_SimpleDerivedClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleDerivedClass", @"");
@@ -245,7 +245,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write24_SimpleDerivedClass(@"SimpleDerivedClass", @"", ((global::SimpleDerivedClass)o), true, false);
         }
 
-        public void Write150_BaseIXmlSerializable(object o) {
+        public void Write153_BaseIXmlSerializable(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseIXmlSerializable", @"http://example.com/serializer-test-namespace");
@@ -255,7 +255,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::XmlSerializableBaseClass)o), @"BaseIXmlSerializable", @"http://example.com/serializer-test-namespace", true, true);
         }
 
-        public void Write151_DerivedIXmlSerializable(object o) {
+        public void Write154_DerivedIXmlSerializable(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedIXmlSerializable", @"");
@@ -265,7 +265,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::XmlSerializableDerivedClass)o), @"DerivedIXmlSerializable", @"", true, true);
         }
 
-        public void Write152_PurchaseOrder(object o) {
+        public void Write155_PurchaseOrder(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"PurchaseOrder", @"http://www.contoso1.com");
@@ -275,7 +275,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write28_PurchaseOrder(@"PurchaseOrder", @"http://www.contoso1.com", ((global::PurchaseOrder)o), false, false);
         }
 
-        public void Write153_Address(object o) {
+        public void Write156_Address(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Address", @"");
@@ -285,7 +285,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write29_Address(@"Address", @"", ((global::Address)o), true, false);
         }
 
-        public void Write154_OrderedItem(object o) {
+        public void Write157_OrderedItem(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"OrderedItem", @"");
@@ -295,7 +295,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write30_OrderedItem(@"OrderedItem", @"", ((global::OrderedItem)o), true, false);
         }
 
-        public void Write155_AliasedTestType(object o) {
+        public void Write158_AliasedTestType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"AliasedTestType", @"");
@@ -305,7 +305,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write31_AliasedTestType(@"AliasedTestType", @"", ((global::AliasedTestType)o), true, false);
         }
 
-        public void Write156_BaseClass1(object o) {
+        public void Write159_BaseClass1(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseClass1", @"");
@@ -315,7 +315,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write32_BaseClass1(@"BaseClass1", @"", ((global::BaseClass1)o), true, false);
         }
 
-        public void Write157_DerivedClass1(object o) {
+        public void Write160_DerivedClass1(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedClass1", @"");
@@ -325,7 +325,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write33_DerivedClass1(@"DerivedClass1", @"", ((global::DerivedClass1)o), true, false);
         }
 
-        public void Write158_ArrayOfDateTime(object o) {
+        public void Write161_ArrayOfDateTime(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ArrayOfDateTime", @"");
@@ -350,7 +350,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        public void Write159_Orchestra(object o) {
+        public void Write162_Orchestra(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Orchestra", @"");
@@ -360,7 +360,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write35_Orchestra(@"Orchestra", @"", ((global::Orchestra)o), true, false);
         }
 
-        public void Write160_Instrument(object o) {
+        public void Write163_Instrument(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Instrument", @"");
@@ -370,7 +370,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write34_Instrument(@"Instrument", @"", ((global::Instrument)o), true, false);
         }
 
-        public void Write161_Brass(object o) {
+        public void Write164_Brass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Brass", @"");
@@ -380,7 +380,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write36_Brass(@"Brass", @"", ((global::Brass)o), true, false);
         }
 
-        public void Write162_Trumpet(object o) {
+        public void Write165_Trumpet(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Trumpet", @"");
@@ -390,7 +390,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write37_Trumpet(@"Trumpet", @"", ((global::Trumpet)o), true, false);
         }
 
-        public void Write163_Pet(object o) {
+        public void Write166_Pet(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Pet", @"");
@@ -400,7 +400,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write38_Pet(@"Pet", @"", ((global::Pet)o), true, false);
         }
 
-        public void Write164_DefaultValuesSetToNaN(object o) {
+        public void Write167_DefaultValuesSetToNaN(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DefaultValuesSetToNaN", @"");
@@ -410,7 +410,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write39_DefaultValuesSetToNaN(@"DefaultValuesSetToNaN", @"", ((global::DefaultValuesSetToNaN)o), true, false);
         }
 
-        public void Write165_Item(object o) {
+        public void Write168_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DefaultValuesSetToPositiveInfinity", @"");
@@ -420,7 +420,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write40_Item(@"DefaultValuesSetToPositiveInfinity", @"", ((global::DefaultValuesSetToPositiveInfinity)o), true, false);
         }
 
-        public void Write166_Item(object o) {
+        public void Write169_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DefaultValuesSetToNegativeInfinity", @"");
@@ -430,7 +430,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write41_Item(@"DefaultValuesSetToNegativeInfinity", @"", ((global::DefaultValuesSetToNegativeInfinity)o), true, false);
         }
 
-        public void Write167_RootElement(object o) {
+        public void Write170_RootElement(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"RootElement", @"");
@@ -440,7 +440,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write42_Item(@"RootElement", @"", ((global::TypeWithMismatchBetweenAttributeAndPropertyType)o), true, false);
         }
 
-        public void Write168_TypeWithLinkedProperty(object o) {
+        public void Write171_TypeWithLinkedProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithLinkedProperty", @"");
@@ -450,7 +450,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write43_TypeWithLinkedProperty(@"TypeWithLinkedProperty", @"", ((global::TypeWithLinkedProperty)o), true, false);
         }
 
-        public void Write169_Document(object o) {
+        public void Write172_Document(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Document", @"http://example.com");
@@ -460,7 +460,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write44_MsgDocumentType(@"Document", @"http://example.com", ((global::MsgDocumentType)o), true, false);
         }
 
-        public void Write170_RootClass(object o) {
+        public void Write173_RootClass(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"RootClass", @"");
@@ -470,7 +470,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write47_RootClass(@"RootClass", @"", ((global::RootClass)o), true, false);
         }
 
-        public void Write171_Parameter(object o) {
+        public void Write174_Parameter(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Parameter", @"");
@@ -480,7 +480,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write46_Parameter(@"Parameter", @"", ((global::Parameter)o), true, false);
         }
 
-        public void Write172_XElementWrapper(object o) {
+        public void Write175_XElementWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"XElementWrapper", @"");
@@ -490,7 +490,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write48_XElementWrapper(@"XElementWrapper", @"", ((global::XElementWrapper)o), true, false);
         }
 
-        public void Write173_XElementStruct(object o) {
+        public void Write176_XElementStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"XElementStruct", @"");
@@ -499,7 +499,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write49_XElementStruct(@"XElementStruct", @"", ((global::XElementStruct)o), false);
         }
 
-        public void Write174_XElementArrayWrapper(object o) {
+        public void Write177_XElementArrayWrapper(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"XElementArrayWrapper", @"");
@@ -509,7 +509,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             Write50_XElementArrayWrapper(@"XElementArrayWrapper", @"", ((global::XElementArrayWrapper)o), true, false);
         }
 
-        public void Write175_Item(object o) {
+        public void Write178_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DateTimeOffsetIXmlSerializableContainer", @"");
@@ -519,86 +519,116 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::DateTimeOffsetIXmlSerializableContainer)o), @"DateTimeOffsetIXmlSerializableContainer", @"", true, true);
         }
 
-        public void Write176_TypeWithDateTimeStringProperty(object o) {
+        public void Write179_TypeWithReadOnlyCollections(object o) {
+            WriteStartDocument();
+            if (o == null) {
+                WriteNullTagLiteral(@"TypeWithReadOnlyCollections", @"");
+                return;
+            }
+            TopLevelElement();
+            Write51_TypeWithReadOnlyCollections(@"TypeWithReadOnlyCollections", @"", ((global::TypeWithReadOnlyCollections)o), true, false);
+        }
+
+        public void Write180_Item(object o) {
+            WriteStartDocument();
+            if (o == null) {
+                WriteNullTagLiteral(@"TypeWithMutableCollectionMembers", @"");
+                return;
+            }
+            TopLevelElement();
+            Write52_Item(@"TypeWithMutableCollectionMembers", @"", ((global::TypeWithMutableCollectionMembers)o), true, false);
+        }
+
+        public void Write181_Item(object o) {
+            WriteStartDocument();
+            if (o == null) {
+                WriteNullTagLiteral(@"TypeWithGetOnlyReadOnlyCollections", @"");
+                return;
+            }
+            TopLevelElement();
+            Write53_Item(@"TypeWithGetOnlyReadOnlyCollections", @"", ((global::TypeWithGetOnlyReadOnlyCollections)o), true, false);
+        }
+
+        public void Write182_TypeWithDateTimeStringProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDateTimeStringProperty", @"");
                 return;
             }
             TopLevelElement();
-            Write51_TypeWithDateTimeStringProperty(@"TypeWithDateTimeStringProperty", @"", ((global::SerializationTypes.TypeWithDateTimeStringProperty)o), true, false);
+            Write54_TypeWithDateTimeStringProperty(@"TypeWithDateTimeStringProperty", @"", ((global::SerializationTypes.TypeWithDateTimeStringProperty)o), true, false);
         }
 
-        public void Write177_SimpleType(object o) {
+        public void Write183_SimpleType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleType", @"");
                 return;
             }
             TopLevelElement();
-            Write52_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)o), true, false);
+            Write55_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)o), true, false);
         }
 
-        public void Write178_TypeWithGetSetArrayMembers(object o) {
+        public void Write184_TypeWithGetSetArrayMembers(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithGetSetArrayMembers", @"");
                 return;
             }
             TopLevelElement();
-            Write53_TypeWithGetSetArrayMembers(@"TypeWithGetSetArrayMembers", @"", ((global::SerializationTypes.TypeWithGetSetArrayMembers)o), true, false);
+            Write56_TypeWithGetSetArrayMembers(@"TypeWithGetSetArrayMembers", @"", ((global::SerializationTypes.TypeWithGetSetArrayMembers)o), true, false);
         }
 
-        public void Write179_TypeWithGetOnlyArrayProperties(object o) {
+        public void Write185_TypeWithGetOnlyArrayProperties(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithGetOnlyArrayProperties", @"");
                 return;
             }
             TopLevelElement();
-            Write54_TypeWithGetOnlyArrayProperties(@"TypeWithGetOnlyArrayProperties", @"", ((global::SerializationTypes.TypeWithGetOnlyArrayProperties)o), true, false);
+            Write57_TypeWithGetOnlyArrayProperties(@"TypeWithGetOnlyArrayProperties", @"", ((global::SerializationTypes.TypeWithGetOnlyArrayProperties)o), true, false);
         }
 
-        public void Write180_TypeWithArraylikeMembers(object o) {
+        public void Write186_TypeWithArraylikeMembers(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithArraylikeMembers", @"");
                 return;
             }
             TopLevelElement();
-            Write55_TypeWithArraylikeMembers(@"TypeWithArraylikeMembers", @"", ((global::SerializationTypes.TypeWithArraylikeMembers)o), true, false);
+            Write58_TypeWithArraylikeMembers(@"TypeWithArraylikeMembers", @"", ((global::SerializationTypes.TypeWithArraylikeMembers)o), true, false);
         }
 
-        public void Write181_StructNotSerializable(object o) {
+        public void Write187_StructNotSerializable(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"StructNotSerializable", @"");
                 return;
             }
-            Write56_StructNotSerializable(@"StructNotSerializable", @"", ((global::SerializationTypes.StructNotSerializable)o), false);
+            Write59_StructNotSerializable(@"StructNotSerializable", @"", ((global::SerializationTypes.StructNotSerializable)o), false);
         }
 
-        public void Write182_TypeWithMyCollectionField(object o) {
+        public void Write188_TypeWithMyCollectionField(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithMyCollectionField", @"");
                 return;
             }
             TopLevelElement();
-            Write57_TypeWithMyCollectionField(@"TypeWithMyCollectionField", @"", ((global::SerializationTypes.TypeWithMyCollectionField)o), true, false);
+            Write60_TypeWithMyCollectionField(@"TypeWithMyCollectionField", @"", ((global::SerializationTypes.TypeWithMyCollectionField)o), true, false);
         }
 
-        public void Write183_Item(object o) {
+        public void Write189_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithReadOnlyMyCollectionProperty", @"");
                 return;
             }
             TopLevelElement();
-            Write58_Item(@"TypeWithReadOnlyMyCollectionProperty", @"", ((global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty)o), true, false);
+            Write61_Item(@"TypeWithReadOnlyMyCollectionProperty", @"", ((global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty)o), true, false);
         }
 
-        public void Write184_ArrayOfAnyType(object o) {
+        public void Write190_ArrayOfAnyType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ArrayOfAnyType", @"");
@@ -620,355 +650,355 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        public void Write185_MyEnum(object o) {
+        public void Write191_MyEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"MyEnum", @"");
                 return;
             }
-            WriteElementString(@"MyEnum", @"", Write59_MyEnum(((global::SerializationTypes.MyEnum)o)));
+            WriteElementString(@"MyEnum", @"", Write62_MyEnum(((global::SerializationTypes.MyEnum)o)));
         }
 
-        public void Write186_TypeWithEnumMembers(object o) {
+        public void Write192_TypeWithEnumMembers(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithEnumMembers", @"");
                 return;
             }
             TopLevelElement();
-            Write60_TypeWithEnumMembers(@"TypeWithEnumMembers", @"", ((global::SerializationTypes.TypeWithEnumMembers)o), true, false);
+            Write63_TypeWithEnumMembers(@"TypeWithEnumMembers", @"", ((global::SerializationTypes.TypeWithEnumMembers)o), true, false);
         }
 
-        public void Write187_DCStruct(object o) {
+        public void Write193_DCStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"DCStruct", @"");
                 return;
             }
-            Write61_DCStruct(@"DCStruct", @"", ((global::SerializationTypes.DCStruct)o), false);
+            Write64_DCStruct(@"DCStruct", @"", ((global::SerializationTypes.DCStruct)o), false);
         }
 
-        public void Write188_DCClassWithEnumAndStruct(object o) {
+        public void Write194_DCClassWithEnumAndStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DCClassWithEnumAndStruct", @"");
                 return;
             }
             TopLevelElement();
-            Write62_DCClassWithEnumAndStruct(@"DCClassWithEnumAndStruct", @"", ((global::SerializationTypes.DCClassWithEnumAndStruct)o), true, false);
+            Write65_DCClassWithEnumAndStruct(@"DCClassWithEnumAndStruct", @"", ((global::SerializationTypes.DCClassWithEnumAndStruct)o), true, false);
         }
 
-        public void Write189_BuiltInTypes(object o) {
+        public void Write195_BuiltInTypes(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BuiltInTypes", @"");
                 return;
             }
             TopLevelElement();
-            Write63_BuiltInTypes(@"BuiltInTypes", @"", ((global::SerializationTypes.BuiltInTypes)o), true, false);
+            Write66_BuiltInTypes(@"BuiltInTypes", @"", ((global::SerializationTypes.BuiltInTypes)o), true, false);
         }
 
-        public void Write190_TypeWithBuiltInTypedMembers(object o) {
+        public void Write196_TypeWithBuiltInTypedMembers(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithBuiltInTypedMembers", @"");
                 return;
             }
             TopLevelElement();
-            Write64_TypeWithBuiltInTypedMembers(@"TypeWithBuiltInTypedMembers", @"", ((global::SerializationTypes.TypeWithBuiltInTypedMembers)o), true, false);
+            Write67_TypeWithBuiltInTypedMembers(@"TypeWithBuiltInTypedMembers", @"", ((global::SerializationTypes.TypeWithBuiltInTypedMembers)o), true, false);
         }
 
-        public void Write191_Item(object o) {
+        public void Write197_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithNullableBuiltInTypedMembers", @"");
                 return;
             }
             TopLevelElement();
-            Write65_Item(@"TypeWithNullableBuiltInTypedMembers", @"", ((global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)o), true, false);
+            Write68_Item(@"TypeWithNullableBuiltInTypedMembers", @"", ((global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)o), true, false);
         }
 
-        public void Write192_TypeA(object o) {
+        public void Write198_TypeA(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeA", @"");
                 return;
             }
             TopLevelElement();
-            Write66_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)o), true, false);
+            Write69_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)o), true, false);
         }
 
-        public void Write193_TypeB(object o) {
+        public void Write199_TypeB(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeB", @"");
                 return;
             }
             TopLevelElement();
-            Write67_TypeB(@"TypeB", @"", ((global::SerializationTypes.TypeB)o), true, false);
+            Write70_TypeB(@"TypeB", @"", ((global::SerializationTypes.TypeB)o), true, false);
         }
 
-        public void Write194_TypeHasArrayOfASerializedAsB(object o) {
+        public void Write200_TypeHasArrayOfASerializedAsB(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeHasArrayOfASerializedAsB", @"");
                 return;
             }
             TopLevelElement();
-            Write68_TypeHasArrayOfASerializedAsB(@"TypeHasArrayOfASerializedAsB", @"", ((global::SerializationTypes.TypeHasArrayOfASerializedAsB)o), true, false);
+            Write71_TypeHasArrayOfASerializedAsB(@"TypeHasArrayOfASerializedAsB", @"", ((global::SerializationTypes.TypeHasArrayOfASerializedAsB)o), true, false);
         }
 
-        public void Write195_Item(object o) {
+        public void Write201_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"__TypeNameWithSpecialCharacters漢ñ", @"");
                 return;
             }
             TopLevelElement();
-            Write69_Item(@"__TypeNameWithSpecialCharacters漢ñ", @"", ((global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)o), true, false);
+            Write72_Item(@"__TypeNameWithSpecialCharacters漢ñ", @"", ((global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)o), true, false);
         }
 
-        public void Write196_BaseClassWithSamePropertyName(object o) {
+        public void Write202_BaseClassWithSamePropertyName(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseClassWithSamePropertyName", @"");
                 return;
             }
             TopLevelElement();
-            Write70_BaseClassWithSamePropertyName(@"BaseClassWithSamePropertyName", @"", ((global::SerializationTypes.BaseClassWithSamePropertyName)o), true, false);
+            Write73_BaseClassWithSamePropertyName(@"BaseClassWithSamePropertyName", @"", ((global::SerializationTypes.BaseClassWithSamePropertyName)o), true, false);
         }
 
-        public void Write197_DerivedClassWithSameProperty(object o) {
+        public void Write203_DerivedClassWithSameProperty(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedClassWithSameProperty", @"");
                 return;
             }
             TopLevelElement();
-            Write71_DerivedClassWithSameProperty(@"DerivedClassWithSameProperty", @"", ((global::SerializationTypes.DerivedClassWithSameProperty)o), true, false);
+            Write74_DerivedClassWithSameProperty(@"DerivedClassWithSameProperty", @"", ((global::SerializationTypes.DerivedClassWithSameProperty)o), true, false);
         }
 
-        public void Write198_DerivedClassWithSameProperty2(object o) {
+        public void Write204_DerivedClassWithSameProperty2(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedClassWithSameProperty2", @"");
                 return;
             }
             TopLevelElement();
-            Write72_DerivedClassWithSameProperty2(@"DerivedClassWithSameProperty2", @"", ((global::SerializationTypes.DerivedClassWithSameProperty2)o), true, false);
+            Write75_DerivedClassWithSameProperty2(@"DerivedClassWithSameProperty2", @"", ((global::SerializationTypes.DerivedClassWithSameProperty2)o), true, false);
         }
 
-        public void Write199_Item(object o) {
+        public void Write205_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithDateTimePropertyAsXmlTime", @"");
                 return;
             }
             TopLevelElement();
-            Write73_Item(@"TypeWithDateTimePropertyAsXmlTime", @"", ((global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)o), true, false);
+            Write76_Item(@"TypeWithDateTimePropertyAsXmlTime", @"", ((global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)o), true, false);
         }
 
-        public void Write200_TypeWithByteArrayAsXmlText(object o) {
+        public void Write206_TypeWithByteArrayAsXmlText(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithByteArrayAsXmlText", @"");
                 return;
             }
             TopLevelElement();
-            Write74_TypeWithByteArrayAsXmlText(@"TypeWithByteArrayAsXmlText", @"", ((global::SerializationTypes.TypeWithByteArrayAsXmlText)o), true, false);
+            Write77_TypeWithByteArrayAsXmlText(@"TypeWithByteArrayAsXmlText", @"", ((global::SerializationTypes.TypeWithByteArrayAsXmlText)o), true, false);
         }
 
-        public void Write201_SimpleDC(object o) {
+        public void Write207_SimpleDC(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleDC", @"");
                 return;
             }
             TopLevelElement();
-            Write75_SimpleDC(@"SimpleDC", @"", ((global::SerializationTypes.SimpleDC)o), true, false);
+            Write78_SimpleDC(@"SimpleDC", @"", ((global::SerializationTypes.SimpleDC)o), true, false);
         }
 
-        public void Write202_Item(object o) {
+        public void Write208_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"TypeWithXmlTextAttributeOnArray", @"http://schemas.xmlsoap.org/ws/2005/04/discovery");
                 return;
             }
             TopLevelElement();
-            Write76_Item(@"TypeWithXmlTextAttributeOnArray", @"http://schemas.xmlsoap.org/ws/2005/04/discovery", ((global::SerializationTypes.TypeWithXmlTextAttributeOnArray)o), false, false);
+            Write79_Item(@"TypeWithXmlTextAttributeOnArray", @"http://schemas.xmlsoap.org/ws/2005/04/discovery", ((global::SerializationTypes.TypeWithXmlTextAttributeOnArray)o), false, false);
         }
 
-        public void Write203_EnumFlags(object o) {
+        public void Write209_EnumFlags(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"EnumFlags", @"");
                 return;
             }
-            WriteElementString(@"EnumFlags", @"", Write77_EnumFlags(((global::SerializationTypes.EnumFlags)o)));
+            WriteElementString(@"EnumFlags", @"", Write80_EnumFlags(((global::SerializationTypes.EnumFlags)o)));
         }
 
-        public void Write204_ClassImplementsInterface(object o) {
+        public void Write210_ClassImplementsInterface(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ClassImplementsInterface", @"");
                 return;
             }
             TopLevelElement();
-            Write78_ClassImplementsInterface(@"ClassImplementsInterface", @"", ((global::SerializationTypes.ClassImplementsInterface)o), true, false);
+            Write81_ClassImplementsInterface(@"ClassImplementsInterface", @"", ((global::SerializationTypes.ClassImplementsInterface)o), true, false);
         }
 
-        public void Write205_WithStruct(object o) {
+        public void Write211_WithStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"WithStruct", @"");
                 return;
             }
             TopLevelElement();
-            Write80_WithStruct(@"WithStruct", @"", ((global::SerializationTypes.WithStruct)o), true, false);
+            Write83_WithStruct(@"WithStruct", @"", ((global::SerializationTypes.WithStruct)o), true, false);
         }
 
-        public void Write206_SomeStruct(object o) {
+        public void Write212_SomeStruct(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"SomeStruct", @"");
                 return;
             }
-            Write79_SomeStruct(@"SomeStruct", @"", ((global::SerializationTypes.SomeStruct)o), false);
+            Write82_SomeStruct(@"SomeStruct", @"", ((global::SerializationTypes.SomeStruct)o), false);
         }
 
-        public void Write207_WithEnums(object o) {
+        public void Write213_WithEnums(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"WithEnums", @"");
                 return;
             }
             TopLevelElement();
-            Write83_WithEnums(@"WithEnums", @"", ((global::SerializationTypes.WithEnums)o), true, false);
+            Write86_WithEnums(@"WithEnums", @"", ((global::SerializationTypes.WithEnums)o), true, false);
         }
 
-        public void Write208_WithNullables(object o) {
+        public void Write214_WithNullables(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"WithNullables", @"");
                 return;
             }
             TopLevelElement();
-            Write84_WithNullables(@"WithNullables", @"", ((global::SerializationTypes.WithNullables)o), true, false);
+            Write87_WithNullables(@"WithNullables", @"", ((global::SerializationTypes.WithNullables)o), true, false);
         }
 
-        public void Write209_ByteEnum(object o) {
+        public void Write215_ByteEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"ByteEnum", @"");
                 return;
             }
-            WriteElementString(@"ByteEnum", @"", Write85_ByteEnum(((global::SerializationTypes.ByteEnum)o)));
+            WriteElementString(@"ByteEnum", @"", Write88_ByteEnum(((global::SerializationTypes.ByteEnum)o)));
         }
 
-        public void Write210_SByteEnum(object o) {
+        public void Write216_SByteEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"SByteEnum", @"");
                 return;
             }
-            WriteElementString(@"SByteEnum", @"", Write86_SByteEnum(((global::SerializationTypes.SByteEnum)o)));
+            WriteElementString(@"SByteEnum", @"", Write89_SByteEnum(((global::SerializationTypes.SByteEnum)o)));
         }
 
-        public void Write211_ShortEnum(object o) {
+        public void Write217_ShortEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"ShortEnum", @"");
                 return;
             }
-            WriteElementString(@"ShortEnum", @"", Write82_ShortEnum(((global::SerializationTypes.ShortEnum)o)));
+            WriteElementString(@"ShortEnum", @"", Write85_ShortEnum(((global::SerializationTypes.ShortEnum)o)));
         }
 
-        public void Write212_IntEnum(object o) {
+        public void Write218_IntEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"IntEnum", @"");
                 return;
             }
-            WriteElementString(@"IntEnum", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o)));
+            WriteElementString(@"IntEnum", @"", Write84_IntEnum(((global::SerializationTypes.IntEnum)o)));
         }
 
-        public void Write213_UIntEnum(object o) {
+        public void Write219_UIntEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"UIntEnum", @"");
                 return;
             }
-            WriteElementString(@"UIntEnum", @"", Write87_UIntEnum(((global::SerializationTypes.UIntEnum)o)));
+            WriteElementString(@"UIntEnum", @"", Write90_UIntEnum(((global::SerializationTypes.UIntEnum)o)));
         }
 
-        public void Write214_LongEnum(object o) {
+        public void Write220_LongEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"LongEnum", @"");
                 return;
             }
-            WriteElementString(@"LongEnum", @"", Write88_LongEnum(((global::SerializationTypes.LongEnum)o)));
+            WriteElementString(@"LongEnum", @"", Write91_LongEnum(((global::SerializationTypes.LongEnum)o)));
         }
 
-        public void Write215_ULongEnum(object o) {
+        public void Write221_ULongEnum(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"ULongEnum", @"");
                 return;
             }
-            WriteElementString(@"ULongEnum", @"", Write89_ULongEnum(((global::SerializationTypes.ULongEnum)o)));
+            WriteElementString(@"ULongEnum", @"", Write92_ULongEnum(((global::SerializationTypes.ULongEnum)o)));
         }
 
-        public void Write216_AttributeTesting(object o) {
+        public void Write222_AttributeTesting(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"AttributeTesting", @"");
                 return;
             }
             TopLevelElement();
-            Write91_XmlSerializerAttributes(@"AttributeTesting", @"", ((global::SerializationTypes.XmlSerializerAttributes)o), false, false);
+            Write94_XmlSerializerAttributes(@"AttributeTesting", @"", ((global::SerializationTypes.XmlSerializerAttributes)o), false, false);
         }
 
-        public void Write217_ItemChoiceType(object o) {
+        public void Write223_ItemChoiceType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"ItemChoiceType", @"");
                 return;
             }
-            WriteElementString(@"ItemChoiceType", @"", Write90_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)o)));
+            WriteElementString(@"ItemChoiceType", @"", Write93_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)o)));
         }
 
-        public void Write218_TypeWithAnyAttribute(object o) {
+        public void Write224_TypeWithAnyAttribute(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithAnyAttribute", @"");
                 return;
             }
             TopLevelElement();
-            Write92_TypeWithAnyAttribute(@"TypeWithAnyAttribute", @"", ((global::SerializationTypes.TypeWithAnyAttribute)o), true, false);
+            Write95_TypeWithAnyAttribute(@"TypeWithAnyAttribute", @"", ((global::SerializationTypes.TypeWithAnyAttribute)o), true, false);
         }
 
-        public void Write219_KnownTypesThroughConstructor(object o) {
+        public void Write225_KnownTypesThroughConstructor(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"KnownTypesThroughConstructor", @"");
                 return;
             }
             TopLevelElement();
-            Write93_KnownTypesThroughConstructor(@"KnownTypesThroughConstructor", @"", ((global::SerializationTypes.KnownTypesThroughConstructor)o), true, false);
+            Write96_KnownTypesThroughConstructor(@"KnownTypesThroughConstructor", @"", ((global::SerializationTypes.KnownTypesThroughConstructor)o), true, false);
         }
 
-        public void Write220_SimpleKnownTypeValue(object o) {
+        public void Write226_SimpleKnownTypeValue(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"SimpleKnownTypeValue", @"");
                 return;
             }
             TopLevelElement();
-            Write94_SimpleKnownTypeValue(@"SimpleKnownTypeValue", @"", ((global::SerializationTypes.SimpleKnownTypeValue)o), true, false);
+            Write97_SimpleKnownTypeValue(@"SimpleKnownTypeValue", @"", ((global::SerializationTypes.SimpleKnownTypeValue)o), true, false);
         }
 
-        public void Write221_Item(object o) {
+        public void Write227_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ClassImplementingIXmlSerializable", @"");
@@ -978,7 +1008,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::SerializationTypes.ClassImplementingIXmlSerializable)o), @"ClassImplementingIXmlSerializable", @"", true, true);
         }
 
-        public void Write222_Item(object o) {
+        public void Write228_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor", @"");
@@ -987,7 +1017,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor)o), @"StructImplementingIXmlSerializableWithoutParameterlessConstructor", @"", false, true);
         }
 
-        public void Write223_Item(object o) {
+        public void Write229_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"StructImplementingIXmlSerializableWithParameterlessConstructor", @"");
@@ -996,67 +1026,67 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteSerializable((System.Xml.Serialization.IXmlSerializable)((global::SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor)o), @"StructImplementingIXmlSerializableWithParameterlessConstructor", @"", false, true);
         }
 
-        public void Write224_TypeWithPropertyNameSpecified(object o) {
+        public void Write230_TypeWithPropertyNameSpecified(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithPropertyNameSpecified", @"");
                 return;
             }
             TopLevelElement();
-            Write95_TypeWithPropertyNameSpecified(@"TypeWithPropertyNameSpecified", @"", ((global::SerializationTypes.TypeWithPropertyNameSpecified)o), true, false);
+            Write98_TypeWithPropertyNameSpecified(@"TypeWithPropertyNameSpecified", @"", ((global::SerializationTypes.TypeWithPropertyNameSpecified)o), true, false);
         }
 
-        public void Write225_TypeWithXmlSchemaFormAttribute(object o) {
+        public void Write231_TypeWithXmlSchemaFormAttribute(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlSchemaFormAttribute", @"");
                 return;
             }
             TopLevelElement();
-            Write96_TypeWithXmlSchemaFormAttribute(@"TypeWithXmlSchemaFormAttribute", @"", ((global::SerializationTypes.TypeWithXmlSchemaFormAttribute)o), true, false);
+            Write99_TypeWithXmlSchemaFormAttribute(@"TypeWithXmlSchemaFormAttribute", @"", ((global::SerializationTypes.TypeWithXmlSchemaFormAttribute)o), true, false);
         }
 
-        public void Write226_MyXmlType(object o) {
+        public void Write232_MyXmlType(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"MyXmlType", @"");
                 return;
             }
             TopLevelElement();
-            Write97_Item(@"MyXmlType", @"", ((global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)o), true, false);
+            Write100_Item(@"MyXmlType", @"", ((global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)o), true, false);
         }
 
-        public void Write227_Item(object o) {
+        public void Write233_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithSchemaFormInXmlAttribute", @"");
                 return;
             }
             TopLevelElement();
-            Write98_Item(@"TypeWithSchemaFormInXmlAttribute", @"", ((global::SerializationTypes.TypeWithSchemaFormInXmlAttribute)o), true, false);
+            Write101_Item(@"TypeWithSchemaFormInXmlAttribute", @"", ((global::SerializationTypes.TypeWithSchemaFormInXmlAttribute)o), true, false);
         }
 
-        public void Write228_CustomDocument(object o) {
+        public void Write234_CustomDocument(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"CustomDocument", @"");
                 return;
             }
             TopLevelElement();
-            Write100_CustomDocument(@"CustomDocument", @"", ((global::SerializationTypes.CustomDocument)o), true, false);
+            Write103_CustomDocument(@"CustomDocument", @"", ((global::SerializationTypes.CustomDocument)o), true, false);
         }
 
-        public void Write229_CustomElement(object o) {
+        public void Write235_CustomElement(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"CustomElement", @"");
                 return;
             }
             TopLevelElement();
-            Write99_CustomElement(@"CustomElement", @"", ((global::SerializationTypes.CustomElement)o), true, false);
+            Write102_CustomElement(@"CustomElement", @"", ((global::SerializationTypes.CustomElement)o), true, false);
         }
 
-        public void Write230_Item(object o) {
+        public void Write236_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"", null);
@@ -1071,256 +1101,256 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        public void Write231_Item(object o) {
+        public void Write237_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithNonPublicDefaultConstructor", @"");
                 return;
             }
             TopLevelElement();
-            Write101_Item(@"TypeWithNonPublicDefaultConstructor", @"", ((global::SerializationTypes.TypeWithNonPublicDefaultConstructor)o), true, false);
+            Write104_Item(@"TypeWithNonPublicDefaultConstructor", @"", ((global::SerializationTypes.TypeWithNonPublicDefaultConstructor)o), true, false);
         }
 
-        public void Write232_ServerSettings(object o) {
+        public void Write238_ServerSettings(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ServerSettings", @"");
                 return;
             }
             TopLevelElement();
-            Write102_ServerSettings(@"ServerSettings", @"", ((global::SerializationTypes.ServerSettings)o), true, false);
+            Write105_ServerSettings(@"ServerSettings", @"", ((global::SerializationTypes.ServerSettings)o), true, false);
         }
 
-        public void Write233_TypeWithXmlQualifiedName(object o) {
+        public void Write239_TypeWithXmlQualifiedName(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithXmlQualifiedName", @"");
                 return;
             }
             TopLevelElement();
-            Write103_TypeWithXmlQualifiedName(@"TypeWithXmlQualifiedName", @"", ((global::SerializationTypes.TypeWithXmlQualifiedName)o), true, false);
+            Write106_TypeWithXmlQualifiedName(@"TypeWithXmlQualifiedName", @"", ((global::SerializationTypes.TypeWithXmlQualifiedName)o), true, false);
         }
 
-        public void Write234_TypeWith2DArrayProperty2(object o) {
+        public void Write240_TypeWith2DArrayProperty2(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWith2DArrayProperty2", @"");
                 return;
             }
             TopLevelElement();
-            Write104_TypeWith2DArrayProperty2(@"TypeWith2DArrayProperty2", @"", ((global::SerializationTypes.TypeWith2DArrayProperty2)o), true, false);
+            Write107_TypeWith2DArrayProperty2(@"TypeWith2DArrayProperty2", @"", ((global::SerializationTypes.TypeWith2DArrayProperty2)o), true, false);
         }
 
-        public void Write235_Item(object o) {
+        public void Write241_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithPropertiesHavingDefaultValue", @"");
                 return;
             }
             TopLevelElement();
-            Write105_Item(@"TypeWithPropertiesHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)o), true, false);
+            Write108_Item(@"TypeWithPropertiesHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)o), true, false);
         }
 
-        public void Write236_Item(object o) {
+        public void Write242_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithEnumPropertyHavingDefaultValue", @"");
                 return;
             }
             TopLevelElement();
-            Write106_Item(@"TypeWithEnumPropertyHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)o), true, false);
+            Write109_Item(@"TypeWithEnumPropertyHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)o), true, false);
         }
 
-        public void Write237_Item(object o) {
+        public void Write243_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"");
                 return;
             }
             TopLevelElement();
-            Write107_Item(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)o), true, false);
+            Write110_Item(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"", ((global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)o), true, false);
         }
 
-        public void Write238_TypeWithShouldSerializeMethod(object o) {
+        public void Write244_TypeWithShouldSerializeMethod(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithShouldSerializeMethod", @"");
                 return;
             }
             TopLevelElement();
-            Write108_TypeWithShouldSerializeMethod(@"TypeWithShouldSerializeMethod", @"", ((global::SerializationTypes.TypeWithShouldSerializeMethod)o), true, false);
+            Write111_TypeWithShouldSerializeMethod(@"TypeWithShouldSerializeMethod", @"", ((global::SerializationTypes.TypeWithShouldSerializeMethod)o), true, false);
         }
 
-        public void Write239_Item(object o) {
+        public void Write245_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"BaseTypeWithShouldSerializeMethod", @"");
                 return;
             }
             TopLevelElement();
-            Write109_Item(@"BaseTypeWithShouldSerializeMethod", @"", ((global::SerializationTypes.BaseTypeWithShouldSerializeMethod)o), true, false);
+            Write112_Item(@"BaseTypeWithShouldSerializeMethod", @"", ((global::SerializationTypes.BaseTypeWithShouldSerializeMethod)o), true, false);
         }
 
-        public void Write240_Item(object o) {
+        public void Write246_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"DerivedTypeWithInheritedShouldSerialize", @"");
                 return;
             }
             TopLevelElement();
-            Write110_Item(@"DerivedTypeWithInheritedShouldSerialize", @"", ((global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o), true, false);
+            Write113_Item(@"DerivedTypeWithInheritedShouldSerialize", @"", ((global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o), true, false);
         }
 
-        public void Write241_Item(object o) {
+        public void Write247_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithFieldBackedSpecifiedMember", @"");
                 return;
             }
             TopLevelElement();
-            Write111_Item(@"TypeWithFieldBackedSpecifiedMember", @"", ((global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)o), true, false);
+            Write114_Item(@"TypeWithFieldBackedSpecifiedMember", @"", ((global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)o), true, false);
         }
 
-        public void Write242_Item(object o) {
+        public void Write248_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"KnownTypesThroughConstructorWithArrayProperties", @"");
                 return;
             }
             TopLevelElement();
-            Write112_Item(@"KnownTypesThroughConstructorWithArrayProperties", @"", ((global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)o), true, false);
+            Write115_Item(@"KnownTypesThroughConstructorWithArrayProperties", @"", ((global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)o), true, false);
         }
 
-        public void Write243_Item(object o) {
+        public void Write249_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"KnownTypesThroughConstructorWithValue", @"");
                 return;
             }
             TopLevelElement();
-            Write113_Item(@"KnownTypesThroughConstructorWithValue", @"", ((global::SerializationTypes.KnownTypesThroughConstructorWithValue)o), true, false);
+            Write116_Item(@"KnownTypesThroughConstructorWithValue", @"", ((global::SerializationTypes.KnownTypesThroughConstructorWithValue)o), true, false);
         }
 
-        public void Write244_Item(object o) {
+        public void Write250_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithTypesHavingCustomFormatter", @"");
                 return;
             }
             TopLevelElement();
-            Write114_Item(@"TypeWithTypesHavingCustomFormatter", @"", ((global::SerializationTypes.TypeWithTypesHavingCustomFormatter)o), true, false);
+            Write117_Item(@"TypeWithTypesHavingCustomFormatter", @"", ((global::SerializationTypes.TypeWithTypesHavingCustomFormatter)o), true, false);
         }
 
-        public void Write245_Item(object o) {
+        public void Write251_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithArrayPropertyHavingChoice", @"");
                 return;
             }
             TopLevelElement();
-            Write116_Item(@"TypeWithArrayPropertyHavingChoice", @"", ((global::SerializationTypes.TypeWithArrayPropertyHavingChoice)o), true, false);
+            Write119_Item(@"TypeWithArrayPropertyHavingChoice", @"", ((global::SerializationTypes.TypeWithArrayPropertyHavingChoice)o), true, false);
         }
 
-        public void Write246_Item(object o) {
+        public void Write252_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithPropertyHavingComplexChoice", @"");
                 return;
             }
             TopLevelElement();
-            Write119_Item(@"TypeWithPropertyHavingComplexChoice", @"", ((global::SerializationTypes.TypeWithPropertyHavingComplexChoice)o), true, false);
+            Write122_Item(@"TypeWithPropertyHavingComplexChoice", @"", ((global::SerializationTypes.TypeWithPropertyHavingComplexChoice)o), true, false);
         }
 
-        public void Write247_MoreChoices(object o) {
+        public void Write253_MoreChoices(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteEmptyTag(@"MoreChoices", @"");
                 return;
             }
-            WriteElementString(@"MoreChoices", @"", Write115_MoreChoices(((global::SerializationTypes.MoreChoices)o)));
+            WriteElementString(@"MoreChoices", @"", Write118_MoreChoices(((global::SerializationTypes.MoreChoices)o)));
         }
 
-        public void Write248_ComplexChoiceA(object o) {
+        public void Write254_ComplexChoiceA(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ComplexChoiceA", @"");
                 return;
             }
             TopLevelElement();
-            Write118_ComplexChoiceA(@"ComplexChoiceA", @"", ((global::SerializationTypes.ComplexChoiceA)o), true, false);
+            Write121_ComplexChoiceA(@"ComplexChoiceA", @"", ((global::SerializationTypes.ComplexChoiceA)o), true, false);
         }
 
-        public void Write249_ComplexChoiceB(object o) {
+        public void Write255_ComplexChoiceB(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"ComplexChoiceB", @"");
                 return;
             }
             TopLevelElement();
-            Write117_ComplexChoiceB(@"ComplexChoiceB", @"", ((global::SerializationTypes.ComplexChoiceB)o), true, false);
+            Write120_ComplexChoiceB(@"ComplexChoiceB", @"", ((global::SerializationTypes.ComplexChoiceB)o), true, false);
         }
 
-        public void Write250_TypeWithFieldsOrdered(object o) {
+        public void Write256_TypeWithFieldsOrdered(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithFieldsOrdered", @"");
                 return;
             }
             TopLevelElement();
-            Write120_TypeWithFieldsOrdered(@"TypeWithFieldsOrdered", @"", ((global::SerializationTypes.TypeWithFieldsOrdered)o), true, false);
+            Write123_TypeWithFieldsOrdered(@"TypeWithFieldsOrdered", @"", ((global::SerializationTypes.TypeWithFieldsOrdered)o), true, false);
         }
 
-        public void Write251_Item(object o) {
+        public void Write257_Item(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName", @"");
                 return;
             }
             TopLevelElement();
-            Write121_Item(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName", @"", ((global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)o), true, false);
+            Write124_Item(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName", @"", ((global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)o), true, false);
         }
 
-        public void Write252_Root(object o) {
+        public void Write258_Root(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Root", @"");
                 return;
             }
             TopLevelElement();
-            Write124_Item(@"Root", @"", ((global::SerializationTypes.NamespaceTypeNameClashContainer)o), true, false);
+            Write127_Item(@"Root", @"", ((global::SerializationTypes.NamespaceTypeNameClashContainer)o), true, false);
         }
 
-        public void Write253_TypeClashB(object o) {
+        public void Write259_TypeClashB(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeClashB", @"");
                 return;
             }
             TopLevelElement();
-            Write123_TypeNameClash(@"TypeClashB", @"", ((global::SerializationTypes.TypeNameClashB.TypeNameClash)o), true, false);
+            Write126_TypeNameClash(@"TypeClashB", @"", ((global::SerializationTypes.TypeNameClashB.TypeNameClash)o), true, false);
         }
 
-        public void Write254_TypeClashA(object o) {
+        public void Write260_TypeClashA(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"TypeClashA", @"");
                 return;
             }
             TopLevelElement();
-            Write122_TypeNameClash(@"TypeClashA", @"", ((global::SerializationTypes.TypeNameClashA.TypeNameClash)o), true, false);
+            Write125_TypeNameClash(@"TypeClashA", @"", ((global::SerializationTypes.TypeNameClashA.TypeNameClash)o), true, false);
         }
 
-        public void Write255_Person(object o) {
+        public void Write261_Person(object o) {
             WriteStartDocument();
             if (o == null) {
                 WriteNullTagLiteral(@"Person", @"");
                 return;
             }
             TopLevelElement();
-            Write125_Person(@"Person", @"", ((global::Outer.Person)o), true, false);
+            Write128_Person(@"Person", @"", ((global::Outer.Person)o), true, false);
         }
 
-        void Write125_Person(string n, string ns, global::Outer.Person o, bool isNullable, bool needType) {
+        void Write128_Person(string n, string ns, global::Outer.Person o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1341,7 +1371,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write122_TypeNameClash(string n, string ns, global::SerializationTypes.TypeNameClashA.TypeNameClash o, bool isNullable, bool needType) {
+        void Write125_TypeNameClash(string n, string ns, global::SerializationTypes.TypeNameClashA.TypeNameClash o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1360,7 +1390,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write123_TypeNameClash(string n, string ns, global::SerializationTypes.TypeNameClashB.TypeNameClash o, bool isNullable, bool needType) {
+        void Write126_TypeNameClash(string n, string ns, global::SerializationTypes.TypeNameClashB.TypeNameClash o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1379,7 +1409,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write124_Item(string n, string ns, global::SerializationTypes.NamespaceTypeNameClashContainer o, bool isNullable, bool needType) {
+        void Write127_Item(string n, string ns, global::SerializationTypes.NamespaceTypeNameClashContainer o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1398,7 +1428,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 global::SerializationTypes.TypeNameClashA.TypeNameClash[] a = (global::SerializationTypes.TypeNameClashA.TypeNameClash[])o.@A;
                 if (a != null) {
                     for (int ia = 0; ia < a.Length; ia++) {
-                        Write122_TypeNameClash(@"A", @"", ((global::SerializationTypes.TypeNameClashA.TypeNameClash)a[ia]), false, false);
+                        Write125_TypeNameClash(@"A", @"", ((global::SerializationTypes.TypeNameClashA.TypeNameClash)a[ia]), false, false);
                     }
                 }
             }
@@ -1406,14 +1436,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 global::SerializationTypes.TypeNameClashB.TypeNameClash[] a = (global::SerializationTypes.TypeNameClashB.TypeNameClash[])o.@B;
                 if (a != null) {
                     for (int ia = 0; ia < a.Length; ia++) {
-                        Write123_TypeNameClash(@"B", @"", ((global::SerializationTypes.TypeNameClashB.TypeNameClash)a[ia]), false, false);
+                        Write126_TypeNameClash(@"B", @"", ((global::SerializationTypes.TypeNameClashB.TypeNameClash)a[ia]), false, false);
                     }
                 }
             }
             WriteEndElement(o);
         }
 
-        void Write121_Item(string n, string ns, global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName o, bool isNullable, bool needType) {
+        void Write124_Item(string n, string ns, global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -1444,255 +1474,267 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::Outer.Person)) {
-                        Write125_Person(n, ns,(global::Outer.Person)o, isNullable, true);
+                        Write128_Person(n, ns,(global::Outer.Person)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.NamespaceTypeNameClashContainer)) {
-                        Write124_Item(n, ns,(global::SerializationTypes.NamespaceTypeNameClashContainer)o, isNullable, true);
+                        Write127_Item(n, ns,(global::SerializationTypes.NamespaceTypeNameClashContainer)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeNameClashB.TypeNameClash)) {
-                        Write123_TypeNameClash(n, ns,(global::SerializationTypes.TypeNameClashB.TypeNameClash)o, isNullable, true);
+                        Write126_TypeNameClash(n, ns,(global::SerializationTypes.TypeNameClashB.TypeNameClash)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeNameClashA.TypeNameClash)) {
-                        Write122_TypeNameClash(n, ns,(global::SerializationTypes.TypeNameClashA.TypeNameClash)o, isNullable, true);
+                        Write125_TypeNameClash(n, ns,(global::SerializationTypes.TypeNameClashA.TypeNameClash)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)) {
-                        Write121_Item(n, ns,(global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)o, isNullable, true);
+                        Write124_Item(n, ns,(global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithFieldsOrdered)) {
-                        Write120_TypeWithFieldsOrdered(n, ns,(global::SerializationTypes.TypeWithFieldsOrdered)o, isNullable, true);
+                        Write123_TypeWithFieldsOrdered(n, ns,(global::SerializationTypes.TypeWithFieldsOrdered)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithPropertyHavingComplexChoice)) {
-                        Write119_Item(n, ns,(global::SerializationTypes.TypeWithPropertyHavingComplexChoice)o, isNullable, true);
+                        Write122_Item(n, ns,(global::SerializationTypes.TypeWithPropertyHavingComplexChoice)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ComplexChoiceA)) {
-                        Write118_ComplexChoiceA(n, ns,(global::SerializationTypes.ComplexChoiceA)o, isNullable, true);
+                        Write121_ComplexChoiceA(n, ns,(global::SerializationTypes.ComplexChoiceA)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ComplexChoiceB)) {
-                        Write117_ComplexChoiceB(n, ns,(global::SerializationTypes.ComplexChoiceB)o, isNullable, true);
+                        Write120_ComplexChoiceB(n, ns,(global::SerializationTypes.ComplexChoiceB)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithArrayPropertyHavingChoice)) {
-                        Write116_Item(n, ns,(global::SerializationTypes.TypeWithArrayPropertyHavingChoice)o, isNullable, true);
+                        Write119_Item(n, ns,(global::SerializationTypes.TypeWithArrayPropertyHavingChoice)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithTypesHavingCustomFormatter)) {
-                        Write114_Item(n, ns,(global::SerializationTypes.TypeWithTypesHavingCustomFormatter)o, isNullable, true);
+                        Write117_Item(n, ns,(global::SerializationTypes.TypeWithTypesHavingCustomFormatter)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.KnownTypesThroughConstructorWithValue)) {
-                        Write113_Item(n, ns,(global::SerializationTypes.KnownTypesThroughConstructorWithValue)o, isNullable, true);
+                        Write116_Item(n, ns,(global::SerializationTypes.KnownTypesThroughConstructorWithValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)) {
-                        Write112_Item(n, ns,(global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)o, isNullable, true);
+                        Write115_Item(n, ns,(global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)) {
-                        Write111_Item(n, ns,(global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)o, isNullable, true);
+                        Write114_Item(n, ns,(global::SerializationTypes.TypeWithFieldBackedSpecifiedMember)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.BaseTypeWithShouldSerializeMethod)) {
-                        Write109_Item(n, ns,(global::SerializationTypes.BaseTypeWithShouldSerializeMethod)o, isNullable, true);
+                        Write112_Item(n, ns,(global::SerializationTypes.BaseTypeWithShouldSerializeMethod)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)) {
-                        Write110_Item(n, ns,(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o, isNullable, true);
+                        Write113_Item(n, ns,(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithShouldSerializeMethod)) {
-                        Write108_TypeWithShouldSerializeMethod(n, ns,(global::SerializationTypes.TypeWithShouldSerializeMethod)o, isNullable, true);
+                        Write111_TypeWithShouldSerializeMethod(n, ns,(global::SerializationTypes.TypeWithShouldSerializeMethod)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)) {
-                        Write107_Item(n, ns,(global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)o, isNullable, true);
+                        Write110_Item(n, ns,(global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)) {
-                        Write106_Item(n, ns,(global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)o, isNullable, true);
+                        Write109_Item(n, ns,(global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)) {
-                        Write105_Item(n, ns,(global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)o, isNullable, true);
+                        Write108_Item(n, ns,(global::SerializationTypes.TypeWithPropertiesHavingDefaultValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWith2DArrayProperty2)) {
-                        Write104_TypeWith2DArrayProperty2(n, ns,(global::SerializationTypes.TypeWith2DArrayProperty2)o, isNullable, true);
+                        Write107_TypeWith2DArrayProperty2(n, ns,(global::SerializationTypes.TypeWith2DArrayProperty2)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithXmlQualifiedName)) {
-                        Write103_TypeWithXmlQualifiedName(n, ns,(global::SerializationTypes.TypeWithXmlQualifiedName)o, isNullable, true);
+                        Write106_TypeWithXmlQualifiedName(n, ns,(global::SerializationTypes.TypeWithXmlQualifiedName)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ServerSettings)) {
-                        Write102_ServerSettings(n, ns,(global::SerializationTypes.ServerSettings)o, isNullable, true);
+                        Write105_ServerSettings(n, ns,(global::SerializationTypes.ServerSettings)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithNonPublicDefaultConstructor)) {
-                        Write101_Item(n, ns,(global::SerializationTypes.TypeWithNonPublicDefaultConstructor)o, isNullable, true);
+                        Write104_Item(n, ns,(global::SerializationTypes.TypeWithNonPublicDefaultConstructor)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.CustomDocument)) {
-                        Write100_CustomDocument(n, ns,(global::SerializationTypes.CustomDocument)o, isNullable, true);
+                        Write103_CustomDocument(n, ns,(global::SerializationTypes.CustomDocument)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.CustomElement)) {
-                        Write99_CustomElement(n, ns,(global::SerializationTypes.CustomElement)o, isNullable, true);
+                        Write102_CustomElement(n, ns,(global::SerializationTypes.CustomElement)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)) {
-                        Write97_Item(n, ns,(global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)o, isNullable, true);
+                        Write100_Item(n, ns,(global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithXmlSchemaFormAttribute)) {
-                        Write96_TypeWithXmlSchemaFormAttribute(n, ns,(global::SerializationTypes.TypeWithXmlSchemaFormAttribute)o, isNullable, true);
+                        Write99_TypeWithXmlSchemaFormAttribute(n, ns,(global::SerializationTypes.TypeWithXmlSchemaFormAttribute)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithPropertyNameSpecified)) {
-                        Write95_TypeWithPropertyNameSpecified(n, ns,(global::SerializationTypes.TypeWithPropertyNameSpecified)o, isNullable, true);
+                        Write98_TypeWithPropertyNameSpecified(n, ns,(global::SerializationTypes.TypeWithPropertyNameSpecified)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.SimpleKnownTypeValue)) {
-                        Write94_SimpleKnownTypeValue(n, ns,(global::SerializationTypes.SimpleKnownTypeValue)o, isNullable, true);
+                        Write97_SimpleKnownTypeValue(n, ns,(global::SerializationTypes.SimpleKnownTypeValue)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.KnownTypesThroughConstructor)) {
-                        Write93_KnownTypesThroughConstructor(n, ns,(global::SerializationTypes.KnownTypesThroughConstructor)o, isNullable, true);
+                        Write96_KnownTypesThroughConstructor(n, ns,(global::SerializationTypes.KnownTypesThroughConstructor)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithAnyAttribute)) {
-                        Write92_TypeWithAnyAttribute(n, ns,(global::SerializationTypes.TypeWithAnyAttribute)o, isNullable, true);
+                        Write95_TypeWithAnyAttribute(n, ns,(global::SerializationTypes.TypeWithAnyAttribute)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.XmlSerializerAttributes)) {
-                        Write91_XmlSerializerAttributes(n, ns,(global::SerializationTypes.XmlSerializerAttributes)o, isNullable, true);
+                        Write94_XmlSerializerAttributes(n, ns,(global::SerializationTypes.XmlSerializerAttributes)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.WithNullables)) {
-                        Write84_WithNullables(n, ns,(global::SerializationTypes.WithNullables)o, isNullable, true);
+                        Write87_WithNullables(n, ns,(global::SerializationTypes.WithNullables)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.WithEnums)) {
-                        Write83_WithEnums(n, ns,(global::SerializationTypes.WithEnums)o, isNullable, true);
+                        Write86_WithEnums(n, ns,(global::SerializationTypes.WithEnums)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.WithStruct)) {
-                        Write80_WithStruct(n, ns,(global::SerializationTypes.WithStruct)o, isNullable, true);
+                        Write83_WithStruct(n, ns,(global::SerializationTypes.WithStruct)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.SomeStruct)) {
-                        Write79_SomeStruct(n, ns,(global::SerializationTypes.SomeStruct)o, true);
+                        Write82_SomeStruct(n, ns,(global::SerializationTypes.SomeStruct)o, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ClassImplementsInterface)) {
-                        Write78_ClassImplementsInterface(n, ns,(global::SerializationTypes.ClassImplementsInterface)o, isNullable, true);
+                        Write81_ClassImplementsInterface(n, ns,(global::SerializationTypes.ClassImplementsInterface)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithXmlTextAttributeOnArray)) {
-                        Write76_Item(n, ns,(global::SerializationTypes.TypeWithXmlTextAttributeOnArray)o, isNullable, true);
+                        Write79_Item(n, ns,(global::SerializationTypes.TypeWithXmlTextAttributeOnArray)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.SimpleDC)) {
-                        Write75_SimpleDC(n, ns,(global::SerializationTypes.SimpleDC)o, isNullable, true);
+                        Write78_SimpleDC(n, ns,(global::SerializationTypes.SimpleDC)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithByteArrayAsXmlText)) {
-                        Write74_TypeWithByteArrayAsXmlText(n, ns,(global::SerializationTypes.TypeWithByteArrayAsXmlText)o, isNullable, true);
+                        Write77_TypeWithByteArrayAsXmlText(n, ns,(global::SerializationTypes.TypeWithByteArrayAsXmlText)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)) {
-                        Write73_Item(n, ns,(global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)o, isNullable, true);
+                        Write76_Item(n, ns,(global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.BaseClassWithSamePropertyName)) {
-                        Write70_BaseClassWithSamePropertyName(n, ns,(global::SerializationTypes.BaseClassWithSamePropertyName)o, isNullable, true);
+                        Write73_BaseClassWithSamePropertyName(n, ns,(global::SerializationTypes.BaseClassWithSamePropertyName)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty)) {
-                        Write71_DerivedClassWithSameProperty(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty)o, isNullable, true);
+                        Write74_DerivedClassWithSameProperty(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty2)) {
-                        Write72_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
+                        Write75_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)) {
-                        Write69_Item(n, ns,(global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)o, isNullable, true);
+                        Write72_Item(n, ns,(global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeHasArrayOfASerializedAsB)) {
-                        Write68_TypeHasArrayOfASerializedAsB(n, ns,(global::SerializationTypes.TypeHasArrayOfASerializedAsB)o, isNullable, true);
+                        Write71_TypeHasArrayOfASerializedAsB(n, ns,(global::SerializationTypes.TypeHasArrayOfASerializedAsB)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeB)) {
-                        Write67_TypeB(n, ns,(global::SerializationTypes.TypeB)o, isNullable, true);
+                        Write70_TypeB(n, ns,(global::SerializationTypes.TypeB)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeA)) {
-                        Write66_TypeA(n, ns,(global::SerializationTypes.TypeA)o, isNullable, true);
+                        Write69_TypeA(n, ns,(global::SerializationTypes.TypeA)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)) {
-                        Write65_Item(n, ns,(global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)o, isNullable, true);
+                        Write68_Item(n, ns,(global::SerializationTypes.TypeWithNullableBuiltInTypedMembers)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithBuiltInTypedMembers)) {
-                        Write64_TypeWithBuiltInTypedMembers(n, ns,(global::SerializationTypes.TypeWithBuiltInTypedMembers)o, isNullable, true);
+                        Write67_TypeWithBuiltInTypedMembers(n, ns,(global::SerializationTypes.TypeWithBuiltInTypedMembers)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.BuiltInTypes)) {
-                        Write63_BuiltInTypes(n, ns,(global::SerializationTypes.BuiltInTypes)o, isNullable, true);
+                        Write66_BuiltInTypes(n, ns,(global::SerializationTypes.BuiltInTypes)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DCClassWithEnumAndStruct)) {
-                        Write62_DCClassWithEnumAndStruct(n, ns,(global::SerializationTypes.DCClassWithEnumAndStruct)o, isNullable, true);
+                        Write65_DCClassWithEnumAndStruct(n, ns,(global::SerializationTypes.DCClassWithEnumAndStruct)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DCStruct)) {
-                        Write61_DCStruct(n, ns,(global::SerializationTypes.DCStruct)o, true);
+                        Write64_DCStruct(n, ns,(global::SerializationTypes.DCStruct)o, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithEnumMembers)) {
-                        Write60_TypeWithEnumMembers(n, ns,(global::SerializationTypes.TypeWithEnumMembers)o, isNullable, true);
+                        Write63_TypeWithEnumMembers(n, ns,(global::SerializationTypes.TypeWithEnumMembers)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty)) {
-                        Write58_Item(n, ns,(global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty)o, isNullable, true);
+                        Write61_Item(n, ns,(global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithMyCollectionField)) {
-                        Write57_TypeWithMyCollectionField(n, ns,(global::SerializationTypes.TypeWithMyCollectionField)o, isNullable, true);
+                        Write60_TypeWithMyCollectionField(n, ns,(global::SerializationTypes.TypeWithMyCollectionField)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.StructNotSerializable)) {
-                        Write56_StructNotSerializable(n, ns,(global::SerializationTypes.StructNotSerializable)o, true);
+                        Write59_StructNotSerializable(n, ns,(global::SerializationTypes.StructNotSerializable)o, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithArraylikeMembers)) {
-                        Write55_TypeWithArraylikeMembers(n, ns,(global::SerializationTypes.TypeWithArraylikeMembers)o, isNullable, true);
+                        Write58_TypeWithArraylikeMembers(n, ns,(global::SerializationTypes.TypeWithArraylikeMembers)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithGetOnlyArrayProperties)) {
-                        Write54_TypeWithGetOnlyArrayProperties(n, ns,(global::SerializationTypes.TypeWithGetOnlyArrayProperties)o, isNullable, true);
+                        Write57_TypeWithGetOnlyArrayProperties(n, ns,(global::SerializationTypes.TypeWithGetOnlyArrayProperties)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithGetSetArrayMembers)) {
-                        Write53_TypeWithGetSetArrayMembers(n, ns,(global::SerializationTypes.TypeWithGetSetArrayMembers)o, isNullable, true);
+                        Write56_TypeWithGetSetArrayMembers(n, ns,(global::SerializationTypes.TypeWithGetSetArrayMembers)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.SimpleType)) {
-                        Write52_SimpleType(n, ns,(global::SerializationTypes.SimpleType)o, isNullable, true);
+                        Write55_SimpleType(n, ns,(global::SerializationTypes.SimpleType)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.TypeWithDateTimeStringProperty)) {
-                        Write51_TypeWithDateTimeStringProperty(n, ns,(global::SerializationTypes.TypeWithDateTimeStringProperty)o, isNullable, true);
+                        Write54_TypeWithDateTimeStringProperty(n, ns,(global::SerializationTypes.TypeWithDateTimeStringProperty)o, isNullable, true);
+                        return;
+                    }
+                    if (t == typeof(global::TypeWithGetOnlyReadOnlyCollections)) {
+                        Write53_Item(n, ns,(global::TypeWithGetOnlyReadOnlyCollections)o, isNullable, true);
+                        return;
+                    }
+                    if (t == typeof(global::TypeWithMutableCollectionMembers)) {
+                        Write52_Item(n, ns,(global::TypeWithMutableCollectionMembers)o, isNullable, true);
+                        return;
+                    }
+                    if (t == typeof(global::TypeWithReadOnlyCollections)) {
+                        Write51_TypeWithReadOnlyCollections(n, ns,(global::TypeWithReadOnlyCollections)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::XElementArrayWrapper)) {
@@ -2030,7 +2072,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             global::SerializationTypes.SimpleType[] a = (global::SerializationTypes.SimpleType[])o;
                             if (a != null) {
                                 for (int ia = 0; ia < a.Length; ia++) {
-                                    Write52_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)a[ia]), true, false);
+                                    Write55_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)a[ia]), true, false);
                                 }
                             }
                         }
@@ -2054,7 +2096,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     if (t == typeof(global::SerializationTypes.MyEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"MyEnum", @"");
-                        Writer.WriteString(Write59_MyEnum((global::SerializationTypes.MyEnum)o));
+                        Writer.WriteString(Write62_MyEnum((global::SerializationTypes.MyEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
@@ -2065,7 +2107,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             global::SerializationTypes.TypeA[] a = (global::SerializationTypes.TypeA[])o;
                             if (a != null) {
                                 for (int ia = 0; ia < a.Length; ia++) {
-                                    Write66_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)a[ia]), true, false);
+                                    Write69_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)a[ia]), true, false);
                                 }
                             }
                         }
@@ -2075,63 +2117,63 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     if (t == typeof(global::SerializationTypes.EnumFlags)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"EnumFlags", @"");
-                        Writer.WriteString(Write77_EnumFlags((global::SerializationTypes.EnumFlags)o));
+                        Writer.WriteString(Write80_EnumFlags((global::SerializationTypes.EnumFlags)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.IntEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"IntEnum", @"");
-                        Writer.WriteString(Write81_IntEnum((global::SerializationTypes.IntEnum)o));
+                        Writer.WriteString(Write84_IntEnum((global::SerializationTypes.IntEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ShortEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"ShortEnum", @"");
-                        Writer.WriteString(Write82_ShortEnum((global::SerializationTypes.ShortEnum)o));
+                        Writer.WriteString(Write85_ShortEnum((global::SerializationTypes.ShortEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ByteEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"ByteEnum", @"");
-                        Writer.WriteString(Write85_ByteEnum((global::SerializationTypes.ByteEnum)o));
+                        Writer.WriteString(Write88_ByteEnum((global::SerializationTypes.ByteEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.SByteEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"SByteEnum", @"");
-                        Writer.WriteString(Write86_SByteEnum((global::SerializationTypes.SByteEnum)o));
+                        Writer.WriteString(Write89_SByteEnum((global::SerializationTypes.SByteEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.UIntEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"UIntEnum", @"");
-                        Writer.WriteString(Write87_UIntEnum((global::SerializationTypes.UIntEnum)o));
+                        Writer.WriteString(Write90_UIntEnum((global::SerializationTypes.UIntEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.LongEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"LongEnum", @"");
-                        Writer.WriteString(Write88_LongEnum((global::SerializationTypes.LongEnum)o));
+                        Writer.WriteString(Write91_LongEnum((global::SerializationTypes.LongEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ULongEnum)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"ULongEnum", @"");
-                        Writer.WriteString(Write89_ULongEnum((global::SerializationTypes.ULongEnum)o));
+                        Writer.WriteString(Write92_ULongEnum((global::SerializationTypes.ULongEnum)o));
                         Writer.WriteEndElement();
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.ItemChoiceType)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"ItemChoiceType", @"");
-                        Writer.WriteString(Write90_ItemChoiceType((global::SerializationTypes.ItemChoiceType)o));
+                        Writer.WriteString(Write93_ItemChoiceType((global::SerializationTypes.ItemChoiceType)o));
                         Writer.WriteEndElement();
                         return;
                     }
@@ -2142,7 +2184,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             global::SerializationTypes.ItemChoiceType[] a = (global::SerializationTypes.ItemChoiceType[])o;
                             if (a != null) {
                                 for (int ia = 0; ia < a.Length; ia++) {
-                                    WriteElementString(@"ItemChoiceType", @"", Write90_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)a[ia])));
+                                    WriteElementString(@"ItemChoiceType", @"", Write93_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)a[ia])));
                                 }
                             }
                         }
@@ -2199,7 +2241,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             if (a != null){
                                 WriteStartElement(@"SimpleType", @"", null, false);
                                 for (int ia = 0; ia < a.Length; ia++) {
-                                    Write52_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)a[ia]), true, false);
+                                    Write55_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)a[ia]), true, false);
                                 }
                                 WriteEndElement();
                             }
@@ -2210,7 +2252,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     if (t == typeof(global::SerializationTypes.MoreChoices)) {
                         Writer.WriteStartElement(n, ns);
                         WriteXsiType(@"MoreChoices", @"");
-                        Writer.WriteString(Write115_MoreChoices((global::SerializationTypes.MoreChoices)o));
+                        Writer.WriteString(Write118_MoreChoices((global::SerializationTypes.MoreChoices)o));
                         Writer.WriteEndElement();
                         return;
                     }
@@ -2222,7 +2264,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        string Write115_MoreChoices(global::SerializationTypes.MoreChoices v) {
+        string Write118_MoreChoices(global::SerializationTypes.MoreChoices v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.MoreChoices.@None: s = @"None"; break;
@@ -2233,7 +2275,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        void Write52_SimpleType(string n, string ns, global::SerializationTypes.SimpleType o, bool isNullable, bool needType) {
+        void Write55_SimpleType(string n, string ns, global::SerializationTypes.SimpleType o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -2253,7 +2295,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        string Write90_ItemChoiceType(global::SerializationTypes.ItemChoiceType v) {
+        string Write93_ItemChoiceType(global::SerializationTypes.ItemChoiceType v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.ItemChoiceType.@None: s = @"None"; break;
@@ -2265,7 +2307,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write89_ULongEnum(global::SerializationTypes.ULongEnum v) {
+        string Write92_ULongEnum(global::SerializationTypes.ULongEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.ULongEnum.@Option0: s = @"Option0"; break;
@@ -2276,7 +2318,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write88_LongEnum(global::SerializationTypes.LongEnum v) {
+        string Write91_LongEnum(global::SerializationTypes.LongEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.LongEnum.@Option0: s = @"Option0"; break;
@@ -2287,7 +2329,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write87_UIntEnum(global::SerializationTypes.UIntEnum v) {
+        string Write90_UIntEnum(global::SerializationTypes.UIntEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.UIntEnum.@Option0: s = @"Option0"; break;
@@ -2298,7 +2340,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write86_SByteEnum(global::SerializationTypes.SByteEnum v) {
+        string Write89_SByteEnum(global::SerializationTypes.SByteEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.SByteEnum.@Option0: s = @"Option0"; break;
@@ -2309,7 +2351,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write85_ByteEnum(global::SerializationTypes.ByteEnum v) {
+        string Write88_ByteEnum(global::SerializationTypes.ByteEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.ByteEnum.@Option0: s = @"Option0"; break;
@@ -2320,7 +2362,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write82_ShortEnum(global::SerializationTypes.ShortEnum v) {
+        string Write85_ShortEnum(global::SerializationTypes.ShortEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.ShortEnum.@Option0: s = @"Option0"; break;
@@ -2331,7 +2373,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write81_IntEnum(global::SerializationTypes.IntEnum v) {
+        string Write84_IntEnum(global::SerializationTypes.IntEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.IntEnum.@Option0: s = @"Option0"; break;
@@ -2342,7 +2384,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        string Write77_EnumFlags(global::SerializationTypes.EnumFlags v) {
+        string Write80_EnumFlags(global::SerializationTypes.EnumFlags v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.EnumFlags.@One: s = @"One"; break;
@@ -2360,7 +2402,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return s;
         }
 
-        void Write66_TypeA(string n, string ns, global::SerializationTypes.TypeA o, bool isNullable, bool needType) {
+        void Write69_TypeA(string n, string ns, global::SerializationTypes.TypeA o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -2379,7 +2421,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        string Write59_MyEnum(global::SerializationTypes.MyEnum v) {
+        string Write62_MyEnum(global::SerializationTypes.MyEnum v) {
             string s = null;
             switch (v) {
                 case global::SerializationTypes.MyEnum.@One: s = @"One"; break;
@@ -3623,7 +3665,167 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write51_TypeWithDateTimeStringProperty(string n, string ns, global::SerializationTypes.TypeWithDateTimeStringProperty o, bool isNullable, bool needType) {
+        void Write51_TypeWithReadOnlyCollections(string n, string ns, global::TypeWithReadOnlyCollections o, bool isNullable, bool needType) {
+            if ((object)o == null) {
+                if (isNullable) WriteNullTagLiteral(n, ns);
+                return;
+            }
+            if (!needType) {
+                System.Type t = o.GetType();
+                if (t == typeof(global::TypeWithReadOnlyCollections)) {
+                }
+                else {
+                    throw CreateUnknownTypeException(o);
+                }
+            }
+            WriteStartElement(n, ns, o, false, null);
+            if (needType) WriteXsiType(@"TypeWithReadOnlyCollections", @"");
+            {
+                global::System.Collections.Immutable.ImmutableArray<global::System.Int32> a = (global::System.Collections.Immutable.ImmutableArray<global::System.Int32>)((global::System.Collections.Immutable.ImmutableArray<global::System.Int32>)o.@ImmutableArray);
+                {
+                    WriteStartElement(@"ImmutableArray", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteElementStringRaw(@"int", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)a[ia])));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
+                global::System.Collections.Immutable.ImmutableList<global::System.String> a = (global::System.Collections.Immutable.ImmutableList<global::System.String>)((global::System.Collections.Immutable.ImmutableList<global::System.String>)o.@ImmutableList);
+                if (a != null){
+                    WriteStartElement(@"ImmutableList", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteNullableStringLiteral(@"string", @"", ((global::System.String)a[ia]));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
+                global::System.Collections.ObjectModel.ReadOnlyCollection<global::System.Int32> a = (global::System.Collections.ObjectModel.ReadOnlyCollection<global::System.Int32>)((global::System.Collections.ObjectModel.ReadOnlyCollection<global::System.Int32>)o.@ReadOnlyCollection);
+                if (a != null){
+                    WriteStartElement(@"ReadOnlyCollection", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteElementStringRaw(@"int", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)a[ia])));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
+                global::System.Collections.Frozen.FrozenSet<global::System.Int32> a = (global::System.Collections.Frozen.FrozenSet<global::System.Int32>)((global::System.Collections.Frozen.FrozenSet<global::System.Int32>)o.@FrozenSet);
+                if (a != null){
+                    WriteStartElement(@"FrozenSet", @"", null, false);
+                    System.Collections.IEnumerator e = a.@GetEnumerator();
+                    if (e != null)
+                    while (e.MoveNext()) {
+                        global::System.Int32 ai = (global::System.Int32)e.Current;
+                        WriteElementStringRaw(@"int", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)ai)));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
+                global::System.Collections.Immutable.ImmutableQueue<global::System.Int32> a = (global::System.Collections.Immutable.ImmutableQueue<global::System.Int32>)((global::System.Collections.Immutable.ImmutableQueue<global::System.Int32>)o.@ImmutableQueue);
+                if (a != null){
+                    WriteStartElement(@"ImmutableQueue", @"", null, false);
+                    System.Collections.IEnumerator e = ((System.Collections.Generic.IEnumerable<global::System.Int32>)a).GetEnumerator();
+                    if (e != null)
+                    while (e.MoveNext()) {
+                        global::System.Int32 ai = (global::System.Int32)e.Current;
+                        WriteElementStringRaw(@"int", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)ai)));
+                    }
+                    WriteEndElement();
+                }
+            }
+            WriteEndElement(o);
+        }
+
+        void Write52_Item(string n, string ns, global::TypeWithMutableCollectionMembers o, bool isNullable, bool needType) {
+            if ((object)o == null) {
+                if (isNullable) WriteNullTagLiteral(n, ns);
+                return;
+            }
+            if (!needType) {
+                System.Type t = o.GetType();
+                if (t == typeof(global::TypeWithMutableCollectionMembers)) {
+                }
+                else {
+                    throw CreateUnknownTypeException(o);
+                }
+            }
+            WriteStartElement(n, ns, o, false, null);
+            if (needType) WriteXsiType(@"TypeWithMutableCollectionMembers", @"");
+            {
+                global::System.Collections.Generic.List<global::System.Int32> a = (global::System.Collections.Generic.List<global::System.Int32>)((global::System.Collections.Generic.List<global::System.Int32>)o.@List);
+                if (a != null){
+                    WriteStartElement(@"List", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteElementStringRaw(@"int", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)a[ia])));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
+                global::System.Int32[] a = (global::System.Int32[])((global::System.Int32[])o.@Array);
+                if (a != null){
+                    WriteStartElement(@"Array", @"", null, false);
+                    for (int ia = 0; ia < a.Length; ia++) {
+                        WriteElementStringRaw(@"int", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)a[ia])));
+                    }
+                    WriteEndElement();
+                }
+            }
+            WriteEndElement(o);
+        }
+
+        void Write53_Item(string n, string ns, global::TypeWithGetOnlyReadOnlyCollections o, bool isNullable, bool needType) {
+            if ((object)o == null) {
+                if (isNullable) WriteNullTagLiteral(n, ns);
+                return;
+            }
+            if (!needType) {
+                System.Type t = o.GetType();
+                if (t == typeof(global::TypeWithGetOnlyReadOnlyCollections)) {
+                }
+                else {
+                    throw CreateUnknownTypeException(o);
+                }
+            }
+            WriteStartElement(n, ns, o, false, null);
+            if (needType) WriteXsiType(@"TypeWithGetOnlyReadOnlyCollections", @"");
+            {
+                global::System.Collections.Immutable.ImmutableList<global::System.String> a = (global::System.Collections.Immutable.ImmutableList<global::System.String>)((global::System.Collections.Immutable.ImmutableList<global::System.String>)o.@ImmutableList);
+                if (a != null){
+                    WriteStartElement(@"ImmutableList", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteNullableStringLiteral(@"string", @"", ((global::System.String)a[ia]));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
+                global::System.Collections.ObjectModel.ReadOnlyCollection<global::System.Int32> a = (global::System.Collections.ObjectModel.ReadOnlyCollection<global::System.Int32>)((global::System.Collections.ObjectModel.ReadOnlyCollection<global::System.Int32>)o.@ReadOnlyCollection);
+                if (a != null){
+                    WriteStartElement(@"ReadOnlyCollection", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteElementStringRaw(@"int", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)a[ia])));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
+                global::System.Collections.Immutable.ImmutableArray<global::System.String> a = (global::System.Collections.Immutable.ImmutableArray<global::System.String>)((global::System.Collections.Immutable.ImmutableArray<global::System.String>)o.@ImmutableArray);
+                {
+                    WriteStartElement(@"ImmutableArray", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteNullableStringLiteral(@"string", @"", ((global::System.String)a[ia]));
+                    }
+                    WriteEndElement();
+                }
+            }
+            WriteEndElement(o);
+        }
+
+        void Write54_TypeWithDateTimeStringProperty(string n, string ns, global::SerializationTypes.TypeWithDateTimeStringProperty o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3643,7 +3845,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write53_TypeWithGetSetArrayMembers(string n, string ns, global::SerializationTypes.TypeWithGetSetArrayMembers o, bool isNullable, bool needType) {
+        void Write56_TypeWithGetSetArrayMembers(string n, string ns, global::SerializationTypes.TypeWithGetSetArrayMembers o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3663,7 +3865,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (a != null){
                     WriteStartElement(@"F1", @"", null, false);
                     for (int ia = 0; ia < a.Length; ia++) {
-                        Write52_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)a[ia]), true, false);
+                        Write55_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)a[ia]), true, false);
                     }
                     WriteEndElement();
                 }
@@ -3683,7 +3885,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (a != null){
                     WriteStartElement(@"P1", @"", null, false);
                     for (int ia = 0; ia < a.Length; ia++) {
-                        Write52_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)a[ia]), true, false);
+                        Write55_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)a[ia]), true, false);
                     }
                     WriteEndElement();
                 }
@@ -3701,7 +3903,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write54_TypeWithGetOnlyArrayProperties(string n, string ns, global::SerializationTypes.TypeWithGetOnlyArrayProperties o, bool isNullable, bool needType) {
+        void Write57_TypeWithGetOnlyArrayProperties(string n, string ns, global::SerializationTypes.TypeWithGetOnlyArrayProperties o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3719,7 +3921,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write55_TypeWithArraylikeMembers(string n, string ns, global::SerializationTypes.TypeWithArraylikeMembers o, bool isNullable, bool needType) {
+        void Write58_TypeWithArraylikeMembers(string n, string ns, global::SerializationTypes.TypeWithArraylikeMembers o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3823,7 +4025,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write56_StructNotSerializable(string n, string ns, global::SerializationTypes.StructNotSerializable o, bool needType) {
+        void Write59_StructNotSerializable(string n, string ns, global::SerializationTypes.StructNotSerializable o, bool needType) {
             if (!needType) {
                 System.Type t = o.GetType();
                 if (t == typeof(global::SerializationTypes.StructNotSerializable)) {
@@ -3838,7 +4040,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write57_TypeWithMyCollectionField(string n, string ns, global::SerializationTypes.TypeWithMyCollectionField o, bool isNullable, bool needType) {
+        void Write60_TypeWithMyCollectionField(string n, string ns, global::SerializationTypes.TypeWithMyCollectionField o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3869,7 +4071,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write58_Item(string n, string ns, global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty o, bool isNullable, bool needType) {
+        void Write61_Item(string n, string ns, global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3900,7 +4102,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write60_TypeWithEnumMembers(string n, string ns, global::SerializationTypes.TypeWithEnumMembers o, bool isNullable, bool needType) {
+        void Write63_TypeWithEnumMembers(string n, string ns, global::SerializationTypes.TypeWithEnumMembers o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3915,12 +4117,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"TypeWithEnumMembers", @"");
-            WriteElementString(@"F1", @"", Write59_MyEnum(((global::SerializationTypes.MyEnum)o.@F1)));
-            WriteElementString(@"P1", @"", Write59_MyEnum(((global::SerializationTypes.MyEnum)o.@P1)));
+            WriteElementString(@"F1", @"", Write62_MyEnum(((global::SerializationTypes.MyEnum)o.@F1)));
+            WriteElementString(@"P1", @"", Write62_MyEnum(((global::SerializationTypes.MyEnum)o.@P1)));
             WriteEndElement(o);
         }
 
-        void Write61_DCStruct(string n, string ns, global::SerializationTypes.DCStruct o, bool needType) {
+        void Write64_DCStruct(string n, string ns, global::SerializationTypes.DCStruct o, bool needType) {
             if (!needType) {
                 System.Type t = o.GetType();
                 if (t == typeof(global::SerializationTypes.DCStruct)) {
@@ -3935,7 +4137,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write62_DCClassWithEnumAndStruct(string n, string ns, global::SerializationTypes.DCClassWithEnumAndStruct o, bool isNullable, bool needType) {
+        void Write65_DCClassWithEnumAndStruct(string n, string ns, global::SerializationTypes.DCClassWithEnumAndStruct o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3950,12 +4152,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"DCClassWithEnumAndStruct", @"");
-            Write61_DCStruct(@"MyStruct", @"", ((global::SerializationTypes.DCStruct)o.@MyStruct), false);
-            WriteElementString(@"MyEnum1", @"", Write59_MyEnum(((global::SerializationTypes.MyEnum)o.@MyEnum1)));
+            Write64_DCStruct(@"MyStruct", @"", ((global::SerializationTypes.DCStruct)o.@MyStruct), false);
+            WriteElementString(@"MyEnum1", @"", Write62_MyEnum(((global::SerializationTypes.MyEnum)o.@MyEnum1)));
             WriteEndElement(o);
         }
 
-        void Write63_BuiltInTypes(string n, string ns, global::SerializationTypes.BuiltInTypes o, bool isNullable, bool needType) {
+        void Write66_BuiltInTypes(string n, string ns, global::SerializationTypes.BuiltInTypes o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -3974,7 +4176,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write64_TypeWithBuiltInTypedMembers(string n, string ns, global::SerializationTypes.TypeWithBuiltInTypedMembers o, bool isNullable, bool needType) {
+        void Write67_TypeWithBuiltInTypedMembers(string n, string ns, global::SerializationTypes.TypeWithBuiltInTypedMembers o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4020,7 +4222,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write65_Item(string n, string ns, global::SerializationTypes.TypeWithNullableBuiltInTypedMembers o, bool isNullable, bool needType) {
+        void Write68_Item(string n, string ns, global::SerializationTypes.TypeWithNullableBuiltInTypedMembers o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4065,7 +4267,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write67_TypeB(string n, string ns, global::SerializationTypes.TypeB o, bool isNullable, bool needType) {
+        void Write70_TypeB(string n, string ns, global::SerializationTypes.TypeB o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4084,7 +4286,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write68_TypeHasArrayOfASerializedAsB(string n, string ns, global::SerializationTypes.TypeHasArrayOfASerializedAsB o, bool isNullable, bool needType) {
+        void Write71_TypeHasArrayOfASerializedAsB(string n, string ns, global::SerializationTypes.TypeHasArrayOfASerializedAsB o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4104,7 +4306,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (a != null){
                     WriteStartElement(@"Items", @"", null, false);
                     for (int ia = 0; ia < a.Length; ia++) {
-                        Write66_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)a[ia]), true, false);
+                        Write69_TypeA(@"TypeA", @"", ((global::SerializationTypes.TypeA)a[ia]), true, false);
                     }
                     WriteEndElement();
                 }
@@ -4112,7 +4314,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write69_Item(string n, string ns, global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ o, bool isNullable, bool needType) {
+        void Write72_Item(string n, string ns, global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4131,7 +4333,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write72_DerivedClassWithSameProperty2(string n, string ns, global::SerializationTypes.DerivedClassWithSameProperty2 o, bool isNullable, bool needType) {
+        void Write75_DerivedClassWithSameProperty2(string n, string ns, global::SerializationTypes.DerivedClassWithSameProperty2 o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4162,7 +4364,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write71_DerivedClassWithSameProperty(string n, string ns, global::SerializationTypes.DerivedClassWithSameProperty o, bool isNullable, bool needType) {
+        void Write74_DerivedClassWithSameProperty(string n, string ns, global::SerializationTypes.DerivedClassWithSameProperty o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4173,7 +4375,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty2)) {
-                        Write72_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
+                        Write75_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
                         return;
                     }
                     throw CreateUnknownTypeException(o);
@@ -4197,7 +4399,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write70_BaseClassWithSamePropertyName(string n, string ns, global::SerializationTypes.BaseClassWithSamePropertyName o, bool isNullable, bool needType) {
+        void Write73_BaseClassWithSamePropertyName(string n, string ns, global::SerializationTypes.BaseClassWithSamePropertyName o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4208,11 +4410,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty)) {
-                        Write71_DerivedClassWithSameProperty(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty)o, isNullable, true);
+                        Write74_DerivedClassWithSameProperty(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty)o, isNullable, true);
                         return;
                     }
                     if (t == typeof(global::SerializationTypes.DerivedClassWithSameProperty2)) {
-                        Write72_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
+                        Write75_DerivedClassWithSameProperty2(n, ns,(global::SerializationTypes.DerivedClassWithSameProperty2)o, isNullable, true);
                         return;
                     }
                     throw CreateUnknownTypeException(o);
@@ -4236,7 +4438,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write73_Item(string n, string ns, global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime o, bool isNullable, bool needType) {
+        void Write76_Item(string n, string ns, global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4257,7 +4459,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write74_TypeWithByteArrayAsXmlText(string n, string ns, global::SerializationTypes.TypeWithByteArrayAsXmlText o, bool isNullable, bool needType) {
+        void Write77_TypeWithByteArrayAsXmlText(string n, string ns, global::SerializationTypes.TypeWithByteArrayAsXmlText o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4278,7 +4480,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write75_SimpleDC(string n, string ns, global::SerializationTypes.SimpleDC o, bool isNullable, bool needType) {
+        void Write78_SimpleDC(string n, string ns, global::SerializationTypes.SimpleDC o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4297,7 +4499,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write76_Item(string n, string ns, global::SerializationTypes.TypeWithXmlTextAttributeOnArray o, bool isNullable, bool needType) {
+        void Write79_Item(string n, string ns, global::SerializationTypes.TypeWithXmlTextAttributeOnArray o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4326,7 +4528,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write78_ClassImplementsInterface(string n, string ns, global::SerializationTypes.ClassImplementsInterface o, bool isNullable, bool needType) {
+        void Write81_ClassImplementsInterface(string n, string ns, global::SerializationTypes.ClassImplementsInterface o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4348,7 +4550,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write79_SomeStruct(string n, string ns, global::SerializationTypes.SomeStruct o, bool needType) {
+        void Write82_SomeStruct(string n, string ns, global::SerializationTypes.SomeStruct o, bool needType) {
             if (!needType) {
                 System.Type t = o.GetType();
                 if (t == typeof(global::SerializationTypes.SomeStruct)) {
@@ -4364,7 +4566,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write80_WithStruct(string n, string ns, global::SerializationTypes.WithStruct o, bool isNullable, bool needType) {
+        void Write83_WithStruct(string n, string ns, global::SerializationTypes.WithStruct o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4379,11 +4581,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"WithStruct", @"");
-            Write79_SomeStruct(@"Some", @"", ((global::SerializationTypes.SomeStruct)o.@Some), false);
+            Write82_SomeStruct(@"Some", @"", ((global::SerializationTypes.SomeStruct)o.@Some), false);
             WriteEndElement(o);
         }
 
-        void Write83_WithEnums(string n, string ns, global::SerializationTypes.WithEnums o, bool isNullable, bool needType) {
+        void Write86_WithEnums(string n, string ns, global::SerializationTypes.WithEnums o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4398,12 +4600,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"WithEnums", @"");
-            WriteElementString(@"Int", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o.@Int)));
-            WriteElementString(@"Short", @"", Write82_ShortEnum(((global::SerializationTypes.ShortEnum)o.@Short)));
+            WriteElementString(@"Int", @"", Write84_IntEnum(((global::SerializationTypes.IntEnum)o.@Int)));
+            WriteElementString(@"Short", @"", Write85_ShortEnum(((global::SerializationTypes.ShortEnum)o.@Short)));
             WriteEndElement(o);
         }
 
-        void Write84_WithNullables(string n, string ns, global::SerializationTypes.WithNullables o, bool isNullable, bool needType) {
+        void Write87_WithNullables(string n, string ns, global::SerializationTypes.WithNullables o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4419,13 +4621,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"WithNullables", @"");
             if (o.@Optional != null) {
-                WriteElementString(@"Optional", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o.@Optional)));
+                WriteElementString(@"Optional", @"", Write84_IntEnum(((global::SerializationTypes.IntEnum)o.@Optional)));
             }
             else {
                 WriteNullTagLiteral(@"Optional", @"");
             }
             if (o.@Optionull != null) {
-                WriteElementString(@"Optionull", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o.@Optionull)));
+                WriteElementString(@"Optionull", @"", Write84_IntEnum(((global::SerializationTypes.IntEnum)o.@Optionull)));
             }
             else {
                 WriteNullTagLiteral(@"Optionull", @"");
@@ -4443,13 +4645,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 WriteNullTagLiteral(@"OptionullInt", @"");
             }
             if (o.@Struct1 != null) {
-                Write79_SomeStruct(@"Struct1", @"", ((global::SerializationTypes.SomeStruct)o.@Struct1), false);
+                Write82_SomeStruct(@"Struct1", @"", ((global::SerializationTypes.SomeStruct)o.@Struct1), false);
             }
             else {
                 WriteNullTagLiteral(@"Struct1", @"");
             }
             if (o.@Struct2 != null) {
-                Write79_SomeStruct(@"Struct2", @"", ((global::SerializationTypes.SomeStruct)o.@Struct2), false);
+                Write82_SomeStruct(@"Struct2", @"", ((global::SerializationTypes.SomeStruct)o.@Struct2), false);
             }
             else {
                 WriteNullTagLiteral(@"Struct2", @"");
@@ -4457,7 +4659,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write91_XmlSerializerAttributes(string n, string ns, global::SerializationTypes.XmlSerializerAttributes o, bool isNullable, bool needType) {
+        void Write94_XmlSerializerAttributes(string n, string ns, global::SerializationTypes.XmlSerializerAttributes o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4496,7 +4698,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (a != null){
                     WriteStartElement(@"XmlEnumProperty", @"", null, false);
                     for (int ia = 0; ia < a.Length; ia++) {
-                        WriteElementString(@"ItemChoiceType", @"", Write90_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)a[ia])));
+                        WriteElementString(@"ItemChoiceType", @"", Write93_ItemChoiceType(((global::SerializationTypes.ItemChoiceType)a[ia])));
                     }
                     WriteEndElement();
                 }
@@ -4519,7 +4721,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write92_TypeWithAnyAttribute(string n, string ns, global::SerializationTypes.TypeWithAnyAttribute o, bool isNullable, bool needType) {
+        void Write95_TypeWithAnyAttribute(string n, string ns, global::SerializationTypes.TypeWithAnyAttribute o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4548,7 +4750,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write93_KnownTypesThroughConstructor(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructor o, bool isNullable, bool needType) {
+        void Write96_KnownTypesThroughConstructor(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructor o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4568,7 +4770,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write94_SimpleKnownTypeValue(string n, string ns, global::SerializationTypes.SimpleKnownTypeValue o, bool isNullable, bool needType) {
+        void Write97_SimpleKnownTypeValue(string n, string ns, global::SerializationTypes.SimpleKnownTypeValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4587,7 +4789,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write95_TypeWithPropertyNameSpecified(string n, string ns, global::SerializationTypes.TypeWithPropertyNameSpecified o, bool isNullable, bool needType) {
+        void Write98_TypeWithPropertyNameSpecified(string n, string ns, global::SerializationTypes.TypeWithPropertyNameSpecified o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4611,7 +4813,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write96_TypeWithXmlSchemaFormAttribute(string n, string ns, global::SerializationTypes.TypeWithXmlSchemaFormAttribute o, bool isNullable, bool needType) {
+        void Write99_TypeWithXmlSchemaFormAttribute(string n, string ns, global::SerializationTypes.TypeWithXmlSchemaFormAttribute o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4659,7 +4861,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write97_Item(string n, string ns, global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute o, bool isNullable, bool needType) {
+        void Write100_Item(string n, string ns, global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4678,7 +4880,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write99_CustomElement(string n, string ns, global::SerializationTypes.CustomElement o, bool isNullable, bool needType) {
+        void Write102_CustomElement(string n, string ns, global::SerializationTypes.CustomElement o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4715,7 +4917,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write100_CustomDocument(string n, string ns, global::SerializationTypes.CustomDocument o, bool isNullable, bool needType) {
+        void Write103_CustomDocument(string n, string ns, global::SerializationTypes.CustomDocument o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4734,7 +4936,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 global::System.Collections.Generic.List<global::SerializationTypes.CustomElement> a = (global::System.Collections.Generic.List<global::SerializationTypes.CustomElement>)o.@CustomItems;
                 if (a != null) {
                     for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
-                        Write99_CustomElement(@"customElement", @"", ((global::SerializationTypes.CustomElement)a[ia]), false, false);
+                        Write102_CustomElement(@"customElement", @"", ((global::SerializationTypes.CustomElement)a[ia]), false, false);
                     }
                 }
             }
@@ -4754,7 +4956,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write101_Item(string n, string ns, global::SerializationTypes.TypeWithNonPublicDefaultConstructor o, bool isNullable, bool needType) {
+        void Write104_Item(string n, string ns, global::SerializationTypes.TypeWithNonPublicDefaultConstructor o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4773,7 +4975,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write102_ServerSettings(string n, string ns, global::SerializationTypes.ServerSettings o, bool isNullable, bool needType) {
+        void Write105_ServerSettings(string n, string ns, global::SerializationTypes.ServerSettings o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4793,7 +4995,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write103_TypeWithXmlQualifiedName(string n, string ns, global::SerializationTypes.TypeWithXmlQualifiedName o, bool isNullable, bool needType) {
+        void Write106_TypeWithXmlQualifiedName(string n, string ns, global::SerializationTypes.TypeWithXmlQualifiedName o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4812,7 +5014,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write104_TypeWith2DArrayProperty2(string n, string ns, global::SerializationTypes.TypeWith2DArrayProperty2 o, bool isNullable, bool needType) {
+        void Write107_TypeWith2DArrayProperty2(string n, string ns, global::SerializationTypes.TypeWith2DArrayProperty2 o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4837,7 +5039,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             if (aa != null){
                                 WriteStartElement(@"SimpleType", @"", null, false);
                                 for (int iaa = 0; iaa < aa.Length; iaa++) {
-                                    Write52_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)aa[iaa]), true, false);
+                                    Write55_SimpleType(@"SimpleType", @"", ((global::SerializationTypes.SimpleType)aa[iaa]), true, false);
                                 }
                                 WriteEndElement();
                             }
@@ -4849,7 +5051,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write105_Item(string n, string ns, global::SerializationTypes.TypeWithPropertiesHavingDefaultValue o, bool isNullable, bool needType) {
+        void Write108_Item(string n, string ns, global::SerializationTypes.TypeWithPropertiesHavingDefaultValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4877,7 +5079,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write106_Item(string n, string ns, global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue o, bool isNullable, bool needType) {
+        void Write109_Item(string n, string ns, global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4893,12 +5095,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"TypeWithEnumPropertyHavingDefaultValue", @"");
             if (((global::SerializationTypes.IntEnum)o.@EnumProperty) != global::SerializationTypes.IntEnum.@Option1) {
-                WriteElementString(@"EnumProperty", @"", Write81_IntEnum(((global::SerializationTypes.IntEnum)o.@EnumProperty)));
+                WriteElementString(@"EnumProperty", @"", Write84_IntEnum(((global::SerializationTypes.IntEnum)o.@EnumProperty)));
             }
             WriteEndElement(o);
         }
 
-        void Write107_Item(string n, string ns, global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue o, bool isNullable, bool needType) {
+        void Write110_Item(string n, string ns, global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4915,12 +5117,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             if (needType) WriteXsiType(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"");
             if (((global::SerializationTypes.EnumFlags)o.@EnumProperty) != (global::SerializationTypes.EnumFlags.@One | 
             global::SerializationTypes.EnumFlags.@Four)) {
-                WriteElementString(@"EnumProperty", @"", Write77_EnumFlags(((global::SerializationTypes.EnumFlags)o.@EnumProperty)));
+                WriteElementString(@"EnumProperty", @"", Write80_EnumFlags(((global::SerializationTypes.EnumFlags)o.@EnumProperty)));
             }
             WriteEndElement(o);
         }
 
-        void Write108_TypeWithShouldSerializeMethod(string n, string ns, global::SerializationTypes.TypeWithShouldSerializeMethod o, bool isNullable, bool needType) {
+        void Write111_TypeWithShouldSerializeMethod(string n, string ns, global::SerializationTypes.TypeWithShouldSerializeMethod o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4941,7 +5143,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write110_Item(string n, string ns, global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize o, bool isNullable, bool needType) {
+        void Write113_Item(string n, string ns, global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4965,7 +5167,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write109_Item(string n, string ns, global::SerializationTypes.BaseTypeWithShouldSerializeMethod o, bool isNullable, bool needType) {
+        void Write112_Item(string n, string ns, global::SerializationTypes.BaseTypeWithShouldSerializeMethod o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -4976,7 +5178,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)) {
-                        Write110_Item(n, ns,(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o, isNullable, true);
+                        Write113_Item(n, ns,(global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize)o, isNullable, true);
                         return;
                     }
                     throw CreateUnknownTypeException(o);
@@ -4993,7 +5195,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write111_Item(string n, string ns, global::SerializationTypes.TypeWithFieldBackedSpecifiedMember o, bool isNullable, bool needType) {
+        void Write114_Item(string n, string ns, global::SerializationTypes.TypeWithFieldBackedSpecifiedMember o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5014,7 +5216,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write112_Item(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties o, bool isNullable, bool needType) {
+        void Write115_Item(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5034,7 +5236,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write113_Item(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructorWithValue o, bool isNullable, bool needType) {
+        void Write116_Item(string n, string ns, global::SerializationTypes.KnownTypesThroughConstructorWithValue o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5053,7 +5255,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write114_Item(string n, string ns, global::SerializationTypes.TypeWithTypesHavingCustomFormatter o, bool isNullable, bool needType) {
+        void Write117_Item(string n, string ns, global::SerializationTypes.TypeWithTypesHavingCustomFormatter o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5080,7 +5282,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write116_Item(string n, string ns, global::SerializationTypes.TypeWithArrayPropertyHavingChoice o, bool isNullable, bool needType) {
+        void Write119_Item(string n, string ns, global::SerializationTypes.TypeWithArrayPropertyHavingChoice o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5123,7 +5325,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write117_ComplexChoiceB(string n, string ns, global::SerializationTypes.ComplexChoiceB o, bool isNullable, bool needType) {
+        void Write120_ComplexChoiceB(string n, string ns, global::SerializationTypes.ComplexChoiceB o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5142,7 +5344,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write118_ComplexChoiceA(string n, string ns, global::SerializationTypes.ComplexChoiceA o, bool isNullable, bool needType) {
+        void Write121_ComplexChoiceA(string n, string ns, global::SerializationTypes.ComplexChoiceA o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5153,7 +5355,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 }
                 else {
                     if (t == typeof(global::SerializationTypes.ComplexChoiceB)) {
-                        Write117_ComplexChoiceB(n, ns,(global::SerializationTypes.ComplexChoiceB)o, isNullable, true);
+                        Write120_ComplexChoiceB(n, ns,(global::SerializationTypes.ComplexChoiceB)o, isNullable, true);
                         return;
                     }
                     throw CreateUnknownTypeException(o);
@@ -5165,7 +5367,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write119_Item(string n, string ns, global::SerializationTypes.TypeWithPropertyHavingComplexChoice o, bool isNullable, bool needType) {
+        void Write122_Item(string n, string ns, global::SerializationTypes.TypeWithPropertyHavingComplexChoice o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5196,7 +5398,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             else if (ci == SerializationTypes.MoreChoices.@Item && ((object)(ai) != null)) {
                                 if (((object)ai) != null && !(ai is global::SerializationTypes.ComplexChoiceA)) throw CreateMismatchChoiceException(@"SerializationTypes.ComplexChoiceA", @"ChoiceArray", @"SerializationTypes.MoreChoices.@Item");
-                                Write118_ComplexChoiceA(@"Item", @"", ((global::SerializationTypes.ComplexChoiceA)ai), false, false);
+                                Write121_ComplexChoiceA(@"Item", @"", ((global::SerializationTypes.ComplexChoiceA)ai), false, false);
                             }
                             else  if ((object)(ai) != null){
                                 throw CreateUnknownTypeException(ai);
@@ -5208,7 +5410,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write120_TypeWithFieldsOrdered(string n, string ns, global::SerializationTypes.TypeWithFieldsOrdered o, bool isNullable, bool needType) {
+        void Write123_TypeWithFieldsOrdered(string n, string ns, global::SerializationTypes.TypeWithFieldsOrdered o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5230,7 +5432,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteEndElement(o);
         }
 
-        void Write98_Item(string n, string ns, global::SerializationTypes.TypeWithSchemaFormInXmlAttribute o, bool isNullable, bool needType) {
+        void Write101_Item(string n, string ns, global::SerializationTypes.TypeWithSchemaFormInXmlAttribute o, bool isNullable, bool needType) {
             if ((object)o == null) {
                 if (isNullable) WriteNullTagLiteral(n, ns);
                 return;
@@ -5255,7 +5457,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
 
     public class XmlSerializationReader1 : System.Xml.Serialization.XmlSerializationReader {
 
-        public object Read132_TypeWithXmlElementProperty() {
+        public object Read135_TypeWithXmlElementProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5273,7 +5475,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read133_TypeWithXmlDocumentProperty() {
+        public object Read136_TypeWithXmlDocumentProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5291,7 +5493,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read134_TypeWithBinaryProperty() {
+        public object Read137_TypeWithBinaryProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5309,7 +5511,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read135_Item() {
+        public object Read138_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5327,7 +5529,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read136_Item() {
+        public object Read139_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5345,7 +5547,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read137_DateOnlyWrapper() {
+        public object Read140_DateOnlyWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5363,7 +5565,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read138_TimeOnlyWrapper() {
+        public object Read141_TimeOnlyWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5381,7 +5583,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read139_TimeOnlyAsXsdTimeWrapper() {
+        public object Read142_TimeOnlyAsXsdTimeWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5399,7 +5601,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read140_DateTimeDateWrapper() {
+        public object Read143_DateTimeDateWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5417,7 +5619,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read141_DateTimeTimeWrapper() {
+        public object Read144_DateTimeTimeWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5435,7 +5637,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read142_TypeWithTimeSpanProperty() {
+        public object Read145_TypeWithTimeSpanProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5453,7 +5655,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read143_Item() {
+        public object Read146_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5471,7 +5673,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read144_TypeWithByteProperty() {
+        public object Read147_TypeWithByteProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5489,7 +5691,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read145_TypeWithXmlNodeArrayProperty() {
+        public object Read148_TypeWithXmlNodeArrayProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5507,7 +5709,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read146_Animal() {
+        public object Read149_Animal() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5525,7 +5727,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read147_Dog() {
+        public object Read150_Dog() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5543,7 +5745,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read148_DogBreed() {
+        public object Read151_DogBreed() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5571,7 +5773,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read149_Group() {
+        public object Read152_Group() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5589,7 +5791,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read150_Vehicle() {
+        public object Read153_Vehicle() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5607,7 +5809,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read151_Employee() {
+        public object Read154_Employee() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5625,7 +5827,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read152_BaseClass() {
+        public object Read155_BaseClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5643,7 +5845,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read153_DerivedClass() {
+        public object Read156_DerivedClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5661,7 +5863,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read154_SimpleBaseClass() {
+        public object Read157_SimpleBaseClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5679,7 +5881,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read155_SimpleDerivedClass() {
+        public object Read158_SimpleDerivedClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5697,7 +5899,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read156_BaseIXmlSerializable() {
+        public object Read159_BaseIXmlSerializable() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5724,7 +5926,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read157_DerivedIXmlSerializable() {
+        public object Read160_DerivedIXmlSerializable() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5742,7 +5944,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read158_PurchaseOrder() {
+        public object Read161_PurchaseOrder() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5760,7 +5962,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read159_Address() {
+        public object Read162_Address() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5778,7 +5980,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read160_OrderedItem() {
+        public object Read163_OrderedItem() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5796,7 +5998,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read161_AliasedTestType() {
+        public object Read164_AliasedTestType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5814,7 +6016,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read162_BaseClass1() {
+        public object Read165_BaseClass1() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5832,7 +6034,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read163_DerivedClass1() {
+        public object Read166_DerivedClass1() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5850,7 +6052,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read164_ArrayOfDateTime() {
+        public object Read167_ArrayOfDateTime() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5916,7 +6118,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read165_Orchestra() {
+        public object Read168_Orchestra() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5934,7 +6136,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read166_Instrument() {
+        public object Read169_Instrument() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5952,7 +6154,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read167_Brass() {
+        public object Read170_Brass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5970,7 +6172,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read168_Trumpet() {
+        public object Read171_Trumpet() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -5988,7 +6190,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read169_Pet() {
+        public object Read172_Pet() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6006,7 +6208,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read170_DefaultValuesSetToNaN() {
+        public object Read173_DefaultValuesSetToNaN() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6024,7 +6226,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read171_Item() {
+        public object Read174_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6042,7 +6244,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read172_Item() {
+        public object Read175_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6060,7 +6262,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read173_RootElement() {
+        public object Read176_RootElement() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6078,7 +6280,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read174_TypeWithLinkedProperty() {
+        public object Read177_TypeWithLinkedProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6096,7 +6298,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read175_Document() {
+        public object Read178_Document() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6114,7 +6316,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read176_RootClass() {
+        public object Read179_RootClass() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6132,7 +6334,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read177_Parameter() {
+        public object Read180_Parameter() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6150,7 +6352,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read178_XElementWrapper() {
+        public object Read181_XElementWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6168,7 +6370,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read179_XElementStruct() {
+        public object Read182_XElementStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6186,7 +6388,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read180_XElementArrayWrapper() {
+        public object Read183_XElementArrayWrapper() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6204,7 +6406,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read181_Item() {
+        public object Read184_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -6222,13 +6424,67 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read182_TypeWithDateTimeStringProperty() {
+        public object Read185_TypeWithReadOnlyCollections() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id56_TypeWithDateTimeStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read54_TypeWithDateTimeStringProperty(true, true);
+                    if (((object) Reader.LocalName == (object)id56_TypeWithReadOnlyCollections && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read54_TypeWithReadOnlyCollections(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":TypeWithReadOnlyCollections");
+            }
+            return (object)o;
+        }
+
+        public object Read186_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id57_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read55_Item(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":TypeWithMutableCollectionMembers");
+            }
+            return (object)o;
+        }
+
+        public object Read187_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id58_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read56_Item(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":TypeWithGetOnlyReadOnlyCollections");
+            }
+            return (object)o;
+        }
+
+        public object Read188_TypeWithDateTimeStringProperty() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id59_TypeWithDateTimeStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read57_TypeWithDateTimeStringProperty(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6240,13 +6496,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read183_SimpleType() {
+        public object Read189_SimpleType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read55_SimpleType(true, true);
+                    if (((object) Reader.LocalName == (object)id60_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read58_SimpleType(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6258,13 +6514,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read184_TypeWithGetSetArrayMembers() {
+        public object Read190_TypeWithGetSetArrayMembers() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id58_TypeWithGetSetArrayMembers && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read56_TypeWithGetSetArrayMembers(true, true);
+                    if (((object) Reader.LocalName == (object)id61_TypeWithGetSetArrayMembers && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read59_TypeWithGetSetArrayMembers(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6276,13 +6532,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read185_TypeWithGetOnlyArrayProperties() {
+        public object Read191_TypeWithGetOnlyArrayProperties() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id59_TypeWithGetOnlyArrayProperties && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read57_TypeWithGetOnlyArrayProperties(true, true);
+                    if (((object) Reader.LocalName == (object)id62_TypeWithGetOnlyArrayProperties && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read60_TypeWithGetOnlyArrayProperties(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6294,13 +6550,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read186_TypeWithArraylikeMembers() {
+        public object Read192_TypeWithArraylikeMembers() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id60_TypeWithArraylikeMembers && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read58_TypeWithArraylikeMembers(true, true);
+                    if (((object) Reader.LocalName == (object)id63_TypeWithArraylikeMembers && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read61_TypeWithArraylikeMembers(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6312,13 +6568,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read187_StructNotSerializable() {
+        public object Read193_StructNotSerializable() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id61_StructNotSerializable && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read59_StructNotSerializable(true);
+                    if (((object) Reader.LocalName == (object)id64_StructNotSerializable && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read62_StructNotSerializable(true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6330,13 +6586,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read188_TypeWithMyCollectionField() {
+        public object Read194_TypeWithMyCollectionField() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id62_TypeWithMyCollectionField && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read60_TypeWithMyCollectionField(true, true);
+                    if (((object) Reader.LocalName == (object)id65_TypeWithMyCollectionField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read63_TypeWithMyCollectionField(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6348,13 +6604,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read189_Item() {
+        public object Read195_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id63_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read61_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id66_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read64_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6366,12 +6622,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read190_ArrayOfAnyType() {
+        public object Read196_ArrayOfAnyType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id64_ArrayOfAnyType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id67_ArrayOfAnyType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -6392,7 +6648,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id65_anyType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id68_anyType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 if ((object)(a_0_0) == null) Reader.Skip(); else a_0_0.Add(Read1_Object(true, true));
                                                 break;
                                             }
@@ -6422,12 +6678,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read191_MyEnum() {
+        public object Read197_MyEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id66_MyEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id69_MyEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -6437,7 +6693,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read62_MyEnum(Reader.ReadElementString());
+                            o = Read65_MyEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6450,13 +6706,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read192_TypeWithEnumMembers() {
+        public object Read198_TypeWithEnumMembers() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id67_TypeWithEnumMembers && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read63_TypeWithEnumMembers(true, true);
+                    if (((object) Reader.LocalName == (object)id70_TypeWithEnumMembers && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read66_TypeWithEnumMembers(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6468,13 +6724,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read193_DCStruct() {
+        public object Read199_DCStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id68_DCStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read64_DCStruct(true);
+                    if (((object) Reader.LocalName == (object)id71_DCStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read67_DCStruct(true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6486,13 +6742,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read194_DCClassWithEnumAndStruct() {
+        public object Read200_DCClassWithEnumAndStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id69_DCClassWithEnumAndStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read65_DCClassWithEnumAndStruct(true, true);
+                    if (((object) Reader.LocalName == (object)id72_DCClassWithEnumAndStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read68_DCClassWithEnumAndStruct(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6504,13 +6760,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read195_BuiltInTypes() {
+        public object Read201_BuiltInTypes() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id70_BuiltInTypes && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read66_BuiltInTypes(true, true);
+                    if (((object) Reader.LocalName == (object)id73_BuiltInTypes && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read69_BuiltInTypes(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6522,13 +6778,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read196_TypeWithBuiltInTypedMembers() {
+        public object Read202_TypeWithBuiltInTypedMembers() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id71_TypeWithBuiltInTypedMembers && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read68_TypeWithBuiltInTypedMembers(true, true);
+                    if (((object) Reader.LocalName == (object)id74_TypeWithBuiltInTypedMembers && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read71_TypeWithBuiltInTypedMembers(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6540,13 +6796,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read197_Item() {
+        public object Read203_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id72_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read69_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id75_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read72_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6558,13 +6814,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read198_TypeA() {
+        public object Read204_TypeA() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id73_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read70_TypeA(true, true);
+                    if (((object) Reader.LocalName == (object)id76_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read73_TypeA(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6576,13 +6832,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read199_TypeB() {
+        public object Read205_TypeB() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id74_TypeB && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read71_TypeB(true, true);
+                    if (((object) Reader.LocalName == (object)id77_TypeB && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read74_TypeB(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6594,13 +6850,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read200_TypeHasArrayOfASerializedAsB() {
+        public object Read206_TypeHasArrayOfASerializedAsB() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id75_TypeHasArrayOfASerializedAsB && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read72_TypeHasArrayOfASerializedAsB(true, true);
+                    if (((object) Reader.LocalName == (object)id78_TypeHasArrayOfASerializedAsB && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read75_TypeHasArrayOfASerializedAsB(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6612,13 +6868,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read201_Item() {
+        public object Read207_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id76_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read73_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id79_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read76_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6630,13 +6886,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read202_BaseClassWithSamePropertyName() {
+        public object Read208_BaseClassWithSamePropertyName() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id77_BaseClassWithSamePropertyName && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read74_BaseClassWithSamePropertyName(true, true);
+                    if (((object) Reader.LocalName == (object)id80_BaseClassWithSamePropertyName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read77_BaseClassWithSamePropertyName(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6648,13 +6904,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read203_DerivedClassWithSameProperty() {
+        public object Read209_DerivedClassWithSameProperty() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id78_DerivedClassWithSameProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read75_DerivedClassWithSameProperty(true, true);
+                    if (((object) Reader.LocalName == (object)id81_DerivedClassWithSameProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read78_DerivedClassWithSameProperty(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6666,13 +6922,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read204_DerivedClassWithSameProperty2() {
+        public object Read210_DerivedClassWithSameProperty2() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id79_DerivedClassWithSameProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read76_DerivedClassWithSameProperty2(true, true);
+                    if (((object) Reader.LocalName == (object)id82_DerivedClassWithSameProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read79_DerivedClassWithSameProperty2(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6684,13 +6940,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read205_Item() {
+        public object Read211_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id80_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read77_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id83_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read80_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6702,13 +6958,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read206_TypeWithByteArrayAsXmlText() {
+        public object Read212_TypeWithByteArrayAsXmlText() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id81_TypeWithByteArrayAsXmlText && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read78_TypeWithByteArrayAsXmlText(true, true);
+                    if (((object) Reader.LocalName == (object)id84_TypeWithByteArrayAsXmlText && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read81_TypeWithByteArrayAsXmlText(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6720,13 +6976,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read207_SimpleDC() {
+        public object Read213_SimpleDC() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id82_SimpleDC && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read79_SimpleDC(true, true);
+                    if (((object) Reader.LocalName == (object)id85_SimpleDC && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read82_SimpleDC(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6738,13 +6994,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read208_Item() {
+        public object Read214_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id83_Item && (object) Reader.NamespaceURI == (object)id84_Item)) {
-                        o = Read80_Item(false, true);
+                    if (((object) Reader.LocalName == (object)id86_Item && (object) Reader.NamespaceURI == (object)id87_Item)) {
+                        o = Read83_Item(false, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6756,12 +7012,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read209_EnumFlags() {
+        public object Read215_EnumFlags() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id85_EnumFlags && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id88_EnumFlags && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -6771,7 +7027,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read81_EnumFlags(Reader.ReadElementString());
+                            o = Read84_EnumFlags(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6784,13 +7040,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read210_ClassImplementsInterface() {
+        public object Read216_ClassImplementsInterface() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id86_ClassImplementsInterface && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read82_ClassImplementsInterface(true, true);
+                    if (((object) Reader.LocalName == (object)id89_ClassImplementsInterface && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read85_ClassImplementsInterface(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6802,13 +7058,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read211_WithStruct() {
+        public object Read217_WithStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id87_WithStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read84_WithStruct(true, true);
+                    if (((object) Reader.LocalName == (object)id90_WithStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read87_WithStruct(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6820,13 +7076,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read212_SomeStruct() {
+        public object Read218_SomeStruct() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id88_SomeStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read83_SomeStruct(true);
+                    if (((object) Reader.LocalName == (object)id91_SomeStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read86_SomeStruct(true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6838,13 +7094,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read213_WithEnums() {
+        public object Read219_WithEnums() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id89_WithEnums && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read87_WithEnums(true, true);
+                    if (((object) Reader.LocalName == (object)id92_WithEnums && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read90_WithEnums(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6856,13 +7112,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read214_WithNullables() {
+        public object Read220_WithNullables() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id90_WithNullables && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read90_WithNullables(true, true);
+                    if (((object) Reader.LocalName == (object)id93_WithNullables && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read93_WithNullables(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -6874,12 +7130,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read215_ByteEnum() {
+        public object Read221_ByteEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id91_ByteEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id94_ByteEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -6889,7 +7145,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read91_ByteEnum(Reader.ReadElementString());
+                            o = Read94_ByteEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6902,12 +7158,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read216_SByteEnum() {
+        public object Read222_SByteEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id92_SByteEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id95_SByteEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -6917,7 +7173,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read92_SByteEnum(Reader.ReadElementString());
+                            o = Read95_SByteEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6930,12 +7186,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read217_ShortEnum() {
+        public object Read223_ShortEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id93_ShortEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id96_ShortEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -6945,7 +7201,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read86_ShortEnum(Reader.ReadElementString());
+                            o = Read89_ShortEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6958,12 +7214,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read218_IntEnum() {
+        public object Read224_IntEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id94_IntEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id97_IntEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -6973,7 +7229,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read85_IntEnum(Reader.ReadElementString());
+                            o = Read88_IntEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -6986,12 +7242,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read219_UIntEnum() {
+        public object Read225_UIntEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id95_UIntEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id98_UIntEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -7001,7 +7257,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read93_UIntEnum(Reader.ReadElementString());
+                            o = Read96_UIntEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -7014,12 +7270,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read220_LongEnum() {
+        public object Read226_LongEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id96_LongEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id99_LongEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -7029,7 +7285,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read94_LongEnum(Reader.ReadElementString());
+                            o = Read97_LongEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -7042,12 +7298,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read221_ULongEnum() {
+        public object Read227_ULongEnum() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id97_ULongEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id100_ULongEnum && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -7057,7 +7313,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read95_ULongEnum(Reader.ReadElementString());
+                            o = Read98_ULongEnum(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -7070,13 +7326,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read222_AttributeTesting() {
+        public object Read228_AttributeTesting() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id98_AttributeTesting && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read97_XmlSerializerAttributes(false, true);
+                    if (((object) Reader.LocalName == (object)id101_AttributeTesting && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read100_XmlSerializerAttributes(false, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7088,12 +7344,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read223_ItemChoiceType() {
+        public object Read229_ItemChoiceType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id99_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id102_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -7103,7 +7359,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read96_ItemChoiceType(Reader.ReadElementString());
+                            o = Read99_ItemChoiceType(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -7116,13 +7372,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read224_TypeWithAnyAttribute() {
+        public object Read230_TypeWithAnyAttribute() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id100_TypeWithAnyAttribute && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read98_TypeWithAnyAttribute(true, true);
+                    if (((object) Reader.LocalName == (object)id103_TypeWithAnyAttribute && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read101_TypeWithAnyAttribute(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7134,13 +7390,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read225_KnownTypesThroughConstructor() {
+        public object Read231_KnownTypesThroughConstructor() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id101_KnownTypesThroughConstructor && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read99_KnownTypesThroughConstructor(true, true);
+                    if (((object) Reader.LocalName == (object)id104_KnownTypesThroughConstructor && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read102_KnownTypesThroughConstructor(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7152,13 +7408,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read226_SimpleKnownTypeValue() {
+        public object Read232_SimpleKnownTypeValue() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id102_SimpleKnownTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read100_SimpleKnownTypeValue(true, true);
+                    if (((object) Reader.LocalName == (object)id105_SimpleKnownTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read103_SimpleKnownTypeValue(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7170,12 +7426,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read227_Item() {
+        public object Read233_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id103_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id106_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         o = (global::SerializationTypes.ClassImplementingIXmlSerializable)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::SerializationTypes.ClassImplementingIXmlSerializable());
                         break;
                     }
@@ -7188,12 +7444,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read228_Item() {
+        public object Read234_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id104_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id107_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         o = (global::SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)System.Activator.CreateInstance(typeof(global::SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor), System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.CreateInstance | System.Reflection.BindingFlags.NonPublic, null, new object[0], null));
                         break;
                     }
@@ -7206,12 +7462,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read229_Item() {
+        public object Read235_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id105_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id108_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         o = (global::SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor());
                         break;
                     }
@@ -7224,13 +7480,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read230_TypeWithPropertyNameSpecified() {
+        public object Read236_TypeWithPropertyNameSpecified() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id106_TypeWithPropertyNameSpecified && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read101_TypeWithPropertyNameSpecified(true, true);
+                    if (((object) Reader.LocalName == (object)id109_TypeWithPropertyNameSpecified && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read104_TypeWithPropertyNameSpecified(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7242,13 +7498,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read231_TypeWithXmlSchemaFormAttribute() {
+        public object Read237_TypeWithXmlSchemaFormAttribute() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id107_TypeWithXmlSchemaFormAttribute && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read102_TypeWithXmlSchemaFormAttribute(true, true);
+                    if (((object) Reader.LocalName == (object)id110_TypeWithXmlSchemaFormAttribute && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read105_TypeWithXmlSchemaFormAttribute(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7260,13 +7516,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read232_MyXmlType() {
+        public object Read238_MyXmlType() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id108_MyXmlType && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read103_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id111_MyXmlType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read106_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7278,73 +7534,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read233_Item() {
-            object o = null;
-            Reader.MoveToContent();
-            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                do {
-                    if (((object) Reader.LocalName == (object)id109_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read104_Item(true, true);
-                        break;
-                    }
-                    throw CreateUnknownNodeException();
-                } while (false);
-            }
-            else {
-                UnknownNode(null, @":TypeWithSchemaFormInXmlAttribute");
-            }
-            return (object)o;
-        }
-
-        public object Read234_CustomDocument() {
-            object o = null;
-            Reader.MoveToContent();
-            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                do {
-                    if (((object) Reader.LocalName == (object)id110_CustomDocument && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read106_CustomDocument(true, true);
-                        break;
-                    }
-                    throw CreateUnknownNodeException();
-                } while (false);
-            }
-            else {
-                UnknownNode(null, @":CustomDocument");
-            }
-            return (object)o;
-        }
-
-        public object Read235_CustomElement() {
-            object o = null;
-            Reader.MoveToContent();
-            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                do {
-                    if (((object) Reader.LocalName == (object)id111_CustomElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read105_CustomElement(true, true);
-                        break;
-                    }
-                    throw CreateUnknownNodeException();
-                } while (false);
-            }
-            else {
-                UnknownNode(null, @":CustomElement");
-            }
-            return (object)o;
-        }
-
-        public object Read236_Item() {
-            object o = null;
-            Reader.MoveToContent();
-            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                o = (global::SerializationTypes.CustomAttribute)ReadXmlNode(false);
-            }
-            else {
-                UnknownNode(null, @"");
-            }
-            return (object)o;
-        }
-
-        public object Read237_Item() {
+        public object Read239_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7357,18 +7547,84 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
+                UnknownNode(null, @":TypeWithSchemaFormInXmlAttribute");
+            }
+            return (object)o;
+        }
+
+        public object Read240_CustomDocument() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id113_CustomDocument && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read109_CustomDocument(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":CustomDocument");
+            }
+            return (object)o;
+        }
+
+        public object Read241_CustomElement() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id114_CustomElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read108_CustomElement(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":CustomElement");
+            }
+            return (object)o;
+        }
+
+        public object Read242_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                o = (global::SerializationTypes.CustomAttribute)ReadXmlNode(false);
+            }
+            else {
+                UnknownNode(null, @"");
+            }
+            return (object)o;
+        }
+
+        public object Read243_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id115_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read110_Item(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
                 UnknownNode(null, @":TypeWithNonPublicDefaultConstructor");
             }
             return (object)o;
         }
 
-        public object Read238_ServerSettings() {
+        public object Read244_ServerSettings() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id113_ServerSettings && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read108_ServerSettings(true, true);
+                    if (((object) Reader.LocalName == (object)id116_ServerSettings && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read111_ServerSettings(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7380,13 +7636,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read239_TypeWithXmlQualifiedName() {
+        public object Read245_TypeWithXmlQualifiedName() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id114_TypeWithXmlQualifiedName && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read109_TypeWithXmlQualifiedName(true, true);
+                    if (((object) Reader.LocalName == (object)id117_TypeWithXmlQualifiedName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read112_TypeWithXmlQualifiedName(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7398,13 +7654,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read240_TypeWith2DArrayProperty2() {
+        public object Read246_TypeWith2DArrayProperty2() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id115_TypeWith2DArrayProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read110_TypeWith2DArrayProperty2(true, true);
+                    if (((object) Reader.LocalName == (object)id118_TypeWith2DArrayProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read113_TypeWith2DArrayProperty2(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7416,13 +7672,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read241_Item() {
+        public object Read247_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id116_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read111_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id119_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read114_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7434,61 +7690,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read242_Item() {
-            object o = null;
-            Reader.MoveToContent();
-            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                do {
-                    if (((object) Reader.LocalName == (object)id117_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read112_Item(true, true);
-                        break;
-                    }
-                    throw CreateUnknownNodeException();
-                } while (false);
-            }
-            else {
-                UnknownNode(null, @":TypeWithEnumPropertyHavingDefaultValue");
-            }
-            return (object)o;
-        }
-
-        public object Read243_Item() {
-            object o = null;
-            Reader.MoveToContent();
-            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                do {
-                    if (((object) Reader.LocalName == (object)id118_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read113_Item(true, true);
-                        break;
-                    }
-                    throw CreateUnknownNodeException();
-                } while (false);
-            }
-            else {
-                UnknownNode(null, @":TypeWithEnumFlagPropertyHavingDefaultValue");
-            }
-            return (object)o;
-        }
-
-        public object Read244_TypeWithShouldSerializeMethod() {
-            object o = null;
-            Reader.MoveToContent();
-            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                do {
-                    if (((object) Reader.LocalName == (object)id119_TypeWithShouldSerializeMethod && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read114_TypeWithShouldSerializeMethod(true, true);
-                        break;
-                    }
-                    throw CreateUnknownNodeException();
-                } while (false);
-            }
-            else {
-                UnknownNode(null, @":TypeWithShouldSerializeMethod");
-            }
-            return (object)o;
-        }
-
-        public object Read245_Item() {
+        public object Read248_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7501,12 +7703,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":BaseTypeWithShouldSerializeMethod");
+                UnknownNode(null, @":TypeWithEnumPropertyHavingDefaultValue");
             }
             return (object)o;
         }
 
-        public object Read246_Item() {
+        public object Read249_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7519,30 +7721,30 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":DerivedTypeWithInheritedShouldSerialize");
+                UnknownNode(null, @":TypeWithEnumFlagPropertyHavingDefaultValue");
             }
             return (object)o;
         }
 
-        public object Read247_Item() {
+        public object Read250_TypeWithShouldSerializeMethod() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id122_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read117_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id122_TypeWithShouldSerializeMethod && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read117_TypeWithShouldSerializeMethod(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
                 } while (false);
             }
             else {
-                UnknownNode(null, @":TypeWithFieldBackedSpecifiedMember");
+                UnknownNode(null, @":TypeWithShouldSerializeMethod");
             }
             return (object)o;
         }
 
-        public object Read248_Item() {
+        public object Read251_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7555,12 +7757,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":KnownTypesThroughConstructorWithArrayProperties");
+                UnknownNode(null, @":BaseTypeWithShouldSerializeMethod");
             }
             return (object)o;
         }
 
-        public object Read249_Item() {
+        public object Read252_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7573,12 +7775,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":KnownTypesThroughConstructorWithValue");
+                UnknownNode(null, @":DerivedTypeWithInheritedShouldSerialize");
             }
             return (object)o;
         }
 
-        public object Read250_Item() {
+        public object Read253_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
@@ -7591,18 +7793,72 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 } while (false);
             }
             else {
-                UnknownNode(null, @":TypeWithTypesHavingCustomFormatter");
+                UnknownNode(null, @":TypeWithFieldBackedSpecifiedMember");
             }
             return (object)o;
         }
 
-        public object Read251_Item() {
+        public object Read254_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
                     if (((object) Reader.LocalName == (object)id126_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read121_Item(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":KnownTypesThroughConstructorWithArrayProperties");
+            }
+            return (object)o;
+        }
+
+        public object Read255_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id127_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         o = Read122_Item(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":KnownTypesThroughConstructorWithValue");
+            }
+            return (object)o;
+        }
+
+        public object Read256_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id128_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read123_Item(true, true);
+                        break;
+                    }
+                    throw CreateUnknownNodeException();
+                } while (false);
+            }
+            else {
+                UnknownNode(null, @":TypeWithTypesHavingCustomFormatter");
+            }
+            return (object)o;
+        }
+
+        public object Read257_Item() {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                do {
+                    if (((object) Reader.LocalName == (object)id129_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read125_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7614,13 +7870,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read252_Item() {
+        public object Read258_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id127_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read125_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id130_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read128_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7632,12 +7888,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read253_MoreChoices() {
+        public object Read259_MoreChoices() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id128_MoreChoices && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                    if (((object) Reader.LocalName == (object)id131_MoreChoices && (object) Reader.NamespaceURI == (object)id2_Item)) {
                         if (Reader.HasAttributes) {
                             while (Reader.MoveToNextAttribute()) {
                                 if (!IsXmlnsAttribute(Reader.Name)) {
@@ -7647,7 +7903,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             Reader.MoveToElement();
                         }
                         {
-                            o = Read121_MoreChoices(Reader.ReadElementString());
+                            o = Read124_MoreChoices(Reader.ReadElementString());
                         }
                         break;
                     }
@@ -7660,13 +7916,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read254_ComplexChoiceA() {
+        public object Read260_ComplexChoiceA() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id129_ComplexChoiceA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read124_ComplexChoiceA(true, true);
+                    if (((object) Reader.LocalName == (object)id132_ComplexChoiceA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read127_ComplexChoiceA(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7678,13 +7934,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read255_ComplexChoiceB() {
+        public object Read261_ComplexChoiceB() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id130_ComplexChoiceB && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read123_ComplexChoiceB(true, true);
+                    if (((object) Reader.LocalName == (object)id133_ComplexChoiceB && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read126_ComplexChoiceB(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7696,13 +7952,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read256_TypeWithFieldsOrdered() {
+        public object Read262_TypeWithFieldsOrdered() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id131_TypeWithFieldsOrdered && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read126_TypeWithFieldsOrdered(true, true);
+                    if (((object) Reader.LocalName == (object)id134_TypeWithFieldsOrdered && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read129_TypeWithFieldsOrdered(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7714,13 +7970,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read257_Item() {
+        public object Read263_Item() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id132_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read127_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id135_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read130_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7732,13 +7988,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read258_Root() {
+        public object Read264_Root() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id133_Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read130_Item(true, true);
+                    if (((object) Reader.LocalName == (object)id136_Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read133_Item(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7750,13 +8006,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read259_TypeClashB() {
+        public object Read265_TypeClashB() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id134_TypeClashB && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read129_TypeNameClash(true, true);
+                    if (((object) Reader.LocalName == (object)id137_TypeClashB && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read132_TypeNameClash(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7768,13 +8024,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read260_TypeClashA() {
+        public object Read266_TypeClashA() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id135_TypeClashA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read128_TypeNameClash(true, true);
+                    if (((object) Reader.LocalName == (object)id138_TypeClashA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read131_TypeNameClash(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7786,13 +8042,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        public object Read261_Person() {
+        public object Read267_Person() {
             object o = null;
             Reader.MoveToContent();
             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                 do {
-                    if (((object) Reader.LocalName == (object)id136_Person && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                        o = Read131_Person(true, true);
+                    if (((object) Reader.LocalName == (object)id139_Person && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        o = Read134_Person(true, true);
                         break;
                     }
                     throw CreateUnknownNodeException();
@@ -7804,12 +8060,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return (object)o;
         }
 
-        global::Outer.Person Read131_Person(bool isNullable, bool checkType) {
+        global::Outer.Person Read134_Person(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id136_Person && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id139_Person && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -7834,7 +8090,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id137_FirstName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_FirstName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -7849,7 +8105,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id138_MiddleName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id141_MiddleName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -7864,7 +8120,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id139_LastName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id142_LastName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -7891,12 +8147,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeNameClashA.TypeNameClash Read128_TypeNameClash(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeNameClashA.TypeNameClash Read131_TypeNameClash(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id135_TypeClashA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id138_TypeClashA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -7921,7 +8177,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -7948,12 +8204,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeNameClashB.TypeNameClash Read129_TypeNameClash(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeNameClashB.TypeNameClash Read132_TypeNameClash(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id134_TypeClashB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id137_TypeClashB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -7978,7 +8234,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -8005,12 +8261,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.NamespaceTypeNameClashContainer Read130_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.NamespaceTypeNameClashContainer Read133_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id141_ContainerType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id144_ContainerType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -8041,12 +8297,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id142_A && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            a_0 = (global::SerializationTypes.TypeNameClashA.TypeNameClash[])EnsureArrayIndex(a_0, ca_0, typeof(global::SerializationTypes.TypeNameClashA.TypeNameClash));a_0[ca_0++] = Read128_TypeNameClash(false, true);
+                        if (((object) Reader.LocalName == (object)id145_A && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            a_0 = (global::SerializationTypes.TypeNameClashA.TypeNameClash[])EnsureArrayIndex(a_0, ca_0, typeof(global::SerializationTypes.TypeNameClashA.TypeNameClash));a_0[ca_0++] = Read131_TypeNameClash(false, true);
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id143_B && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            a_1 = (global::SerializationTypes.TypeNameClashB.TypeNameClash[])EnsureArrayIndex(a_1, ca_1, typeof(global::SerializationTypes.TypeNameClashB.TypeNameClash));a_1[ca_1++] = Read129_TypeNameClash(false, true);
+                        if (((object) Reader.LocalName == (object)id146_B && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            a_1 = (global::SerializationTypes.TypeNameClashB.TypeNameClash[])EnsureArrayIndex(a_1, ca_1, typeof(global::SerializationTypes.TypeNameClashB.TypeNameClash));a_1[ca_1++] = Read132_TypeNameClash(false, true);
                             break;
                         }
                         UnknownNode((object)o, @":A, :B");
@@ -8063,12 +8319,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName Read127_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName Read130_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id132_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id135_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -8093,12 +8349,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id144_Value1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id147_Value1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Value1 = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id145_Value2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id148_Value2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Value2 = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -8128,132 +8384,138 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     return ReadTypedPrimitive(new System.Xml.XmlQualifiedName("anyType", "http://www.w3.org/2001/XMLSchema"));
                 }
                 else {
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id136_Person && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read131_Person(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id141_ContainerType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id139_Person && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read134_Person(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id144_ContainerType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read133_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id137_TypeClashB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read132_TypeNameClash(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id138_TypeClashA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read131_TypeNameClash(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id135_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read130_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id134_TypeClashB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read129_TypeNameClash(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id135_TypeClashA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read128_TypeNameClash(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id132_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read127_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id131_TypeWithFieldsOrdered && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read126_TypeWithFieldsOrdered(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id127_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id134_TypeWithFieldsOrdered && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read129_TypeWithFieldsOrdered(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read128_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id132_ComplexChoiceA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read127_ComplexChoiceA(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id133_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read126_ComplexChoiceB(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id129_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read125_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id129_ComplexChoiceA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read124_ComplexChoiceA(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read123_ComplexChoiceB(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id126_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id128_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read123_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id127_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read122_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id126_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read121_Item(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id125_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read120_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id124_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read119_Item(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id123_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read118_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id122_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read117_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id120_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read115_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id124_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read119_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id122_TypeWithShouldSerializeMethod && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read117_TypeWithShouldSerializeMethod(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id121_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read116_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id119_TypeWithShouldSerializeMethod && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read114_TypeWithShouldSerializeMethod(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id118_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read113_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id117_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read112_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id116_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read111_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id115_TypeWith2DArrayProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read110_TypeWith2DArrayProperty2(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id114_TypeWithXmlQualifiedName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read109_TypeWithXmlQualifiedName(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id113_ServerSettings && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read108_ServerSettings(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id112_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read107_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id110_CustomDocument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read106_CustomDocument(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id111_CustomElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read105_CustomElement(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id108_MyXmlType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read103_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id107_TypeWithXmlSchemaFormAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read102_TypeWithXmlSchemaFormAttribute(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id106_TypeWithPropertyNameSpecified && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read101_TypeWithPropertyNameSpecified(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id102_SimpleKnownTypeValue && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read100_SimpleKnownTypeValue(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id101_KnownTypesThroughConstructor && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read99_KnownTypesThroughConstructor(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id100_TypeWithAnyAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read98_TypeWithAnyAttribute(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id146_XmlSerializerAttributes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read97_XmlSerializerAttributes(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id90_WithNullables && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read90_WithNullables(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id89_WithEnums && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read87_WithEnums(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id87_WithStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read84_WithStruct(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id88_SomeStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read83_SomeStruct(false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id86_ClassImplementsInterface && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read82_ClassImplementsInterface(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id83_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id84_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id120_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read115_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id119_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read114_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id118_TypeWith2DArrayProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read113_TypeWith2DArrayProperty2(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id117_TypeWithXmlQualifiedName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read112_TypeWithXmlQualifiedName(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id116_ServerSettings && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read111_ServerSettings(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id115_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read110_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id113_CustomDocument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read109_CustomDocument(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id114_CustomElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read108_CustomElement(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id111_MyXmlType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read106_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id110_TypeWithXmlSchemaFormAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read105_TypeWithXmlSchemaFormAttribute(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id109_TypeWithPropertyNameSpecified && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read104_TypeWithPropertyNameSpecified(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id105_SimpleKnownTypeValue && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read103_SimpleKnownTypeValue(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id104_KnownTypesThroughConstructor && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read102_KnownTypesThroughConstructor(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id103_TypeWithAnyAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read101_TypeWithAnyAttribute(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id149_XmlSerializerAttributes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read100_XmlSerializerAttributes(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id93_WithNullables && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read93_WithNullables(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id92_WithEnums && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read90_WithEnums(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id90_WithStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read87_WithStruct(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id91_SomeStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read86_SomeStruct(false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id89_ClassImplementsInterface && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read85_ClassImplementsInterface(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id86_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id87_Item))
+                        return Read83_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id85_SimpleDC && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read82_SimpleDC(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id84_TypeWithByteArrayAsXmlText && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read81_TypeWithByteArrayAsXmlText(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id83_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read80_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id82_SimpleDC && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read79_SimpleDC(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id81_TypeWithByteArrayAsXmlText && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read78_TypeWithByteArrayAsXmlText(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id80_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read77_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_BaseClassWithSamePropertyName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read74_BaseClassWithSamePropertyName(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read75_DerivedClassWithSameProperty(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read76_DerivedClassWithSameProperty2(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id76_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read73_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id75_TypeHasArrayOfASerializedAsB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read72_TypeHasArrayOfASerializedAsB(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id74_TypeB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read71_TypeB(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id73_TypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read70_TypeA(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id72_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read69_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id71_TypeWithBuiltInTypedMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read68_TypeWithBuiltInTypedMembers(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id70_BuiltInTypes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read66_BuiltInTypes(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id69_DCClassWithEnumAndStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read65_DCClassWithEnumAndStruct(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id68_DCStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read64_DCStruct(false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id67_TypeWithEnumMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read63_TypeWithEnumMembers(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id63_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read61_Item(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id62_TypeWithMyCollectionField && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read60_TypeWithMyCollectionField(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id61_StructNotSerializable && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read59_StructNotSerializable(false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id60_TypeWithArraylikeMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read58_TypeWithArraylikeMembers(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id59_TypeWithGetOnlyArrayProperties && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read57_TypeWithGetOnlyArrayProperties(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id58_TypeWithGetSetArrayMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read56_TypeWithGetSetArrayMembers(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id57_SimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read55_SimpleType(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id56_TypeWithDateTimeStringProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                        return Read54_TypeWithDateTimeStringProperty(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id80_BaseClassWithSamePropertyName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read77_BaseClassWithSamePropertyName(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id81_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read78_DerivedClassWithSameProperty(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id82_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read79_DerivedClassWithSameProperty2(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read76_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_TypeHasArrayOfASerializedAsB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read75_TypeHasArrayOfASerializedAsB(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_TypeB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read74_TypeB(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id76_TypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read73_TypeA(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id75_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read72_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id74_TypeWithBuiltInTypedMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read71_TypeWithBuiltInTypedMembers(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id73_BuiltInTypes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read69_BuiltInTypes(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id72_DCClassWithEnumAndStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read68_DCClassWithEnumAndStruct(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id71_DCStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read67_DCStruct(false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id70_TypeWithEnumMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read66_TypeWithEnumMembers(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id66_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read64_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id65_TypeWithMyCollectionField && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read63_TypeWithMyCollectionField(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id64_StructNotSerializable && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read62_StructNotSerializable(false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id63_TypeWithArraylikeMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read61_TypeWithArraylikeMembers(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id62_TypeWithGetOnlyArrayProperties && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read60_TypeWithGetOnlyArrayProperties(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id61_TypeWithGetSetArrayMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read59_TypeWithGetSetArrayMembers(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id60_SimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read58_SimpleType(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id59_TypeWithDateTimeStringProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read57_TypeWithDateTimeStringProperty(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id58_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read56_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id57_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read55_Item(isNullable, false);
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id56_TypeWithReadOnlyCollections && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                        return Read54_TypeWithReadOnlyCollections(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id54_XElementArrayWrapper && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read53_XElementArrayWrapper(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id53_XElementStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
@@ -8264,13 +8526,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         return Read50_RootClass(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id51_Parameter && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read49_Parameter(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id147_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id150_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read48_ParameterOfString(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id148_MsgDocumentType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id49_httpexamplecom))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id151_MsgDocumentType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id49_httpexamplecom))
                         return Read47_MsgDocumentType(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id47_TypeWithLinkedProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read46_TypeWithLinkedProperty(isNullable, false);
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id149_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id152_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read45_Item(isNullable, false);
                     if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id45_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                         return Read44_Item(isNullable, false);
@@ -8356,7 +8618,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id150_ArrayOfOrderedItem && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id30_httpwwwcontoso1com)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id153_ArrayOfOrderedItem && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id30_httpwwwcontoso1com)) {
                         global::OrderedItem[] a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8396,7 +8658,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id151_ArrayOfInt && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id154_ArrayOfInt && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.Int32> a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8418,7 +8680,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 if (Reader.HasAttributes) {
                                                     while (Reader.MoveToNextAttribute()) {
                                                         if (!IsXmlnsAttribute(Reader.Name)) {
@@ -8445,7 +8707,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id153_ArrayOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id156_ArrayOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.String> a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8467,7 +8729,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 if (ReadNull()) {
                                                     z_0_0.Add(null);
                                                 }
@@ -8499,7 +8761,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id155_ArrayOfDouble && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id158_ArrayOfDouble && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.Double> a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8521,7 +8783,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id156_double && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id159_double && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 if (Reader.HasAttributes) {
                                                     while (Reader.MoveToNextAttribute()) {
                                                         if (!IsXmlnsAttribute(Reader.Name)) {
@@ -8597,7 +8859,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id157_ArrayOfInstrument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id160_ArrayOfInstrument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::Instrument[] a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8637,7 +8899,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id158_ArrayOfTypeWithLinkedProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id161_ArrayOfTypeWithLinkedProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::TypeWithLinkedProperty> a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8676,7 +8938,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id159_ArrayOfParameter && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id162_ArrayOfParameter && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::Parameter> a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8715,7 +8977,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id160_ArrayOfXElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id163_ArrayOfXElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Xml.Linq.XElement[] a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8737,7 +8999,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id161_XElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id164_XElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 z_0_0 = (global::System.Xml.Linq.XElement[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::System.Xml.Linq.XElement));z_0_0[cz_0_0++] = (global::System.Xml.Linq.XElement)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::System.Xml.Linq.XElement("default"), true
                                                 );
                                                 break;
@@ -8756,7 +9018,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id162_ArrayOfSimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id165_ArrayOfSimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.SimpleType[] a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8778,8 +9040,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                z_0_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.SimpleType));z_0_0[cz_0_0++] = Read55_SimpleType(true, true);
+                                            if (((object) Reader.LocalName == (object)id60_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                z_0_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.SimpleType));z_0_0[cz_0_0++] = Read58_SimpleType(true, true);
                                                 break;
                                             }
                                             UnknownNode(null, @":SimpleType");
@@ -8796,7 +9058,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id64_ArrayOfAnyType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id67_ArrayOfAnyType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.MyList a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8818,7 +9080,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id65_anyType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id68_anyType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 if ((object)(z_0_0) == null) Reader.Skip(); else z_0_0.Add(Read1_Object(true, true));
                                                 break;
                                             }
@@ -8835,13 +9097,13 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id66_MyEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id69_MyEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read62_MyEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read65_MyEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id163_ArrayOfTypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id166_ArrayOfTypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.TypeA[] a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8863,8 +9125,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id73_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                z_0_0 = (global::SerializationTypes.TypeA[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.TypeA));z_0_0[cz_0_0++] = Read70_TypeA(true, true);
+                                            if (((object) Reader.LocalName == (object)id76_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                z_0_0 = (global::SerializationTypes.TypeA[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.TypeA));z_0_0[cz_0_0++] = Read73_TypeA(true, true);
                                                 break;
                                             }
                                             UnknownNode(null, @":TypeA");
@@ -8881,61 +9143,61 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id85_EnumFlags && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id88_EnumFlags && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read81_EnumFlags(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read84_EnumFlags(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id94_IntEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id97_IntEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read85_IntEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read88_IntEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id93_ShortEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id96_ShortEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read86_ShortEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read89_ShortEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id91_ByteEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id94_ByteEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read91_ByteEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read94_ByteEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id92_SByteEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id95_SByteEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read92_SByteEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read95_SByteEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id95_UIntEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id98_UIntEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read93_UIntEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read96_UIntEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id96_LongEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id99_LongEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read94_LongEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read97_LongEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id97_ULongEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id100_ULongEnum && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read95_ULongEnum(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read98_ULongEnum(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id99_ItemChoiceType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id102_ItemChoiceType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read96_ItemChoiceType(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read99_ItemChoiceType(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id164_ArrayOfItemChoiceType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id167_ArrayOfItemChoiceType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.ItemChoiceType[] a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -8957,7 +9219,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id99_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id102_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 if (Reader.HasAttributes) {
                                                     while (Reader.MoveToNextAttribute()) {
                                                         if (!IsXmlnsAttribute(Reader.Name)) {
@@ -8967,7 +9229,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                                     Reader.MoveToElement();
                                                 }
                                                 {
-                                                    z_0_0 = (global::SerializationTypes.ItemChoiceType[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.ItemChoiceType));z_0_0[cz_0_0++] = Read96_ItemChoiceType(Reader.ReadElementString());
+                                                    z_0_0 = (global::SerializationTypes.ItemChoiceType[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::SerializationTypes.ItemChoiceType));z_0_0[cz_0_0++] = Read99_ItemChoiceType(Reader.ReadElementString());
                                                 }
                                                 break;
                                             }
@@ -8985,7 +9247,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id153_ArrayOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id165_httpmynamespace)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id156_ArrayOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id168_httpmynamespace)) {
                         global::System.Object[] a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -9007,7 +9269,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id165_httpmynamespace)) {
+                                            if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id168_httpmynamespace)) {
                                                 if (ReadNull()) {
                                                     z_0_0 = (global::System.Object[])EnsureArrayIndex(z_0_0, cz_0_0, typeof(global::System.Object));z_0_0[cz_0_0++] = null;
                                                 }
@@ -9040,7 +9302,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id166_ArrayOfString1 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id169_ArrayOfString1 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.String> a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -9062,7 +9324,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id167_NoneParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id170_NoneParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 if (Reader.HasAttributes) {
                                                     while (Reader.MoveToNextAttribute()) {
                                                         if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9089,7 +9351,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id168_ArrayOfBoolean && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id171_ArrayOfBoolean && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::System.Collections.Generic.List<global::System.Boolean> a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -9111,7 +9373,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id169_QualifiedParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id172_QualifiedParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 if (Reader.HasAttributes) {
                                                     while (Reader.MoveToNextAttribute()) {
                                                         if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9138,7 +9400,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id170_ArrayOfArrayOfSimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id173_ArrayOfArrayOfSimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         global::SerializationTypes.SimpleType[][] a = null;
                         if (!ReadNull()) {
                             if (Reader.HasAttributes) {
@@ -9160,7 +9422,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                     if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                         do {
-                                            if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                            if (((object) Reader.LocalName == (object)id60_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                 if (!ReadNull()) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
@@ -9181,8 +9443,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                                         while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                                             if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                                                 do {
-                                                                    if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                                        z_0_0_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(z_0_0_0, cz_0_0_0, typeof(global::SerializationTypes.SimpleType));z_0_0_0[cz_0_0_0++] = Read55_SimpleType(true, true);
+                                                                    if (((object) Reader.LocalName == (object)id60_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                                        z_0_0_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(z_0_0_0, cz_0_0_0, typeof(global::SerializationTypes.SimpleType));z_0_0_0[cz_0_0_0++] = Read58_SimpleType(true, true);
                                                                         break;
                                                                     }
                                                                     UnknownNode(null, @":SimpleType");
@@ -9213,9 +9475,9 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         }
                         return a;
                     }
-                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id128_MoreChoices && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+                    if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id131_MoreChoices && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
                         Reader.ReadStartElement();
-                        object e = Read121_MoreChoices(CollapseWhitespace(Reader.ReadString()));
+                        object e = Read124_MoreChoices(CollapseWhitespace(Reader.ReadString()));
                         ReadEndElement();
                         return e;
                     }
@@ -9251,7 +9513,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.MoreChoices Read121_MoreChoices(string s) {
+        global::SerializationTypes.MoreChoices Read124_MoreChoices(string s) {
             switch (s) {
                 case @"None": return global::SerializationTypes.MoreChoices.@None;
                 case @"Item": return global::SerializationTypes.MoreChoices.@Item;
@@ -9260,12 +9522,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.SimpleType Read55_SimpleType(bool isNullable, bool checkType) {
+        global::SerializationTypes.SimpleType Read58_SimpleType(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id57_SimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id60_SimpleType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -9290,7 +9552,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id171_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id174_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9305,7 +9567,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id172_P2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id175_P2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9332,7 +9594,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ItemChoiceType Read96_ItemChoiceType(string s) {
+        global::SerializationTypes.ItemChoiceType Read99_ItemChoiceType(string s) {
             switch (s) {
                 case @"None": return global::SerializationTypes.ItemChoiceType.@None;
                 case @"Word": return global::SerializationTypes.ItemChoiceType.@Word;
@@ -9342,7 +9604,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.ULongEnum Read95_ULongEnum(string s) {
+        global::SerializationTypes.ULongEnum Read98_ULongEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.ULongEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.ULongEnum.@Option1;
@@ -9351,7 +9613,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.LongEnum Read94_LongEnum(string s) {
+        global::SerializationTypes.LongEnum Read97_LongEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.LongEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.LongEnum.@Option1;
@@ -9360,7 +9622,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.UIntEnum Read93_UIntEnum(string s) {
+        global::SerializationTypes.UIntEnum Read96_UIntEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.UIntEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.UIntEnum.@Option1;
@@ -9369,7 +9631,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.SByteEnum Read92_SByteEnum(string s) {
+        global::SerializationTypes.SByteEnum Read95_SByteEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.SByteEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.SByteEnum.@Option1;
@@ -9378,7 +9640,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.ByteEnum Read91_ByteEnum(string s) {
+        global::SerializationTypes.ByteEnum Read94_ByteEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.ByteEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.ByteEnum.@Option1;
@@ -9387,7 +9649,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.ShortEnum Read86_ShortEnum(string s) {
+        global::SerializationTypes.ShortEnum Read89_ShortEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.ShortEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.ShortEnum.@Option1;
@@ -9396,7 +9658,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.IntEnum Read85_IntEnum(string s) {
+        global::SerializationTypes.IntEnum Read88_IntEnum(string s) {
             switch (s) {
                 case @"Option0": return global::SerializationTypes.IntEnum.@Option0;
                 case @"Option1": return global::SerializationTypes.IntEnum.@Option1;
@@ -9421,16 +9683,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             }
         }
 
-        global::SerializationTypes.EnumFlags Read81_EnumFlags(string s) {
+        global::SerializationTypes.EnumFlags Read84_EnumFlags(string s) {
             return (global::SerializationTypes.EnumFlags)ToEnum(s, EnumFlagsValues, @"global::SerializationTypes.EnumFlags");
         }
 
-        global::SerializationTypes.TypeA Read70_TypeA(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeA Read73_TypeA(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id73_TypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id76_TypeA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -9455,7 +9717,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9482,7 +9744,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.MyEnum Read62_MyEnum(string s) {
+        global::SerializationTypes.MyEnum Read65_MyEnum(string s) {
             switch (s) {
                 case @"One": return global::SerializationTypes.MyEnum.@One;
                 case @"Two": return global::SerializationTypes.MyEnum.@Two;
@@ -9499,7 +9761,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id51_Parameter && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id147_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id150_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
                     return Read48_ParameterOfString(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
@@ -9509,7 +9771,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::Parameter();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -9542,7 +9804,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id147_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id150_ParameterOfString && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -9553,7 +9815,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::Parameter<global::System.String>();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -9571,7 +9833,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id176_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9630,12 +9892,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id174_Child && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id177_Child && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Child = Read46_TypeWithLinkedProperty(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id175_Children && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id178_Children && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -9719,7 +9981,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9776,7 +10038,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9791,7 +10053,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id176_IsValved && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id179_IsValved && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9806,7 +10068,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id177_Modulation && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id180_Modulation && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9865,7 +10127,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9880,7 +10142,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id176_IsValved && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id179_IsValved && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9937,7 +10199,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id178_ItemName && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id181_ItemName && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9952,7 +10214,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id179_Description && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id182_Description && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9967,7 +10229,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id180_UnitPrice && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id183_UnitPrice && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9982,7 +10244,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id181_Quantity && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id184_Quantity && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -9997,7 +10259,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id182_LineTotal && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id185_LineTotal && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10153,7 +10415,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id183_BinaryHexContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id186_BinaryHexContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10168,7 +10430,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id184_Base64Content && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id187_Base64Content && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10225,7 +10487,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id185_DTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id188_DTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10246,7 +10508,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id186_DTO2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id189_DTO2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10267,7 +10529,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id187_DefaultDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id190_DefaultDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10291,12 +10553,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id188_NullableDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id191_NullableDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDTO = Read5_NullableOfDateTimeOffset(true);
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id189_NullableDefaultDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id192_NullableDefaultDTO && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDTOWithDefault = Read5_NullableOfDateTimeOffset(true);
                             paramsRead[4] = true;
                             break;
@@ -10367,7 +10629,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id190_Today && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id193_Today && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10388,7 +10650,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id191_MyDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id194_MyDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10409,7 +10671,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id192_DefaultDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id195_DefaultDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10433,22 +10695,22 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id193_NullableDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id196_NullableDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDate = Read7_NullableOfDateOnly(true);
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id194_NullableDateWithValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id197_NullableDateWithValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDateWithValue = Read7_NullableOfDateOnly(true);
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id195_NullableDefaultDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id198_NullableDefaultDate && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDefaultDate = Read7_NullableOfDateOnly(true);
                             paramsRead[5] = true;
                             break;
                         }
-                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id196_Now && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id199_Now && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10469,7 +10731,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[6] = true;
                             break;
                         }
-                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id197_MyTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id200_MyTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10490,7 +10752,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[7] = true;
                             break;
                         }
-                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id198_DefaultTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id201_DefaultTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10514,17 +10776,17 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[8] = true;
                             break;
                         }
-                        if (!paramsRead[9] && ((object) Reader.LocalName == (object)id199_NullableTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[9] && ((object) Reader.LocalName == (object)id202_NullableTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableTime = Read8_NullableOfTimeOnly(true);
                             paramsRead[9] = true;
                             break;
                         }
-                        if (!paramsRead[10] && ((object) Reader.LocalName == (object)id200_NullableTimeWithValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[10] && ((object) Reader.LocalName == (object)id203_NullableTimeWithValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableTimeWithValue = Read8_NullableOfTimeOnly(true);
                             paramsRead[10] = true;
                             break;
                         }
-                        if (!paramsRead[11] && ((object) Reader.LocalName == (object)id201_NullableDefaultTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[11] && ((object) Reader.LocalName == (object)id204_NullableDefaultTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableDefaultTime = Read8_NullableOfTimeOnly(true);
                             paramsRead[11] = true;
                             break;
@@ -10619,7 +10881,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id205_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10682,7 +10944,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id205_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10745,7 +11007,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id205_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10808,7 +11070,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id205_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10865,7 +11127,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id202_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id205_TestValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10922,7 +11184,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id203_TimeSpanProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id206_TimeSpanProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -10985,7 +11247,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id203_TimeSpanProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id206_TimeSpanProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11009,7 +11271,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id204_TimeSpanProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id207_TimeSpanProperty2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11075,7 +11337,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id205_ByteProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id208_ByteProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11183,7 +11445,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id206_Age && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id209_Age && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11198,7 +11460,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11213,7 +11475,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id207_Breed && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id210_Breed && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11272,7 +11534,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id206_Age && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id209_Age && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11287,7 +11549,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11344,7 +11606,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id208_LicenseNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id211_LicenseNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11401,7 +11663,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id209_GroupName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id212_GroupName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11416,7 +11678,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id210_GroupVehicle && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id213_GroupVehicle && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@GroupVehicle = Read22_Vehicle(false, true);
                             paramsRead[1] = true;
                             break;
@@ -11463,7 +11725,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id211_EmployeeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id214_EmployeeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11520,7 +11782,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id176_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11535,7 +11797,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id212_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id215_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11594,7 +11856,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id176_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11609,7 +11871,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id212_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id215_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11652,15 +11914,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SimpleDerivedClass();
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id213_AttributeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id216_AttributeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@AttributeString = Reader.Value;
                     paramsRead[0] = true;
                 }
-                else if (!paramsRead[1] && ((object) Reader.LocalName == (object)id214_DateTimeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                else if (!paramsRead[1] && ((object) Reader.LocalName == (object)id217_DateTimeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@DateTimeValue = ToDateTime(Reader.Value);
                     paramsRead[1] = true;
                 }
-                else if (!paramsRead[2] && ((object) Reader.LocalName == (object)id215_BoolValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                else if (!paramsRead[2] && ((object) Reader.LocalName == (object)id218_BoolValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@BoolValue = System.Xml.XmlConvert.ToBoolean(Reader.Value);
                     paramsRead[2] = true;
                 }
@@ -11706,11 +11968,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SimpleBaseClass();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id213_AttributeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id216_AttributeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@AttributeString = Reader.Value;
                     paramsRead[0] = true;
                 }
-                else if (!paramsRead[1] && ((object) Reader.LocalName == (object)id214_DateTimeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                else if (!paramsRead[1] && ((object) Reader.LocalName == (object)id217_DateTimeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@DateTimeValue = ToDateTime(Reader.Value);
                     paramsRead[1] = true;
                 }
@@ -11754,7 +12016,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::Address();
             System.Span<bool> paramsRead = stackalloc bool[5];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -11772,7 +12034,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id216_Line1 && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id219_Line1 && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11787,7 +12049,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id217_City && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id220_City && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11802,7 +12064,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id218_State && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id221_State && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11817,7 +12079,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id219_Zip && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id222_Zip && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11876,12 +12138,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id220_ShipTo && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id223_ShipTo && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             o.@ShipTo = Read29_Address(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id221_OrderDate && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id224_OrderDate && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11896,7 +12158,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id222_Items && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (((object) Reader.LocalName == (object)id225_Items && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -11935,7 +12197,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id223_SubTotal && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id226_SubTotal && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11950,7 +12212,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id224_ShipCost && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id227_ShipCost && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -11965,7 +12227,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id225_TotalCost && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id228_TotalCost && (object) Reader.NamespaceURI == (object)id30_httpwwwcontoso1com)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12008,7 +12270,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::Address();
             System.Span<bool> paramsRead = stackalloc bool[5];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -12026,7 +12288,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id216_Line1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id219_Line1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12041,7 +12303,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id217_City && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id220_City && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12056,7 +12318,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id218_State && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id221_State && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12071,7 +12333,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id219_Zip && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id222_Zip && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12128,7 +12390,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id178_ItemName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id181_ItemName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12143,7 +12405,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id179_Description && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id182_Description && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12158,7 +12420,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id180_UnitPrice && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id183_UnitPrice && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12173,7 +12435,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id181_Quantity && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id184_Quantity && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12188,7 +12450,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id182_LineTotal && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id185_LineTotal && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12245,7 +12507,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id226_X && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id229_X && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -12266,7 +12528,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12294,7 +12556,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id227_Y && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id230_Y && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -12315,7 +12577,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (ReadNull()) {
                                                         a_0_0.Add(null);
                                                     }
@@ -12348,7 +12610,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id228_Z && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id231_Z && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -12369,7 +12631,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id156_double && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id159_double && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12441,7 +12703,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id229_Prop && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id232_Prop && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12501,7 +12763,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id229_Prop && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id232_Prop && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12559,7 +12821,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id230_Instruments && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id233_Instruments && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -12655,7 +12917,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id231_Comment2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id234_Comment2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12712,7 +12974,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id232_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id235_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12730,7 +12992,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id233_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id236_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12748,7 +13010,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id234_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id237_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12766,7 +13028,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id235_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id238_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12826,7 +13088,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id232_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id235_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12844,7 +13106,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id233_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id236_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12862,7 +13124,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id234_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id237_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12880,7 +13142,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id235_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id238_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12940,7 +13202,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id232_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id235_DoubleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12958,7 +13220,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id233_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id236_SingleField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12976,7 +13238,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id234_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id237_DoubleProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -12994,7 +13256,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id235_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id238_FloatProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -13029,7 +13291,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id149_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id152_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13040,7 +13302,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::TypeWithMismatchBetweenAttributeAndPropertyType();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id236_IntValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id239_IntValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@IntValue = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[0] = true;
                 }
@@ -13073,7 +13335,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id148_MsgDocumentType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id49_httpexamplecom)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id151_MsgDocumentType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id49_httpexamplecom)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13086,11 +13348,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_1 = 0;
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id237_id && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id240_id && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Id = CollapseWhitespace(Reader.Value);
                     paramsRead[0] = true;
                 }
-                else if (((object) Reader.LocalName == (object)id238_refs && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                else if (((object) Reader.LocalName == (object)id241_refs && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     string listValues = Reader.Value;
                     string[] vals = listValues.Split(xmlListSeparators);
                     for (int i = 0; i < vals.Length; i++) {
@@ -13155,7 +13417,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id239_Parameters && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id242_Parameters && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13235,7 +13497,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id176_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Value = (global::System.Xml.Linq.XElement)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::System.Xml.Linq.XElement("default"), true
                             );
                             paramsRead[0] = true;
@@ -13289,7 +13551,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id240_xelement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id243_xelement && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@xelement = (global::System.Xml.Linq.XElement)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::System.Xml.Linq.XElement("default"), true
                             );
                             paramsRead[0] = true;
@@ -13339,7 +13601,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id241_xelements && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id244_xelements && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13360,7 +13622,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id161_XElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id164_XElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     a_0_0 = (global::System.Xml.Linq.XElement[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::System.Xml.Linq.XElement));a_0_0[ca_0_0++] = (global::System.Xml.Linq.XElement)ReadSerializable(( System.Xml.Serialization.IXmlSerializable)new global::System.Xml.Linq.XElement("default"), true
                                                     );
                                                     break;
@@ -13391,12 +13653,711 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithDateTimeStringProperty Read54_TypeWithDateTimeStringProperty(bool isNullable, bool checkType) {
+        global::TypeWithReadOnlyCollections Read54_TypeWithReadOnlyCollections(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id56_TypeWithDateTimeStringProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id56_TypeWithReadOnlyCollections && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            }
+            else {
+                throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
+            }
+            }
+            if (isNull) return null;
+            global::TypeWithReadOnlyCollections o;
+            o = new global::TypeWithReadOnlyCollections();
+            global::System.Int32[] a_0 = null;
+            o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+            int ca_0 = 0;
+            global::System.String[] a_1 = null;
+            o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
+            int ca_1 = 0;
+            global::System.Int32[] a_2 = null;
+            o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+            int ca_2 = 0;
+            global::System.Int32[] a_3 = null;
+            o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+            int ca_3 = 0;
+            global::System.Int32[] a_4 = null;
+            o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+            int ca_4 = 0;
+            System.Span<bool> paramsRead = stackalloc bool[5];
+            while (Reader.MoveToNextAttribute()) {
+                if (!IsXmlnsAttribute(Reader.Name)) {
+                    UnknownNode((object)o);
+                }
+            }
+            Reader.MoveToElement();
+            if (Reader.IsEmptyElement) {
+                Reader.Skip();
+                return o;
+            }
+            Reader.ReadStartElement();
+            Reader.MoveToContent();
+            while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                    do {
+                        if (((object) Reader.LocalName == (object)id245_ImmutableArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.Int32[] a_0_0 = null;
+                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_0_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (Reader.HasAttributes) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_0_0 = (global::System.Int32[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::System.Int32));a_0_0[ca_0_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_0_0, ca_0_0, typeof(global::System.Int32), false));
+                            }
+                            else {
+                                global::System.Int32[] a_0_0 = null;
+                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_0_0 = 0;
+                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_0_0, ca_0_0, typeof(global::System.Int32), false));
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id246_ImmutableList && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.String[] a_1_0 = null;
+                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
+                                int ca_1_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (ReadNull()) {
+                                                        a_1_0 = (global::System.String[])EnsureArrayIndex(a_1_0, ca_1_0, typeof(global::System.String));a_1_0[ca_1_0++] = null;
+                                                    }
+                                                    else {
+                                                        if (Reader.HasAttributes) {
+                                                            while (Reader.MoveToNextAttribute()) {
+                                                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                    UnknownNode(null);
+                                                                }
+                                                            }
+                                                            Reader.MoveToElement();
+                                                        }
+                                                        {
+                                                            a_1_0 = (global::System.String[])EnsureArrayIndex(a_1_0, ca_1_0, typeof(global::System.String));a_1_0[ca_1_0++] = Reader.ReadElementString();
+                                                        }
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":string");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":string");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(a_1_0, ca_1_0, typeof(global::System.String), false));
+                            }
+                            else {
+                                global::System.String[] a_1_0 = null;
+                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
+                                int ca_1_0 = 0;
+                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(a_1_0, ca_1_0, typeof(global::System.String), false));
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id247_ReadOnlyCollection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.Int32[] a_2_0 = null;
+                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_2_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (Reader.HasAttributes) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_2_0 = (global::System.Int32[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::System.Int32));a_2_0[ca_2_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_2_0, ca_2_0, typeof(global::System.Int32), false));
+                            }
+                            else {
+                                global::System.Int32[] a_2_0 = null;
+                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_2_0 = 0;
+                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_2_0, ca_2_0, typeof(global::System.Int32), false));
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id248_FrozenSet && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.Int32[] a_3_0 = null;
+                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_3_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (Reader.HasAttributes) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_3_0 = (global::System.Int32[])EnsureArrayIndex(a_3_0, ca_3_0, typeof(global::System.Int32));a_3_0[ca_3_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_3_0, ca_3_0, typeof(global::System.Int32), false));
+                            }
+                            else {
+                                global::System.Int32[] a_3_0 = null;
+                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_3_0 = 0;
+                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_3_0, ca_3_0, typeof(global::System.Int32), false));
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id249_ImmutableQueue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.Int32[] a_4_0 = null;
+                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_4_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (Reader.HasAttributes) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_4_0 = (global::System.Int32[])EnsureArrayIndex(a_4_0, ca_4_0, typeof(global::System.Int32));a_4_0[ca_4_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_4_0, ca_4_0, typeof(global::System.Int32), false));
+                            }
+                            else {
+                                global::System.Int32[] a_4_0 = null;
+                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_4_0 = 0;
+                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_4_0, ca_4_0, typeof(global::System.Int32), false));
+                            }
+                            break;
+                        }
+                        UnknownNode((object)o, @":ImmutableArray, :ImmutableList, :ReadOnlyCollection, :FrozenSet, :ImmutableQueue");
+                    } while (false);
+                }
+                else {
+                    UnknownNode((object)o, @":ImmutableArray, :ImmutableList, :ReadOnlyCollection, :FrozenSet, :ImmutableQueue");
+                }
+                Reader.MoveToContent();
+            }
+            ReadEndElement();
+            return o;
+        }
+
+        global::TypeWithMutableCollectionMembers Read55_Item(bool isNullable, bool checkType) {
+            System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
+            bool isNull = false;
+            if (isNullable) isNull = ReadNull();
+            if (checkType) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id57_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            }
+            else {
+                throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
+            }
+            }
+            if (isNull) return null;
+            global::TypeWithMutableCollectionMembers o;
+            o = new global::TypeWithMutableCollectionMembers();
+            if ((object)(o.@List) == null) o.@List = new global::System.Collections.Generic.List<global::System.Int32>();
+            global::System.Collections.Generic.List<global::System.Int32> a_0 = (global::System.Collections.Generic.List<global::System.Int32>)o.@List;
+            global::System.Int32[] a_1 = null;
+            int ca_1 = 0;
+            System.Span<bool> paramsRead = stackalloc bool[2];
+            while (Reader.MoveToNextAttribute()) {
+                if (!IsXmlnsAttribute(Reader.Name)) {
+                    UnknownNode((object)o);
+                }
+            }
+            Reader.MoveToElement();
+            if (Reader.IsEmptyElement) {
+                Reader.Skip();
+                return o;
+            }
+            Reader.ReadStartElement();
+            Reader.MoveToContent();
+            while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                    do {
+                        if (((object) Reader.LocalName == (object)id250_List && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                if ((object)(o.@List) == null) o.@List = new global::System.Collections.Generic.List<global::System.Int32>();
+                                global::System.Collections.Generic.List<global::System.Int32> a_0_0 = (global::System.Collections.Generic.List<global::System.Int32>)o.@List;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (Reader.HasAttributes) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_0_0.Add(System.Xml.XmlConvert.ToInt32(Reader.ReadElementString()));
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id251_Array && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.Int32[] a_1_0 = null;
+                                int ca_1_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (Reader.HasAttributes) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_1_0 = (global::System.Int32[])EnsureArrayIndex(a_1_0, ca_1_0, typeof(global::System.Int32));a_1_0[ca_1_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@Array = (global::System.Int32[])ShrinkArray(a_1_0, ca_1_0, typeof(global::System.Int32), false);
+                            }
+                            break;
+                        }
+                        UnknownNode((object)o, @":List, :Array");
+                    } while (false);
+                }
+                else {
+                    UnknownNode((object)o, @":List, :Array");
+                }
+                Reader.MoveToContent();
+            }
+            ReadEndElement();
+            return o;
+        }
+
+        global::TypeWithGetOnlyReadOnlyCollections Read56_Item(bool isNullable, bool checkType) {
+            System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
+            bool isNull = false;
+            if (isNullable) isNull = ReadNull();
+            if (checkType) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id58_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            }
+            else {
+                throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
+            }
+            }
+            if (isNull) return null;
+            global::TypeWithGetOnlyReadOnlyCollections o;
+            o = new global::TypeWithGetOnlyReadOnlyCollections();
+            global::System.String[] a_0 = null;
+            int ca_0 = 0;
+            global::System.Int32[] a_1 = null;
+            int ca_1 = 0;
+            global::System.String[] a_2 = null;
+            int ca_2 = 0;
+            System.Span<bool> paramsRead = stackalloc bool[3];
+            while (Reader.MoveToNextAttribute()) {
+                if (!IsXmlnsAttribute(Reader.Name)) {
+                    UnknownNode((object)o);
+                }
+            }
+            Reader.MoveToElement();
+            if (Reader.IsEmptyElement) {
+                Reader.Skip();
+                return o;
+            }
+            Reader.ReadStartElement();
+            Reader.MoveToContent();
+            while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                    do {
+                        if (((object) Reader.LocalName == (object)id246_ImmutableList && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.String[] a_0_0 = null;
+                                int ca_0_0 = 0;
+                                if (((object)(a_0_0) == null) || (Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (ReadNull()) {
+                                                        a_0_0 = (global::System.String[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::System.String));a_0_0[ca_0_0++] = null;
+                                                    }
+                                                    else {
+                                                        if (Reader.HasAttributes) {
+                                                            while (Reader.MoveToNextAttribute()) {
+                                                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                    UnknownNode(null);
+                                                                }
+                                                            }
+                                                            Reader.MoveToElement();
+                                                        }
+                                                        {
+                                                            a_0_0 = (global::System.String[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::System.String));a_0_0[ca_0_0++] = Reader.ReadElementString();
+                                                        }
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":string");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":string");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                            }
+                            else {
+                                global::System.String[] a_0_0 = null;
+                                int ca_0_0 = 0;
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id247_ReadOnlyCollection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.Int32[] a_1_0 = null;
+                                int ca_1_0 = 0;
+                                if (((object)(a_1_0) == null) || (Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (Reader.HasAttributes) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_1_0 = (global::System.Int32[])EnsureArrayIndex(a_1_0, ca_1_0, typeof(global::System.Int32));a_1_0[ca_1_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                            }
+                            else {
+                                global::System.Int32[] a_1_0 = null;
+                                int ca_1_0 = 0;
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id245_ImmutableArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.String[] a_2_0 = null;
+                                int ca_2_0 = 0;
+                                if (((object)(a_2_0) == null) || (Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (ReadNull()) {
+                                                        a_2_0 = (global::System.String[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::System.String));a_2_0[ca_2_0++] = null;
+                                                    }
+                                                    else {
+                                                        if (Reader.HasAttributes) {
+                                                            while (Reader.MoveToNextAttribute()) {
+                                                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                    UnknownNode(null);
+                                                                }
+                                                            }
+                                                            Reader.MoveToElement();
+                                                        }
+                                                        {
+                                                            a_2_0 = (global::System.String[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::System.String));a_2_0[ca_2_0++] = Reader.ReadElementString();
+                                                        }
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":string");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":string");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                            }
+                            else {
+                                global::System.String[] a_2_0 = null;
+                                int ca_2_0 = 0;
+                            }
+                            break;
+                        }
+                        UnknownNode((object)o, @":ImmutableList, :ReadOnlyCollection, :ImmutableArray");
+                    } while (false);
+                }
+                else {
+                    UnknownNode((object)o, @":ImmutableList, :ReadOnlyCollection, :ImmutableArray");
+                }
+                Reader.MoveToContent();
+            }
+            ReadEndElement();
+            return o;
+        }
+
+        global::SerializationTypes.TypeWithDateTimeStringProperty Read57_TypeWithDateTimeStringProperty(bool isNullable, bool checkType) {
+            System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
+            bool isNull = false;
+            if (isNullable) isNull = ReadNull();
+            if (checkType) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id59_TypeWithDateTimeStringProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13421,7 +14382,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id242_DateTimeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id252_DateTimeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -13436,7 +14397,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id243_CurrentDateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id253_CurrentDateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -13463,12 +14424,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithGetSetArrayMembers Read56_TypeWithGetSetArrayMembers(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithGetSetArrayMembers Read59_TypeWithGetSetArrayMembers(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id58_TypeWithGetSetArrayMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id61_TypeWithGetSetArrayMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13501,7 +14462,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id244_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id254_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13522,8 +14483,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                    a_0_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::SerializationTypes.SimpleType));a_0_0[ca_0_0++] = Read55_SimpleType(true, true);
+                                                if (((object) Reader.LocalName == (object)id60_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    a_0_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::SerializationTypes.SimpleType));a_0_0[ca_0_0++] = Read58_SimpleType(true, true);
                                                     break;
                                                 }
                                                 UnknownNode(null, @":SimpleType");
@@ -13540,7 +14501,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id245_F2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id255_F2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13561,7 +14522,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -13589,7 +14550,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id171_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id174_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13610,8 +14571,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                    a_2_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::SerializationTypes.SimpleType));a_2_0[ca_2_0++] = Read55_SimpleType(true, true);
+                                                if (((object) Reader.LocalName == (object)id60_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    a_2_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::SerializationTypes.SimpleType));a_2_0[ca_2_0++] = Read58_SimpleType(true, true);
                                                     break;
                                                 }
                                                 UnknownNode(null, @":SimpleType");
@@ -13628,7 +14589,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id172_P2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id175_P2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13649,7 +14610,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -13689,12 +14650,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithGetOnlyArrayProperties Read57_TypeWithGetOnlyArrayProperties(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithGetOnlyArrayProperties Read60_TypeWithGetOnlyArrayProperties(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id59_TypeWithGetOnlyArrayProperties && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id62_TypeWithGetOnlyArrayProperties && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13729,12 +14690,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithArraylikeMembers Read58_TypeWithArraylikeMembers(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithArraylikeMembers Read61_TypeWithArraylikeMembers(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id60_TypeWithArraylikeMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id63_TypeWithArraylikeMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -13775,7 +14736,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id246_IntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id256_IntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13796,7 +14757,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -13824,7 +14785,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id247_NIntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id257_NIntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13845,7 +14806,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -13873,7 +14834,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id248_IntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id258_IntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13894,7 +14855,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -13921,7 +14882,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id249_NIntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id259_NIntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13942,7 +14903,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -13973,7 +14934,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id250_IntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id260_IntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13994,7 +14955,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14022,7 +14983,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id251_NIntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id261_NIntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14043,7 +15004,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14076,7 +15037,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id252_IntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id262_IntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14097,7 +15058,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14124,7 +15085,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id253_NIntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id263_NIntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14145,7 +15106,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14184,11 +15145,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.StructNotSerializable Read59_StructNotSerializable(bool checkType) {
+        global::SerializationTypes.StructNotSerializable Read62_StructNotSerializable(bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id61_StructNotSerializable && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id64_StructNotSerializable && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14220,7 +15181,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id212_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id215_value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14247,12 +15208,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithMyCollectionField Read60_TypeWithMyCollectionField(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithMyCollectionField Read63_TypeWithMyCollectionField(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id62_TypeWithMyCollectionField && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id65_TypeWithMyCollectionField && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14279,7 +15240,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id254_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id264_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14300,7 +15261,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (ReadNull()) {
                                                         a_0_0.Add(null);
                                                     }
@@ -14344,12 +15305,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty Read61_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithReadOnlyMyCollectionProperty Read64_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id63_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id66_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14375,7 +15336,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id254_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id264_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14395,7 +15356,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (ReadNull()) {
                                                         a_0_0.Add(null);
                                                     }
@@ -14439,12 +15400,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithEnumMembers Read63_TypeWithEnumMembers(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithEnumMembers Read66_TypeWithEnumMembers(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id67_TypeWithEnumMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id70_TypeWithEnumMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14469,7 +15430,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id244_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id254_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14479,12 +15440,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 Reader.MoveToElement();
                             }
                             {
-                                o.@F1 = Read62_MyEnum(Reader.ReadElementString());
+                                o.@F1 = Read65_MyEnum(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id171_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id174_P1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14494,7 +15455,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 Reader.MoveToElement();
                             }
                             {
-                                o.@P1 = Read62_MyEnum(Reader.ReadElementString());
+                                o.@P1 = Read65_MyEnum(Reader.ReadElementString());
                             }
                             paramsRead[1] = true;
                             break;
@@ -14511,11 +15472,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.DCStruct Read64_DCStruct(bool checkType) {
+        global::SerializationTypes.DCStruct Read67_DCStruct(bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id68_DCStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id71_DCStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14547,7 +15508,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id255_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14574,12 +15535,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.DCClassWithEnumAndStruct Read65_DCClassWithEnumAndStruct(bool isNullable, bool checkType) {
+        global::SerializationTypes.DCClassWithEnumAndStruct Read68_DCClassWithEnumAndStruct(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id69_DCClassWithEnumAndStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id72_DCClassWithEnumAndStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14604,12 +15565,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id256_MyStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@MyStruct = Read64_DCStruct(true);
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id266_MyStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@MyStruct = Read67_DCStruct(true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id257_MyEnum1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id267_MyEnum1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14619,7 +15580,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 Reader.MoveToElement();
                             }
                             {
-                                o.@MyEnum1 = Read62_MyEnum(Reader.ReadElementString());
+                                o.@MyEnum1 = Read65_MyEnum(Reader.ReadElementString());
                             }
                             paramsRead[1] = true;
                             break;
@@ -14636,12 +15597,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.BuiltInTypes Read66_BuiltInTypes(bool isNullable, bool checkType) {
+        global::SerializationTypes.BuiltInTypes Read69_BuiltInTypes(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id70_BuiltInTypes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id73_BuiltInTypes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14666,7 +15627,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id258_ByteArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id268_ByteArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14693,12 +15654,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithBuiltInTypedMembers Read68_TypeWithBuiltInTypedMembers(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithBuiltInTypedMembers Read71_TypeWithBuiltInTypedMembers(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id71_TypeWithBuiltInTypedMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id74_TypeWithBuiltInTypedMembers && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14727,7 +15688,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id259_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id269_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14742,7 +15703,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id260_IntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id270_IntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14757,12 +15718,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id261_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@NullableIntMember = Read67_NullableOfInt32(true);
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id271_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@NullableIntMember = Read70_NullableOfInt32(true);
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id262_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id272_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14783,7 +15744,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (ReadNull()) {
                                                         a_3_0.Add(null);
                                                     }
@@ -14815,7 +15776,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id263_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id273_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14836,7 +15797,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14876,7 +15837,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::System.Nullable<global::System.Int32> Read67_NullableOfInt32(bool checkType) {
+        global::System.Nullable<global::System.Int32> Read70_NullableOfInt32(bool checkType) {
             global::System.Nullable<global::System.Int32> o = default(global::System.Nullable<global::System.Int32>);
             if (ReadNull())
                 return o;
@@ -14894,12 +15855,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithNullableBuiltInTypedMembers Read69_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithNullableBuiltInTypedMembers Read72_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id72_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id75_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -14928,7 +15889,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id259_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id269_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (ReadNull()) {
                                 o.@StringMember = null;
                             }
@@ -14948,12 +15909,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id261_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@NullableIntMember = Read67_NullableOfInt32(true);
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id271_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@NullableIntMember = Read70_NullableOfInt32(true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id263_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id273_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14974,7 +15935,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15002,7 +15963,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id262_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id272_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15023,7 +15984,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (ReadNull()) {
                                                         a_3_0.Add(null);
                                                     }
@@ -15067,12 +16028,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeB Read71_TypeB(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeB Read74_TypeB(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id74_TypeB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_TypeB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15097,7 +16058,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15124,12 +16085,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeHasArrayOfASerializedAsB Read72_TypeHasArrayOfASerializedAsB(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeHasArrayOfASerializedAsB Read75_TypeHasArrayOfASerializedAsB(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id75_TypeHasArrayOfASerializedAsB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_TypeHasArrayOfASerializedAsB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15156,7 +16117,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id222_Items && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id225_Items && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15177,8 +16138,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id73_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                    a_0_0 = (global::SerializationTypes.TypeA[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::SerializationTypes.TypeA));a_0_0[ca_0_0++] = Read70_TypeA(true, true);
+                                                if (((object) Reader.LocalName == (object)id76_TypeA && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    a_0_0 = (global::SerializationTypes.TypeA[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::SerializationTypes.TypeA));a_0_0[ca_0_0++] = Read73_TypeA(true, true);
                                                     break;
                                                 }
                                                 UnknownNode(null, @":TypeA");
@@ -15207,12 +16168,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ Read73_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.@__TypeNameWithSpecialCharacters漢ñ Read76_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id76_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15237,7 +16198,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id264_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id274_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15264,12 +16225,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.DerivedClassWithSameProperty2 Read76_DerivedClassWithSameProperty2(bool isNullable, bool checkType) {
+        global::SerializationTypes.DerivedClassWithSameProperty2 Read79_DerivedClassWithSameProperty2(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id82_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15296,7 +16257,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id275_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15311,7 +16272,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15326,7 +16287,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id267_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id277_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15341,7 +16302,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id268_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id278_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15362,7 +16323,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (ReadNull()) {
                                                         a_3_0.Add(null);
                                                     }
@@ -15406,16 +16367,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.DerivedClassWithSameProperty Read75_DerivedClassWithSameProperty(bool isNullable, bool checkType) {
+        global::SerializationTypes.DerivedClassWithSameProperty Read78_DerivedClassWithSameProperty(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id81_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read76_DerivedClassWithSameProperty2(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id82_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read79_DerivedClassWithSameProperty2(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
             }
@@ -15440,7 +16401,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id275_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15455,7 +16416,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15470,7 +16431,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id267_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id277_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15485,7 +16446,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id268_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id278_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15506,7 +16467,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (ReadNull()) {
                                                         a_3_0.Add(null);
                                                     }
@@ -15550,18 +16511,18 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.BaseClassWithSamePropertyName Read74_BaseClassWithSamePropertyName(bool isNullable, bool checkType) {
+        global::SerializationTypes.BaseClassWithSamePropertyName Read77_BaseClassWithSamePropertyName(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id77_BaseClassWithSamePropertyName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id80_BaseClassWithSamePropertyName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id78_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read75_DerivedClassWithSameProperty(isNullable, false);
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id79_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read76_DerivedClassWithSameProperty2(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id81_DerivedClassWithSameProperty && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read78_DerivedClassWithSameProperty(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id82_DerivedClassWithSameProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read79_DerivedClassWithSameProperty2(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
             }
@@ -15586,7 +16547,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id275_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15601,7 +16562,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15616,7 +16577,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id267_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id277_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15631,7 +16592,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id268_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id278_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15652,7 +16613,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (ReadNull()) {
                                                         a_3_0.Add(null);
                                                     }
@@ -15696,12 +16657,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime Read77_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithDateTimePropertyAsXmlTime Read80_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id80_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id83_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15743,12 +16704,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithByteArrayAsXmlText Read78_TypeWithByteArrayAsXmlText(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithByteArrayAsXmlText Read81_TypeWithByteArrayAsXmlText(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id81_TypeWithByteArrayAsXmlText && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id84_TypeWithByteArrayAsXmlText && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15790,12 +16751,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.SimpleDC Read79_SimpleDC(bool isNullable, bool checkType) {
+        global::SerializationTypes.SimpleDC Read82_SimpleDC(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id82_SimpleDC && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id85_SimpleDC && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15820,7 +16781,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id255_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15847,12 +16808,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithXmlTextAttributeOnArray Read80_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithXmlTextAttributeOnArray Read83_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id83_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id84_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id86_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id87_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15902,12 +16863,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ClassImplementsInterface Read82_ClassImplementsInterface(bool isNullable, bool checkType) {
+        global::SerializationTypes.ClassImplementsInterface Read85_ClassImplementsInterface(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id86_ClassImplementsInterface && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id89_ClassImplementsInterface && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -15932,7 +16893,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id269_ClassID && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id279_ClassID && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15947,7 +16908,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id270_DisplayName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id280_DisplayName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15962,7 +16923,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id271_Id && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id281_Id && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15977,7 +16938,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id272_IsLoaded && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id282_IsLoaded && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16004,11 +16965,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.SomeStruct Read83_SomeStruct(bool checkType) {
+        global::SerializationTypes.SomeStruct Read86_SomeStruct(bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id88_SomeStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id91_SomeStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16040,7 +17001,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id142_A && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id145_A && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16055,7 +17016,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id143_B && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id146_B && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16082,12 +17043,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.WithStruct Read84_WithStruct(bool isNullable, bool checkType) {
+        global::SerializationTypes.WithStruct Read87_WithStruct(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id87_WithStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id90_WithStruct && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16112,8 +17073,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id273_Some && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Some = Read83_SomeStruct(true);
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id283_Some && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Some = Read86_SomeStruct(true);
                             paramsRead[0] = true;
                             break;
                         }
@@ -16129,12 +17090,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.WithEnums Read87_WithEnums(bool isNullable, bool checkType) {
+        global::SerializationTypes.WithEnums Read90_WithEnums(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id89_WithEnums && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id92_WithEnums && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16159,7 +17120,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id274_Int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id284_Int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16169,12 +17130,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 Reader.MoveToElement();
                             }
                             {
-                                o.@Int = Read85_IntEnum(Reader.ReadElementString());
+                                o.@Int = Read88_IntEnum(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id275_Short && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id285_Short && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16184,7 +17145,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 Reader.MoveToElement();
                             }
                             {
-                                o.@Short = Read86_ShortEnum(Reader.ReadElementString());
+                                o.@Short = Read89_ShortEnum(Reader.ReadElementString());
                             }
                             paramsRead[1] = true;
                             break;
@@ -16201,12 +17162,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.WithNullables Read90_WithNullables(bool isNullable, bool checkType) {
+        global::SerializationTypes.WithNullables Read93_WithNullables(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id90_WithNullables && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id93_WithNullables && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16231,33 +17192,33 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_Optional && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Optional = Read88_NullableOfIntEnum(true);
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id286_Optional && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Optional = Read91_NullableOfIntEnum(true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_Optionull && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Optionull = Read88_NullableOfIntEnum(true);
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id287_Optionull && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Optionull = Read91_NullableOfIntEnum(true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id278_OptionalInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@OptionalInt = Read67_NullableOfInt32(true);
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id288_OptionalInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@OptionalInt = Read70_NullableOfInt32(true);
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id279_OptionullInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@OptionullInt = Read67_NullableOfInt32(true);
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id289_OptionullInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@OptionullInt = Read70_NullableOfInt32(true);
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id280_Struct1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Struct1 = Read89_NullableOfSomeStruct(true);
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id290_Struct1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Struct1 = Read92_NullableOfSomeStruct(true);
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id281_Struct2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            o.@Struct2 = Read89_NullableOfSomeStruct(true);
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id291_Struct2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            o.@Struct2 = Read92_NullableOfSomeStruct(true);
                             paramsRead[5] = true;
                             break;
                         }
@@ -16273,15 +17234,15 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::System.Nullable<global::SerializationTypes.SomeStruct> Read89_NullableOfSomeStruct(bool checkType) {
+        global::System.Nullable<global::SerializationTypes.SomeStruct> Read92_NullableOfSomeStruct(bool checkType) {
             global::System.Nullable<global::SerializationTypes.SomeStruct> o = default(global::System.Nullable<global::SerializationTypes.SomeStruct>);
             if (ReadNull())
                 return o;
-            o = Read83_SomeStruct(true);
+            o = Read86_SomeStruct(true);
             return o;
         }
 
-        global::System.Nullable<global::SerializationTypes.IntEnum> Read88_NullableOfIntEnum(bool checkType) {
+        global::System.Nullable<global::SerializationTypes.IntEnum> Read91_NullableOfIntEnum(bool checkType) {
             global::System.Nullable<global::SerializationTypes.IntEnum> o = default(global::System.Nullable<global::SerializationTypes.IntEnum>);
             if (ReadNull())
                 return o;
@@ -16294,17 +17255,17 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 Reader.MoveToElement();
             }
             {
-                o = Read85_IntEnum(Reader.ReadElementString());
+                o = Read88_IntEnum(Reader.ReadElementString());
             }
             return o;
         }
 
-        global::SerializationTypes.XmlSerializerAttributes Read97_XmlSerializerAttributes(bool isNullable, bool checkType) {
+        global::SerializationTypes.XmlSerializerAttributes Read100_XmlSerializerAttributes(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id146_XmlSerializerAttributes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id149_XmlSerializerAttributes && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16319,7 +17280,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_7 = 0;
             System.Span<bool> paramsRead = stackalloc bool[8];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[6] && ((object) Reader.LocalName == (object)id282_XmlAttributeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[6] && ((object) Reader.LocalName == (object)id292_XmlAttributeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@XmlAttributeProperty = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[6] = true;
                 }
@@ -16338,7 +17299,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 string tmp = null;
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id283_Word && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id293_Word && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16354,7 +17315,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id284_Number && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id294_Number && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16370,7 +17331,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id285_DecimalNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id295_DecimalNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16386,12 +17347,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id286_XmlIncludeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id296_XmlIncludeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@XmlIncludeProperty = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id287_XmlEnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id297_XmlEnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16412,7 +17373,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id99_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id102_ItemChoiceType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16422,7 +17383,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                                         Reader.MoveToElement();
                                                     }
                                                     {
-                                                        a_2_0 = (global::SerializationTypes.ItemChoiceType[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::SerializationTypes.ItemChoiceType));a_2_0[ca_2_0++] = Read96_ItemChoiceType(Reader.ReadElementString());
+                                                        a_2_0 = (global::SerializationTypes.ItemChoiceType[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::SerializationTypes.ItemChoiceType));a_2_0[ca_2_0++] = Read99_ItemChoiceType(Reader.ReadElementString());
                                                     }
                                                     break;
                                                 }
@@ -16440,7 +17401,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id288_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id298_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16455,7 +17416,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id289_XmlElementPropertyNode && (object) Reader.NamespaceURI == (object)id290_httpelement)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id299_XmlElementPropertyNode && (object) Reader.NamespaceURI == (object)id300_httpelement)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16470,7 +17431,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[5] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id291_CustomXmlArrayProperty && (object) Reader.NamespaceURI == (object)id165_httpmynamespace)) {
+                        if (((object) Reader.LocalName == (object)id301_CustomXmlArrayProperty && (object) Reader.NamespaceURI == (object)id168_httpmynamespace)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16491,7 +17452,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id154_string && (object) Reader.NamespaceURI == (object)id165_httpmynamespace)) {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id168_httpmynamespace)) {
                                                     if (ReadNull()) {
                                                         a_7_0 = (global::System.Object[])EnsureArrayIndex(a_7_0, ca_7_0, typeof(global::System.Object));a_7_0[ca_7_0++] = null;
                                                     }
@@ -16543,12 +17504,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithAnyAttribute Read98_TypeWithAnyAttribute(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithAnyAttribute Read101_TypeWithAnyAttribute(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id100_TypeWithAnyAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id103_TypeWithAnyAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16561,7 +17522,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_2 = 0;
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@IntProperty = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[1] = true;
                 }
@@ -16583,7 +17544,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16611,12 +17572,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.KnownTypesThroughConstructor Read99_KnownTypesThroughConstructor(bool isNullable, bool checkType) {
+        global::SerializationTypes.KnownTypesThroughConstructor Read102_KnownTypesThroughConstructor(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id101_KnownTypesThroughConstructor && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id104_KnownTypesThroughConstructor && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16641,12 +17602,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id292_EnumValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id302_EnumValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@EnumValue = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id293_SimpleTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id303_SimpleTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@SimpleTypeValue = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -16663,12 +17624,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.SimpleKnownTypeValue Read100_SimpleKnownTypeValue(bool isNullable, bool checkType) {
+        global::SerializationTypes.SimpleKnownTypeValue Read103_SimpleKnownTypeValue(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id102_SimpleKnownTypeValue && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id105_SimpleKnownTypeValue && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16693,7 +17654,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id294_StrProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id304_StrProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16720,12 +17681,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithPropertyNameSpecified Read101_TypeWithPropertyNameSpecified(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithPropertyNameSpecified Read104_TypeWithPropertyNameSpecified(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id106_TypeWithPropertyNameSpecified && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id109_TypeWithPropertyNameSpecified && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16750,7 +17711,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id295_MyField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id305_MyField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyFieldSpecified = true;
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -16766,7 +17727,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id296_MyFieldIgnored && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id306_MyFieldIgnored && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyFieldIgnoredSpecified = true;
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -16794,12 +17755,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithXmlSchemaFormAttribute Read102_TypeWithXmlSchemaFormAttribute(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithXmlSchemaFormAttribute Read105_TypeWithXmlSchemaFormAttribute(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id107_TypeWithXmlSchemaFormAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id110_TypeWithXmlSchemaFormAttribute && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -16830,7 +17791,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id297_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id307_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16851,7 +17812,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id152_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16878,7 +17839,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id298_NoneSchemaFormListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id308_NoneSchemaFormListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16899,7 +17860,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id167_NoneParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id170_NoneParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16926,7 +17887,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id299_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id309_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16947,7 +17908,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id169_QualifiedParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id172_QualifiedParameter && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (Reader.HasAttributes) {
                                                         while (Reader.MoveToNextAttribute()) {
                                                             if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16986,12 +17947,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute Read103_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute Read106_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id108_MyXmlType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id111_MyXmlType && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17002,7 +17963,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id300_XmlAttributeForm && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id310_XmlAttributeForm && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@XmlAttributeForm = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -17030,12 +17991,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.CustomElement Read105_CustomElement(bool isNullable, bool checkType) {
+        global::SerializationTypes.CustomElement Read108_CustomElement(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id111_CustomElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id114_CustomElement && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17050,7 +18011,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_2 = 0;
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id301_name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id311_name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -17088,12 +18049,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.CustomDocument Read106_CustomDocument(bool isNullable, bool checkType) {
+        global::SerializationTypes.CustomDocument Read109_CustomDocument(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id110_CustomDocument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id113_CustomDocument && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17123,8 +18084,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id302_customElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            if ((object)(a_0) == null) Reader.Skip(); else a_0.Add(Read105_CustomElement(false, true));
+                        if (((object) Reader.LocalName == (object)id312_customElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if ((object)(a_0) == null) Reader.Skip(); else a_0.Add(Read108_CustomElement(false, true));
                             break;
                         }
                         a_1 = (global::System.Xml.XmlNode[])EnsureArrayIndex(a_1, ca_1, typeof(global::System.Xml.XmlNode));a_1[ca_1++] = (global::System.Xml.XmlNode)ReadXmlNode(false);
@@ -17140,12 +18101,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithNonPublicDefaultConstructor Read107_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithNonPublicDefaultConstructor Read110_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id112_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id115_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17178,7 +18139,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17205,12 +18166,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ServerSettings Read108_ServerSettings(bool isNullable, bool checkType) {
+        global::SerializationTypes.ServerSettings Read111_ServerSettings(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id113_ServerSettings && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id116_ServerSettings && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17235,7 +18196,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id303_DS2Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id313_DS2Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17250,7 +18211,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id304_MetricConfigUrl && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id314_MetricConfigUrl && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17277,12 +18238,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithXmlQualifiedName Read109_TypeWithXmlQualifiedName(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithXmlQualifiedName Read112_TypeWithXmlQualifiedName(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id114_TypeWithXmlQualifiedName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id117_TypeWithXmlQualifiedName && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17307,7 +18268,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id176_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17334,12 +18295,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWith2DArrayProperty2 Read110_TypeWith2DArrayProperty2(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWith2DArrayProperty2 Read113_TypeWith2DArrayProperty2(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id115_TypeWith2DArrayProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id118_TypeWith2DArrayProperty2 && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17366,7 +18327,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id305_TwoDArrayOfSimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id315_TwoDArrayOfSimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17387,7 +18348,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                         if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                             do {
-                                                if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                if (((object) Reader.LocalName == (object)id60_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (!ReadNull()) {
                                                         if (Reader.HasAttributes) {
                                                             while (Reader.MoveToNextAttribute()) {
@@ -17408,8 +18369,8 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                                             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                                                                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                                                                     do {
-                                                                        if (((object) Reader.LocalName == (object)id57_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                                            a_0_0_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(a_0_0_0, ca_0_0_0, typeof(global::SerializationTypes.SimpleType));a_0_0_0[ca_0_0_0++] = Read55_SimpleType(true, true);
+                                                                        if (((object) Reader.LocalName == (object)id60_SimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                                            a_0_0_0 = (global::SerializationTypes.SimpleType[])EnsureArrayIndex(a_0_0_0, ca_0_0_0, typeof(global::SerializationTypes.SimpleType));a_0_0_0[ca_0_0_0++] = Read58_SimpleType(true, true);
                                                                             break;
                                                                         }
                                                                         UnknownNode(null, @":SimpleType");
@@ -17452,12 +18413,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithPropertiesHavingDefaultValue Read111_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithPropertiesHavingDefaultValue Read114_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id116_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id119_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17482,7 +18443,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id306_EmptyStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id316_EmptyStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17497,7 +18458,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id265_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id275_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17512,7 +18473,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id266_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17530,7 +18491,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id307_CharProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id317_CharProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17560,12 +18521,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue Read112_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithEnumPropertyHavingDefaultValue Read115_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id117_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id120_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17590,7 +18551,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id308_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id318_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17603,7 +18564,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 Reader.Skip();
                             }
                             else {
-                                o.@EnumProperty = Read85_IntEnum(Reader.ReadElementString());
+                                o.@EnumProperty = Read88_IntEnum(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
@@ -17620,12 +18581,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue Read113_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue Read116_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id118_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id121_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17650,7 +18611,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id308_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id318_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17663,7 +18624,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                 Reader.Skip();
                             }
                             else {
-                                o.@EnumProperty = Read81_EnumFlags(Reader.ReadElementString());
+                                o.@EnumProperty = Read84_EnumFlags(Reader.ReadElementString());
                             }
                             paramsRead[0] = true;
                             break;
@@ -17680,12 +18641,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithShouldSerializeMethod Read114_TypeWithShouldSerializeMethod(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithShouldSerializeMethod Read117_TypeWithShouldSerializeMethod(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id119_TypeWithShouldSerializeMethod && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id122_TypeWithShouldSerializeMethod && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17710,7 +18671,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id309_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17737,12 +18698,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize Read116_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize Read119_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id121_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id124_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17753,7 +18714,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id310_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id320_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Bar = Reader.Value;
                     paramsRead[1] = true;
                 }
@@ -17771,7 +18732,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id309_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17798,16 +18759,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.BaseTypeWithShouldSerializeMethod Read115_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.BaseTypeWithShouldSerializeMethod Read118_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id120_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id123_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id121_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read116_Item(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id124_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read119_Item(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
             }
@@ -17816,7 +18777,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.BaseTypeWithShouldSerializeMethod();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id310_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id320_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Bar = Reader.Value;
                     paramsRead[1] = true;
                 }
@@ -17834,7 +18795,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id309_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17861,12 +18822,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithFieldBackedSpecifiedMember Read117_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithFieldBackedSpecifiedMember Read120_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id122_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id125_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17891,7 +18852,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id309_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@FooSpecified = true;
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -17919,12 +18880,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties Read118_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.KnownTypesThroughConstructorWithArrayProperties Read121_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id123_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id126_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -17949,12 +18910,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id311_StringArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id321_StringArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@StringArrayValue = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id312_IntArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id322_IntArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@IntArrayValue = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -17971,12 +18932,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.KnownTypesThroughConstructorWithValue Read119_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.KnownTypesThroughConstructorWithValue Read122_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id124_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id127_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -18001,7 +18962,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id173_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id176_Value && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Value = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
@@ -18018,12 +18979,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithTypesHavingCustomFormatter Read120_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithTypesHavingCustomFormatter Read123_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id125_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id128_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -18048,7 +19009,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id313_DateTimeContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id323_DateTimeContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18063,7 +19024,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id314_QNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id324_QNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18078,7 +19039,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id315_DateContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id325_DateContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18093,7 +19054,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id316_NameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id326_NameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18108,7 +19069,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id317_NCNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id327_NCNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18123,7 +19084,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id318_NMTOKENContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id328_NMTOKENContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18138,7 +19099,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[5] = true;
                             break;
                         }
-                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id319_NMTOKENSContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id329_NMTOKENSContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18153,7 +19114,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[6] = true;
                             break;
                         }
-                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id320_Base64BinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id330_Base64BinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18168,7 +19129,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[7] = true;
                             break;
                         }
-                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id321_HexBinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id331_HexBinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18195,12 +19156,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithArrayPropertyHavingChoice Read122_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithArrayPropertyHavingChoice Read125_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id126_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id129_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -18231,7 +19192,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id322_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id332_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18246,7 +19207,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             choice_a_0 = (global::SerializationTypes.MoreChoices[])EnsureArrayIndex(choice_a_0, cchoice_a_0, typeof(global::SerializationTypes.MoreChoices));choice_a_0[cchoice_a_0++] = global::SerializationTypes.MoreChoices.@Item;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id323_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id333_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18275,12 +19236,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ComplexChoiceB Read123_ComplexChoiceB(bool isNullable, bool checkType) {
+        global::SerializationTypes.ComplexChoiceB Read126_ComplexChoiceB(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id133_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -18305,7 +19266,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18332,16 +19293,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.ComplexChoiceA Read124_ComplexChoiceA(bool isNullable, bool checkType) {
+        global::SerializationTypes.ComplexChoiceA Read127_ComplexChoiceA(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id129_ComplexChoiceA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id132_ComplexChoiceA && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
-                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
-                    return Read123_ComplexChoiceB(isNullable, false);
+                if (((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id133_ComplexChoiceB && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item))
+                    return Read126_ComplexChoiceB(isNullable, false);
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
             }
             }
@@ -18364,7 +19325,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id140_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id143_Name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18391,12 +19352,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithPropertyHavingComplexChoice Read125_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithPropertyHavingComplexChoice Read128_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id127_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id130_Item && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -18427,12 +19388,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id322_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            a_0 = (global::System.Object[])EnsureArrayIndex(a_0, ca_0, typeof(global::System.Object));a_0[ca_0++] = Read124_ComplexChoiceA(false, true);
+                        if (((object) Reader.LocalName == (object)id332_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            a_0 = (global::System.Object[])EnsureArrayIndex(a_0, ca_0, typeof(global::System.Object));a_0[ca_0++] = Read127_ComplexChoiceA(false, true);
                             choice_a_0 = (global::SerializationTypes.MoreChoices[])EnsureArrayIndex(choice_a_0, cchoice_a_0, typeof(global::SerializationTypes.MoreChoices));choice_a_0[cchoice_a_0++] = global::SerializationTypes.MoreChoices.@Item;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id323_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id333_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18461,12 +19422,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithFieldsOrdered Read126_TypeWithFieldsOrdered(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithFieldsOrdered Read129_TypeWithFieldsOrdered(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
             if (checkType) {
-            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id131_TypeWithFieldsOrdered && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
+            if (xsiType == null || ((object) ((System.Xml.XmlQualifiedName)xsiType).Name == (object)id134_TypeWithFieldsOrdered && (object) ((System.Xml.XmlQualifiedName)xsiType).Namespace == (object)id2_Item)) {
             }
             else {
                 throw CreateUnknownTypeException((System.Xml.XmlQualifiedName)xsiType);
@@ -18493,7 +19454,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     switch (state) {
                     case 0:
-                        if (((object) Reader.LocalName == (object)id324_IntField2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id334_IntField2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18509,7 +19470,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 1;
                         break;
                     case 1:
-                        if (((object) Reader.LocalName == (object)id325_IntField1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id335_IntField1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18525,7 +19486,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 2;
                         break;
                     case 2:
-                        if (((object) Reader.LocalName == (object)id326_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id336_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18541,7 +19502,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 3;
                         break;
                     case 3:
-                        if (((object) Reader.LocalName == (object)id326_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id336_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18570,7 +19531,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             return o;
         }
 
-        global::SerializationTypes.TypeWithSchemaFormInXmlAttribute Read104_Item(bool isNullable, bool checkType) {
+        global::SerializationTypes.TypeWithSchemaFormInXmlAttribute Read107_Item(bool isNullable, bool checkType) {
             System.Xml.XmlQualifiedName xsiType = checkType ? GetXsiType() : null;
             bool isNull = false;
             if (isNullable) isNull = ReadNull();
@@ -18586,7 +19547,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.TypeWithSchemaFormInXmlAttribute();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id327_TestProperty && (object) Reader.NamespaceURI == (object)id328_httptestcom)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id337_TestProperty && (object) Reader.NamespaceURI == (object)id338_httptestcom)) {
                     o.@TestProperty = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -18617,666 +19578,686 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         protected override void InitCallbacks() {
         }
 
-        string id24_SimpleBaseClass;
-        string id303_DS2Root;
-        string id111_CustomElement;
-        string id246_IntAField;
-        string id62_TypeWithMyCollectionField;
-        string id66_MyEnum;
-        string id207_Breed;
-        string id265_StringProperty;
-        string id47_TypeWithLinkedProperty;
-        string id26_BaseIXmlSerializable;
-        string id319_NMTOKENSContent;
-        string id213_AttributeString;
-        string id57_SimpleType;
-        string id38_Orchestra;
-        string id323_Amount;
-        string id87_WithStruct;
-        string id199_NullableTime;
-        string id277_Optionull;
-        string id248_IntLField;
-        string id7_DateOnlyWrapper;
-        string id168_ArrayOfBoolean;
-        string id175_Children;
-        string id227_Y;
-        string id206_Age;
-        string id188_NullableDTO;
-        string id11_DateTimeTimeWrapper;
-        string id81_TypeWithByteArrayAsXmlText;
-        string id2_Item;
-        string id98_AttributeTesting;
-        string id89_WithEnums;
-        string id40_Brass;
-        string id174_Child;
-        string id112_Item;
-        string id127_Item;
-        string id239_Parameters;
-        string id197_MyTime;
-        string id186_DTO2;
-        string id218_State;
-        string id244_F1;
-        string id203_TimeSpanProperty;
-        string id114_TypeWithXmlQualifiedName;
-        string id116_Item;
-        string id281_Struct2;
-        string id178_ItemName;
-        string id79_DerivedClassWithSameProperty2;
-        string id148_MsgDocumentType;
-        string id304_MetricConfigUrl;
-        string id144_Value1;
-        string id180_UnitPrice;
-        string id318_NMTOKENContent;
-        string id250_IntAProp;
-        string id194_NullableDateWithValue;
-        string id225_TotalCost;
-        string id105_Item;
-        string id161_XElement;
-        string id289_XmlElementPropertyNode;
-        string id9_TimeOnlyAsXsdTimeWrapper;
-        string id78_DerivedClassWithSameProperty;
-        string id270_DisplayName;
-        string id208_LicenseNumber;
-        string id241_xelements;
-        string id254_Collection;
-        string id216_Line1;
-        string id121_Item;
-        string id287_XmlEnumProperty;
-        string id14_TypeWithByteProperty;
-        string id209_GroupName;
-        string id220_ShipTo;
-        string id147_ParameterOfString;
-        string id99_ItemChoiceType;
-        string id234_DoubleProp;
-        string id269_ClassID;
-        string id13_Item;
-        string id30_httpwwwcontoso1com;
-        string id151_ArrayOfInt;
-        string id126_Item;
-        string id320_Base64BinaryContent;
-        string id1_TypeWithXmlElementProperty;
-        string id93_ShortEnum;
-        string id53_XElementStruct;
-        string id155_ArrayOfDouble;
-        string id25_SimpleDerivedClass;
-        string id77_BaseClassWithSamePropertyName;
-        string id273_Some;
-        string id8_TimeOnlyWrapper;
-        string id135_TypeClashA;
-        string id113_ServerSettings;
-        string id202_TestValue;
-        string id80_Item;
-        string id310_Bar;
-        string id296_MyFieldIgnored;
-        string id130_ComplexChoiceB;
-        string id238_refs;
-        string id137_FirstName;
-        string id123_Item;
-        string id23_DerivedClass;
-        string id146_XmlSerializerAttributes;
-        string id233_SingleField;
-        string id249_NIntLField;
-        string id39_Instrument;
-        string id196_Now;
-        string id268_ListProperty;
-        string id160_ArrayOfXElement;
-        string id279_OptionullInt;
-        string id293_SimpleTypeValue;
-        string id60_TypeWithArraylikeMembers;
-        string id285_DecimalNumber;
-        string id101_KnownTypesThroughConstructor;
-        string id118_Item;
-        string id201_NullableDefaultTime;
-        string id31_Address;
-        string id34_BaseClass1;
-        string id46_RootElement;
-        string id10_DateTimeDateWrapper;
-        string id115_TypeWith2DArrayProperty2;
-        string id261_NullableIntMember;
-        string id19_Group;
-        string id143_B;
-        string id69_DCClassWithEnumAndStruct;
-        string id134_TypeClashB;
-        string id165_httpmynamespace;
-        string id154_string;
-        string id74_TypeB;
-        string id312_IntArrayValue;
-        string id294_StrProperty;
-        string id322_Item;
-        string id210_GroupVehicle;
-        string id190_Today;
-        string id3_TypeWithXmlDocumentProperty;
-        string id309_Foo;
-        string id280_Struct1;
-        string id142_A;
-        string id36_ArrayOfDateTime;
-        string id169_QualifiedParameter;
-        string id272_IsLoaded;
-        string id311_StringArrayValue;
-        string id326_strfld;
-        string id290_httpelement;
-        string id284_Number;
-        string id300_XmlAttributeForm;
-        string id313_DateTimeContent;
-        string id5_Item;
-        string id52_XElementWrapper;
-        string id257_MyEnum1;
-        string id162_ArrayOfSimpleType;
-        string id55_Item;
-        string id138_MiddleName;
-        string id259_StringMember;
-        string id324_IntField2;
-        string id164_ArrayOfItemChoiceType;
-        string id230_Instruments;
-        string id109_Item;
-        string id256_MyStruct;
-        string id193_NullableDate;
-        string id28_DerivedIXmlSerializable;
-        string id176_IsValved;
-        string id166_ArrayOfString1;
-        string id129_ComplexChoiceA;
-        string id158_ArrayOfTypeWithLinkedProperty;
-        string id141_ContainerType;
-        string id191_MyDate;
-        string id159_ArrayOfParameter;
-        string id102_SimpleKnownTypeValue;
-        string id50_RootClass;
-        string id325_IntField1;
-        string id263_ArrayMember;
-        string id65_anyType;
-        string id92_SByteEnum;
-        string id317_NCNameContent;
-        string id35_DerivedClass1;
-        string id73_TypeA;
-        string id91_ByteEnum;
-        string id243_CurrentDateTime;
-        string id104_Item;
-        string id37_dateTime;
-        string id305_TwoDArrayOfSimpleType;
-        string id171_P1;
-        string id70_BuiltInTypes;
-        string id237_id;
-        string id251_NIntAProp;
-        string id132_Item;
-        string id215_BoolValue;
-        string id124_Item;
-        string id44_Item;
-        string id179_Description;
-        string id217_City;
-        string id4_TypeWithBinaryProperty;
-        string id170_ArrayOfArrayOfSimpleType;
-        string id122_Item;
-        string id308_EnumProperty;
-        string id167_NoneParameter;
-        string id51_Parameter;
-        string id97_ULongEnum;
-        string id152_int;
-        string id189_NullableDefaultDTO;
-        string id212_value;
-        string id301_name;
-        string id276_Optional;
-        string id316_NameContent;
-        string id252_IntLProp;
-        string id286_XmlIncludeProperty;
-        string id156_double;
-        string id56_TypeWithDateTimeStringProperty;
-        string id182_LineTotal;
-        string id266_IntProperty;
-        string id22_BaseClass;
-        string id306_EmptyStringProperty;
-        string id12_TypeWithTimeSpanProperty;
-        string id214_DateTimeValue;
-        string id236_IntValue;
-        string id274_Int;
-        string id292_EnumValue;
-        string id17_Dog;
-        string id247_NIntAField;
-        string id83_Item;
-        string id94_IntEnum;
-        string id240_xelement;
-        string id42_Pet;
-        string id298_NoneSchemaFormListProperty;
-        string id49_httpexamplecom;
-        string id120_Item;
-        string id231_Comment2;
-        string id76_Item;
-        string id68_DCStruct;
-        string id163_ArrayOfTypeA;
-        string id145_Value2;
-        string id64_ArrayOfAnyType;
-        string id187_DefaultDTO;
-        string id192_DefaultDate;
-        string id107_TypeWithXmlSchemaFormAttribute;
-        string id108_MyXmlType;
-        string id253_NIntLProp;
-        string id328_httptestcom;
-        string id103_Item;
-        string id82_SimpleDC;
-        string id204_TimeSpanProperty2;
-        string id32_OrderedItem;
-        string id153_ArrayOfString;
-        string id84_Item;
-        string id67_TypeWithEnumMembers;
-        string id43_DefaultValuesSetToNaN;
-        string id117_Item;
-        string id136_Person;
-        string id185_DTO;
-        string id222_Items;
-        string id41_Trumpet;
-        string id110_CustomDocument;
-        string id295_MyField;
-        string id219_Zip;
-        string id223_SubTotal;
-        string id149_Item;
-        string id100_TypeWithAnyAttribute;
-        string id106_TypeWithPropertyNameSpecified;
-        string id195_NullableDefaultDate;
-        string id211_EmployeeName;
-        string id245_F2;
-        string id16_Animal;
-        string id307_CharProperty;
-        string id139_LastName;
-        string id75_TypeHasArrayOfASerializedAsB;
-        string id229_Prop;
-        string id95_UIntEnum;
-        string id258_ByteArray;
-        string id184_Base64Content;
-        string id278_OptionalInt;
-        string id226_X;
-        string id172_P2;
-        string id59_TypeWithGetOnlyArrayProperties;
-        string id133_Root;
-        string id131_TypeWithFieldsOrdered;
-        string id125_Item;
-        string id315_DateContent;
-        string id255_Data;
-        string id205_ByteProperty;
-        string id177_Modulation;
-        string id198_DefaultTime;
-        string id242_DateTimeString;
-        string id267_DateTimeProperty;
-        string id119_TypeWithShouldSerializeMethod;
-        string id58_TypeWithGetSetArrayMembers;
-        string id86_ClassImplementsInterface;
-        string id20_Vehicle;
-        string id128_MoreChoices;
-        string id314_QNameContent;
-        string id61_StructNotSerializable;
-        string id6_Item;
-        string id48_Document;
-        string id221_OrderDate;
-        string id21_Employee;
-        string id291_CustomXmlArrayProperty;
-        string id54_XElementArrayWrapper;
-        string id150_ArrayOfOrderedItem;
-        string id228_Z;
-        string id45_Item;
-        string id275_Short;
-        string id235_FloatProp;
+        string id117_TypeWithXmlQualifiedName;
+        string id155_int;
+        string id130_Item;
         string id29_PurchaseOrder;
-        string id72_Item;
-        string id299_Item;
-        string id264_Item;
-        string id157_ArrayOfInstrument;
-        string id288_Item;
-        string id224_ShipCost;
-        string id173_Value;
-        string id271_Id;
-        string id15_TypeWithXmlNodeArrayProperty;
-        string id85_EnumFlags;
-        string id283_Word;
-        string id327_TestProperty;
+        string id234_Comment2;
+        string id290_Struct1;
+        string id2_Item;
+        string id212_GroupName;
+        string id296_XmlIncludeProperty;
+        string id244_xelements;
+        string id35_DerivedClass1;
+        string id113_CustomDocument;
+        string id173_ArrayOfArrayOfSimpleType;
+        string id330_Base64BinaryContent;
+        string id316_EmptyStringProperty;
+        string id40_Brass;
+        string id308_NoneSchemaFormListProperty;
+        string id57_Item;
+        string id192_NullableDefaultDTO;
+        string id153_ArrayOfOrderedItem;
+        string id39_Instrument;
+        string id236_SingleField;
+        string id176_Value;
+        string id273_ArrayMember;
+        string id63_TypeWithArraylikeMembers;
+        string id52_XElementWrapper;
+        string id320_Bar;
+        string id304_StrProperty;
+        string id237_DoubleProp;
+        string id171_ArrayOfBoolean;
+        string id181_ItemName;
+        string id262_IntLProp;
+        string id144_ContainerType;
+        string id137_TypeClashB;
+        string id206_TimeSpanProperty;
+        string id138_TypeClashA;
+        string id89_ClassImplementsInterface;
+        string id62_TypeWithGetOnlyArrayProperties;
+        string id194_MyDate;
+        string id319_Foo;
+        string id185_LineTotal;
+        string id3_TypeWithXmlDocumentProperty;
+        string id6_Item;
+        string id258_IntLField;
+        string id90_WithStruct;
+        string id76_TypeA;
+        string id300_httpelement;
+        string id301_CustomXmlArrayProperty;
+        string id256_IntAField;
+        string id25_SimpleDerivedClass;
+        string id267_MyEnum1;
+        string id30_httpwwwcontoso1com;
+        string id324_QNameContent;
+        string id158_ArrayOfDouble;
+        string id315_TwoDArrayOfSimpleType;
+        string id175_P2;
+        string id7_DateOnlyWrapper;
+        string id282_IsLoaded;
+        string id280_DisplayName;
+        string id193_Today;
+        string id243_xelement;
+        string id318_EnumProperty;
+        string id314_MetricConfigUrl;
+        string id338_httptestcom;
+        string id305_MyField;
+        string id83_Item;
+        string id202_NullableTime;
+        string id97_IntEnum;
+        string id295_DecimalNumber;
+        string id229_X;
+        string id328_NMTOKENContent;
+        string id99_LongEnum;
+        string id26_BaseIXmlSerializable;
+        string id123_Item;
+        string id302_EnumValue;
+        string id199_Now;
+        string id310_XmlAttributeForm;
+        string id136_Root;
+        string id67_ArrayOfAnyType;
+        string id108_Item;
+        string id102_ItemChoiceType;
+        string id228_TotalCost;
+        string id257_NIntAField;
+        string id32_OrderedItem;
+        string id54_XElementArrayWrapper;
+        string id51_Parameter;
+        string id198_NullableDefaultDate;
+        string id31_Address;
+        string id70_TypeWithEnumMembers;
+        string id265_Data;
         string id18_DogBreed;
-        string id262_ListMember;
-        string id181_Quantity;
-        string id140_Name;
-        string id88_SomeStruct;
-        string id297_Item;
-        string id90_WithNullables;
-        string id321_HexBinaryContent;
-        string id282_XmlAttributeName;
-        string id200_NullableTimeWithValue;
-        string id260_IntMember;
-        string id232_DoubleField;
-        string id96_LongEnum;
-        string id71_TypeWithBuiltInTypedMembers;
-        string id183_BinaryHexContent;
-        string id63_Item;
+        string id126_Item;
+        string id227_ShipCost;
+        string id45_Item;
+        string id50_RootClass;
+        string id69_MyEnum;
+        string id279_ClassID;
+        string id75_Item;
+        string id147_Value1;
+        string id13_Item;
+        string id232_Prop;
+        string id252_DateTimeString;
+        string id72_DCClassWithEnumAndStruct;
+        string id225_Items;
+        string id184_Quantity;
+        string id133_ComplexChoiceB;
+        string id101_AttributeTesting;
+        string id254_F1;
+        string id332_Item;
+        string id134_TypeWithFieldsOrdered;
+        string id323_DateTimeContent;
+        string id150_ParameterOfString;
+        string id42_Pet;
+        string id178_Children;
+        string id148_Value2;
+        string id309_Item;
+        string id114_CustomElement;
+        string id110_TypeWithXmlSchemaFormAttribute;
+        string id168_httpmynamespace;
+        string id73_BuiltInTypes;
+        string id255_F2;
+        string id187_Base64Content;
+        string id293_Word;
+        string id269_StringMember;
+        string id259_NIntLField;
+        string id84_TypeWithByteArrayAsXmlText;
+        string id215_value;
+        string id19_Group;
+        string id329_NMTOKENSContent;
+        string id10_DateTimeDateWrapper;
+        string id82_DerivedClassWithSameProperty2;
+        string id322_IntArrayValue;
+        string id238_FloatProp;
+        string id189_DTO2;
+        string id291_Struct2;
+        string id131_MoreChoices;
+        string id116_ServerSettings;
         string id33_AliasedTestType;
+        string id79_Item;
+        string id210_Breed;
+        string id207_TimeSpanProperty2;
+        string id80_BaseClassWithSamePropertyName;
+        string id217_DateTimeValue;
+        string id146_B;
+        string id245_ImmutableArray;
+        string id248_FrozenSet;
+        string id59_TypeWithDateTimeStringProperty;
+        string id235_DoubleField;
+        string id88_EnumFlags;
+        string id38_Orchestra;
+        string id128_Item;
+        string id170_NoneParameter;
+        string id272_ListMember;
+        string id224_OrderDate;
+        string id22_BaseClass;
+        string id140_FirstName;
+        string id268_ByteArray;
+        string id275_StringProperty;
+        string id327_NCNameContent;
+        string id87_Item;
+        string id167_ArrayOfItemChoiceType;
+        string id58_Item;
+        string id41_Trumpet;
+        string id124_Item;
+        string id141_MiddleName;
+        string id36_ArrayOfDateTime;
+        string id157_string;
+        string id274_Item;
+        string id326_NameContent;
+        string id221_State;
+        string id161_ArrayOfTypeWithLinkedProperty;
+        string id180_Modulation;
+        string id23_DerivedClass;
+        string id34_BaseClass1;
+        string id121_Item;
+        string id9_TimeOnlyAsXsdTimeWrapper;
         string id27_Item;
-        string id302_customElement;
+        string id208_ByteProperty;
+        string id298_Item;
+        string id43_DefaultValuesSetToNaN;
+        string id196_NullableDate;
+        string id151_MsgDocumentType;
+        string id115_Item;
+        string id246_ImmutableList;
+        string id169_ArrayOfString1;
+        string id250_List;
+        string id321_StringArrayValue;
+        string id294_Number;
+        string id283_Some;
+        string id125_Item;
+        string id127_Item;
+        string id64_StructNotSerializable;
+        string id74_TypeWithBuiltInTypedMembers;
+        string id48_Document;
+        string id154_ArrayOfInt;
+        string id277_DateTimeProperty;
+        string id71_DCStruct;
+        string id68_anyType;
+        string id231_Z;
+        string id203_NullableTimeWithValue;
+        string id240_id;
+        string id179_IsValved;
+        string id145_A;
+        string id177_Child;
+        string id81_DerivedClassWithSameProperty;
+        string id139_Person;
+        string id247_ReadOnlyCollection;
+        string id174_P1;
+        string id241_refs;
+        string id312_customElement;
+        string id289_OptionullInt;
+        string id287_Optionull;
+        string id8_TimeOnlyWrapper;
+        string id337_TestProperty;
+        string id306_MyFieldIgnored;
+        string id85_SimpleDC;
+        string id129_Item;
+        string id183_UnitPrice;
+        string id303_SimpleTypeValue;
+        string id78_TypeHasArrayOfASerializedAsB;
+        string id260_IntAProp;
+        string id37_dateTime;
+        string id107_Item;
+        string id91_SomeStruct;
+        string id95_SByteEnum;
+        string id197_NullableDateWithValue;
+        string id118_TypeWith2DArrayProperty2;
+        string id266_MyStruct;
+        string id214_EmployeeName;
+        string id20_Vehicle;
+        string id94_ByteEnum;
+        string id216_AttributeString;
+        string id92_WithEnums;
+        string id143_Name;
+        string id55_Item;
+        string id334_IntField2;
+        string id44_Item;
+        string id288_OptionalInt;
+        string id190_DefaultDTO;
+        string id122_TypeWithShouldSerializeMethod;
+        string id61_TypeWithGetSetArrayMembers;
+        string id261_NIntAProp;
+        string id205_TestValue;
+        string id253_CurrentDateTime;
+        string id271_NullableIntMember;
+        string id263_NIntLProp;
+        string id299_XmlElementPropertyNode;
+        string id213_GroupVehicle;
+        string id49_httpexamplecom;
+        string id5_Item;
+        string id249_ImmutableQueue;
+        string id223_ShipTo;
+        string id335_IntField1;
+        string id317_CharProperty;
+        string id162_ArrayOfParameter;
+        string id109_TypeWithPropertyNameSpecified;
+        string id165_ArrayOfSimpleType;
+        string id65_TypeWithMyCollectionField;
+        string id297_XmlEnumProperty;
+        string id105_SimpleKnownTypeValue;
+        string id16_Animal;
+        string id156_ArrayOfString;
+        string id142_LastName;
+        string id204_NullableDefaultTime;
+        string id200_MyTime;
+        string id120_Item;
+        string id149_XmlSerializerAttributes;
+        string id17_Dog;
+        string id226_SubTotal;
+        string id135_Item;
+        string id160_ArrayOfInstrument;
+        string id152_Item;
+        string id278_ListProperty;
+        string id201_DefaultTime;
+        string id53_XElementStruct;
+        string id98_UIntEnum;
+        string id182_Description;
+        string id230_Y;
+        string id100_ULongEnum;
+        string id220_City;
+        string id284_Int;
+        string id47_TypeWithLinkedProperty;
+        string id313_DS2Root;
+        string id111_MyXmlType;
+        string id12_TypeWithTimeSpanProperty;
+        string id93_WithNullables;
+        string id211_LicenseNumber;
+        string id307_Item;
+        string id66_Item;
+        string id195_DefaultDate;
+        string id286_Optional;
+        string id106_Item;
+        string id14_TypeWithByteProperty;
+        string id24_SimpleBaseClass;
+        string id276_IntProperty;
+        string id325_DateContent;
+        string id15_TypeWithXmlNodeArrayProperty;
+        string id21_Employee;
+        string id281_Id;
+        string id28_DerivedIXmlSerializable;
+        string id292_XmlAttributeName;
+        string id46_RootElement;
+        string id191_NullableDTO;
+        string id4_TypeWithBinaryProperty;
+        string id77_TypeB;
+        string id56_TypeWithReadOnlyCollections;
+        string id222_Zip;
+        string id172_QualifiedParameter;
+        string id86_Item;
+        string id242_Parameters;
+        string id331_HexBinaryContent;
+        string id132_ComplexChoiceA;
+        string id264_Collection;
+        string id119_Item;
+        string id166_ArrayOfTypeA;
+        string id159_double;
+        string id311_name;
+        string id60_SimpleType;
+        string id112_Item;
+        string id164_XElement;
+        string id104_KnownTypesThroughConstructor;
+        string id233_Instruments;
+        string id163_ArrayOfXElement;
+        string id239_IntValue;
+        string id103_TypeWithAnyAttribute;
+        string id11_DateTimeTimeWrapper;
+        string id1_TypeWithXmlElementProperty;
+        string id186_BinaryHexContent;
+        string id336_strfld;
+        string id285_Short;
+        string id270_IntMember;
+        string id333_Amount;
+        string id219_Line1;
+        string id209_Age;
+        string id218_BoolValue;
+        string id96_ShortEnum;
+        string id188_DTO;
+        string id251_Array;
 
         static readonly char[] xmlListSeparators = System.AppContext.TryGetSwitch("Switch.System.Xml.Serialization.UseLegacyXmlListSeparation", out bool useLegacyXmlListSeparation) && useLegacyXmlListSeparation ? null : new char[] { ' ', '\t', '\n', '\r' };
 
         protected override void InitIDs() {
-            id24_SimpleBaseClass = Reader.NameTable.Add(@"SimpleBaseClass");
-            id303_DS2Root = Reader.NameTable.Add(@"DS2Root");
-            id111_CustomElement = Reader.NameTable.Add(@"CustomElement");
-            id246_IntAField = Reader.NameTable.Add(@"IntAField");
-            id62_TypeWithMyCollectionField = Reader.NameTable.Add(@"TypeWithMyCollectionField");
-            id66_MyEnum = Reader.NameTable.Add(@"MyEnum");
-            id207_Breed = Reader.NameTable.Add(@"Breed");
-            id265_StringProperty = Reader.NameTable.Add(@"StringProperty");
-            id47_TypeWithLinkedProperty = Reader.NameTable.Add(@"TypeWithLinkedProperty");
-            id26_BaseIXmlSerializable = Reader.NameTable.Add(@"BaseIXmlSerializable");
-            id319_NMTOKENSContent = Reader.NameTable.Add(@"NMTOKENSContent");
-            id213_AttributeString = Reader.NameTable.Add(@"AttributeString");
-            id57_SimpleType = Reader.NameTable.Add(@"SimpleType");
-            id38_Orchestra = Reader.NameTable.Add(@"Orchestra");
-            id323_Amount = Reader.NameTable.Add(@"Amount");
-            id87_WithStruct = Reader.NameTable.Add(@"WithStruct");
-            id199_NullableTime = Reader.NameTable.Add(@"NullableTime");
-            id277_Optionull = Reader.NameTable.Add(@"Optionull");
-            id248_IntLField = Reader.NameTable.Add(@"IntLField");
-            id7_DateOnlyWrapper = Reader.NameTable.Add(@"DateOnlyWrapper");
-            id168_ArrayOfBoolean = Reader.NameTable.Add(@"ArrayOfBoolean");
-            id175_Children = Reader.NameTable.Add(@"Children");
-            id227_Y = Reader.NameTable.Add(@"Y");
-            id206_Age = Reader.NameTable.Add(@"Age");
-            id188_NullableDTO = Reader.NameTable.Add(@"NullableDTO");
-            id11_DateTimeTimeWrapper = Reader.NameTable.Add(@"DateTimeTimeWrapper");
-            id81_TypeWithByteArrayAsXmlText = Reader.NameTable.Add(@"TypeWithByteArrayAsXmlText");
-            id2_Item = Reader.NameTable.Add(@"");
-            id98_AttributeTesting = Reader.NameTable.Add(@"AttributeTesting");
-            id89_WithEnums = Reader.NameTable.Add(@"WithEnums");
-            id40_Brass = Reader.NameTable.Add(@"Brass");
-            id174_Child = Reader.NameTable.Add(@"Child");
-            id112_Item = Reader.NameTable.Add(@"TypeWithNonPublicDefaultConstructor");
-            id127_Item = Reader.NameTable.Add(@"TypeWithPropertyHavingComplexChoice");
-            id239_Parameters = Reader.NameTable.Add(@"Parameters");
-            id197_MyTime = Reader.NameTable.Add(@"MyTime");
-            id186_DTO2 = Reader.NameTable.Add(@"DTO2");
-            id218_State = Reader.NameTable.Add(@"State");
-            id244_F1 = Reader.NameTable.Add(@"F1");
-            id203_TimeSpanProperty = Reader.NameTable.Add(@"TimeSpanProperty");
-            id114_TypeWithXmlQualifiedName = Reader.NameTable.Add(@"TypeWithXmlQualifiedName");
-            id116_Item = Reader.NameTable.Add(@"TypeWithPropertiesHavingDefaultValue");
-            id281_Struct2 = Reader.NameTable.Add(@"Struct2");
-            id178_ItemName = Reader.NameTable.Add(@"ItemName");
-            id79_DerivedClassWithSameProperty2 = Reader.NameTable.Add(@"DerivedClassWithSameProperty2");
-            id148_MsgDocumentType = Reader.NameTable.Add(@"MsgDocumentType");
-            id304_MetricConfigUrl = Reader.NameTable.Add(@"MetricConfigUrl");
-            id144_Value1 = Reader.NameTable.Add(@"Value1");
-            id180_UnitPrice = Reader.NameTable.Add(@"UnitPrice");
-            id318_NMTOKENContent = Reader.NameTable.Add(@"NMTOKENContent");
-            id250_IntAProp = Reader.NameTable.Add(@"IntAProp");
-            id194_NullableDateWithValue = Reader.NameTable.Add(@"NullableDateWithValue");
-            id225_TotalCost = Reader.NameTable.Add(@"TotalCost");
-            id105_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithParameterlessConstructor");
-            id161_XElement = Reader.NameTable.Add(@"XElement");
-            id289_XmlElementPropertyNode = Reader.NameTable.Add(@"XmlElementPropertyNode");
-            id9_TimeOnlyAsXsdTimeWrapper = Reader.NameTable.Add(@"TimeOnlyAsXsdTimeWrapper");
-            id78_DerivedClassWithSameProperty = Reader.NameTable.Add(@"DerivedClassWithSameProperty");
-            id270_DisplayName = Reader.NameTable.Add(@"DisplayName");
-            id208_LicenseNumber = Reader.NameTable.Add(@"LicenseNumber");
-            id241_xelements = Reader.NameTable.Add(@"xelements");
-            id254_Collection = Reader.NameTable.Add(@"Collection");
-            id216_Line1 = Reader.NameTable.Add(@"Line1");
-            id121_Item = Reader.NameTable.Add(@"DerivedTypeWithInheritedShouldSerialize");
-            id287_XmlEnumProperty = Reader.NameTable.Add(@"XmlEnumProperty");
-            id14_TypeWithByteProperty = Reader.NameTable.Add(@"TypeWithByteProperty");
-            id209_GroupName = Reader.NameTable.Add(@"GroupName");
-            id220_ShipTo = Reader.NameTable.Add(@"ShipTo");
-            id147_ParameterOfString = Reader.NameTable.Add(@"ParameterOfString");
-            id99_ItemChoiceType = Reader.NameTable.Add(@"ItemChoiceType");
-            id234_DoubleProp = Reader.NameTable.Add(@"DoubleProp");
-            id269_ClassID = Reader.NameTable.Add(@"ClassID");
-            id13_Item = Reader.NameTable.Add(@"TypeWithDefaultTimeSpanProperty");
-            id30_httpwwwcontoso1com = Reader.NameTable.Add(@"http://www.contoso1.com");
-            id151_ArrayOfInt = Reader.NameTable.Add(@"ArrayOfInt");
-            id126_Item = Reader.NameTable.Add(@"TypeWithArrayPropertyHavingChoice");
-            id320_Base64BinaryContent = Reader.NameTable.Add(@"Base64BinaryContent");
-            id1_TypeWithXmlElementProperty = Reader.NameTable.Add(@"TypeWithXmlElementProperty");
-            id93_ShortEnum = Reader.NameTable.Add(@"ShortEnum");
-            id53_XElementStruct = Reader.NameTable.Add(@"XElementStruct");
-            id155_ArrayOfDouble = Reader.NameTable.Add(@"ArrayOfDouble");
-            id25_SimpleDerivedClass = Reader.NameTable.Add(@"SimpleDerivedClass");
-            id77_BaseClassWithSamePropertyName = Reader.NameTable.Add(@"BaseClassWithSamePropertyName");
-            id273_Some = Reader.NameTable.Add(@"Some");
-            id8_TimeOnlyWrapper = Reader.NameTable.Add(@"TimeOnlyWrapper");
-            id135_TypeClashA = Reader.NameTable.Add(@"TypeClashA");
-            id113_ServerSettings = Reader.NameTable.Add(@"ServerSettings");
-            id202_TestValue = Reader.NameTable.Add(@"TestValue");
-            id80_Item = Reader.NameTable.Add(@"TypeWithDateTimePropertyAsXmlTime");
-            id310_Bar = Reader.NameTable.Add(@"Bar");
-            id296_MyFieldIgnored = Reader.NameTable.Add(@"MyFieldIgnored");
-            id130_ComplexChoiceB = Reader.NameTable.Add(@"ComplexChoiceB");
-            id238_refs = Reader.NameTable.Add(@"refs");
-            id137_FirstName = Reader.NameTable.Add(@"FirstName");
-            id123_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithArrayProperties");
-            id23_DerivedClass = Reader.NameTable.Add(@"DerivedClass");
-            id146_XmlSerializerAttributes = Reader.NameTable.Add(@"XmlSerializerAttributes");
-            id233_SingleField = Reader.NameTable.Add(@"SingleField");
-            id249_NIntLField = Reader.NameTable.Add(@"NIntLField");
-            id39_Instrument = Reader.NameTable.Add(@"Instrument");
-            id196_Now = Reader.NameTable.Add(@"Now");
-            id268_ListProperty = Reader.NameTable.Add(@"ListProperty");
-            id160_ArrayOfXElement = Reader.NameTable.Add(@"ArrayOfXElement");
-            id279_OptionullInt = Reader.NameTable.Add(@"OptionullInt");
-            id293_SimpleTypeValue = Reader.NameTable.Add(@"SimpleTypeValue");
-            id60_TypeWithArraylikeMembers = Reader.NameTable.Add(@"TypeWithArraylikeMembers");
-            id285_DecimalNumber = Reader.NameTable.Add(@"DecimalNumber");
-            id101_KnownTypesThroughConstructor = Reader.NameTable.Add(@"KnownTypesThroughConstructor");
-            id118_Item = Reader.NameTable.Add(@"TypeWithEnumFlagPropertyHavingDefaultValue");
-            id201_NullableDefaultTime = Reader.NameTable.Add(@"NullableDefaultTime");
-            id31_Address = Reader.NameTable.Add(@"Address");
-            id34_BaseClass1 = Reader.NameTable.Add(@"BaseClass1");
-            id46_RootElement = Reader.NameTable.Add(@"RootElement");
-            id10_DateTimeDateWrapper = Reader.NameTable.Add(@"DateTimeDateWrapper");
-            id115_TypeWith2DArrayProperty2 = Reader.NameTable.Add(@"TypeWith2DArrayProperty2");
-            id261_NullableIntMember = Reader.NameTable.Add(@"NullableIntMember");
-            id19_Group = Reader.NameTable.Add(@"Group");
-            id143_B = Reader.NameTable.Add(@"B");
-            id69_DCClassWithEnumAndStruct = Reader.NameTable.Add(@"DCClassWithEnumAndStruct");
-            id134_TypeClashB = Reader.NameTable.Add(@"TypeClashB");
-            id165_httpmynamespace = Reader.NameTable.Add(@"http://mynamespace");
-            id154_string = Reader.NameTable.Add(@"string");
-            id74_TypeB = Reader.NameTable.Add(@"TypeB");
-            id312_IntArrayValue = Reader.NameTable.Add(@"IntArrayValue");
-            id294_StrProperty = Reader.NameTable.Add(@"StrProperty");
-            id322_Item = Reader.NameTable.Add(@"Item");
-            id210_GroupVehicle = Reader.NameTable.Add(@"GroupVehicle");
-            id190_Today = Reader.NameTable.Add(@"Today");
-            id3_TypeWithXmlDocumentProperty = Reader.NameTable.Add(@"TypeWithXmlDocumentProperty");
-            id309_Foo = Reader.NameTable.Add(@"Foo");
-            id280_Struct1 = Reader.NameTable.Add(@"Struct1");
-            id142_A = Reader.NameTable.Add(@"A");
-            id36_ArrayOfDateTime = Reader.NameTable.Add(@"ArrayOfDateTime");
-            id169_QualifiedParameter = Reader.NameTable.Add(@"QualifiedParameter");
-            id272_IsLoaded = Reader.NameTable.Add(@"IsLoaded");
-            id311_StringArrayValue = Reader.NameTable.Add(@"StringArrayValue");
-            id326_strfld = Reader.NameTable.Add(@"strfld");
-            id290_httpelement = Reader.NameTable.Add(@"http://element");
-            id284_Number = Reader.NameTable.Add(@"Number");
-            id300_XmlAttributeForm = Reader.NameTable.Add(@"XmlAttributeForm");
-            id313_DateTimeContent = Reader.NameTable.Add(@"DateTimeContent");
-            id5_Item = Reader.NameTable.Add(@"TypeWithDateTimeOffsetProperties");
-            id52_XElementWrapper = Reader.NameTable.Add(@"XElementWrapper");
-            id257_MyEnum1 = Reader.NameTable.Add(@"MyEnum1");
-            id162_ArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfSimpleType");
-            id55_Item = Reader.NameTable.Add(@"DateTimeOffsetIXmlSerializableContainer");
-            id138_MiddleName = Reader.NameTable.Add(@"MiddleName");
-            id259_StringMember = Reader.NameTable.Add(@"StringMember");
-            id324_IntField2 = Reader.NameTable.Add(@"IntField2");
-            id164_ArrayOfItemChoiceType = Reader.NameTable.Add(@"ArrayOfItemChoiceType");
-            id230_Instruments = Reader.NameTable.Add(@"Instruments");
-            id109_Item = Reader.NameTable.Add(@"TypeWithSchemaFormInXmlAttribute");
-            id256_MyStruct = Reader.NameTable.Add(@"MyStruct");
-            id193_NullableDate = Reader.NameTable.Add(@"NullableDate");
-            id28_DerivedIXmlSerializable = Reader.NameTable.Add(@"DerivedIXmlSerializable");
-            id176_IsValved = Reader.NameTable.Add(@"IsValved");
-            id166_ArrayOfString1 = Reader.NameTable.Add(@"ArrayOfString1");
-            id129_ComplexChoiceA = Reader.NameTable.Add(@"ComplexChoiceA");
-            id158_ArrayOfTypeWithLinkedProperty = Reader.NameTable.Add(@"ArrayOfTypeWithLinkedProperty");
-            id141_ContainerType = Reader.NameTable.Add(@"ContainerType");
-            id191_MyDate = Reader.NameTable.Add(@"MyDate");
-            id159_ArrayOfParameter = Reader.NameTable.Add(@"ArrayOfParameter");
-            id102_SimpleKnownTypeValue = Reader.NameTable.Add(@"SimpleKnownTypeValue");
-            id50_RootClass = Reader.NameTable.Add(@"RootClass");
-            id325_IntField1 = Reader.NameTable.Add(@"IntField1");
-            id263_ArrayMember = Reader.NameTable.Add(@"ArrayMember");
-            id65_anyType = Reader.NameTable.Add(@"anyType");
-            id92_SByteEnum = Reader.NameTable.Add(@"SByteEnum");
-            id317_NCNameContent = Reader.NameTable.Add(@"NCNameContent");
-            id35_DerivedClass1 = Reader.NameTable.Add(@"DerivedClass1");
-            id73_TypeA = Reader.NameTable.Add(@"TypeA");
-            id91_ByteEnum = Reader.NameTable.Add(@"ByteEnum");
-            id243_CurrentDateTime = Reader.NameTable.Add(@"CurrentDateTime");
-            id104_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor");
-            id37_dateTime = Reader.NameTable.Add(@"dateTime");
-            id305_TwoDArrayOfSimpleType = Reader.NameTable.Add(@"TwoDArrayOfSimpleType");
-            id171_P1 = Reader.NameTable.Add(@"P1");
-            id70_BuiltInTypes = Reader.NameTable.Add(@"BuiltInTypes");
-            id237_id = Reader.NameTable.Add(@"id");
-            id251_NIntAProp = Reader.NameTable.Add(@"NIntAProp");
-            id132_Item = Reader.NameTable.Add(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName");
-            id215_BoolValue = Reader.NameTable.Add(@"BoolValue");
-            id124_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithValue");
-            id44_Item = Reader.NameTable.Add(@"DefaultValuesSetToPositiveInfinity");
-            id179_Description = Reader.NameTable.Add(@"Description");
-            id217_City = Reader.NameTable.Add(@"City");
-            id4_TypeWithBinaryProperty = Reader.NameTable.Add(@"TypeWithBinaryProperty");
-            id170_ArrayOfArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfArrayOfSimpleType");
-            id122_Item = Reader.NameTable.Add(@"TypeWithFieldBackedSpecifiedMember");
-            id308_EnumProperty = Reader.NameTable.Add(@"EnumProperty");
-            id167_NoneParameter = Reader.NameTable.Add(@"NoneParameter");
-            id51_Parameter = Reader.NameTable.Add(@"Parameter");
-            id97_ULongEnum = Reader.NameTable.Add(@"ULongEnum");
-            id152_int = Reader.NameTable.Add(@"int");
-            id189_NullableDefaultDTO = Reader.NameTable.Add(@"NullableDefaultDTO");
-            id212_value = Reader.NameTable.Add(@"value");
-            id301_name = Reader.NameTable.Add(@"name");
-            id276_Optional = Reader.NameTable.Add(@"Optional");
-            id316_NameContent = Reader.NameTable.Add(@"NameContent");
-            id252_IntLProp = Reader.NameTable.Add(@"IntLProp");
-            id286_XmlIncludeProperty = Reader.NameTable.Add(@"XmlIncludeProperty");
-            id156_double = Reader.NameTable.Add(@"double");
-            id56_TypeWithDateTimeStringProperty = Reader.NameTable.Add(@"TypeWithDateTimeStringProperty");
-            id182_LineTotal = Reader.NameTable.Add(@"LineTotal");
-            id266_IntProperty = Reader.NameTable.Add(@"IntProperty");
-            id22_BaseClass = Reader.NameTable.Add(@"BaseClass");
-            id306_EmptyStringProperty = Reader.NameTable.Add(@"EmptyStringProperty");
-            id12_TypeWithTimeSpanProperty = Reader.NameTable.Add(@"TypeWithTimeSpanProperty");
-            id214_DateTimeValue = Reader.NameTable.Add(@"DateTimeValue");
-            id236_IntValue = Reader.NameTable.Add(@"IntValue");
-            id274_Int = Reader.NameTable.Add(@"Int");
-            id292_EnumValue = Reader.NameTable.Add(@"EnumValue");
-            id17_Dog = Reader.NameTable.Add(@"Dog");
-            id247_NIntAField = Reader.NameTable.Add(@"NIntAField");
-            id83_Item = Reader.NameTable.Add(@"TypeWithXmlTextAttributeOnArray");
-            id94_IntEnum = Reader.NameTable.Add(@"IntEnum");
-            id240_xelement = Reader.NameTable.Add(@"xelement");
-            id42_Pet = Reader.NameTable.Add(@"Pet");
-            id298_NoneSchemaFormListProperty = Reader.NameTable.Add(@"NoneSchemaFormListProperty");
-            id49_httpexamplecom = Reader.NameTable.Add(@"http://example.com");
-            id120_Item = Reader.NameTable.Add(@"BaseTypeWithShouldSerializeMethod");
-            id231_Comment2 = Reader.NameTable.Add(@"Comment2");
-            id76_Item = Reader.NameTable.Add(@"__TypeNameWithSpecialCharacters漢ñ");
-            id68_DCStruct = Reader.NameTable.Add(@"DCStruct");
-            id163_ArrayOfTypeA = Reader.NameTable.Add(@"ArrayOfTypeA");
-            id145_Value2 = Reader.NameTable.Add(@"Value2");
-            id64_ArrayOfAnyType = Reader.NameTable.Add(@"ArrayOfAnyType");
-            id187_DefaultDTO = Reader.NameTable.Add(@"DefaultDTO");
-            id192_DefaultDate = Reader.NameTable.Add(@"DefaultDate");
-            id107_TypeWithXmlSchemaFormAttribute = Reader.NameTable.Add(@"TypeWithXmlSchemaFormAttribute");
-            id108_MyXmlType = Reader.NameTable.Add(@"MyXmlType");
-            id253_NIntLProp = Reader.NameTable.Add(@"NIntLProp");
-            id328_httptestcom = Reader.NameTable.Add(@"http://test.com");
-            id103_Item = Reader.NameTable.Add(@"ClassImplementingIXmlSerializable");
-            id82_SimpleDC = Reader.NameTable.Add(@"SimpleDC");
-            id204_TimeSpanProperty2 = Reader.NameTable.Add(@"TimeSpanProperty2");
-            id32_OrderedItem = Reader.NameTable.Add(@"OrderedItem");
-            id153_ArrayOfString = Reader.NameTable.Add(@"ArrayOfString");
-            id84_Item = Reader.NameTable.Add(@"http://schemas.xmlsoap.org/ws/2005/04/discovery");
-            id67_TypeWithEnumMembers = Reader.NameTable.Add(@"TypeWithEnumMembers");
-            id43_DefaultValuesSetToNaN = Reader.NameTable.Add(@"DefaultValuesSetToNaN");
-            id117_Item = Reader.NameTable.Add(@"TypeWithEnumPropertyHavingDefaultValue");
-            id136_Person = Reader.NameTable.Add(@"Person");
-            id185_DTO = Reader.NameTable.Add(@"DTO");
-            id222_Items = Reader.NameTable.Add(@"Items");
-            id41_Trumpet = Reader.NameTable.Add(@"Trumpet");
-            id110_CustomDocument = Reader.NameTable.Add(@"CustomDocument");
-            id295_MyField = Reader.NameTable.Add(@"MyField");
-            id219_Zip = Reader.NameTable.Add(@"Zip");
-            id223_SubTotal = Reader.NameTable.Add(@"SubTotal");
-            id149_Item = Reader.NameTable.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType");
-            id100_TypeWithAnyAttribute = Reader.NameTable.Add(@"TypeWithAnyAttribute");
-            id106_TypeWithPropertyNameSpecified = Reader.NameTable.Add(@"TypeWithPropertyNameSpecified");
-            id195_NullableDefaultDate = Reader.NameTable.Add(@"NullableDefaultDate");
-            id211_EmployeeName = Reader.NameTable.Add(@"EmployeeName");
-            id245_F2 = Reader.NameTable.Add(@"F2");
-            id16_Animal = Reader.NameTable.Add(@"Animal");
-            id307_CharProperty = Reader.NameTable.Add(@"CharProperty");
-            id139_LastName = Reader.NameTable.Add(@"LastName");
-            id75_TypeHasArrayOfASerializedAsB = Reader.NameTable.Add(@"TypeHasArrayOfASerializedAsB");
-            id229_Prop = Reader.NameTable.Add(@"Prop");
-            id95_UIntEnum = Reader.NameTable.Add(@"UIntEnum");
-            id258_ByteArray = Reader.NameTable.Add(@"ByteArray");
-            id184_Base64Content = Reader.NameTable.Add(@"Base64Content");
-            id278_OptionalInt = Reader.NameTable.Add(@"OptionalInt");
-            id226_X = Reader.NameTable.Add(@"X");
-            id172_P2 = Reader.NameTable.Add(@"P2");
-            id59_TypeWithGetOnlyArrayProperties = Reader.NameTable.Add(@"TypeWithGetOnlyArrayProperties");
-            id133_Root = Reader.NameTable.Add(@"Root");
-            id131_TypeWithFieldsOrdered = Reader.NameTable.Add(@"TypeWithFieldsOrdered");
-            id125_Item = Reader.NameTable.Add(@"TypeWithTypesHavingCustomFormatter");
-            id315_DateContent = Reader.NameTable.Add(@"DateContent");
-            id255_Data = Reader.NameTable.Add(@"Data");
-            id205_ByteProperty = Reader.NameTable.Add(@"ByteProperty");
-            id177_Modulation = Reader.NameTable.Add(@"Modulation");
-            id198_DefaultTime = Reader.NameTable.Add(@"DefaultTime");
-            id242_DateTimeString = Reader.NameTable.Add(@"DateTimeString");
-            id267_DateTimeProperty = Reader.NameTable.Add(@"DateTimeProperty");
-            id119_TypeWithShouldSerializeMethod = Reader.NameTable.Add(@"TypeWithShouldSerializeMethod");
-            id58_TypeWithGetSetArrayMembers = Reader.NameTable.Add(@"TypeWithGetSetArrayMembers");
-            id86_ClassImplementsInterface = Reader.NameTable.Add(@"ClassImplementsInterface");
-            id20_Vehicle = Reader.NameTable.Add(@"Vehicle");
-            id128_MoreChoices = Reader.NameTable.Add(@"MoreChoices");
-            id314_QNameContent = Reader.NameTable.Add(@"QNameContent");
-            id61_StructNotSerializable = Reader.NameTable.Add(@"StructNotSerializable");
-            id6_Item = Reader.NameTable.Add(@"TypeWithDateAndTimeOnlyProperties");
-            id48_Document = Reader.NameTable.Add(@"Document");
-            id221_OrderDate = Reader.NameTable.Add(@"OrderDate");
-            id21_Employee = Reader.NameTable.Add(@"Employee");
-            id291_CustomXmlArrayProperty = Reader.NameTable.Add(@"CustomXmlArrayProperty");
-            id54_XElementArrayWrapper = Reader.NameTable.Add(@"XElementArrayWrapper");
-            id150_ArrayOfOrderedItem = Reader.NameTable.Add(@"ArrayOfOrderedItem");
-            id228_Z = Reader.NameTable.Add(@"Z");
-            id45_Item = Reader.NameTable.Add(@"DefaultValuesSetToNegativeInfinity");
-            id275_Short = Reader.NameTable.Add(@"Short");
-            id235_FloatProp = Reader.NameTable.Add(@"FloatProp");
+            id117_TypeWithXmlQualifiedName = Reader.NameTable.Add(@"TypeWithXmlQualifiedName");
+            id155_int = Reader.NameTable.Add(@"int");
+            id130_Item = Reader.NameTable.Add(@"TypeWithPropertyHavingComplexChoice");
             id29_PurchaseOrder = Reader.NameTable.Add(@"PurchaseOrder");
-            id72_Item = Reader.NameTable.Add(@"TypeWithNullableBuiltInTypedMembers");
-            id299_Item = Reader.NameTable.Add(@"QualifiedSchemaFormListProperty");
-            id264_Item = Reader.NameTable.Add(@"PropertyNameWithSpecialCharacters漢ñ");
-            id157_ArrayOfInstrument = Reader.NameTable.Add(@"ArrayOfInstrument");
-            id288_Item = Reader.NameTable.Add(@"XmlNamespaceDeclarationsProperty");
-            id224_ShipCost = Reader.NameTable.Add(@"ShipCost");
-            id173_Value = Reader.NameTable.Add(@"Value");
-            id271_Id = Reader.NameTable.Add(@"Id");
-            id15_TypeWithXmlNodeArrayProperty = Reader.NameTable.Add(@"TypeWithXmlNodeArrayProperty");
-            id85_EnumFlags = Reader.NameTable.Add(@"EnumFlags");
-            id283_Word = Reader.NameTable.Add(@"Word");
-            id327_TestProperty = Reader.NameTable.Add(@"TestProperty");
+            id234_Comment2 = Reader.NameTable.Add(@"Comment2");
+            id290_Struct1 = Reader.NameTable.Add(@"Struct1");
+            id2_Item = Reader.NameTable.Add(@"");
+            id212_GroupName = Reader.NameTable.Add(@"GroupName");
+            id296_XmlIncludeProperty = Reader.NameTable.Add(@"XmlIncludeProperty");
+            id244_xelements = Reader.NameTable.Add(@"xelements");
+            id35_DerivedClass1 = Reader.NameTable.Add(@"DerivedClass1");
+            id113_CustomDocument = Reader.NameTable.Add(@"CustomDocument");
+            id173_ArrayOfArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfArrayOfSimpleType");
+            id330_Base64BinaryContent = Reader.NameTable.Add(@"Base64BinaryContent");
+            id316_EmptyStringProperty = Reader.NameTable.Add(@"EmptyStringProperty");
+            id40_Brass = Reader.NameTable.Add(@"Brass");
+            id308_NoneSchemaFormListProperty = Reader.NameTable.Add(@"NoneSchemaFormListProperty");
+            id57_Item = Reader.NameTable.Add(@"TypeWithMutableCollectionMembers");
+            id192_NullableDefaultDTO = Reader.NameTable.Add(@"NullableDefaultDTO");
+            id153_ArrayOfOrderedItem = Reader.NameTable.Add(@"ArrayOfOrderedItem");
+            id39_Instrument = Reader.NameTable.Add(@"Instrument");
+            id236_SingleField = Reader.NameTable.Add(@"SingleField");
+            id176_Value = Reader.NameTable.Add(@"Value");
+            id273_ArrayMember = Reader.NameTable.Add(@"ArrayMember");
+            id63_TypeWithArraylikeMembers = Reader.NameTable.Add(@"TypeWithArraylikeMembers");
+            id52_XElementWrapper = Reader.NameTable.Add(@"XElementWrapper");
+            id320_Bar = Reader.NameTable.Add(@"Bar");
+            id304_StrProperty = Reader.NameTable.Add(@"StrProperty");
+            id237_DoubleProp = Reader.NameTable.Add(@"DoubleProp");
+            id171_ArrayOfBoolean = Reader.NameTable.Add(@"ArrayOfBoolean");
+            id181_ItemName = Reader.NameTable.Add(@"ItemName");
+            id262_IntLProp = Reader.NameTable.Add(@"IntLProp");
+            id144_ContainerType = Reader.NameTable.Add(@"ContainerType");
+            id137_TypeClashB = Reader.NameTable.Add(@"TypeClashB");
+            id206_TimeSpanProperty = Reader.NameTable.Add(@"TimeSpanProperty");
+            id138_TypeClashA = Reader.NameTable.Add(@"TypeClashA");
+            id89_ClassImplementsInterface = Reader.NameTable.Add(@"ClassImplementsInterface");
+            id62_TypeWithGetOnlyArrayProperties = Reader.NameTable.Add(@"TypeWithGetOnlyArrayProperties");
+            id194_MyDate = Reader.NameTable.Add(@"MyDate");
+            id319_Foo = Reader.NameTable.Add(@"Foo");
+            id185_LineTotal = Reader.NameTable.Add(@"LineTotal");
+            id3_TypeWithXmlDocumentProperty = Reader.NameTable.Add(@"TypeWithXmlDocumentProperty");
+            id6_Item = Reader.NameTable.Add(@"TypeWithDateAndTimeOnlyProperties");
+            id258_IntLField = Reader.NameTable.Add(@"IntLField");
+            id90_WithStruct = Reader.NameTable.Add(@"WithStruct");
+            id76_TypeA = Reader.NameTable.Add(@"TypeA");
+            id300_httpelement = Reader.NameTable.Add(@"http://element");
+            id301_CustomXmlArrayProperty = Reader.NameTable.Add(@"CustomXmlArrayProperty");
+            id256_IntAField = Reader.NameTable.Add(@"IntAField");
+            id25_SimpleDerivedClass = Reader.NameTable.Add(@"SimpleDerivedClass");
+            id267_MyEnum1 = Reader.NameTable.Add(@"MyEnum1");
+            id30_httpwwwcontoso1com = Reader.NameTable.Add(@"http://www.contoso1.com");
+            id324_QNameContent = Reader.NameTable.Add(@"QNameContent");
+            id158_ArrayOfDouble = Reader.NameTable.Add(@"ArrayOfDouble");
+            id315_TwoDArrayOfSimpleType = Reader.NameTable.Add(@"TwoDArrayOfSimpleType");
+            id175_P2 = Reader.NameTable.Add(@"P2");
+            id7_DateOnlyWrapper = Reader.NameTable.Add(@"DateOnlyWrapper");
+            id282_IsLoaded = Reader.NameTable.Add(@"IsLoaded");
+            id280_DisplayName = Reader.NameTable.Add(@"DisplayName");
+            id193_Today = Reader.NameTable.Add(@"Today");
+            id243_xelement = Reader.NameTable.Add(@"xelement");
+            id318_EnumProperty = Reader.NameTable.Add(@"EnumProperty");
+            id314_MetricConfigUrl = Reader.NameTable.Add(@"MetricConfigUrl");
+            id338_httptestcom = Reader.NameTable.Add(@"http://test.com");
+            id305_MyField = Reader.NameTable.Add(@"MyField");
+            id83_Item = Reader.NameTable.Add(@"TypeWithDateTimePropertyAsXmlTime");
+            id202_NullableTime = Reader.NameTable.Add(@"NullableTime");
+            id97_IntEnum = Reader.NameTable.Add(@"IntEnum");
+            id295_DecimalNumber = Reader.NameTable.Add(@"DecimalNumber");
+            id229_X = Reader.NameTable.Add(@"X");
+            id328_NMTOKENContent = Reader.NameTable.Add(@"NMTOKENContent");
+            id99_LongEnum = Reader.NameTable.Add(@"LongEnum");
+            id26_BaseIXmlSerializable = Reader.NameTable.Add(@"BaseIXmlSerializable");
+            id123_Item = Reader.NameTable.Add(@"BaseTypeWithShouldSerializeMethod");
+            id302_EnumValue = Reader.NameTable.Add(@"EnumValue");
+            id199_Now = Reader.NameTable.Add(@"Now");
+            id310_XmlAttributeForm = Reader.NameTable.Add(@"XmlAttributeForm");
+            id136_Root = Reader.NameTable.Add(@"Root");
+            id67_ArrayOfAnyType = Reader.NameTable.Add(@"ArrayOfAnyType");
+            id108_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithParameterlessConstructor");
+            id102_ItemChoiceType = Reader.NameTable.Add(@"ItemChoiceType");
+            id228_TotalCost = Reader.NameTable.Add(@"TotalCost");
+            id257_NIntAField = Reader.NameTable.Add(@"NIntAField");
+            id32_OrderedItem = Reader.NameTable.Add(@"OrderedItem");
+            id54_XElementArrayWrapper = Reader.NameTable.Add(@"XElementArrayWrapper");
+            id51_Parameter = Reader.NameTable.Add(@"Parameter");
+            id198_NullableDefaultDate = Reader.NameTable.Add(@"NullableDefaultDate");
+            id31_Address = Reader.NameTable.Add(@"Address");
+            id70_TypeWithEnumMembers = Reader.NameTable.Add(@"TypeWithEnumMembers");
+            id265_Data = Reader.NameTable.Add(@"Data");
             id18_DogBreed = Reader.NameTable.Add(@"DogBreed");
-            id262_ListMember = Reader.NameTable.Add(@"ListMember");
-            id181_Quantity = Reader.NameTable.Add(@"Quantity");
-            id140_Name = Reader.NameTable.Add(@"Name");
-            id88_SomeStruct = Reader.NameTable.Add(@"SomeStruct");
-            id297_Item = Reader.NameTable.Add(@"UnqualifiedSchemaFormListProperty");
-            id90_WithNullables = Reader.NameTable.Add(@"WithNullables");
-            id321_HexBinaryContent = Reader.NameTable.Add(@"HexBinaryContent");
-            id282_XmlAttributeName = Reader.NameTable.Add(@"XmlAttributeName");
-            id200_NullableTimeWithValue = Reader.NameTable.Add(@"NullableTimeWithValue");
-            id260_IntMember = Reader.NameTable.Add(@"IntMember");
-            id232_DoubleField = Reader.NameTable.Add(@"DoubleField");
-            id96_LongEnum = Reader.NameTable.Add(@"LongEnum");
-            id71_TypeWithBuiltInTypedMembers = Reader.NameTable.Add(@"TypeWithBuiltInTypedMembers");
-            id183_BinaryHexContent = Reader.NameTable.Add(@"BinaryHexContent");
-            id63_Item = Reader.NameTable.Add(@"TypeWithReadOnlyMyCollectionProperty");
+            id126_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithArrayProperties");
+            id227_ShipCost = Reader.NameTable.Add(@"ShipCost");
+            id45_Item = Reader.NameTable.Add(@"DefaultValuesSetToNegativeInfinity");
+            id50_RootClass = Reader.NameTable.Add(@"RootClass");
+            id69_MyEnum = Reader.NameTable.Add(@"MyEnum");
+            id279_ClassID = Reader.NameTable.Add(@"ClassID");
+            id75_Item = Reader.NameTable.Add(@"TypeWithNullableBuiltInTypedMembers");
+            id147_Value1 = Reader.NameTable.Add(@"Value1");
+            id13_Item = Reader.NameTable.Add(@"TypeWithDefaultTimeSpanProperty");
+            id232_Prop = Reader.NameTable.Add(@"Prop");
+            id252_DateTimeString = Reader.NameTable.Add(@"DateTimeString");
+            id72_DCClassWithEnumAndStruct = Reader.NameTable.Add(@"DCClassWithEnumAndStruct");
+            id225_Items = Reader.NameTable.Add(@"Items");
+            id184_Quantity = Reader.NameTable.Add(@"Quantity");
+            id133_ComplexChoiceB = Reader.NameTable.Add(@"ComplexChoiceB");
+            id101_AttributeTesting = Reader.NameTable.Add(@"AttributeTesting");
+            id254_F1 = Reader.NameTable.Add(@"F1");
+            id332_Item = Reader.NameTable.Add(@"Item");
+            id134_TypeWithFieldsOrdered = Reader.NameTable.Add(@"TypeWithFieldsOrdered");
+            id323_DateTimeContent = Reader.NameTable.Add(@"DateTimeContent");
+            id150_ParameterOfString = Reader.NameTable.Add(@"ParameterOfString");
+            id42_Pet = Reader.NameTable.Add(@"Pet");
+            id178_Children = Reader.NameTable.Add(@"Children");
+            id148_Value2 = Reader.NameTable.Add(@"Value2");
+            id309_Item = Reader.NameTable.Add(@"QualifiedSchemaFormListProperty");
+            id114_CustomElement = Reader.NameTable.Add(@"CustomElement");
+            id110_TypeWithXmlSchemaFormAttribute = Reader.NameTable.Add(@"TypeWithXmlSchemaFormAttribute");
+            id168_httpmynamespace = Reader.NameTable.Add(@"http://mynamespace");
+            id73_BuiltInTypes = Reader.NameTable.Add(@"BuiltInTypes");
+            id255_F2 = Reader.NameTable.Add(@"F2");
+            id187_Base64Content = Reader.NameTable.Add(@"Base64Content");
+            id293_Word = Reader.NameTable.Add(@"Word");
+            id269_StringMember = Reader.NameTable.Add(@"StringMember");
+            id259_NIntLField = Reader.NameTable.Add(@"NIntLField");
+            id84_TypeWithByteArrayAsXmlText = Reader.NameTable.Add(@"TypeWithByteArrayAsXmlText");
+            id215_value = Reader.NameTable.Add(@"value");
+            id19_Group = Reader.NameTable.Add(@"Group");
+            id329_NMTOKENSContent = Reader.NameTable.Add(@"NMTOKENSContent");
+            id10_DateTimeDateWrapper = Reader.NameTable.Add(@"DateTimeDateWrapper");
+            id82_DerivedClassWithSameProperty2 = Reader.NameTable.Add(@"DerivedClassWithSameProperty2");
+            id322_IntArrayValue = Reader.NameTable.Add(@"IntArrayValue");
+            id238_FloatProp = Reader.NameTable.Add(@"FloatProp");
+            id189_DTO2 = Reader.NameTable.Add(@"DTO2");
+            id291_Struct2 = Reader.NameTable.Add(@"Struct2");
+            id131_MoreChoices = Reader.NameTable.Add(@"MoreChoices");
+            id116_ServerSettings = Reader.NameTable.Add(@"ServerSettings");
             id33_AliasedTestType = Reader.NameTable.Add(@"AliasedTestType");
+            id79_Item = Reader.NameTable.Add(@"__TypeNameWithSpecialCharacters漢ñ");
+            id210_Breed = Reader.NameTable.Add(@"Breed");
+            id207_TimeSpanProperty2 = Reader.NameTable.Add(@"TimeSpanProperty2");
+            id80_BaseClassWithSamePropertyName = Reader.NameTable.Add(@"BaseClassWithSamePropertyName");
+            id217_DateTimeValue = Reader.NameTable.Add(@"DateTimeValue");
+            id146_B = Reader.NameTable.Add(@"B");
+            id245_ImmutableArray = Reader.NameTable.Add(@"ImmutableArray");
+            id248_FrozenSet = Reader.NameTable.Add(@"FrozenSet");
+            id59_TypeWithDateTimeStringProperty = Reader.NameTable.Add(@"TypeWithDateTimeStringProperty");
+            id235_DoubleField = Reader.NameTable.Add(@"DoubleField");
+            id88_EnumFlags = Reader.NameTable.Add(@"EnumFlags");
+            id38_Orchestra = Reader.NameTable.Add(@"Orchestra");
+            id128_Item = Reader.NameTable.Add(@"TypeWithTypesHavingCustomFormatter");
+            id170_NoneParameter = Reader.NameTable.Add(@"NoneParameter");
+            id272_ListMember = Reader.NameTable.Add(@"ListMember");
+            id224_OrderDate = Reader.NameTable.Add(@"OrderDate");
+            id22_BaseClass = Reader.NameTable.Add(@"BaseClass");
+            id140_FirstName = Reader.NameTable.Add(@"FirstName");
+            id268_ByteArray = Reader.NameTable.Add(@"ByteArray");
+            id275_StringProperty = Reader.NameTable.Add(@"StringProperty");
+            id327_NCNameContent = Reader.NameTable.Add(@"NCNameContent");
+            id87_Item = Reader.NameTable.Add(@"http://schemas.xmlsoap.org/ws/2005/04/discovery");
+            id167_ArrayOfItemChoiceType = Reader.NameTable.Add(@"ArrayOfItemChoiceType");
+            id58_Item = Reader.NameTable.Add(@"TypeWithGetOnlyReadOnlyCollections");
+            id41_Trumpet = Reader.NameTable.Add(@"Trumpet");
+            id124_Item = Reader.NameTable.Add(@"DerivedTypeWithInheritedShouldSerialize");
+            id141_MiddleName = Reader.NameTable.Add(@"MiddleName");
+            id36_ArrayOfDateTime = Reader.NameTable.Add(@"ArrayOfDateTime");
+            id157_string = Reader.NameTable.Add(@"string");
+            id274_Item = Reader.NameTable.Add(@"PropertyNameWithSpecialCharacters漢ñ");
+            id326_NameContent = Reader.NameTable.Add(@"NameContent");
+            id221_State = Reader.NameTable.Add(@"State");
+            id161_ArrayOfTypeWithLinkedProperty = Reader.NameTable.Add(@"ArrayOfTypeWithLinkedProperty");
+            id180_Modulation = Reader.NameTable.Add(@"Modulation");
+            id23_DerivedClass = Reader.NameTable.Add(@"DerivedClass");
+            id34_BaseClass1 = Reader.NameTable.Add(@"BaseClass1");
+            id121_Item = Reader.NameTable.Add(@"TypeWithEnumFlagPropertyHavingDefaultValue");
+            id9_TimeOnlyAsXsdTimeWrapper = Reader.NameTable.Add(@"TimeOnlyAsXsdTimeWrapper");
             id27_Item = Reader.NameTable.Add(@"http://example.com/serializer-test-namespace");
-            id302_customElement = Reader.NameTable.Add(@"customElement");
+            id208_ByteProperty = Reader.NameTable.Add(@"ByteProperty");
+            id298_Item = Reader.NameTable.Add(@"XmlNamespaceDeclarationsProperty");
+            id43_DefaultValuesSetToNaN = Reader.NameTable.Add(@"DefaultValuesSetToNaN");
+            id196_NullableDate = Reader.NameTable.Add(@"NullableDate");
+            id151_MsgDocumentType = Reader.NameTable.Add(@"MsgDocumentType");
+            id115_Item = Reader.NameTable.Add(@"TypeWithNonPublicDefaultConstructor");
+            id246_ImmutableList = Reader.NameTable.Add(@"ImmutableList");
+            id169_ArrayOfString1 = Reader.NameTable.Add(@"ArrayOfString1");
+            id250_List = Reader.NameTable.Add(@"List");
+            id321_StringArrayValue = Reader.NameTable.Add(@"StringArrayValue");
+            id294_Number = Reader.NameTable.Add(@"Number");
+            id283_Some = Reader.NameTable.Add(@"Some");
+            id125_Item = Reader.NameTable.Add(@"TypeWithFieldBackedSpecifiedMember");
+            id127_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithValue");
+            id64_StructNotSerializable = Reader.NameTable.Add(@"StructNotSerializable");
+            id74_TypeWithBuiltInTypedMembers = Reader.NameTable.Add(@"TypeWithBuiltInTypedMembers");
+            id48_Document = Reader.NameTable.Add(@"Document");
+            id154_ArrayOfInt = Reader.NameTable.Add(@"ArrayOfInt");
+            id277_DateTimeProperty = Reader.NameTable.Add(@"DateTimeProperty");
+            id71_DCStruct = Reader.NameTable.Add(@"DCStruct");
+            id68_anyType = Reader.NameTable.Add(@"anyType");
+            id231_Z = Reader.NameTable.Add(@"Z");
+            id203_NullableTimeWithValue = Reader.NameTable.Add(@"NullableTimeWithValue");
+            id240_id = Reader.NameTable.Add(@"id");
+            id179_IsValved = Reader.NameTable.Add(@"IsValved");
+            id145_A = Reader.NameTable.Add(@"A");
+            id177_Child = Reader.NameTable.Add(@"Child");
+            id81_DerivedClassWithSameProperty = Reader.NameTable.Add(@"DerivedClassWithSameProperty");
+            id139_Person = Reader.NameTable.Add(@"Person");
+            id247_ReadOnlyCollection = Reader.NameTable.Add(@"ReadOnlyCollection");
+            id174_P1 = Reader.NameTable.Add(@"P1");
+            id241_refs = Reader.NameTable.Add(@"refs");
+            id312_customElement = Reader.NameTable.Add(@"customElement");
+            id289_OptionullInt = Reader.NameTable.Add(@"OptionullInt");
+            id287_Optionull = Reader.NameTable.Add(@"Optionull");
+            id8_TimeOnlyWrapper = Reader.NameTable.Add(@"TimeOnlyWrapper");
+            id337_TestProperty = Reader.NameTable.Add(@"TestProperty");
+            id306_MyFieldIgnored = Reader.NameTable.Add(@"MyFieldIgnored");
+            id85_SimpleDC = Reader.NameTable.Add(@"SimpleDC");
+            id129_Item = Reader.NameTable.Add(@"TypeWithArrayPropertyHavingChoice");
+            id183_UnitPrice = Reader.NameTable.Add(@"UnitPrice");
+            id303_SimpleTypeValue = Reader.NameTable.Add(@"SimpleTypeValue");
+            id78_TypeHasArrayOfASerializedAsB = Reader.NameTable.Add(@"TypeHasArrayOfASerializedAsB");
+            id260_IntAProp = Reader.NameTable.Add(@"IntAProp");
+            id37_dateTime = Reader.NameTable.Add(@"dateTime");
+            id107_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor");
+            id91_SomeStruct = Reader.NameTable.Add(@"SomeStruct");
+            id95_SByteEnum = Reader.NameTable.Add(@"SByteEnum");
+            id197_NullableDateWithValue = Reader.NameTable.Add(@"NullableDateWithValue");
+            id118_TypeWith2DArrayProperty2 = Reader.NameTable.Add(@"TypeWith2DArrayProperty2");
+            id266_MyStruct = Reader.NameTable.Add(@"MyStruct");
+            id214_EmployeeName = Reader.NameTable.Add(@"EmployeeName");
+            id20_Vehicle = Reader.NameTable.Add(@"Vehicle");
+            id94_ByteEnum = Reader.NameTable.Add(@"ByteEnum");
+            id216_AttributeString = Reader.NameTable.Add(@"AttributeString");
+            id92_WithEnums = Reader.NameTable.Add(@"WithEnums");
+            id143_Name = Reader.NameTable.Add(@"Name");
+            id55_Item = Reader.NameTable.Add(@"DateTimeOffsetIXmlSerializableContainer");
+            id334_IntField2 = Reader.NameTable.Add(@"IntField2");
+            id44_Item = Reader.NameTable.Add(@"DefaultValuesSetToPositiveInfinity");
+            id288_OptionalInt = Reader.NameTable.Add(@"OptionalInt");
+            id190_DefaultDTO = Reader.NameTable.Add(@"DefaultDTO");
+            id122_TypeWithShouldSerializeMethod = Reader.NameTable.Add(@"TypeWithShouldSerializeMethod");
+            id61_TypeWithGetSetArrayMembers = Reader.NameTable.Add(@"TypeWithGetSetArrayMembers");
+            id261_NIntAProp = Reader.NameTable.Add(@"NIntAProp");
+            id205_TestValue = Reader.NameTable.Add(@"TestValue");
+            id253_CurrentDateTime = Reader.NameTable.Add(@"CurrentDateTime");
+            id271_NullableIntMember = Reader.NameTable.Add(@"NullableIntMember");
+            id263_NIntLProp = Reader.NameTable.Add(@"NIntLProp");
+            id299_XmlElementPropertyNode = Reader.NameTable.Add(@"XmlElementPropertyNode");
+            id213_GroupVehicle = Reader.NameTable.Add(@"GroupVehicle");
+            id49_httpexamplecom = Reader.NameTable.Add(@"http://example.com");
+            id5_Item = Reader.NameTable.Add(@"TypeWithDateTimeOffsetProperties");
+            id249_ImmutableQueue = Reader.NameTable.Add(@"ImmutableQueue");
+            id223_ShipTo = Reader.NameTable.Add(@"ShipTo");
+            id335_IntField1 = Reader.NameTable.Add(@"IntField1");
+            id317_CharProperty = Reader.NameTable.Add(@"CharProperty");
+            id162_ArrayOfParameter = Reader.NameTable.Add(@"ArrayOfParameter");
+            id109_TypeWithPropertyNameSpecified = Reader.NameTable.Add(@"TypeWithPropertyNameSpecified");
+            id165_ArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfSimpleType");
+            id65_TypeWithMyCollectionField = Reader.NameTable.Add(@"TypeWithMyCollectionField");
+            id297_XmlEnumProperty = Reader.NameTable.Add(@"XmlEnumProperty");
+            id105_SimpleKnownTypeValue = Reader.NameTable.Add(@"SimpleKnownTypeValue");
+            id16_Animal = Reader.NameTable.Add(@"Animal");
+            id156_ArrayOfString = Reader.NameTable.Add(@"ArrayOfString");
+            id142_LastName = Reader.NameTable.Add(@"LastName");
+            id204_NullableDefaultTime = Reader.NameTable.Add(@"NullableDefaultTime");
+            id200_MyTime = Reader.NameTable.Add(@"MyTime");
+            id120_Item = Reader.NameTable.Add(@"TypeWithEnumPropertyHavingDefaultValue");
+            id149_XmlSerializerAttributes = Reader.NameTable.Add(@"XmlSerializerAttributes");
+            id17_Dog = Reader.NameTable.Add(@"Dog");
+            id226_SubTotal = Reader.NameTable.Add(@"SubTotal");
+            id135_Item = Reader.NameTable.Add(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName");
+            id160_ArrayOfInstrument = Reader.NameTable.Add(@"ArrayOfInstrument");
+            id152_Item = Reader.NameTable.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType");
+            id278_ListProperty = Reader.NameTable.Add(@"ListProperty");
+            id201_DefaultTime = Reader.NameTable.Add(@"DefaultTime");
+            id53_XElementStruct = Reader.NameTable.Add(@"XElementStruct");
+            id98_UIntEnum = Reader.NameTable.Add(@"UIntEnum");
+            id182_Description = Reader.NameTable.Add(@"Description");
+            id230_Y = Reader.NameTable.Add(@"Y");
+            id100_ULongEnum = Reader.NameTable.Add(@"ULongEnum");
+            id220_City = Reader.NameTable.Add(@"City");
+            id284_Int = Reader.NameTable.Add(@"Int");
+            id47_TypeWithLinkedProperty = Reader.NameTable.Add(@"TypeWithLinkedProperty");
+            id313_DS2Root = Reader.NameTable.Add(@"DS2Root");
+            id111_MyXmlType = Reader.NameTable.Add(@"MyXmlType");
+            id12_TypeWithTimeSpanProperty = Reader.NameTable.Add(@"TypeWithTimeSpanProperty");
+            id93_WithNullables = Reader.NameTable.Add(@"WithNullables");
+            id211_LicenseNumber = Reader.NameTable.Add(@"LicenseNumber");
+            id307_Item = Reader.NameTable.Add(@"UnqualifiedSchemaFormListProperty");
+            id66_Item = Reader.NameTable.Add(@"TypeWithReadOnlyMyCollectionProperty");
+            id195_DefaultDate = Reader.NameTable.Add(@"DefaultDate");
+            id286_Optional = Reader.NameTable.Add(@"Optional");
+            id106_Item = Reader.NameTable.Add(@"ClassImplementingIXmlSerializable");
+            id14_TypeWithByteProperty = Reader.NameTable.Add(@"TypeWithByteProperty");
+            id24_SimpleBaseClass = Reader.NameTable.Add(@"SimpleBaseClass");
+            id276_IntProperty = Reader.NameTable.Add(@"IntProperty");
+            id325_DateContent = Reader.NameTable.Add(@"DateContent");
+            id15_TypeWithXmlNodeArrayProperty = Reader.NameTable.Add(@"TypeWithXmlNodeArrayProperty");
+            id21_Employee = Reader.NameTable.Add(@"Employee");
+            id281_Id = Reader.NameTable.Add(@"Id");
+            id28_DerivedIXmlSerializable = Reader.NameTable.Add(@"DerivedIXmlSerializable");
+            id292_XmlAttributeName = Reader.NameTable.Add(@"XmlAttributeName");
+            id46_RootElement = Reader.NameTable.Add(@"RootElement");
+            id191_NullableDTO = Reader.NameTable.Add(@"NullableDTO");
+            id4_TypeWithBinaryProperty = Reader.NameTable.Add(@"TypeWithBinaryProperty");
+            id77_TypeB = Reader.NameTable.Add(@"TypeB");
+            id56_TypeWithReadOnlyCollections = Reader.NameTable.Add(@"TypeWithReadOnlyCollections");
+            id222_Zip = Reader.NameTable.Add(@"Zip");
+            id172_QualifiedParameter = Reader.NameTable.Add(@"QualifiedParameter");
+            id86_Item = Reader.NameTable.Add(@"TypeWithXmlTextAttributeOnArray");
+            id242_Parameters = Reader.NameTable.Add(@"Parameters");
+            id331_HexBinaryContent = Reader.NameTable.Add(@"HexBinaryContent");
+            id132_ComplexChoiceA = Reader.NameTable.Add(@"ComplexChoiceA");
+            id264_Collection = Reader.NameTable.Add(@"Collection");
+            id119_Item = Reader.NameTable.Add(@"TypeWithPropertiesHavingDefaultValue");
+            id166_ArrayOfTypeA = Reader.NameTable.Add(@"ArrayOfTypeA");
+            id159_double = Reader.NameTable.Add(@"double");
+            id311_name = Reader.NameTable.Add(@"name");
+            id60_SimpleType = Reader.NameTable.Add(@"SimpleType");
+            id112_Item = Reader.NameTable.Add(@"TypeWithSchemaFormInXmlAttribute");
+            id164_XElement = Reader.NameTable.Add(@"XElement");
+            id104_KnownTypesThroughConstructor = Reader.NameTable.Add(@"KnownTypesThroughConstructor");
+            id233_Instruments = Reader.NameTable.Add(@"Instruments");
+            id163_ArrayOfXElement = Reader.NameTable.Add(@"ArrayOfXElement");
+            id239_IntValue = Reader.NameTable.Add(@"IntValue");
+            id103_TypeWithAnyAttribute = Reader.NameTable.Add(@"TypeWithAnyAttribute");
+            id11_DateTimeTimeWrapper = Reader.NameTable.Add(@"DateTimeTimeWrapper");
+            id1_TypeWithXmlElementProperty = Reader.NameTable.Add(@"TypeWithXmlElementProperty");
+            id186_BinaryHexContent = Reader.NameTable.Add(@"BinaryHexContent");
+            id336_strfld = Reader.NameTable.Add(@"strfld");
+            id285_Short = Reader.NameTable.Add(@"Short");
+            id270_IntMember = Reader.NameTable.Add(@"IntMember");
+            id333_Amount = Reader.NameTable.Add(@"Amount");
+            id219_Line1 = Reader.NameTable.Add(@"Line1");
+            id209_Age = Reader.NameTable.Add(@"Age");
+            id218_BoolValue = Reader.NameTable.Add(@"BoolValue");
+            id96_ShortEnum = Reader.NameTable.Add(@"ShortEnum");
+            id188_DTO = Reader.NameTable.Add(@"DTO");
+            id251_Array = Reader.NameTable.Add(@"Array");
         }
     }
 
@@ -19296,11 +20277,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write126_TypeWithXmlElementProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write129_TypeWithXmlElementProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read132_TypeWithXmlElementProperty();
+            return ((XmlSerializationReader1)reader).Read135_TypeWithXmlElementProperty();
         }
     }
 
@@ -19311,11 +20292,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write127_TypeWithXmlDocumentProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write130_TypeWithXmlDocumentProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read133_TypeWithXmlDocumentProperty();
+            return ((XmlSerializationReader1)reader).Read136_TypeWithXmlDocumentProperty();
         }
     }
 
@@ -19326,11 +20307,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write128_TypeWithBinaryProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write131_TypeWithBinaryProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read134_TypeWithBinaryProperty();
+            return ((XmlSerializationReader1)reader).Read137_TypeWithBinaryProperty();
         }
     }
 
@@ -19341,11 +20322,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write129_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write132_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read135_Item();
+            return ((XmlSerializationReader1)reader).Read138_Item();
         }
     }
 
@@ -19356,11 +20337,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write130_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write133_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read136_Item();
+            return ((XmlSerializationReader1)reader).Read139_Item();
         }
     }
 
@@ -19371,11 +20352,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write131_DateOnlyWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write134_DateOnlyWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read137_DateOnlyWrapper();
+            return ((XmlSerializationReader1)reader).Read140_DateOnlyWrapper();
         }
     }
 
@@ -19386,11 +20367,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write132_TimeOnlyWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write135_TimeOnlyWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read138_TimeOnlyWrapper();
+            return ((XmlSerializationReader1)reader).Read141_TimeOnlyWrapper();
         }
     }
 
@@ -19401,11 +20382,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write133_TimeOnlyAsXsdTimeWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write136_TimeOnlyAsXsdTimeWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read139_TimeOnlyAsXsdTimeWrapper();
+            return ((XmlSerializationReader1)reader).Read142_TimeOnlyAsXsdTimeWrapper();
         }
     }
 
@@ -19416,11 +20397,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write134_DateTimeDateWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write137_DateTimeDateWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read140_DateTimeDateWrapper();
+            return ((XmlSerializationReader1)reader).Read143_DateTimeDateWrapper();
         }
     }
 
@@ -19431,11 +20412,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write135_DateTimeTimeWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write138_DateTimeTimeWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read141_DateTimeTimeWrapper();
+            return ((XmlSerializationReader1)reader).Read144_DateTimeTimeWrapper();
         }
     }
 
@@ -19446,11 +20427,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write136_TypeWithTimeSpanProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write139_TypeWithTimeSpanProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read142_TypeWithTimeSpanProperty();
+            return ((XmlSerializationReader1)reader).Read145_TypeWithTimeSpanProperty();
         }
     }
 
@@ -19461,11 +20442,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write137_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write140_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read143_Item();
+            return ((XmlSerializationReader1)reader).Read146_Item();
         }
     }
 
@@ -19476,11 +20457,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write138_TypeWithByteProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write141_TypeWithByteProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read144_TypeWithByteProperty();
+            return ((XmlSerializationReader1)reader).Read147_TypeWithByteProperty();
         }
     }
 
@@ -19491,11 +20472,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write139_TypeWithXmlNodeArrayProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write142_TypeWithXmlNodeArrayProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read145_TypeWithXmlNodeArrayProperty();
+            return ((XmlSerializationReader1)reader).Read148_TypeWithXmlNodeArrayProperty();
         }
     }
 
@@ -19506,11 +20487,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write140_Animal(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write143_Animal(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read146_Animal();
+            return ((XmlSerializationReader1)reader).Read149_Animal();
         }
     }
 
@@ -19521,11 +20502,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write141_Dog(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write144_Dog(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read147_Dog();
+            return ((XmlSerializationReader1)reader).Read150_Dog();
         }
     }
 
@@ -19536,11 +20517,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write142_DogBreed(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write145_DogBreed(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read148_DogBreed();
+            return ((XmlSerializationReader1)reader).Read151_DogBreed();
         }
     }
 
@@ -19551,11 +20532,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write143_Group(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write146_Group(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read149_Group();
+            return ((XmlSerializationReader1)reader).Read152_Group();
         }
     }
 
@@ -19566,11 +20547,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write144_Vehicle(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write147_Vehicle(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read150_Vehicle();
+            return ((XmlSerializationReader1)reader).Read153_Vehicle();
         }
     }
 
@@ -19581,11 +20562,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write145_Employee(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write148_Employee(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read151_Employee();
+            return ((XmlSerializationReader1)reader).Read154_Employee();
         }
     }
 
@@ -19596,11 +20577,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write146_BaseClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write149_BaseClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read152_BaseClass();
+            return ((XmlSerializationReader1)reader).Read155_BaseClass();
         }
     }
 
@@ -19611,11 +20592,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write147_DerivedClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write150_DerivedClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read153_DerivedClass();
+            return ((XmlSerializationReader1)reader).Read156_DerivedClass();
         }
     }
 
@@ -19626,11 +20607,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write148_SimpleBaseClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write151_SimpleBaseClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read154_SimpleBaseClass();
+            return ((XmlSerializationReader1)reader).Read157_SimpleBaseClass();
         }
     }
 
@@ -19641,11 +20622,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write149_SimpleDerivedClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write152_SimpleDerivedClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read155_SimpleDerivedClass();
+            return ((XmlSerializationReader1)reader).Read158_SimpleDerivedClass();
         }
     }
 
@@ -19656,11 +20637,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write150_BaseIXmlSerializable(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write153_BaseIXmlSerializable(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read156_BaseIXmlSerializable();
+            return ((XmlSerializationReader1)reader).Read159_BaseIXmlSerializable();
         }
     }
 
@@ -19671,11 +20652,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write151_DerivedIXmlSerializable(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write154_DerivedIXmlSerializable(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read157_DerivedIXmlSerializable();
+            return ((XmlSerializationReader1)reader).Read160_DerivedIXmlSerializable();
         }
     }
 
@@ -19686,11 +20667,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write152_PurchaseOrder(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write155_PurchaseOrder(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read158_PurchaseOrder();
+            return ((XmlSerializationReader1)reader).Read161_PurchaseOrder();
         }
     }
 
@@ -19701,11 +20682,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write153_Address(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write156_Address(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read159_Address();
+            return ((XmlSerializationReader1)reader).Read162_Address();
         }
     }
 
@@ -19716,11 +20697,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write154_OrderedItem(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write157_OrderedItem(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read160_OrderedItem();
+            return ((XmlSerializationReader1)reader).Read163_OrderedItem();
         }
     }
 
@@ -19731,11 +20712,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write155_AliasedTestType(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write158_AliasedTestType(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read161_AliasedTestType();
+            return ((XmlSerializationReader1)reader).Read164_AliasedTestType();
         }
     }
 
@@ -19746,11 +20727,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write156_BaseClass1(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write159_BaseClass1(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read162_BaseClass1();
+            return ((XmlSerializationReader1)reader).Read165_BaseClass1();
         }
     }
 
@@ -19761,11 +20742,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write157_DerivedClass1(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write160_DerivedClass1(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read163_DerivedClass1();
+            return ((XmlSerializationReader1)reader).Read166_DerivedClass1();
         }
     }
 
@@ -19776,11 +20757,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write158_ArrayOfDateTime(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write161_ArrayOfDateTime(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read164_ArrayOfDateTime();
+            return ((XmlSerializationReader1)reader).Read167_ArrayOfDateTime();
         }
     }
 
@@ -19791,11 +20772,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write159_Orchestra(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write162_Orchestra(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read165_Orchestra();
+            return ((XmlSerializationReader1)reader).Read168_Orchestra();
         }
     }
 
@@ -19806,11 +20787,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write160_Instrument(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write163_Instrument(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read166_Instrument();
+            return ((XmlSerializationReader1)reader).Read169_Instrument();
         }
     }
 
@@ -19821,11 +20802,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write161_Brass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write164_Brass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read167_Brass();
+            return ((XmlSerializationReader1)reader).Read170_Brass();
         }
     }
 
@@ -19836,11 +20817,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write162_Trumpet(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write165_Trumpet(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read168_Trumpet();
+            return ((XmlSerializationReader1)reader).Read171_Trumpet();
         }
     }
 
@@ -19851,11 +20832,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write163_Pet(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write166_Pet(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read169_Pet();
+            return ((XmlSerializationReader1)reader).Read172_Pet();
         }
     }
 
@@ -19866,11 +20847,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write164_DefaultValuesSetToNaN(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write167_DefaultValuesSetToNaN(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read170_DefaultValuesSetToNaN();
+            return ((XmlSerializationReader1)reader).Read173_DefaultValuesSetToNaN();
         }
     }
 
@@ -19881,11 +20862,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write165_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write168_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read171_Item();
+            return ((XmlSerializationReader1)reader).Read174_Item();
         }
     }
 
@@ -19896,11 +20877,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write166_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write169_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read172_Item();
+            return ((XmlSerializationReader1)reader).Read175_Item();
         }
     }
 
@@ -19911,11 +20892,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write167_RootElement(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write170_RootElement(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read173_RootElement();
+            return ((XmlSerializationReader1)reader).Read176_RootElement();
         }
     }
 
@@ -19926,11 +20907,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write168_TypeWithLinkedProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write171_TypeWithLinkedProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read174_TypeWithLinkedProperty();
+            return ((XmlSerializationReader1)reader).Read177_TypeWithLinkedProperty();
         }
     }
 
@@ -19941,11 +20922,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write169_Document(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write172_Document(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read175_Document();
+            return ((XmlSerializationReader1)reader).Read178_Document();
         }
     }
 
@@ -19956,11 +20937,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write170_RootClass(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write173_RootClass(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read176_RootClass();
+            return ((XmlSerializationReader1)reader).Read179_RootClass();
         }
     }
 
@@ -19971,11 +20952,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write171_Parameter(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write174_Parameter(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read177_Parameter();
+            return ((XmlSerializationReader1)reader).Read180_Parameter();
         }
     }
 
@@ -19986,11 +20967,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write172_XElementWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write175_XElementWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read178_XElementWrapper();
+            return ((XmlSerializationReader1)reader).Read181_XElementWrapper();
         }
     }
 
@@ -20001,11 +20982,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write173_XElementStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write176_XElementStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read179_XElementStruct();
+            return ((XmlSerializationReader1)reader).Read182_XElementStruct();
         }
     }
 
@@ -20016,11 +20997,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write174_XElementArrayWrapper(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write177_XElementArrayWrapper(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read180_XElementArrayWrapper();
+            return ((XmlSerializationReader1)reader).Read183_XElementArrayWrapper();
         }
     }
 
@@ -20031,11 +21012,56 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write175_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write178_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read181_Item();
+            return ((XmlSerializationReader1)reader).Read184_Item();
+        }
+    }
+
+    public sealed class TypeWithReadOnlyCollectionsSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithReadOnlyCollections", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write179_TypeWithReadOnlyCollections(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read185_TypeWithReadOnlyCollections();
+        }
+    }
+
+    public sealed class TypeWithMutableCollectionMembersSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithMutableCollectionMembers", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write180_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read186_Item();
+        }
+    }
+
+    public sealed class TypeWithGetOnlyReadOnlyCollectionsSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithGetOnlyReadOnlyCollections", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write181_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read187_Item();
         }
     }
 
@@ -20046,11 +21072,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write176_TypeWithDateTimeStringProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write182_TypeWithDateTimeStringProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read182_TypeWithDateTimeStringProperty();
+            return ((XmlSerializationReader1)reader).Read188_TypeWithDateTimeStringProperty();
         }
     }
 
@@ -20061,11 +21087,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write177_SimpleType(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write183_SimpleType(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read183_SimpleType();
+            return ((XmlSerializationReader1)reader).Read189_SimpleType();
         }
     }
 
@@ -20076,11 +21102,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write178_TypeWithGetSetArrayMembers(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write184_TypeWithGetSetArrayMembers(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read184_TypeWithGetSetArrayMembers();
+            return ((XmlSerializationReader1)reader).Read190_TypeWithGetSetArrayMembers();
         }
     }
 
@@ -20091,11 +21117,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write179_TypeWithGetOnlyArrayProperties(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write185_TypeWithGetOnlyArrayProperties(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read185_TypeWithGetOnlyArrayProperties();
+            return ((XmlSerializationReader1)reader).Read191_TypeWithGetOnlyArrayProperties();
         }
     }
 
@@ -20106,11 +21132,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write180_TypeWithArraylikeMembers(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write186_TypeWithArraylikeMembers(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read186_TypeWithArraylikeMembers();
+            return ((XmlSerializationReader1)reader).Read192_TypeWithArraylikeMembers();
         }
     }
 
@@ -20121,11 +21147,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write181_StructNotSerializable(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write187_StructNotSerializable(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read187_StructNotSerializable();
+            return ((XmlSerializationReader1)reader).Read193_StructNotSerializable();
         }
     }
 
@@ -20136,11 +21162,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write182_TypeWithMyCollectionField(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write188_TypeWithMyCollectionField(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read188_TypeWithMyCollectionField();
+            return ((XmlSerializationReader1)reader).Read194_TypeWithMyCollectionField();
         }
     }
 
@@ -20151,11 +21177,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write183_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write189_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read189_Item();
+            return ((XmlSerializationReader1)reader).Read195_Item();
         }
     }
 
@@ -20166,11 +21192,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write184_ArrayOfAnyType(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write190_ArrayOfAnyType(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read190_ArrayOfAnyType();
+            return ((XmlSerializationReader1)reader).Read196_ArrayOfAnyType();
         }
     }
 
@@ -20181,11 +21207,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write185_MyEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write191_MyEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read191_MyEnum();
+            return ((XmlSerializationReader1)reader).Read197_MyEnum();
         }
     }
 
@@ -20196,11 +21222,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write186_TypeWithEnumMembers(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write192_TypeWithEnumMembers(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read192_TypeWithEnumMembers();
+            return ((XmlSerializationReader1)reader).Read198_TypeWithEnumMembers();
         }
     }
 
@@ -20211,11 +21237,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write187_DCStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write193_DCStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read193_DCStruct();
+            return ((XmlSerializationReader1)reader).Read199_DCStruct();
         }
     }
 
@@ -20226,11 +21252,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write188_DCClassWithEnumAndStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write194_DCClassWithEnumAndStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read194_DCClassWithEnumAndStruct();
+            return ((XmlSerializationReader1)reader).Read200_DCClassWithEnumAndStruct();
         }
     }
 
@@ -20241,11 +21267,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write189_BuiltInTypes(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write195_BuiltInTypes(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read195_BuiltInTypes();
+            return ((XmlSerializationReader1)reader).Read201_BuiltInTypes();
         }
     }
 
@@ -20256,11 +21282,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write190_TypeWithBuiltInTypedMembers(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write196_TypeWithBuiltInTypedMembers(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read196_TypeWithBuiltInTypedMembers();
+            return ((XmlSerializationReader1)reader).Read202_TypeWithBuiltInTypedMembers();
         }
     }
 
@@ -20271,11 +21297,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write191_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write197_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read197_Item();
+            return ((XmlSerializationReader1)reader).Read203_Item();
         }
     }
 
@@ -20286,11 +21312,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write192_TypeA(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write198_TypeA(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read198_TypeA();
+            return ((XmlSerializationReader1)reader).Read204_TypeA();
         }
     }
 
@@ -20301,11 +21327,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write193_TypeB(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write199_TypeB(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read199_TypeB();
+            return ((XmlSerializationReader1)reader).Read205_TypeB();
         }
     }
 
@@ -20316,11 +21342,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write194_TypeHasArrayOfASerializedAsB(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write200_TypeHasArrayOfASerializedAsB(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read200_TypeHasArrayOfASerializedAsB();
+            return ((XmlSerializationReader1)reader).Read206_TypeHasArrayOfASerializedAsB();
         }
     }
 
@@ -20331,11 +21357,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write195_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write201_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read201_Item();
+            return ((XmlSerializationReader1)reader).Read207_Item();
         }
     }
 
@@ -20346,11 +21372,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write196_BaseClassWithSamePropertyName(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write202_BaseClassWithSamePropertyName(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read202_BaseClassWithSamePropertyName();
+            return ((XmlSerializationReader1)reader).Read208_BaseClassWithSamePropertyName();
         }
     }
 
@@ -20361,11 +21387,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write197_DerivedClassWithSameProperty(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write203_DerivedClassWithSameProperty(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read203_DerivedClassWithSameProperty();
+            return ((XmlSerializationReader1)reader).Read209_DerivedClassWithSameProperty();
         }
     }
 
@@ -20376,11 +21402,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write198_DerivedClassWithSameProperty2(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write204_DerivedClassWithSameProperty2(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read204_DerivedClassWithSameProperty2();
+            return ((XmlSerializationReader1)reader).Read210_DerivedClassWithSameProperty2();
         }
     }
 
@@ -20391,11 +21417,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write199_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write205_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read205_Item();
+            return ((XmlSerializationReader1)reader).Read211_Item();
         }
     }
 
@@ -20406,11 +21432,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write200_TypeWithByteArrayAsXmlText(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write206_TypeWithByteArrayAsXmlText(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read206_TypeWithByteArrayAsXmlText();
+            return ((XmlSerializationReader1)reader).Read212_TypeWithByteArrayAsXmlText();
         }
     }
 
@@ -20421,11 +21447,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write201_SimpleDC(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write207_SimpleDC(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read207_SimpleDC();
+            return ((XmlSerializationReader1)reader).Read213_SimpleDC();
         }
     }
 
@@ -20436,11 +21462,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write202_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write208_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read208_Item();
+            return ((XmlSerializationReader1)reader).Read214_Item();
         }
     }
 
@@ -20451,11 +21477,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write203_EnumFlags(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write209_EnumFlags(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read209_EnumFlags();
+            return ((XmlSerializationReader1)reader).Read215_EnumFlags();
         }
     }
 
@@ -20466,11 +21492,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write204_ClassImplementsInterface(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write210_ClassImplementsInterface(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read210_ClassImplementsInterface();
+            return ((XmlSerializationReader1)reader).Read216_ClassImplementsInterface();
         }
     }
 
@@ -20481,11 +21507,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write205_WithStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write211_WithStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read211_WithStruct();
+            return ((XmlSerializationReader1)reader).Read217_WithStruct();
         }
     }
 
@@ -20496,11 +21522,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write206_SomeStruct(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write212_SomeStruct(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read212_SomeStruct();
+            return ((XmlSerializationReader1)reader).Read218_SomeStruct();
         }
     }
 
@@ -20511,11 +21537,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write207_WithEnums(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write213_WithEnums(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read213_WithEnums();
+            return ((XmlSerializationReader1)reader).Read219_WithEnums();
         }
     }
 
@@ -20526,11 +21552,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write208_WithNullables(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write214_WithNullables(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read214_WithNullables();
+            return ((XmlSerializationReader1)reader).Read220_WithNullables();
         }
     }
 
@@ -20541,11 +21567,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write209_ByteEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write215_ByteEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read215_ByteEnum();
+            return ((XmlSerializationReader1)reader).Read221_ByteEnum();
         }
     }
 
@@ -20556,11 +21582,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write210_SByteEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write216_SByteEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read216_SByteEnum();
+            return ((XmlSerializationReader1)reader).Read222_SByteEnum();
         }
     }
 
@@ -20571,11 +21597,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write211_ShortEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write217_ShortEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read217_ShortEnum();
+            return ((XmlSerializationReader1)reader).Read223_ShortEnum();
         }
     }
 
@@ -20586,11 +21612,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write212_IntEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write218_IntEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read218_IntEnum();
+            return ((XmlSerializationReader1)reader).Read224_IntEnum();
         }
     }
 
@@ -20601,11 +21627,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write213_UIntEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write219_UIntEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read219_UIntEnum();
+            return ((XmlSerializationReader1)reader).Read225_UIntEnum();
         }
     }
 
@@ -20616,11 +21642,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write214_LongEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write220_LongEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read220_LongEnum();
+            return ((XmlSerializationReader1)reader).Read226_LongEnum();
         }
     }
 
@@ -20631,11 +21657,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write215_ULongEnum(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write221_ULongEnum(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read221_ULongEnum();
+            return ((XmlSerializationReader1)reader).Read227_ULongEnum();
         }
     }
 
@@ -20646,11 +21672,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write216_AttributeTesting(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write222_AttributeTesting(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read222_AttributeTesting();
+            return ((XmlSerializationReader1)reader).Read228_AttributeTesting();
         }
     }
 
@@ -20661,11 +21687,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write217_ItemChoiceType(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write223_ItemChoiceType(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read223_ItemChoiceType();
+            return ((XmlSerializationReader1)reader).Read229_ItemChoiceType();
         }
     }
 
@@ -20676,11 +21702,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write218_TypeWithAnyAttribute(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write224_TypeWithAnyAttribute(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read224_TypeWithAnyAttribute();
+            return ((XmlSerializationReader1)reader).Read230_TypeWithAnyAttribute();
         }
     }
 
@@ -20691,11 +21717,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write219_KnownTypesThroughConstructor(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write225_KnownTypesThroughConstructor(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read225_KnownTypesThroughConstructor();
+            return ((XmlSerializationReader1)reader).Read231_KnownTypesThroughConstructor();
         }
     }
 
@@ -20706,11 +21732,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write220_SimpleKnownTypeValue(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write226_SimpleKnownTypeValue(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read226_SimpleKnownTypeValue();
+            return ((XmlSerializationReader1)reader).Read232_SimpleKnownTypeValue();
         }
     }
 
@@ -20718,96 +21744,6 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
             return xmlReader.IsStartElement(@"ClassImplementingIXmlSerializable", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write221_Item(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read227_Item();
-        }
-    }
-
-    public sealed class StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write222_Item(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read228_Item();
-        }
-    }
-
-    public sealed class StructImplementingIXmlSerializableWithParameterlessConstructorSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"StructImplementingIXmlSerializableWithParameterlessConstructor", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write223_Item(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read229_Item();
-        }
-    }
-
-    public sealed class TypeWithPropertyNameSpecifiedSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithPropertyNameSpecified", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write224_TypeWithPropertyNameSpecified(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read230_TypeWithPropertyNameSpecified();
-        }
-    }
-
-    public sealed class TypeWithXmlSchemaFormAttributeSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithXmlSchemaFormAttribute", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write225_TypeWithXmlSchemaFormAttribute(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read231_TypeWithXmlSchemaFormAttribute();
-        }
-    }
-
-    public sealed class TypeWithTypeNameInXmlTypeAttributeSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"MyXmlType", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write226_MyXmlType(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read232_MyXmlType();
-        }
-    }
-
-    public sealed class TypeWithSchemaFormInXmlAttributeSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithSchemaFormInXmlAttribute", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -20819,6 +21755,96 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
+    public sealed class StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write228_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read234_Item();
+        }
+    }
+
+    public sealed class StructImplementingIXmlSerializableWithParameterlessConstructorSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"StructImplementingIXmlSerializableWithParameterlessConstructor", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write229_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read235_Item();
+        }
+    }
+
+    public sealed class TypeWithPropertyNameSpecifiedSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithPropertyNameSpecified", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write230_TypeWithPropertyNameSpecified(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read236_TypeWithPropertyNameSpecified();
+        }
+    }
+
+    public sealed class TypeWithXmlSchemaFormAttributeSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithXmlSchemaFormAttribute", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write231_TypeWithXmlSchemaFormAttribute(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read237_TypeWithXmlSchemaFormAttribute();
+        }
+    }
+
+    public sealed class TypeWithTypeNameInXmlTypeAttributeSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"MyXmlType", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write232_MyXmlType(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read238_MyXmlType();
+        }
+    }
+
+    public sealed class TypeWithSchemaFormInXmlAttributeSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithSchemaFormInXmlAttribute", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write233_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read239_Item();
+        }
+    }
+
     public sealed class CustomDocumentSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
@@ -20826,11 +21852,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write228_CustomDocument(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write234_CustomDocument(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read234_CustomDocument();
+            return ((XmlSerializationReader1)reader).Read240_CustomDocument();
         }
     }
 
@@ -20841,11 +21867,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write229_CustomElement(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write235_CustomElement(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read235_CustomElement();
+            return ((XmlSerializationReader1)reader).Read241_CustomElement();
         }
     }
 
@@ -20853,96 +21879,6 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
             return true;
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write230_Item(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read236_Item();
-        }
-    }
-
-    public sealed class TypeWithNonPublicDefaultConstructorSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithNonPublicDefaultConstructor", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write231_Item(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read237_Item();
-        }
-    }
-
-    public sealed class ServerSettingsSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"ServerSettings", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write232_ServerSettings(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read238_ServerSettings();
-        }
-    }
-
-    public sealed class TypeWithXmlQualifiedNameSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithXmlQualifiedName", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write233_TypeWithXmlQualifiedName(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read239_TypeWithXmlQualifiedName();
-        }
-    }
-
-    public sealed class TypeWith2DArrayProperty2Serializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWith2DArrayProperty2", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write234_TypeWith2DArrayProperty2(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read240_TypeWith2DArrayProperty2();
-        }
-    }
-
-    public sealed class TypeWithPropertiesHavingDefaultValueSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithPropertiesHavingDefaultValue", @"");
-        }
-
-        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write235_Item(objectToSerialize);
-        }
-
-        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read241_Item();
-        }
-    }
-
-    public sealed class TypeWithEnumPropertyHavingDefaultValueSerializer : XmlSerializer1 {
-
-        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithEnumPropertyHavingDefaultValue", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -20954,10 +21890,10 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class TypeWithEnumFlagPropertyHavingDefaultValueSerializer : XmlSerializer1 {
+    public sealed class TypeWithNonPublicDefaultConstructorSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"");
+            return xmlReader.IsStartElement(@"TypeWithNonPublicDefaultConstructor", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -20969,55 +21905,55 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class TypeWithShouldSerializeMethodSerializer : XmlSerializer1 {
+    public sealed class ServerSettingsSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithShouldSerializeMethod", @"");
+            return xmlReader.IsStartElement(@"ServerSettings", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write238_TypeWithShouldSerializeMethod(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write238_ServerSettings(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read244_TypeWithShouldSerializeMethod();
+            return ((XmlSerializationReader1)reader).Read244_ServerSettings();
         }
     }
 
-    public sealed class BaseTypeWithShouldSerializeMethodSerializer : XmlSerializer1 {
+    public sealed class TypeWithXmlQualifiedNameSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"BaseTypeWithShouldSerializeMethod", @"");
+            return xmlReader.IsStartElement(@"TypeWithXmlQualifiedName", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write239_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write239_TypeWithXmlQualifiedName(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read245_Item();
+            return ((XmlSerializationReader1)reader).Read245_TypeWithXmlQualifiedName();
         }
     }
 
-    public sealed class DerivedTypeWithInheritedShouldSerializeSerializer : XmlSerializer1 {
+    public sealed class TypeWith2DArrayProperty2Serializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"DerivedTypeWithInheritedShouldSerialize", @"");
+            return xmlReader.IsStartElement(@"TypeWith2DArrayProperty2", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write240_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write240_TypeWith2DArrayProperty2(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read246_Item();
+            return ((XmlSerializationReader1)reader).Read246_TypeWith2DArrayProperty2();
         }
     }
 
-    public sealed class TypeWithFieldBackedSpecifiedMemberSerializer : XmlSerializer1 {
+    public sealed class TypeWithPropertiesHavingDefaultValueSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithFieldBackedSpecifiedMember", @"");
+            return xmlReader.IsStartElement(@"TypeWithPropertiesHavingDefaultValue", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -21029,10 +21965,10 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class KnownTypesThroughConstructorWithArrayPropertiesSerializer : XmlSerializer1 {
+    public sealed class TypeWithEnumPropertyHavingDefaultValueSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"KnownTypesThroughConstructorWithArrayProperties", @"");
+            return xmlReader.IsStartElement(@"TypeWithEnumPropertyHavingDefaultValue", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -21044,10 +21980,10 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class KnownTypesThroughConstructorWithValueSerializer : XmlSerializer1 {
+    public sealed class TypeWithEnumFlagPropertyHavingDefaultValueSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"KnownTypesThroughConstructorWithValue", @"");
+            return xmlReader.IsStartElement(@"TypeWithEnumFlagPropertyHavingDefaultValue", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -21059,25 +21995,25 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class TypeWithTypesHavingCustomFormatterSerializer : XmlSerializer1 {
+    public sealed class TypeWithShouldSerializeMethodSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithTypesHavingCustomFormatter", @"");
+            return xmlReader.IsStartElement(@"TypeWithShouldSerializeMethod", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write244_Item(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write244_TypeWithShouldSerializeMethod(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read250_Item();
+            return ((XmlSerializationReader1)reader).Read250_TypeWithShouldSerializeMethod();
         }
     }
 
-    public sealed class TypeWithArrayPropertyHavingChoiceSerializer : XmlSerializer1 {
+    public sealed class BaseTypeWithShouldSerializeMethodSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithArrayPropertyHavingChoice", @"");
+            return xmlReader.IsStartElement(@"BaseTypeWithShouldSerializeMethod", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -21089,10 +22025,10 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class TypeWithPropertyHavingComplexChoiceSerializer : XmlSerializer1 {
+    public sealed class DerivedTypeWithInheritedShouldSerializeSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithPropertyHavingComplexChoice", @"");
+            return xmlReader.IsStartElement(@"DerivedTypeWithInheritedShouldSerialize", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -21104,70 +22040,70 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
-    public sealed class MoreChoicesSerializer : XmlSerializer1 {
+    public sealed class TypeWithFieldBackedSpecifiedMemberSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"MoreChoices", @"");
+            return xmlReader.IsStartElement(@"TypeWithFieldBackedSpecifiedMember", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write247_MoreChoices(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write247_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read253_MoreChoices();
+            return ((XmlSerializationReader1)reader).Read253_Item();
         }
     }
 
-    public sealed class ComplexChoiceASerializer : XmlSerializer1 {
+    public sealed class KnownTypesThroughConstructorWithArrayPropertiesSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"ComplexChoiceA", @"");
+            return xmlReader.IsStartElement(@"KnownTypesThroughConstructorWithArrayProperties", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write248_ComplexChoiceA(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write248_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read254_ComplexChoiceA();
+            return ((XmlSerializationReader1)reader).Read254_Item();
         }
     }
 
-    public sealed class ComplexChoiceBSerializer : XmlSerializer1 {
+    public sealed class KnownTypesThroughConstructorWithValueSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"ComplexChoiceB", @"");
+            return xmlReader.IsStartElement(@"KnownTypesThroughConstructorWithValue", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write249_ComplexChoiceB(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write249_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read255_ComplexChoiceB();
+            return ((XmlSerializationReader1)reader).Read255_Item();
         }
     }
 
-    public sealed class TypeWithFieldsOrderedSerializer : XmlSerializer1 {
+    public sealed class TypeWithTypesHavingCustomFormatterSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithFieldsOrdered", @"");
+            return xmlReader.IsStartElement(@"TypeWithTypesHavingCustomFormatter", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write250_TypeWithFieldsOrdered(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write250_Item(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read256_TypeWithFieldsOrdered();
+            return ((XmlSerializationReader1)reader).Read256_Item();
         }
     }
 
-    public sealed class TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer : XmlSerializer1 {
+    public sealed class TypeWithArrayPropertyHavingChoiceSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
-            return xmlReader.IsStartElement(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName", @"");
+            return xmlReader.IsStartElement(@"TypeWithArrayPropertyHavingChoice", @"");
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
@@ -21179,6 +22115,96 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
     }
 
+    public sealed class TypeWithPropertyHavingComplexChoiceSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithPropertyHavingComplexChoice", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write252_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read258_Item();
+        }
+    }
+
+    public sealed class MoreChoicesSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"MoreChoices", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write253_MoreChoices(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read259_MoreChoices();
+        }
+    }
+
+    public sealed class ComplexChoiceASerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"ComplexChoiceA", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write254_ComplexChoiceA(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read260_ComplexChoiceA();
+        }
+    }
+
+    public sealed class ComplexChoiceBSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"ComplexChoiceB", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write255_ComplexChoiceB(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read261_ComplexChoiceB();
+        }
+    }
+
+    public sealed class TypeWithFieldsOrderedSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithFieldsOrdered", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write256_TypeWithFieldsOrdered(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read262_TypeWithFieldsOrdered();
+        }
+    }
+
+    public sealed class TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer : XmlSerializer1 {
+
+        public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
+            return xmlReader.IsStartElement(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName", @"");
+        }
+
+        protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
+            ((XmlSerializationWriter1)writer).Write257_Item(objectToSerialize);
+        }
+
+        protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
+            return ((XmlSerializationReader1)reader).Read263_Item();
+        }
+    }
+
     public sealed class NamespaceTypeNameClashContainerSerializer : XmlSerializer1 {
 
         public override System.Boolean CanDeserialize(System.Xml.XmlReader xmlReader) {
@@ -21186,11 +22212,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write252_Root(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write258_Root(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read258_Root();
+            return ((XmlSerializationReader1)reader).Read264_Root();
         }
     }
 
@@ -21201,11 +22227,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write253_TypeClashB(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write259_TypeClashB(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read259_TypeClashB();
+            return ((XmlSerializationReader1)reader).Read265_TypeClashB();
         }
     }
 
@@ -21216,11 +22242,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write254_TypeClashA(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write260_TypeClashA(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read260_TypeClashA();
+            return ((XmlSerializationReader1)reader).Read266_TypeClashA();
         }
     }
 
@@ -21231,11 +22257,11 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         }
 
         protected override void Serialize(object objectToSerialize, System.Xml.Serialization.XmlSerializationWriter writer) {
-            ((XmlSerializationWriter1)writer).Write255_Person(objectToSerialize);
+            ((XmlSerializationWriter1)writer).Write261_Person(objectToSerialize);
         }
 
         protected override object Deserialize(System.Xml.Serialization.XmlSerializationReader reader) {
-            return ((XmlSerializationReader1)reader).Read261_Person();
+            return ((XmlSerializationReader1)reader).Read267_Person();
         }
     }
 
@@ -21247,136 +22273,139 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             get {
                 if (readMethods == null) {
                     System.Collections.Hashtable _tmp = new System.Collections.Hashtable();
-                    _tmp[@"TypeWithXmlElementProperty::"] = @"Read132_TypeWithXmlElementProperty";
-                    _tmp[@"TypeWithXmlDocumentProperty::"] = @"Read133_TypeWithXmlDocumentProperty";
-                    _tmp[@"TypeWithBinaryProperty::"] = @"Read134_TypeWithBinaryProperty";
-                    _tmp[@"TypeWithDateTimeOffsetProperties::"] = @"Read135_Item";
-                    _tmp[@"TypeWithDateAndTimeOnlyProperties::"] = @"Read136_Item";
-                    _tmp[@"DateOnlyWrapper::"] = @"Read137_DateOnlyWrapper";
-                    _tmp[@"TimeOnlyWrapper::"] = @"Read138_TimeOnlyWrapper";
-                    _tmp[@"TimeOnlyAsXsdTimeWrapper::"] = @"Read139_TimeOnlyAsXsdTimeWrapper";
-                    _tmp[@"DateTimeDateWrapper::"] = @"Read140_DateTimeDateWrapper";
-                    _tmp[@"DateTimeTimeWrapper::"] = @"Read141_DateTimeTimeWrapper";
-                    _tmp[@"TypeWithTimeSpanProperty::"] = @"Read142_TypeWithTimeSpanProperty";
-                    _tmp[@"TypeWithDefaultTimeSpanProperty::"] = @"Read143_Item";
-                    _tmp[@"TypeWithByteProperty::"] = @"Read144_TypeWithByteProperty";
-                    _tmp[@"TypeWithXmlNodeArrayProperty:::True:"] = @"Read145_TypeWithXmlNodeArrayProperty";
-                    _tmp[@"Animal::"] = @"Read146_Animal";
-                    _tmp[@"Dog::"] = @"Read147_Dog";
-                    _tmp[@"DogBreed::"] = @"Read148_DogBreed";
-                    _tmp[@"Group::"] = @"Read149_Group";
-                    _tmp[@"Vehicle::"] = @"Read150_Vehicle";
-                    _tmp[@"Employee::"] = @"Read151_Employee";
-                    _tmp[@"BaseClass::"] = @"Read152_BaseClass";
-                    _tmp[@"DerivedClass::"] = @"Read153_DerivedClass";
-                    _tmp[@"SimpleBaseClass::"] = @"Read154_SimpleBaseClass";
-                    _tmp[@"SimpleDerivedClass::"] = @"Read155_SimpleDerivedClass";
-                    _tmp[@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:"] = @"Read156_BaseIXmlSerializable";
-                    _tmp[@"XmlSerializableDerivedClass::"] = @"Read157_DerivedIXmlSerializable";
-                    _tmp[@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:"] = @"Read158_PurchaseOrder";
-                    _tmp[@"Address::"] = @"Read159_Address";
-                    _tmp[@"OrderedItem::"] = @"Read160_OrderedItem";
-                    _tmp[@"AliasedTestType::"] = @"Read161_AliasedTestType";
-                    _tmp[@"BaseClass1::"] = @"Read162_BaseClass1";
-                    _tmp[@"DerivedClass1::"] = @"Read163_DerivedClass1";
-                    _tmp[@"MyCollection1::"] = @"Read164_ArrayOfDateTime";
-                    _tmp[@"Orchestra::"] = @"Read165_Orchestra";
-                    _tmp[@"Instrument::"] = @"Read166_Instrument";
-                    _tmp[@"Brass::"] = @"Read167_Brass";
-                    _tmp[@"Trumpet::"] = @"Read168_Trumpet";
-                    _tmp[@"Pet::"] = @"Read169_Pet";
-                    _tmp[@"DefaultValuesSetToNaN::"] = @"Read170_DefaultValuesSetToNaN";
-                    _tmp[@"DefaultValuesSetToPositiveInfinity::"] = @"Read171_Item";
-                    _tmp[@"DefaultValuesSetToNegativeInfinity::"] = @"Read172_Item";
-                    _tmp[@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:"] = @"Read173_RootElement";
-                    _tmp[@"TypeWithLinkedProperty::"] = @"Read174_TypeWithLinkedProperty";
-                    _tmp[@"MsgDocumentType:http://example.com:Document:True:"] = @"Read175_Document";
-                    _tmp[@"RootClass::"] = @"Read176_RootClass";
-                    _tmp[@"Parameter::"] = @"Read177_Parameter";
-                    _tmp[@"XElementWrapper::"] = @"Read178_XElementWrapper";
-                    _tmp[@"XElementStruct::"] = @"Read179_XElementStruct";
-                    _tmp[@"XElementArrayWrapper::"] = @"Read180_XElementArrayWrapper";
-                    _tmp[@"DateTimeOffsetIXmlSerializableContainer::"] = @"Read181_Item";
-                    _tmp[@"SerializationTypes.TypeWithDateTimeStringProperty::"] = @"Read182_TypeWithDateTimeStringProperty";
-                    _tmp[@"SerializationTypes.SimpleType::"] = @"Read183_SimpleType";
-                    _tmp[@"SerializationTypes.TypeWithGetSetArrayMembers::"] = @"Read184_TypeWithGetSetArrayMembers";
-                    _tmp[@"SerializationTypes.TypeWithGetOnlyArrayProperties::"] = @"Read185_TypeWithGetOnlyArrayProperties";
-                    _tmp[@"SerializationTypes.TypeWithArraylikeMembers::"] = @"Read186_TypeWithArraylikeMembers";
-                    _tmp[@"SerializationTypes.StructNotSerializable::"] = @"Read187_StructNotSerializable";
-                    _tmp[@"SerializationTypes.TypeWithMyCollectionField::"] = @"Read188_TypeWithMyCollectionField";
-                    _tmp[@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::"] = @"Read189_Item";
-                    _tmp[@"SerializationTypes.MyList::"] = @"Read190_ArrayOfAnyType";
-                    _tmp[@"SerializationTypes.MyEnum::"] = @"Read191_MyEnum";
-                    _tmp[@"SerializationTypes.TypeWithEnumMembers::"] = @"Read192_TypeWithEnumMembers";
-                    _tmp[@"SerializationTypes.DCStruct::"] = @"Read193_DCStruct";
-                    _tmp[@"SerializationTypes.DCClassWithEnumAndStruct::"] = @"Read194_DCClassWithEnumAndStruct";
-                    _tmp[@"SerializationTypes.BuiltInTypes::"] = @"Read195_BuiltInTypes";
-                    _tmp[@"SerializationTypes.TypeWithBuiltInTypedMembers::"] = @"Read196_TypeWithBuiltInTypedMembers";
-                    _tmp[@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::"] = @"Read197_Item";
-                    _tmp[@"SerializationTypes.TypeA::"] = @"Read198_TypeA";
-                    _tmp[@"SerializationTypes.TypeB::"] = @"Read199_TypeB";
-                    _tmp[@"SerializationTypes.TypeHasArrayOfASerializedAsB::"] = @"Read200_TypeHasArrayOfASerializedAsB";
-                    _tmp[@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::"] = @"Read201_Item";
-                    _tmp[@"SerializationTypes.BaseClassWithSamePropertyName::"] = @"Read202_BaseClassWithSamePropertyName";
-                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty::"] = @"Read203_DerivedClassWithSameProperty";
-                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty2::"] = @"Read204_DerivedClassWithSameProperty2";
-                    _tmp[@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::"] = @"Read205_Item";
-                    _tmp[@"SerializationTypes.TypeWithByteArrayAsXmlText::"] = @"Read206_TypeWithByteArrayAsXmlText";
-                    _tmp[@"SerializationTypes.SimpleDC::"] = @"Read207_SimpleDC";
-                    _tmp[@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:"] = @"Read208_Item";
-                    _tmp[@"SerializationTypes.EnumFlags::"] = @"Read209_EnumFlags";
-                    _tmp[@"SerializationTypes.ClassImplementsInterface::"] = @"Read210_ClassImplementsInterface";
-                    _tmp[@"SerializationTypes.WithStruct::"] = @"Read211_WithStruct";
-                    _tmp[@"SerializationTypes.SomeStruct::"] = @"Read212_SomeStruct";
-                    _tmp[@"SerializationTypes.WithEnums::"] = @"Read213_WithEnums";
-                    _tmp[@"SerializationTypes.WithNullables::"] = @"Read214_WithNullables";
-                    _tmp[@"SerializationTypes.ByteEnum::"] = @"Read215_ByteEnum";
-                    _tmp[@"SerializationTypes.SByteEnum::"] = @"Read216_SByteEnum";
-                    _tmp[@"SerializationTypes.ShortEnum::"] = @"Read217_ShortEnum";
-                    _tmp[@"SerializationTypes.IntEnum::"] = @"Read218_IntEnum";
-                    _tmp[@"SerializationTypes.UIntEnum::"] = @"Read219_UIntEnum";
-                    _tmp[@"SerializationTypes.LongEnum::"] = @"Read220_LongEnum";
-                    _tmp[@"SerializationTypes.ULongEnum::"] = @"Read221_ULongEnum";
-                    _tmp[@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:"] = @"Read222_AttributeTesting";
-                    _tmp[@"SerializationTypes.ItemChoiceType::"] = @"Read223_ItemChoiceType";
-                    _tmp[@"SerializationTypes.TypeWithAnyAttribute::"] = @"Read224_TypeWithAnyAttribute";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructor::"] = @"Read225_KnownTypesThroughConstructor";
-                    _tmp[@"SerializationTypes.SimpleKnownTypeValue::"] = @"Read226_SimpleKnownTypeValue";
-                    _tmp[@"SerializationTypes.ClassImplementingIXmlSerializable::"] = @"Read227_Item";
-                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::"] = @"Read228_Item";
-                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::"] = @"Read229_Item";
-                    _tmp[@"SerializationTypes.TypeWithPropertyNameSpecified::"] = @"Read230_TypeWithPropertyNameSpecified";
-                    _tmp[@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:"] = @"Read231_TypeWithXmlSchemaFormAttribute";
-                    _tmp[@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::"] = @"Read232_MyXmlType";
-                    _tmp[@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::"] = @"Read233_Item";
-                    _tmp[@"SerializationTypes.CustomDocument::"] = @"Read234_CustomDocument";
-                    _tmp[@"SerializationTypes.CustomElement::"] = @"Read235_CustomElement";
-                    _tmp[@"SerializationTypes.CustomAttribute::"] = @"Read236_Item";
-                    _tmp[@"SerializationTypes.TypeWithNonPublicDefaultConstructor::"] = @"Read237_Item";
-                    _tmp[@"SerializationTypes.ServerSettings::"] = @"Read238_ServerSettings";
-                    _tmp[@"SerializationTypes.TypeWithXmlQualifiedName::"] = @"Read239_TypeWithXmlQualifiedName";
-                    _tmp[@"SerializationTypes.TypeWith2DArrayProperty2::"] = @"Read240_TypeWith2DArrayProperty2";
-                    _tmp[@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::"] = @"Read241_Item";
-                    _tmp[@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::"] = @"Read242_Item";
-                    _tmp[@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::"] = @"Read243_Item";
-                    _tmp[@"SerializationTypes.TypeWithShouldSerializeMethod::"] = @"Read244_TypeWithShouldSerializeMethod";
-                    _tmp[@"SerializationTypes.BaseTypeWithShouldSerializeMethod::"] = @"Read245_Item";
-                    _tmp[@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::"] = @"Read246_Item";
-                    _tmp[@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::"] = @"Read247_Item";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::"] = @"Read248_Item";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithValue::"] = @"Read249_Item";
-                    _tmp[@"SerializationTypes.TypeWithTypesHavingCustomFormatter::"] = @"Read250_Item";
-                    _tmp[@"SerializationTypes.TypeWithArrayPropertyHavingChoice::"] = @"Read251_Item";
-                    _tmp[@"SerializationTypes.TypeWithPropertyHavingComplexChoice::"] = @"Read252_Item";
-                    _tmp[@"SerializationTypes.MoreChoices::"] = @"Read253_MoreChoices";
-                    _tmp[@"SerializationTypes.ComplexChoiceA::"] = @"Read254_ComplexChoiceA";
-                    _tmp[@"SerializationTypes.ComplexChoiceB::"] = @"Read255_ComplexChoiceB";
-                    _tmp[@"SerializationTypes.TypeWithFieldsOrdered::"] = @"Read256_TypeWithFieldsOrdered";
-                    _tmp[@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::"] = @"Read257_Item";
-                    _tmp[@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:"] = @"Read258_Root";
-                    _tmp[@"SerializationTypes.TypeNameClashB.TypeNameClash::"] = @"Read259_TypeClashB";
-                    _tmp[@"SerializationTypes.TypeNameClashA.TypeNameClash::"] = @"Read260_TypeClashA";
-                    _tmp[@"Outer+Person::"] = @"Read261_Person";
+                    _tmp[@"TypeWithXmlElementProperty::"] = @"Read135_TypeWithXmlElementProperty";
+                    _tmp[@"TypeWithXmlDocumentProperty::"] = @"Read136_TypeWithXmlDocumentProperty";
+                    _tmp[@"TypeWithBinaryProperty::"] = @"Read137_TypeWithBinaryProperty";
+                    _tmp[@"TypeWithDateTimeOffsetProperties::"] = @"Read138_Item";
+                    _tmp[@"TypeWithDateAndTimeOnlyProperties::"] = @"Read139_Item";
+                    _tmp[@"DateOnlyWrapper::"] = @"Read140_DateOnlyWrapper";
+                    _tmp[@"TimeOnlyWrapper::"] = @"Read141_TimeOnlyWrapper";
+                    _tmp[@"TimeOnlyAsXsdTimeWrapper::"] = @"Read142_TimeOnlyAsXsdTimeWrapper";
+                    _tmp[@"DateTimeDateWrapper::"] = @"Read143_DateTimeDateWrapper";
+                    _tmp[@"DateTimeTimeWrapper::"] = @"Read144_DateTimeTimeWrapper";
+                    _tmp[@"TypeWithTimeSpanProperty::"] = @"Read145_TypeWithTimeSpanProperty";
+                    _tmp[@"TypeWithDefaultTimeSpanProperty::"] = @"Read146_Item";
+                    _tmp[@"TypeWithByteProperty::"] = @"Read147_TypeWithByteProperty";
+                    _tmp[@"TypeWithXmlNodeArrayProperty:::True:"] = @"Read148_TypeWithXmlNodeArrayProperty";
+                    _tmp[@"Animal::"] = @"Read149_Animal";
+                    _tmp[@"Dog::"] = @"Read150_Dog";
+                    _tmp[@"DogBreed::"] = @"Read151_DogBreed";
+                    _tmp[@"Group::"] = @"Read152_Group";
+                    _tmp[@"Vehicle::"] = @"Read153_Vehicle";
+                    _tmp[@"Employee::"] = @"Read154_Employee";
+                    _tmp[@"BaseClass::"] = @"Read155_BaseClass";
+                    _tmp[@"DerivedClass::"] = @"Read156_DerivedClass";
+                    _tmp[@"SimpleBaseClass::"] = @"Read157_SimpleBaseClass";
+                    _tmp[@"SimpleDerivedClass::"] = @"Read158_SimpleDerivedClass";
+                    _tmp[@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:"] = @"Read159_BaseIXmlSerializable";
+                    _tmp[@"XmlSerializableDerivedClass::"] = @"Read160_DerivedIXmlSerializable";
+                    _tmp[@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:"] = @"Read161_PurchaseOrder";
+                    _tmp[@"Address::"] = @"Read162_Address";
+                    _tmp[@"OrderedItem::"] = @"Read163_OrderedItem";
+                    _tmp[@"AliasedTestType::"] = @"Read164_AliasedTestType";
+                    _tmp[@"BaseClass1::"] = @"Read165_BaseClass1";
+                    _tmp[@"DerivedClass1::"] = @"Read166_DerivedClass1";
+                    _tmp[@"MyCollection1::"] = @"Read167_ArrayOfDateTime";
+                    _tmp[@"Orchestra::"] = @"Read168_Orchestra";
+                    _tmp[@"Instrument::"] = @"Read169_Instrument";
+                    _tmp[@"Brass::"] = @"Read170_Brass";
+                    _tmp[@"Trumpet::"] = @"Read171_Trumpet";
+                    _tmp[@"Pet::"] = @"Read172_Pet";
+                    _tmp[@"DefaultValuesSetToNaN::"] = @"Read173_DefaultValuesSetToNaN";
+                    _tmp[@"DefaultValuesSetToPositiveInfinity::"] = @"Read174_Item";
+                    _tmp[@"DefaultValuesSetToNegativeInfinity::"] = @"Read175_Item";
+                    _tmp[@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:"] = @"Read176_RootElement";
+                    _tmp[@"TypeWithLinkedProperty::"] = @"Read177_TypeWithLinkedProperty";
+                    _tmp[@"MsgDocumentType:http://example.com:Document:True:"] = @"Read178_Document";
+                    _tmp[@"RootClass::"] = @"Read179_RootClass";
+                    _tmp[@"Parameter::"] = @"Read180_Parameter";
+                    _tmp[@"XElementWrapper::"] = @"Read181_XElementWrapper";
+                    _tmp[@"XElementStruct::"] = @"Read182_XElementStruct";
+                    _tmp[@"XElementArrayWrapper::"] = @"Read183_XElementArrayWrapper";
+                    _tmp[@"DateTimeOffsetIXmlSerializableContainer::"] = @"Read184_Item";
+                    _tmp[@"TypeWithReadOnlyCollections::"] = @"Read185_TypeWithReadOnlyCollections";
+                    _tmp[@"TypeWithMutableCollectionMembers::"] = @"Read186_Item";
+                    _tmp[@"TypeWithGetOnlyReadOnlyCollections::"] = @"Read187_Item";
+                    _tmp[@"SerializationTypes.TypeWithDateTimeStringProperty::"] = @"Read188_TypeWithDateTimeStringProperty";
+                    _tmp[@"SerializationTypes.SimpleType::"] = @"Read189_SimpleType";
+                    _tmp[@"SerializationTypes.TypeWithGetSetArrayMembers::"] = @"Read190_TypeWithGetSetArrayMembers";
+                    _tmp[@"SerializationTypes.TypeWithGetOnlyArrayProperties::"] = @"Read191_TypeWithGetOnlyArrayProperties";
+                    _tmp[@"SerializationTypes.TypeWithArraylikeMembers::"] = @"Read192_TypeWithArraylikeMembers";
+                    _tmp[@"SerializationTypes.StructNotSerializable::"] = @"Read193_StructNotSerializable";
+                    _tmp[@"SerializationTypes.TypeWithMyCollectionField::"] = @"Read194_TypeWithMyCollectionField";
+                    _tmp[@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::"] = @"Read195_Item";
+                    _tmp[@"SerializationTypes.MyList::"] = @"Read196_ArrayOfAnyType";
+                    _tmp[@"SerializationTypes.MyEnum::"] = @"Read197_MyEnum";
+                    _tmp[@"SerializationTypes.TypeWithEnumMembers::"] = @"Read198_TypeWithEnumMembers";
+                    _tmp[@"SerializationTypes.DCStruct::"] = @"Read199_DCStruct";
+                    _tmp[@"SerializationTypes.DCClassWithEnumAndStruct::"] = @"Read200_DCClassWithEnumAndStruct";
+                    _tmp[@"SerializationTypes.BuiltInTypes::"] = @"Read201_BuiltInTypes";
+                    _tmp[@"SerializationTypes.TypeWithBuiltInTypedMembers::"] = @"Read202_TypeWithBuiltInTypedMembers";
+                    _tmp[@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::"] = @"Read203_Item";
+                    _tmp[@"SerializationTypes.TypeA::"] = @"Read204_TypeA";
+                    _tmp[@"SerializationTypes.TypeB::"] = @"Read205_TypeB";
+                    _tmp[@"SerializationTypes.TypeHasArrayOfASerializedAsB::"] = @"Read206_TypeHasArrayOfASerializedAsB";
+                    _tmp[@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::"] = @"Read207_Item";
+                    _tmp[@"SerializationTypes.BaseClassWithSamePropertyName::"] = @"Read208_BaseClassWithSamePropertyName";
+                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty::"] = @"Read209_DerivedClassWithSameProperty";
+                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty2::"] = @"Read210_DerivedClassWithSameProperty2";
+                    _tmp[@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::"] = @"Read211_Item";
+                    _tmp[@"SerializationTypes.TypeWithByteArrayAsXmlText::"] = @"Read212_TypeWithByteArrayAsXmlText";
+                    _tmp[@"SerializationTypes.SimpleDC::"] = @"Read213_SimpleDC";
+                    _tmp[@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:"] = @"Read214_Item";
+                    _tmp[@"SerializationTypes.EnumFlags::"] = @"Read215_EnumFlags";
+                    _tmp[@"SerializationTypes.ClassImplementsInterface::"] = @"Read216_ClassImplementsInterface";
+                    _tmp[@"SerializationTypes.WithStruct::"] = @"Read217_WithStruct";
+                    _tmp[@"SerializationTypes.SomeStruct::"] = @"Read218_SomeStruct";
+                    _tmp[@"SerializationTypes.WithEnums::"] = @"Read219_WithEnums";
+                    _tmp[@"SerializationTypes.WithNullables::"] = @"Read220_WithNullables";
+                    _tmp[@"SerializationTypes.ByteEnum::"] = @"Read221_ByteEnum";
+                    _tmp[@"SerializationTypes.SByteEnum::"] = @"Read222_SByteEnum";
+                    _tmp[@"SerializationTypes.ShortEnum::"] = @"Read223_ShortEnum";
+                    _tmp[@"SerializationTypes.IntEnum::"] = @"Read224_IntEnum";
+                    _tmp[@"SerializationTypes.UIntEnum::"] = @"Read225_UIntEnum";
+                    _tmp[@"SerializationTypes.LongEnum::"] = @"Read226_LongEnum";
+                    _tmp[@"SerializationTypes.ULongEnum::"] = @"Read227_ULongEnum";
+                    _tmp[@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:"] = @"Read228_AttributeTesting";
+                    _tmp[@"SerializationTypes.ItemChoiceType::"] = @"Read229_ItemChoiceType";
+                    _tmp[@"SerializationTypes.TypeWithAnyAttribute::"] = @"Read230_TypeWithAnyAttribute";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructor::"] = @"Read231_KnownTypesThroughConstructor";
+                    _tmp[@"SerializationTypes.SimpleKnownTypeValue::"] = @"Read232_SimpleKnownTypeValue";
+                    _tmp[@"SerializationTypes.ClassImplementingIXmlSerializable::"] = @"Read233_Item";
+                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::"] = @"Read234_Item";
+                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::"] = @"Read235_Item";
+                    _tmp[@"SerializationTypes.TypeWithPropertyNameSpecified::"] = @"Read236_TypeWithPropertyNameSpecified";
+                    _tmp[@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:"] = @"Read237_TypeWithXmlSchemaFormAttribute";
+                    _tmp[@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::"] = @"Read238_MyXmlType";
+                    _tmp[@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::"] = @"Read239_Item";
+                    _tmp[@"SerializationTypes.CustomDocument::"] = @"Read240_CustomDocument";
+                    _tmp[@"SerializationTypes.CustomElement::"] = @"Read241_CustomElement";
+                    _tmp[@"SerializationTypes.CustomAttribute::"] = @"Read242_Item";
+                    _tmp[@"SerializationTypes.TypeWithNonPublicDefaultConstructor::"] = @"Read243_Item";
+                    _tmp[@"SerializationTypes.ServerSettings::"] = @"Read244_ServerSettings";
+                    _tmp[@"SerializationTypes.TypeWithXmlQualifiedName::"] = @"Read245_TypeWithXmlQualifiedName";
+                    _tmp[@"SerializationTypes.TypeWith2DArrayProperty2::"] = @"Read246_TypeWith2DArrayProperty2";
+                    _tmp[@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::"] = @"Read247_Item";
+                    _tmp[@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::"] = @"Read248_Item";
+                    _tmp[@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::"] = @"Read249_Item";
+                    _tmp[@"SerializationTypes.TypeWithShouldSerializeMethod::"] = @"Read250_TypeWithShouldSerializeMethod";
+                    _tmp[@"SerializationTypes.BaseTypeWithShouldSerializeMethod::"] = @"Read251_Item";
+                    _tmp[@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::"] = @"Read252_Item";
+                    _tmp[@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::"] = @"Read253_Item";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::"] = @"Read254_Item";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithValue::"] = @"Read255_Item";
+                    _tmp[@"SerializationTypes.TypeWithTypesHavingCustomFormatter::"] = @"Read256_Item";
+                    _tmp[@"SerializationTypes.TypeWithArrayPropertyHavingChoice::"] = @"Read257_Item";
+                    _tmp[@"SerializationTypes.TypeWithPropertyHavingComplexChoice::"] = @"Read258_Item";
+                    _tmp[@"SerializationTypes.MoreChoices::"] = @"Read259_MoreChoices";
+                    _tmp[@"SerializationTypes.ComplexChoiceA::"] = @"Read260_ComplexChoiceA";
+                    _tmp[@"SerializationTypes.ComplexChoiceB::"] = @"Read261_ComplexChoiceB";
+                    _tmp[@"SerializationTypes.TypeWithFieldsOrdered::"] = @"Read262_TypeWithFieldsOrdered";
+                    _tmp[@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::"] = @"Read263_Item";
+                    _tmp[@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:"] = @"Read264_Root";
+                    _tmp[@"SerializationTypes.TypeNameClashB.TypeNameClash::"] = @"Read265_TypeClashB";
+                    _tmp[@"SerializationTypes.TypeNameClashA.TypeNameClash::"] = @"Read266_TypeClashA";
+                    _tmp[@"Outer+Person::"] = @"Read267_Person";
                     if (readMethods == null) readMethods = _tmp;
                 }
                 return readMethods;
@@ -21387,136 +22416,139 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             get {
                 if (writeMethods == null) {
                     System.Collections.Hashtable _tmp = new System.Collections.Hashtable();
-                    _tmp[@"TypeWithXmlElementProperty::"] = @"Write126_TypeWithXmlElementProperty";
-                    _tmp[@"TypeWithXmlDocumentProperty::"] = @"Write127_TypeWithXmlDocumentProperty";
-                    _tmp[@"TypeWithBinaryProperty::"] = @"Write128_TypeWithBinaryProperty";
-                    _tmp[@"TypeWithDateTimeOffsetProperties::"] = @"Write129_Item";
-                    _tmp[@"TypeWithDateAndTimeOnlyProperties::"] = @"Write130_Item";
-                    _tmp[@"DateOnlyWrapper::"] = @"Write131_DateOnlyWrapper";
-                    _tmp[@"TimeOnlyWrapper::"] = @"Write132_TimeOnlyWrapper";
-                    _tmp[@"TimeOnlyAsXsdTimeWrapper::"] = @"Write133_TimeOnlyAsXsdTimeWrapper";
-                    _tmp[@"DateTimeDateWrapper::"] = @"Write134_DateTimeDateWrapper";
-                    _tmp[@"DateTimeTimeWrapper::"] = @"Write135_DateTimeTimeWrapper";
-                    _tmp[@"TypeWithTimeSpanProperty::"] = @"Write136_TypeWithTimeSpanProperty";
-                    _tmp[@"TypeWithDefaultTimeSpanProperty::"] = @"Write137_Item";
-                    _tmp[@"TypeWithByteProperty::"] = @"Write138_TypeWithByteProperty";
-                    _tmp[@"TypeWithXmlNodeArrayProperty:::True:"] = @"Write139_TypeWithXmlNodeArrayProperty";
-                    _tmp[@"Animal::"] = @"Write140_Animal";
-                    _tmp[@"Dog::"] = @"Write141_Dog";
-                    _tmp[@"DogBreed::"] = @"Write142_DogBreed";
-                    _tmp[@"Group::"] = @"Write143_Group";
-                    _tmp[@"Vehicle::"] = @"Write144_Vehicle";
-                    _tmp[@"Employee::"] = @"Write145_Employee";
-                    _tmp[@"BaseClass::"] = @"Write146_BaseClass";
-                    _tmp[@"DerivedClass::"] = @"Write147_DerivedClass";
-                    _tmp[@"SimpleBaseClass::"] = @"Write148_SimpleBaseClass";
-                    _tmp[@"SimpleDerivedClass::"] = @"Write149_SimpleDerivedClass";
-                    _tmp[@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:"] = @"Write150_BaseIXmlSerializable";
-                    _tmp[@"XmlSerializableDerivedClass::"] = @"Write151_DerivedIXmlSerializable";
-                    _tmp[@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:"] = @"Write152_PurchaseOrder";
-                    _tmp[@"Address::"] = @"Write153_Address";
-                    _tmp[@"OrderedItem::"] = @"Write154_OrderedItem";
-                    _tmp[@"AliasedTestType::"] = @"Write155_AliasedTestType";
-                    _tmp[@"BaseClass1::"] = @"Write156_BaseClass1";
-                    _tmp[@"DerivedClass1::"] = @"Write157_DerivedClass1";
-                    _tmp[@"MyCollection1::"] = @"Write158_ArrayOfDateTime";
-                    _tmp[@"Orchestra::"] = @"Write159_Orchestra";
-                    _tmp[@"Instrument::"] = @"Write160_Instrument";
-                    _tmp[@"Brass::"] = @"Write161_Brass";
-                    _tmp[@"Trumpet::"] = @"Write162_Trumpet";
-                    _tmp[@"Pet::"] = @"Write163_Pet";
-                    _tmp[@"DefaultValuesSetToNaN::"] = @"Write164_DefaultValuesSetToNaN";
-                    _tmp[@"DefaultValuesSetToPositiveInfinity::"] = @"Write165_Item";
-                    _tmp[@"DefaultValuesSetToNegativeInfinity::"] = @"Write166_Item";
-                    _tmp[@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:"] = @"Write167_RootElement";
-                    _tmp[@"TypeWithLinkedProperty::"] = @"Write168_TypeWithLinkedProperty";
-                    _tmp[@"MsgDocumentType:http://example.com:Document:True:"] = @"Write169_Document";
-                    _tmp[@"RootClass::"] = @"Write170_RootClass";
-                    _tmp[@"Parameter::"] = @"Write171_Parameter";
-                    _tmp[@"XElementWrapper::"] = @"Write172_XElementWrapper";
-                    _tmp[@"XElementStruct::"] = @"Write173_XElementStruct";
-                    _tmp[@"XElementArrayWrapper::"] = @"Write174_XElementArrayWrapper";
-                    _tmp[@"DateTimeOffsetIXmlSerializableContainer::"] = @"Write175_Item";
-                    _tmp[@"SerializationTypes.TypeWithDateTimeStringProperty::"] = @"Write176_TypeWithDateTimeStringProperty";
-                    _tmp[@"SerializationTypes.SimpleType::"] = @"Write177_SimpleType";
-                    _tmp[@"SerializationTypes.TypeWithGetSetArrayMembers::"] = @"Write178_TypeWithGetSetArrayMembers";
-                    _tmp[@"SerializationTypes.TypeWithGetOnlyArrayProperties::"] = @"Write179_TypeWithGetOnlyArrayProperties";
-                    _tmp[@"SerializationTypes.TypeWithArraylikeMembers::"] = @"Write180_TypeWithArraylikeMembers";
-                    _tmp[@"SerializationTypes.StructNotSerializable::"] = @"Write181_StructNotSerializable";
-                    _tmp[@"SerializationTypes.TypeWithMyCollectionField::"] = @"Write182_TypeWithMyCollectionField";
-                    _tmp[@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::"] = @"Write183_Item";
-                    _tmp[@"SerializationTypes.MyList::"] = @"Write184_ArrayOfAnyType";
-                    _tmp[@"SerializationTypes.MyEnum::"] = @"Write185_MyEnum";
-                    _tmp[@"SerializationTypes.TypeWithEnumMembers::"] = @"Write186_TypeWithEnumMembers";
-                    _tmp[@"SerializationTypes.DCStruct::"] = @"Write187_DCStruct";
-                    _tmp[@"SerializationTypes.DCClassWithEnumAndStruct::"] = @"Write188_DCClassWithEnumAndStruct";
-                    _tmp[@"SerializationTypes.BuiltInTypes::"] = @"Write189_BuiltInTypes";
-                    _tmp[@"SerializationTypes.TypeWithBuiltInTypedMembers::"] = @"Write190_TypeWithBuiltInTypedMembers";
-                    _tmp[@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::"] = @"Write191_Item";
-                    _tmp[@"SerializationTypes.TypeA::"] = @"Write192_TypeA";
-                    _tmp[@"SerializationTypes.TypeB::"] = @"Write193_TypeB";
-                    _tmp[@"SerializationTypes.TypeHasArrayOfASerializedAsB::"] = @"Write194_TypeHasArrayOfASerializedAsB";
-                    _tmp[@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::"] = @"Write195_Item";
-                    _tmp[@"SerializationTypes.BaseClassWithSamePropertyName::"] = @"Write196_BaseClassWithSamePropertyName";
-                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty::"] = @"Write197_DerivedClassWithSameProperty";
-                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty2::"] = @"Write198_DerivedClassWithSameProperty2";
-                    _tmp[@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::"] = @"Write199_Item";
-                    _tmp[@"SerializationTypes.TypeWithByteArrayAsXmlText::"] = @"Write200_TypeWithByteArrayAsXmlText";
-                    _tmp[@"SerializationTypes.SimpleDC::"] = @"Write201_SimpleDC";
-                    _tmp[@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:"] = @"Write202_Item";
-                    _tmp[@"SerializationTypes.EnumFlags::"] = @"Write203_EnumFlags";
-                    _tmp[@"SerializationTypes.ClassImplementsInterface::"] = @"Write204_ClassImplementsInterface";
-                    _tmp[@"SerializationTypes.WithStruct::"] = @"Write205_WithStruct";
-                    _tmp[@"SerializationTypes.SomeStruct::"] = @"Write206_SomeStruct";
-                    _tmp[@"SerializationTypes.WithEnums::"] = @"Write207_WithEnums";
-                    _tmp[@"SerializationTypes.WithNullables::"] = @"Write208_WithNullables";
-                    _tmp[@"SerializationTypes.ByteEnum::"] = @"Write209_ByteEnum";
-                    _tmp[@"SerializationTypes.SByteEnum::"] = @"Write210_SByteEnum";
-                    _tmp[@"SerializationTypes.ShortEnum::"] = @"Write211_ShortEnum";
-                    _tmp[@"SerializationTypes.IntEnum::"] = @"Write212_IntEnum";
-                    _tmp[@"SerializationTypes.UIntEnum::"] = @"Write213_UIntEnum";
-                    _tmp[@"SerializationTypes.LongEnum::"] = @"Write214_LongEnum";
-                    _tmp[@"SerializationTypes.ULongEnum::"] = @"Write215_ULongEnum";
-                    _tmp[@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:"] = @"Write216_AttributeTesting";
-                    _tmp[@"SerializationTypes.ItemChoiceType::"] = @"Write217_ItemChoiceType";
-                    _tmp[@"SerializationTypes.TypeWithAnyAttribute::"] = @"Write218_TypeWithAnyAttribute";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructor::"] = @"Write219_KnownTypesThroughConstructor";
-                    _tmp[@"SerializationTypes.SimpleKnownTypeValue::"] = @"Write220_SimpleKnownTypeValue";
-                    _tmp[@"SerializationTypes.ClassImplementingIXmlSerializable::"] = @"Write221_Item";
-                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::"] = @"Write222_Item";
-                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::"] = @"Write223_Item";
-                    _tmp[@"SerializationTypes.TypeWithPropertyNameSpecified::"] = @"Write224_TypeWithPropertyNameSpecified";
-                    _tmp[@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:"] = @"Write225_TypeWithXmlSchemaFormAttribute";
-                    _tmp[@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::"] = @"Write226_MyXmlType";
-                    _tmp[@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::"] = @"Write227_Item";
-                    _tmp[@"SerializationTypes.CustomDocument::"] = @"Write228_CustomDocument";
-                    _tmp[@"SerializationTypes.CustomElement::"] = @"Write229_CustomElement";
-                    _tmp[@"SerializationTypes.CustomAttribute::"] = @"Write230_Item";
-                    _tmp[@"SerializationTypes.TypeWithNonPublicDefaultConstructor::"] = @"Write231_Item";
-                    _tmp[@"SerializationTypes.ServerSettings::"] = @"Write232_ServerSettings";
-                    _tmp[@"SerializationTypes.TypeWithXmlQualifiedName::"] = @"Write233_TypeWithXmlQualifiedName";
-                    _tmp[@"SerializationTypes.TypeWith2DArrayProperty2::"] = @"Write234_TypeWith2DArrayProperty2";
-                    _tmp[@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::"] = @"Write235_Item";
-                    _tmp[@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::"] = @"Write236_Item";
-                    _tmp[@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::"] = @"Write237_Item";
-                    _tmp[@"SerializationTypes.TypeWithShouldSerializeMethod::"] = @"Write238_TypeWithShouldSerializeMethod";
-                    _tmp[@"SerializationTypes.BaseTypeWithShouldSerializeMethod::"] = @"Write239_Item";
-                    _tmp[@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::"] = @"Write240_Item";
-                    _tmp[@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::"] = @"Write241_Item";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::"] = @"Write242_Item";
-                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithValue::"] = @"Write243_Item";
-                    _tmp[@"SerializationTypes.TypeWithTypesHavingCustomFormatter::"] = @"Write244_Item";
-                    _tmp[@"SerializationTypes.TypeWithArrayPropertyHavingChoice::"] = @"Write245_Item";
-                    _tmp[@"SerializationTypes.TypeWithPropertyHavingComplexChoice::"] = @"Write246_Item";
-                    _tmp[@"SerializationTypes.MoreChoices::"] = @"Write247_MoreChoices";
-                    _tmp[@"SerializationTypes.ComplexChoiceA::"] = @"Write248_ComplexChoiceA";
-                    _tmp[@"SerializationTypes.ComplexChoiceB::"] = @"Write249_ComplexChoiceB";
-                    _tmp[@"SerializationTypes.TypeWithFieldsOrdered::"] = @"Write250_TypeWithFieldsOrdered";
-                    _tmp[@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::"] = @"Write251_Item";
-                    _tmp[@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:"] = @"Write252_Root";
-                    _tmp[@"SerializationTypes.TypeNameClashB.TypeNameClash::"] = @"Write253_TypeClashB";
-                    _tmp[@"SerializationTypes.TypeNameClashA.TypeNameClash::"] = @"Write254_TypeClashA";
-                    _tmp[@"Outer+Person::"] = @"Write255_Person";
+                    _tmp[@"TypeWithXmlElementProperty::"] = @"Write129_TypeWithXmlElementProperty";
+                    _tmp[@"TypeWithXmlDocumentProperty::"] = @"Write130_TypeWithXmlDocumentProperty";
+                    _tmp[@"TypeWithBinaryProperty::"] = @"Write131_TypeWithBinaryProperty";
+                    _tmp[@"TypeWithDateTimeOffsetProperties::"] = @"Write132_Item";
+                    _tmp[@"TypeWithDateAndTimeOnlyProperties::"] = @"Write133_Item";
+                    _tmp[@"DateOnlyWrapper::"] = @"Write134_DateOnlyWrapper";
+                    _tmp[@"TimeOnlyWrapper::"] = @"Write135_TimeOnlyWrapper";
+                    _tmp[@"TimeOnlyAsXsdTimeWrapper::"] = @"Write136_TimeOnlyAsXsdTimeWrapper";
+                    _tmp[@"DateTimeDateWrapper::"] = @"Write137_DateTimeDateWrapper";
+                    _tmp[@"DateTimeTimeWrapper::"] = @"Write138_DateTimeTimeWrapper";
+                    _tmp[@"TypeWithTimeSpanProperty::"] = @"Write139_TypeWithTimeSpanProperty";
+                    _tmp[@"TypeWithDefaultTimeSpanProperty::"] = @"Write140_Item";
+                    _tmp[@"TypeWithByteProperty::"] = @"Write141_TypeWithByteProperty";
+                    _tmp[@"TypeWithXmlNodeArrayProperty:::True:"] = @"Write142_TypeWithXmlNodeArrayProperty";
+                    _tmp[@"Animal::"] = @"Write143_Animal";
+                    _tmp[@"Dog::"] = @"Write144_Dog";
+                    _tmp[@"DogBreed::"] = @"Write145_DogBreed";
+                    _tmp[@"Group::"] = @"Write146_Group";
+                    _tmp[@"Vehicle::"] = @"Write147_Vehicle";
+                    _tmp[@"Employee::"] = @"Write148_Employee";
+                    _tmp[@"BaseClass::"] = @"Write149_BaseClass";
+                    _tmp[@"DerivedClass::"] = @"Write150_DerivedClass";
+                    _tmp[@"SimpleBaseClass::"] = @"Write151_SimpleBaseClass";
+                    _tmp[@"SimpleDerivedClass::"] = @"Write152_SimpleDerivedClass";
+                    _tmp[@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:"] = @"Write153_BaseIXmlSerializable";
+                    _tmp[@"XmlSerializableDerivedClass::"] = @"Write154_DerivedIXmlSerializable";
+                    _tmp[@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:"] = @"Write155_PurchaseOrder";
+                    _tmp[@"Address::"] = @"Write156_Address";
+                    _tmp[@"OrderedItem::"] = @"Write157_OrderedItem";
+                    _tmp[@"AliasedTestType::"] = @"Write158_AliasedTestType";
+                    _tmp[@"BaseClass1::"] = @"Write159_BaseClass1";
+                    _tmp[@"DerivedClass1::"] = @"Write160_DerivedClass1";
+                    _tmp[@"MyCollection1::"] = @"Write161_ArrayOfDateTime";
+                    _tmp[@"Orchestra::"] = @"Write162_Orchestra";
+                    _tmp[@"Instrument::"] = @"Write163_Instrument";
+                    _tmp[@"Brass::"] = @"Write164_Brass";
+                    _tmp[@"Trumpet::"] = @"Write165_Trumpet";
+                    _tmp[@"Pet::"] = @"Write166_Pet";
+                    _tmp[@"DefaultValuesSetToNaN::"] = @"Write167_DefaultValuesSetToNaN";
+                    _tmp[@"DefaultValuesSetToPositiveInfinity::"] = @"Write168_Item";
+                    _tmp[@"DefaultValuesSetToNegativeInfinity::"] = @"Write169_Item";
+                    _tmp[@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:"] = @"Write170_RootElement";
+                    _tmp[@"TypeWithLinkedProperty::"] = @"Write171_TypeWithLinkedProperty";
+                    _tmp[@"MsgDocumentType:http://example.com:Document:True:"] = @"Write172_Document";
+                    _tmp[@"RootClass::"] = @"Write173_RootClass";
+                    _tmp[@"Parameter::"] = @"Write174_Parameter";
+                    _tmp[@"XElementWrapper::"] = @"Write175_XElementWrapper";
+                    _tmp[@"XElementStruct::"] = @"Write176_XElementStruct";
+                    _tmp[@"XElementArrayWrapper::"] = @"Write177_XElementArrayWrapper";
+                    _tmp[@"DateTimeOffsetIXmlSerializableContainer::"] = @"Write178_Item";
+                    _tmp[@"TypeWithReadOnlyCollections::"] = @"Write179_TypeWithReadOnlyCollections";
+                    _tmp[@"TypeWithMutableCollectionMembers::"] = @"Write180_Item";
+                    _tmp[@"TypeWithGetOnlyReadOnlyCollections::"] = @"Write181_Item";
+                    _tmp[@"SerializationTypes.TypeWithDateTimeStringProperty::"] = @"Write182_TypeWithDateTimeStringProperty";
+                    _tmp[@"SerializationTypes.SimpleType::"] = @"Write183_SimpleType";
+                    _tmp[@"SerializationTypes.TypeWithGetSetArrayMembers::"] = @"Write184_TypeWithGetSetArrayMembers";
+                    _tmp[@"SerializationTypes.TypeWithGetOnlyArrayProperties::"] = @"Write185_TypeWithGetOnlyArrayProperties";
+                    _tmp[@"SerializationTypes.TypeWithArraylikeMembers::"] = @"Write186_TypeWithArraylikeMembers";
+                    _tmp[@"SerializationTypes.StructNotSerializable::"] = @"Write187_StructNotSerializable";
+                    _tmp[@"SerializationTypes.TypeWithMyCollectionField::"] = @"Write188_TypeWithMyCollectionField";
+                    _tmp[@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::"] = @"Write189_Item";
+                    _tmp[@"SerializationTypes.MyList::"] = @"Write190_ArrayOfAnyType";
+                    _tmp[@"SerializationTypes.MyEnum::"] = @"Write191_MyEnum";
+                    _tmp[@"SerializationTypes.TypeWithEnumMembers::"] = @"Write192_TypeWithEnumMembers";
+                    _tmp[@"SerializationTypes.DCStruct::"] = @"Write193_DCStruct";
+                    _tmp[@"SerializationTypes.DCClassWithEnumAndStruct::"] = @"Write194_DCClassWithEnumAndStruct";
+                    _tmp[@"SerializationTypes.BuiltInTypes::"] = @"Write195_BuiltInTypes";
+                    _tmp[@"SerializationTypes.TypeWithBuiltInTypedMembers::"] = @"Write196_TypeWithBuiltInTypedMembers";
+                    _tmp[@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::"] = @"Write197_Item";
+                    _tmp[@"SerializationTypes.TypeA::"] = @"Write198_TypeA";
+                    _tmp[@"SerializationTypes.TypeB::"] = @"Write199_TypeB";
+                    _tmp[@"SerializationTypes.TypeHasArrayOfASerializedAsB::"] = @"Write200_TypeHasArrayOfASerializedAsB";
+                    _tmp[@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::"] = @"Write201_Item";
+                    _tmp[@"SerializationTypes.BaseClassWithSamePropertyName::"] = @"Write202_BaseClassWithSamePropertyName";
+                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty::"] = @"Write203_DerivedClassWithSameProperty";
+                    _tmp[@"SerializationTypes.DerivedClassWithSameProperty2::"] = @"Write204_DerivedClassWithSameProperty2";
+                    _tmp[@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::"] = @"Write205_Item";
+                    _tmp[@"SerializationTypes.TypeWithByteArrayAsXmlText::"] = @"Write206_TypeWithByteArrayAsXmlText";
+                    _tmp[@"SerializationTypes.SimpleDC::"] = @"Write207_SimpleDC";
+                    _tmp[@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:"] = @"Write208_Item";
+                    _tmp[@"SerializationTypes.EnumFlags::"] = @"Write209_EnumFlags";
+                    _tmp[@"SerializationTypes.ClassImplementsInterface::"] = @"Write210_ClassImplementsInterface";
+                    _tmp[@"SerializationTypes.WithStruct::"] = @"Write211_WithStruct";
+                    _tmp[@"SerializationTypes.SomeStruct::"] = @"Write212_SomeStruct";
+                    _tmp[@"SerializationTypes.WithEnums::"] = @"Write213_WithEnums";
+                    _tmp[@"SerializationTypes.WithNullables::"] = @"Write214_WithNullables";
+                    _tmp[@"SerializationTypes.ByteEnum::"] = @"Write215_ByteEnum";
+                    _tmp[@"SerializationTypes.SByteEnum::"] = @"Write216_SByteEnum";
+                    _tmp[@"SerializationTypes.ShortEnum::"] = @"Write217_ShortEnum";
+                    _tmp[@"SerializationTypes.IntEnum::"] = @"Write218_IntEnum";
+                    _tmp[@"SerializationTypes.UIntEnum::"] = @"Write219_UIntEnum";
+                    _tmp[@"SerializationTypes.LongEnum::"] = @"Write220_LongEnum";
+                    _tmp[@"SerializationTypes.ULongEnum::"] = @"Write221_ULongEnum";
+                    _tmp[@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:"] = @"Write222_AttributeTesting";
+                    _tmp[@"SerializationTypes.ItemChoiceType::"] = @"Write223_ItemChoiceType";
+                    _tmp[@"SerializationTypes.TypeWithAnyAttribute::"] = @"Write224_TypeWithAnyAttribute";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructor::"] = @"Write225_KnownTypesThroughConstructor";
+                    _tmp[@"SerializationTypes.SimpleKnownTypeValue::"] = @"Write226_SimpleKnownTypeValue";
+                    _tmp[@"SerializationTypes.ClassImplementingIXmlSerializable::"] = @"Write227_Item";
+                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::"] = @"Write228_Item";
+                    _tmp[@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::"] = @"Write229_Item";
+                    _tmp[@"SerializationTypes.TypeWithPropertyNameSpecified::"] = @"Write230_TypeWithPropertyNameSpecified";
+                    _tmp[@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:"] = @"Write231_TypeWithXmlSchemaFormAttribute";
+                    _tmp[@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::"] = @"Write232_MyXmlType";
+                    _tmp[@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::"] = @"Write233_Item";
+                    _tmp[@"SerializationTypes.CustomDocument::"] = @"Write234_CustomDocument";
+                    _tmp[@"SerializationTypes.CustomElement::"] = @"Write235_CustomElement";
+                    _tmp[@"SerializationTypes.CustomAttribute::"] = @"Write236_Item";
+                    _tmp[@"SerializationTypes.TypeWithNonPublicDefaultConstructor::"] = @"Write237_Item";
+                    _tmp[@"SerializationTypes.ServerSettings::"] = @"Write238_ServerSettings";
+                    _tmp[@"SerializationTypes.TypeWithXmlQualifiedName::"] = @"Write239_TypeWithXmlQualifiedName";
+                    _tmp[@"SerializationTypes.TypeWith2DArrayProperty2::"] = @"Write240_TypeWith2DArrayProperty2";
+                    _tmp[@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::"] = @"Write241_Item";
+                    _tmp[@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::"] = @"Write242_Item";
+                    _tmp[@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::"] = @"Write243_Item";
+                    _tmp[@"SerializationTypes.TypeWithShouldSerializeMethod::"] = @"Write244_TypeWithShouldSerializeMethod";
+                    _tmp[@"SerializationTypes.BaseTypeWithShouldSerializeMethod::"] = @"Write245_Item";
+                    _tmp[@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::"] = @"Write246_Item";
+                    _tmp[@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::"] = @"Write247_Item";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::"] = @"Write248_Item";
+                    _tmp[@"SerializationTypes.KnownTypesThroughConstructorWithValue::"] = @"Write249_Item";
+                    _tmp[@"SerializationTypes.TypeWithTypesHavingCustomFormatter::"] = @"Write250_Item";
+                    _tmp[@"SerializationTypes.TypeWithArrayPropertyHavingChoice::"] = @"Write251_Item";
+                    _tmp[@"SerializationTypes.TypeWithPropertyHavingComplexChoice::"] = @"Write252_Item";
+                    _tmp[@"SerializationTypes.MoreChoices::"] = @"Write253_MoreChoices";
+                    _tmp[@"SerializationTypes.ComplexChoiceA::"] = @"Write254_ComplexChoiceA";
+                    _tmp[@"SerializationTypes.ComplexChoiceB::"] = @"Write255_ComplexChoiceB";
+                    _tmp[@"SerializationTypes.TypeWithFieldsOrdered::"] = @"Write256_TypeWithFieldsOrdered";
+                    _tmp[@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::"] = @"Write257_Item";
+                    _tmp[@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:"] = @"Write258_Root";
+                    _tmp[@"SerializationTypes.TypeNameClashB.TypeNameClash::"] = @"Write259_TypeClashB";
+                    _tmp[@"SerializationTypes.TypeNameClashA.TypeNameClash::"] = @"Write260_TypeClashA";
+                    _tmp[@"Outer+Person::"] = @"Write261_Person";
                     if (writeMethods == null) writeMethods = _tmp;
                 }
                 return writeMethods;
@@ -21527,136 +22559,139 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             get {
                 if (typedSerializers == null) {
                     System.Collections.Hashtable _tmp = new System.Collections.Hashtable();
-                    _tmp.Add(@"Animal::", new AnimalSerializer());
-                    _tmp.Add(@"XElementStruct::", new XElementStructSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeNameClashB.TypeNameClash::", new TypeNameClashSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithFieldsOrdered::", new TypeWithFieldsOrderedSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithArrayPropertyHavingChoice::", new TypeWithArrayPropertyHavingChoiceSerializer());
-                    _tmp.Add(@"SerializationTypes.WithStruct::", new WithStructSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleKnownTypeValue::", new SimpleKnownTypeValueSerializer());
-                    _tmp.Add(@"AliasedTestType::", new AliasedTestTypeSerializer());
-                    _tmp.Add(@"XmlSerializableDerivedClass::", new XmlSerializableDerivedClassSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlQualifiedName::", new TypeWithXmlQualifiedNameSerializer());
-                    _tmp.Add(@"SerializationTypes.StructNotSerializable::", new StructNotSerializableSerializer());
-                    _tmp.Add(@"DateTimeDateWrapper::", new DateTimeDateWrapperSerializer());
-                    _tmp.Add(@"TypeWithXmlDocumentProperty::", new TypeWithXmlDocumentPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithMyCollectionField::", new TypeWithMyCollectionFieldSerializer());
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructor::", new KnownTypesThroughConstructorSerializer());
-                    _tmp.Add(@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:", new XmlSerializableBaseClassSerializer());
-                    _tmp.Add(@"SerializationTypes.BuiltInTypes::", new BuiltInTypesSerializer());
-                    _tmp.Add(@"DefaultValuesSetToNegativeInfinity::", new DefaultValuesSetToNegativeInfinitySerializer());
-                    _tmp.Add(@"DerivedClass1::", new DerivedClass1Serializer());
-                    _tmp.Add(@"SerializationTypes.SomeStruct::", new SomeStructSerializer());
-                    _tmp.Add(@"TypeWithXmlElementProperty::", new TypeWithXmlElementPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::", new TypeWithEnumPropertyHavingDefaultValueSerializer());
-                    _tmp.Add(@"Parameter::", new ParameterSerializer());
-                    _tmp.Add(@"Brass::", new BrassSerializer());
-                    _tmp.Add(@"SerializationTypes.BaseTypeWithShouldSerializeMethod::", new BaseTypeWithShouldSerializeMethodSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeB::", new TypeBSerializer());
-                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::", new StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithAnyAttribute::", new TypeWithAnyAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::", new TypeWithDateTimePropertyAsXmlTimeSerializer());
-                    _tmp.Add(@"TypeWithLinkedProperty::", new TypeWithLinkedPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::", new TypeWithSchemaFormInXmlAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::", new TypeWithTypeNameInXmlTypeAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::", new DerivedTypeWithInheritedShouldSerializeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeHasArrayOfASerializedAsB::", new TypeHasArrayOfASerializedAsBSerializer());
-                    _tmp.Add(@"SerializationTypes.ULongEnum::", new ULongEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.LongEnum::", new LongEnumSerializer());
-                    _tmp.Add(@"DerivedClass::", new DerivedClassSerializer());
-                    _tmp.Add(@"BaseClass::", new BaseClassSerializer());
-                    _tmp.Add(@"DateOnlyWrapper::", new DateOnlyWrapperSerializer());
-                    _tmp.Add(@"DateTimeTimeWrapper::", new DateTimeTimeWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:", new NamespaceTypeNameClashContainerSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleDC::", new SimpleDCSerializer());
-                    _tmp.Add(@"XElementArrayWrapper::", new XElementArrayWrapperSerializer());
-                    _tmp.Add(@"Orchestra::", new OrchestraSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithBuiltInTypedMembers::", new TypeWithBuiltInTypedMembersSerializer());
-                    _tmp.Add(@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::", new __TypeNameWithSpecialCharacters漢ñSerializer());
-                    _tmp.Add(@"XElementWrapper::", new XElementWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:", new XmlSerializerAttributesSerializer());
-                    _tmp.Add(@"DogBreed::", new DogBreedSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty::", new DerivedClassWithSamePropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:", new TypeWithXmlTextAttributeOnArraySerializer());
-                    _tmp.Add(@"Instrument::", new InstrumentSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeNameClashA.TypeNameClash::", new TypeNameClashSerializer1());
-                    _tmp.Add(@"SerializationTypes.MyList::", new MyListSerializer());
-                    _tmp.Add(@"SerializationTypes.EnumFlags::", new EnumFlagsSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::", new TypeWithReadOnlyMyCollectionPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.IntEnum::", new IntEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.ByteEnum::", new ByteEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.UIntEnum::", new UIntEnumSerializer());
-                    _tmp.Add(@"Pet::", new PetSerializer());
-                    _tmp.Add(@"DefaultValuesSetToNaN::", new DefaultValuesSetToNaNSerializer());
-                    _tmp.Add(@"SerializationTypes.MyEnum::", new MyEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeA::", new TypeASerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWith2DArrayProperty2::", new TypeWith2DArrayProperty2Serializer());
-                    _tmp.Add(@"TypeWithDateAndTimeOnlyProperties::", new TypeWithDateAndTimeOnlyPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithGetOnlyArrayProperties::", new TypeWithGetOnlyArrayPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithNonPublicDefaultConstructor::", new TypeWithNonPublicDefaultConstructorSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertyNameSpecified::", new TypeWithPropertyNameSpecifiedSerializer());
-                    _tmp.Add(@"SimpleDerivedClass::", new SimpleDerivedClassSerializer());
-                    _tmp.Add(@"BaseClass1::", new BaseClass1Serializer());
-                    _tmp.Add(@"SerializationTypes.BaseClassWithSamePropertyName::", new BaseClassWithSamePropertyNameSerializer());
-                    _tmp.Add(@"Group::", new GroupSerializer());
-                    _tmp.Add(@"Address::", new AddressSerializer());
-                    _tmp.Add(@"SerializationTypes.ComplexChoiceB::", new ComplexChoiceBSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleType::", new SimpleTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.ServerSettings::", new ServerSettingsSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::", new TypeWithEnumFlagPropertyHavingDefaultValueSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomElement::", new CustomElementSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithArraylikeMembers::", new TypeWithArraylikeMembersSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithShouldSerializeMethod::", new TypeWithShouldSerializeMethodSerializer());
-                    _tmp.Add(@"Dog::", new DogSerializer());
-                    _tmp.Add(@"SerializationTypes.SByteEnum::", new SByteEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.ComplexChoiceA::", new ComplexChoiceASerializer());
-                    _tmp.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:", new TypeWithMismatchBetweenAttributeAndPropertyTypeSerializer());
-                    _tmp.Add(@"TimeOnlyWrapper::", new TimeOnlyWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumMembers::", new TypeWithEnumMembersSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomDocument::", new CustomDocumentSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::", new TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer());
-                    _tmp.Add(@"SerializationTypes.MoreChoices::", new MoreChoicesSerializer());
-                    _tmp.Add(@"RootClass::", new RootClassSerializer());
-                    _tmp.Add(@"SerializationTypes.ShortEnum::", new ShortEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::", new TypeWithPropertiesHavingDefaultValueSerializer());
-                    _tmp.Add(@"DateTimeOffsetIXmlSerializableContainer::", new DateTimeOffsetIXmlSerializableContainerSerializer());
-                    _tmp.Add(@"SerializationTypes.DCStruct::", new DCStructSerializer());
-                    _tmp.Add(@"TimeOnlyAsXsdTimeWrapper::", new TimeOnlyAsXsdTimeWrapperSerializer());
-                    _tmp.Add(@"TypeWithByteProperty::", new TypeWithBytePropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithByteArrayAsXmlText::", new TypeWithByteArrayAsXmlTextSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomAttribute::", new CustomAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.ItemChoiceType::", new ItemChoiceTypeSerializer());
-                    _tmp.Add(@"Vehicle::", new VehicleSerializer());
-                    _tmp.Add(@"TypeWithDefaultTimeSpanProperty::", new TypeWithDefaultTimeSpanPropertySerializer());
-                    _tmp.Add(@"DefaultValuesSetToPositiveInfinity::", new DefaultValuesSetToPositiveInfinitySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:", new TypeWithXmlSchemaFormAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertyHavingComplexChoice::", new TypeWithPropertyHavingComplexChoiceSerializer());
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::", new KnownTypesThroughConstructorWithArrayPropertiesSerializer());
-                    _tmp.Add(@"TypeWithXmlNodeArrayProperty:::True:", new TypeWithXmlNodeArrayPropertySerializer());
-                    _tmp.Add(@"TypeWithDateTimeOffsetProperties::", new TypeWithDateTimeOffsetPropertiesSerializer());
-                    _tmp.Add(@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:", new PurchaseOrderSerializer());
-                    _tmp.Add(@"MyCollection1::", new MyCollection1Serializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithTypesHavingCustomFormatter::", new TypeWithTypesHavingCustomFormatterSerializer());
-                    _tmp.Add(@"TypeWithBinaryProperty::", new TypeWithBinaryPropertySerializer());
                     _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithValue::", new KnownTypesThroughConstructorWithValueSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithDateTimeStringProperty::", new TypeWithDateTimeStringPropertySerializer());
-                    _tmp.Add(@"MsgDocumentType:http://example.com:Document:True:", new MsgDocumentTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::", new StructImplementingIXmlSerializableWithParameterlessConstructorSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty2::", new DerivedClassWithSameProperty2Serializer());
-                    _tmp.Add(@"SimpleBaseClass::", new SimpleBaseClassSerializer());
-                    _tmp.Add(@"SerializationTypes.DCClassWithEnumAndStruct::", new DCClassWithEnumAndStructSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeA::", new TypeASerializer());
                     _tmp.Add(@"SerializationTypes.ClassImplementsInterface::", new ClassImplementsInterfaceSerializer());
+                    _tmp.Add(@"TypeWithXmlDocumentProperty::", new TypeWithXmlDocumentPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:", new NamespaceTypeNameClashContainerSerializer());
+                    _tmp.Add(@"SimpleBaseClass::", new SimpleBaseClassSerializer());
                     _tmp.Add(@"TypeWithTimeSpanProperty::", new TypeWithTimeSpanPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::", new TypeWithFieldBackedSpecifiedMemberSerializer());
+                    _tmp.Add(@"DefaultValuesSetToNegativeInfinity::", new DefaultValuesSetToNegativeInfinitySerializer());
+                    _tmp.Add(@"TypeWithXmlElementProperty::", new TypeWithXmlElementPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::", new TypeWithReadOnlyMyCollectionPropertySerializer());
                     _tmp.Add(@"SerializationTypes.WithEnums::", new WithEnumsSerializer());
-                    _tmp.Add(@"Employee::", new EmployeeSerializer());
-                    _tmp.Add(@"OrderedItem::", new OrderedItemSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithGetSetArrayMembers::", new TypeWithGetSetArrayMembersSerializer());
-                    _tmp.Add(@"SerializationTypes.ClassImplementingIXmlSerializable::", new ClassImplementingIXmlSerializableSerializer());
-                    _tmp.Add(@"SerializationTypes.WithNullables::", new WithNullablesSerializer());
-                    _tmp.Add(@"Trumpet::", new TrumpetSerializer());
+                    _tmp.Add(@"TimeOnlyWrapper::", new TimeOnlyWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::", new TypeWithFieldBackedSpecifiedMemberSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::", new TypeWithTypeNameInXmlTypeAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeNameClashB.TypeNameClash::", new TypeNameClashSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlQualifiedName::", new TypeWithXmlQualifiedNameSerializer());
+                    _tmp.Add(@"TypeWithDateAndTimeOnlyProperties::", new TypeWithDateAndTimeOnlyPropertiesSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:", new TypeWithXmlSchemaFormAttributeSerializer());
+                    _tmp.Add(@"Vehicle::", new VehicleSerializer());
+                    _tmp.Add(@"SerializationTypes.ShortEnum::", new ShortEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomElement::", new CustomElementSerializer());
+                    _tmp.Add(@"TypeWithReadOnlyCollections::", new TypeWithReadOnlyCollectionsSerializer());
+                    _tmp.Add(@"TypeWithLinkedProperty::", new TypeWithLinkedPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.MyEnum::", new MyEnumSerializer());
                     _tmp.Add(@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::", new TypeWithNullableBuiltInTypedMembersSerializer());
+                    _tmp.Add(@"DateTimeTimeWrapper::", new DateTimeTimeWrapperSerializer());
+                    _tmp.Add(@"XElementWrapper::", new XElementWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.ULongEnum::", new ULongEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithDateTimeStringProperty::", new TypeWithDateTimeStringPropertySerializer());
                     _tmp.Add(@"Outer+Person::", new PersonSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::", new TypeWithDateTimePropertyAsXmlTimeSerializer());
+                    _tmp.Add(@"Employee::", new EmployeeSerializer());
+                    _tmp.Add(@"SerializationTypes.ComplexChoiceA::", new ComplexChoiceASerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleDC::", new SimpleDCSerializer());
+                    _tmp.Add(@"SerializationTypes.UIntEnum::", new UIntEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::", new KnownTypesThroughConstructorWithArrayPropertiesSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithBuiltInTypedMembers::", new TypeWithBuiltInTypedMembersSerializer());
+                    _tmp.Add(@"Instrument::", new InstrumentSerializer());
+                    _tmp.Add(@"SerializationTypes.EnumFlags::", new EnumFlagsSerializer());
+                    _tmp.Add(@"DerivedClass1::", new DerivedClass1Serializer());
+                    _tmp.Add(@"XElementStruct::", new XElementStructSerializer());
+                    _tmp.Add(@"SerializationTypes.ClassImplementingIXmlSerializable::", new ClassImplementingIXmlSerializableSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWith2DArrayProperty2::", new TypeWith2DArrayProperty2Serializer());
+                    _tmp.Add(@"SerializationTypes.TypeNameClashA.TypeNameClash::", new TypeNameClashSerializer1());
+                    _tmp.Add(@"SerializationTypes.ServerSettings::", new ServerSettingsSerializer());
+                    _tmp.Add(@"AliasedTestType::", new AliasedTestTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.LongEnum::", new LongEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithArrayPropertyHavingChoice::", new TypeWithArrayPropertyHavingChoiceSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomAttribute::", new CustomAttributeSerializer());
+                    _tmp.Add(@"Pet::", new PetSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleKnownTypeValue::", new SimpleKnownTypeValueSerializer());
+                    _tmp.Add(@"SerializationTypes.MoreChoices::", new MoreChoicesSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::", new TypeWithPropertiesHavingDefaultValueSerializer());
+                    _tmp.Add(@"OrderedItem::", new OrderedItemSerializer());
+                    _tmp.Add(@"SerializationTypes.ItemChoiceType::", new ItemChoiceTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:", new TypeWithXmlTextAttributeOnArraySerializer());
+                    _tmp.Add(@"SerializationTypes.SomeStruct::", new SomeStructSerializer());
+                    _tmp.Add(@"RootClass::", new RootClassSerializer());
+                    _tmp.Add(@"SerializationTypes.MyList::", new MyListSerializer());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructor::", new KnownTypesThroughConstructorSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::", new TypeWithSchemaFormInXmlAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumMembers::", new TypeWithEnumMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::", new TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleType::", new SimpleTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.BaseClassWithSamePropertyName::", new BaseClassWithSamePropertyNameSerializer());
+                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty::", new DerivedClassWithSamePropertySerializer());
+                    _tmp.Add(@"SerializationTypes.IntEnum::", new IntEnumSerializer());
+                    _tmp.Add(@"BaseClass1::", new BaseClass1Serializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithArraylikeMembers::", new TypeWithArraylikeMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithTypesHavingCustomFormatter::", new TypeWithTypesHavingCustomFormatterSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithGetOnlyArrayProperties::", new TypeWithGetOnlyArrayPropertiesSerializer());
+                    _tmp.Add(@"SerializationTypes.WithNullables::", new WithNullablesSerializer());
+                    _tmp.Add(@"Address::", new AddressSerializer());
+                    _tmp.Add(@"TypeWithXmlNodeArrayProperty:::True:", new TypeWithXmlNodeArrayPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithMyCollectionField::", new TypeWithMyCollectionFieldSerializer());
+                    _tmp.Add(@"MsgDocumentType:http://example.com:Document:True:", new MsgDocumentTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithAnyAttribute::", new TypeWithAnyAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithFieldsOrdered::", new TypeWithFieldsOrderedSerializer());
+                    _tmp.Add(@"TypeWithMutableCollectionMembers::", new TypeWithMutableCollectionMembersSerializer());
+                    _tmp.Add(@"DogBreed::", new DogBreedSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::", new TypeWithEnumPropertyHavingDefaultValueSerializer());
+                    _tmp.Add(@"TypeWithBinaryProperty::", new TypeWithBinaryPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.ComplexChoiceB::", new ComplexChoiceBSerializer());
+                    _tmp.Add(@"SerializationTypes.DCStruct::", new DCStructSerializer());
+                    _tmp.Add(@"Animal::", new AnimalSerializer());
+                    _tmp.Add(@"XmlSerializableDerivedClass::", new XmlSerializableDerivedClassSerializer());
+                    _tmp.Add(@"SerializationTypes.ByteEnum::", new ByteEnumSerializer());
+                    _tmp.Add(@"Dog::", new DogSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertyHavingComplexChoice::", new TypeWithPropertyHavingComplexChoiceSerializer());
+                    _tmp.Add(@"TypeWithDefaultTimeSpanProperty::", new TypeWithDefaultTimeSpanPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithGetSetArrayMembers::", new TypeWithGetSetArrayMembersSerializer());
+                    _tmp.Add(@"DateTimeOffsetIXmlSerializableContainer::", new DateTimeOffsetIXmlSerializableContainerSerializer());
+                    _tmp.Add(@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:", new XmlSerializerAttributesSerializer());
+                    _tmp.Add(@"BaseClass::", new BaseClassSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::", new TypeWithEnumFlagPropertyHavingDefaultValueSerializer());
+                    _tmp.Add(@"Trumpet::", new TrumpetSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithShouldSerializeMethod::", new TypeWithShouldSerializeMethodSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithByteArrayAsXmlText::", new TypeWithByteArrayAsXmlTextSerializer());
+                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::", new StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer());
+                    _tmp.Add(@"TypeWithByteProperty::", new TypeWithBytePropertySerializer());
+                    _tmp.Add(@"SerializationTypes.BaseTypeWithShouldSerializeMethod::", new BaseTypeWithShouldSerializeMethodSerializer());
+                    _tmp.Add(@"DefaultValuesSetToPositiveInfinity::", new DefaultValuesSetToPositiveInfinitySerializer());
+                    _tmp.Add(@"Parameter::", new ParameterSerializer());
+                    _tmp.Add(@"XElementArrayWrapper::", new XElementArrayWrapperSerializer());
+                    _tmp.Add(@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:", new XmlSerializableBaseClassSerializer());
+                    _tmp.Add(@"TypeWithDateTimeOffsetProperties::", new TypeWithDateTimeOffsetPropertiesSerializer());
+                    _tmp.Add(@"SerializationTypes.DCClassWithEnumAndStruct::", new DCClassWithEnumAndStructSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertyNameSpecified::", new TypeWithPropertyNameSpecifiedSerializer());
+                    _tmp.Add(@"DerivedClass::", new DerivedClassSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomDocument::", new CustomDocumentSerializer());
+                    _tmp.Add(@"SerializationTypes.SByteEnum::", new SByteEnumSerializer());
+                    _tmp.Add(@"MyCollection1::", new MyCollection1Serializer());
+                    _tmp.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:", new TypeWithMismatchBetweenAttributeAndPropertyTypeSerializer());
+                    _tmp.Add(@"Group::", new GroupSerializer());
+                    _tmp.Add(@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:", new PurchaseOrderSerializer());
+                    _tmp.Add(@"TimeOnlyAsXsdTimeWrapper::", new TimeOnlyAsXsdTimeWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::", new DerivedTypeWithInheritedShouldSerializeSerializer());
+                    _tmp.Add(@"DateTimeDateWrapper::", new DateTimeDateWrapperSerializer());
+                    _tmp.Add(@"TypeWithGetOnlyReadOnlyCollections::", new TypeWithGetOnlyReadOnlyCollectionsSerializer());
+                    _tmp.Add(@"SerializationTypes.BuiltInTypes::", new BuiltInTypesSerializer());
+                    _tmp.Add(@"SimpleDerivedClass::", new SimpleDerivedClassSerializer());
+                    _tmp.Add(@"DefaultValuesSetToNaN::", new DefaultValuesSetToNaNSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithNonPublicDefaultConstructor::", new TypeWithNonPublicDefaultConstructorSerializer());
+                    _tmp.Add(@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::", new __TypeNameWithSpecialCharacters漢ñSerializer());
+                    _tmp.Add(@"SerializationTypes.StructNotSerializable::", new StructNotSerializableSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeHasArrayOfASerializedAsB::", new TypeHasArrayOfASerializedAsBSerializer());
+                    _tmp.Add(@"DateOnlyWrapper::", new DateOnlyWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty2::", new DerivedClassWithSameProperty2Serializer());
+                    _tmp.Add(@"SerializationTypes.WithStruct::", new WithStructSerializer());
+                    _tmp.Add(@"Orchestra::", new OrchestraSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeB::", new TypeBSerializer());
+                    _tmp.Add(@"Brass::", new BrassSerializer());
+                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::", new StructImplementingIXmlSerializableWithParameterlessConstructorSerializer());
                     if (typedSerializers == null) typedSerializers = _tmp;
                 }
                 return typedSerializers;
@@ -21713,6 +22748,9 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             if (type == typeof(global::XElementStruct)) return true;
             if (type == typeof(global::XElementArrayWrapper)) return true;
             if (type == typeof(global::DateTimeOffsetIXmlSerializableContainer)) return true;
+            if (type == typeof(global::TypeWithReadOnlyCollections)) return true;
+            if (type == typeof(global::TypeWithMutableCollectionMembers)) return true;
+            if (type == typeof(global::TypeWithGetOnlyReadOnlyCollections)) return true;
             if (type == typeof(global::SerializationTypes.TypeWithDateTimeStringProperty)) return true;
             if (type == typeof(global::SerializationTypes.SimpleType)) return true;
             if (type == typeof(global::SerializationTypes.TypeWithGetSetArrayMembers)) return true;
@@ -21846,6 +22884,9 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             if (type == typeof(global::XElementStruct)) return new XElementStructSerializer();
             if (type == typeof(global::XElementArrayWrapper)) return new XElementArrayWrapperSerializer();
             if (type == typeof(global::DateTimeOffsetIXmlSerializableContainer)) return new DateTimeOffsetIXmlSerializableContainerSerializer();
+            if (type == typeof(global::TypeWithReadOnlyCollections)) return new TypeWithReadOnlyCollectionsSerializer();
+            if (type == typeof(global::TypeWithMutableCollectionMembers)) return new TypeWithMutableCollectionMembersSerializer();
+            if (type == typeof(global::TypeWithGetOnlyReadOnlyCollections)) return new TypeWithGetOnlyReadOnlyCollectionsSerializer();
             if (type == typeof(global::SerializationTypes.TypeWithDateTimeStringProperty)) return new TypeWithDateTimeStringPropertySerializer();
             if (type == typeof(global::SerializationTypes.SimpleType)) return new SimpleTypeSerializer();
             if (type == typeof(global::SerializationTypes.TypeWithGetSetArrayMembers)) return new TypeWithGetSetArrayMembersSerializer();

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Expected.SerializableAssembly.XmlSerializers.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Expected.SerializableAssembly.XmlSerializers.cs
@@ -3681,6 +3681,16 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             WriteStartElement(n, ns, o, false, null);
             if (needType) WriteXsiType(@"TypeWithReadOnlyCollections", @"");
             {
+                global::System.Collections.Immutable.ImmutableArray<global::System.String> a = (global::System.Collections.Immutable.ImmutableArray<global::System.String>)((global::System.Collections.Immutable.ImmutableArray<global::System.String>)o.@ImmutableArrayField);
+                {
+                    WriteStartElement(@"ImmutableArrayField", @"", null, false);
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteNullableStringLiteral(@"string", @"", ((global::System.String)a[ia]));
+                    }
+                    WriteEndElement();
+                }
+            }
+            {
                 global::System.Collections.Immutable.ImmutableArray<global::System.Int32> a = (global::System.Collections.Immutable.ImmutableArray<global::System.Int32>)((global::System.Collections.Immutable.ImmutableArray<global::System.Int32>)o.@ImmutableArray);
                 {
                     WriteStartElement(@"ImmutableArray", @"", null, false);
@@ -13667,22 +13677,25 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             if (isNull) return null;
             global::TypeWithReadOnlyCollections o;
             o = new global::TypeWithReadOnlyCollections();
-            global::System.Int32[] a_0 = null;
-            o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+            global::System.String[] a_0 = null;
+            o.@ImmutableArrayField = global::System.Collections.Immutable.ImmutableArray.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
             int ca_0 = 0;
-            global::System.String[] a_1 = null;
-            o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
+            global::System.Int32[] a_1 = null;
+            o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
             int ca_1 = 0;
-            global::System.Int32[] a_2 = null;
-            o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+            global::System.String[] a_2 = null;
+            o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
             int ca_2 = 0;
             global::System.Int32[] a_3 = null;
-            o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+            o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
             int ca_3 = 0;
             global::System.Int32[] a_4 = null;
-            o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+            o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
             int ca_4 = 0;
-            System.Span<bool> paramsRead = stackalloc bool[5];
+            global::System.Int32[] a_5 = null;
+            o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+            int ca_5 = 0;
+            System.Span<bool> paramsRead = stackalloc bool[6];
             while (Reader.MoveToNextAttribute()) {
                 if (!IsXmlnsAttribute(Reader.Name)) {
                     UnknownNode((object)o);
@@ -13698,7 +13711,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id245_ImmutableArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id245_ImmutableArrayField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13708,65 +13721,9 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     }
                                     Reader.MoveToElement();
                                 }
-                                global::System.Int32[] a_0_0 = null;
-                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                global::System.String[] a_0_0 = null;
+                                o.@ImmutableArrayField = global::System.Collections.Immutable.ImmutableArray.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
                                 int ca_0_0 = 0;
-                                if ((Reader.IsEmptyElement)) {
-                                    Reader.Skip();
-                                }
-                                else {
-                                    Reader.ReadStartElement();
-                                    Reader.MoveToContent();
-                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
-                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
-                                            do {
-                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                                                    if (Reader.HasAttributes) {
-                                                        while (Reader.MoveToNextAttribute()) {
-                                                            if (!IsXmlnsAttribute(Reader.Name)) {
-                                                                UnknownNode(null);
-                                                            }
-                                                        }
-                                                        Reader.MoveToElement();
-                                                    }
-                                                    {
-                                                        a_0_0 = (global::System.Int32[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::System.Int32));a_0_0[ca_0_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
-                                                    }
-                                                    break;
-                                                }
-                                                UnknownNode(null, @":int");
-                                            } while (false);
-                                        }
-                                        else {
-                                            UnknownNode(null, @":int");
-                                        }
-                                        Reader.MoveToContent();
-                                    }
-                                ReadEndElement();
-                                }
-                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_0_0, ca_0_0, typeof(global::System.Int32), false));
-                            }
-                            else {
-                                global::System.Int32[] a_0_0 = null;
-                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
-                                int ca_0_0 = 0;
-                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_0_0, ca_0_0, typeof(global::System.Int32), false));
-                            }
-                            break;
-                        }
-                        if (((object) Reader.LocalName == (object)id246_ImmutableList && (object) Reader.NamespaceURI == (object)id2_Item)) {
-                            if (!ReadNull()) {
-                                if (Reader.HasAttributes) {
-                                    while (Reader.MoveToNextAttribute()) {
-                                        if (!IsXmlnsAttribute(Reader.Name)) {
-                                            UnknownNode(null);
-                                        }
-                                    }
-                                    Reader.MoveToElement();
-                                }
-                                global::System.String[] a_1_0 = null;
-                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
-                                int ca_1_0 = 0;
                                 if ((Reader.IsEmptyElement)) {
                                     Reader.Skip();
                                 }
@@ -13778,7 +13735,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                             do {
                                                 if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
                                                     if (ReadNull()) {
-                                                        a_1_0 = (global::System.String[])EnsureArrayIndex(a_1_0, ca_1_0, typeof(global::System.String));a_1_0[ca_1_0++] = null;
+                                                        a_0_0 = (global::System.String[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::System.String));a_0_0[ca_0_0++] = null;
                                                     }
                                                     else {
                                                         if (Reader.HasAttributes) {
@@ -13790,7 +13747,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                                             Reader.MoveToElement();
                                                         }
                                                         {
-                                                            a_1_0 = (global::System.String[])EnsureArrayIndex(a_1_0, ca_1_0, typeof(global::System.String));a_1_0[ca_1_0++] = Reader.ReadElementString();
+                                                            a_0_0 = (global::System.String[])EnsureArrayIndex(a_0_0, ca_0_0, typeof(global::System.String));a_0_0[ca_0_0++] = Reader.ReadElementString();
                                                         }
                                                     }
                                                     break;
@@ -13805,17 +13762,17 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     }
                                 ReadEndElement();
                                 }
-                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(a_1_0, ca_1_0, typeof(global::System.String), false));
+                                o.@ImmutableArrayField = global::System.Collections.Immutable.ImmutableArray.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(a_0_0, ca_0_0, typeof(global::System.String), false));
                             }
                             else {
-                                global::System.String[] a_1_0 = null;
-                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
-                                int ca_1_0 = 0;
-                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(a_1_0, ca_1_0, typeof(global::System.String), false));
+                                global::System.String[] a_0_0 = null;
+                                o.@ImmutableArrayField = global::System.Collections.Immutable.ImmutableArray.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
+                                int ca_0_0 = 0;
+                                o.@ImmutableArrayField = global::System.Collections.Immutable.ImmutableArray.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(a_0_0, ca_0_0, typeof(global::System.String), false));
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id247_ReadOnlyCollection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id246_ImmutableArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13825,9 +13782,9 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     }
                                     Reader.MoveToElement();
                                 }
-                                global::System.Int32[] a_2_0 = null;
-                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
-                                int ca_2_0 = 0;
+                                global::System.Int32[] a_1_0 = null;
+                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_1_0 = 0;
                                 if ((Reader.IsEmptyElement)) {
                                     Reader.Skip();
                                 }
@@ -13847,7 +13804,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                                         Reader.MoveToElement();
                                                     }
                                                     {
-                                                        a_2_0 = (global::System.Int32[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::System.Int32));a_2_0[ca_2_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                        a_1_0 = (global::System.Int32[])EnsureArrayIndex(a_1_0, ca_1_0, typeof(global::System.Int32));a_1_0[ca_1_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
                                                     }
                                                     break;
                                                 }
@@ -13861,17 +13818,78 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     }
                                 ReadEndElement();
                                 }
-                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_2_0, ca_2_0, typeof(global::System.Int32), false));
+                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_1_0, ca_1_0, typeof(global::System.Int32), false));
                             }
                             else {
-                                global::System.Int32[] a_2_0 = null;
-                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
-                                int ca_2_0 = 0;
-                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_2_0, ca_2_0, typeof(global::System.Int32), false));
+                                global::System.Int32[] a_1_0 = null;
+                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_1_0 = 0;
+                                o.@ImmutableArray = global::System.Collections.Immutable.ImmutableArray.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_1_0, ca_1_0, typeof(global::System.Int32), false));
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id248_FrozenSet && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id247_ImmutableList && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.String[] a_2_0 = null;
+                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
+                                int ca_2_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id157_string && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (ReadNull()) {
+                                                        a_2_0 = (global::System.String[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::System.String));a_2_0[ca_2_0++] = null;
+                                                    }
+                                                    else {
+                                                        if (Reader.HasAttributes) {
+                                                            while (Reader.MoveToNextAttribute()) {
+                                                                if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                    UnknownNode(null);
+                                                                }
+                                                            }
+                                                            Reader.MoveToElement();
+                                                        }
+                                                        {
+                                                            a_2_0 = (global::System.String[])EnsureArrayIndex(a_2_0, ca_2_0, typeof(global::System.String));a_2_0[ca_2_0++] = Reader.ReadElementString();
+                                                        }
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":string");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":string");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(a_2_0, ca_2_0, typeof(global::System.String), false));
+                            }
+                            else {
+                                global::System.String[] a_2_0 = null;
+                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(null, 0, typeof(global::System.String), false));
+                                int ca_2_0 = 0;
+                                o.@ImmutableList = global::System.Collections.Immutable.ImmutableList.Create<global::System.String>((global::System.ReadOnlySpan<global::System.String>)(global::System.String[])ShrinkArray(a_2_0, ca_2_0, typeof(global::System.String), false));
+                            }
+                            break;
+                        }
+                        if (((object) Reader.LocalName == (object)id248_ReadOnlyCollection && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13882,7 +13900,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     Reader.MoveToElement();
                                 }
                                 global::System.Int32[] a_3_0 = null;
-                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
                                 int ca_3_0 = 0;
                                 if ((Reader.IsEmptyElement)) {
                                     Reader.Skip();
@@ -13917,17 +13935,17 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     }
                                 ReadEndElement();
                                 }
-                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_3_0, ca_3_0, typeof(global::System.Int32), false));
+                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_3_0, ca_3_0, typeof(global::System.Int32), false));
                             }
                             else {
                                 global::System.Int32[] a_3_0 = null;
-                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
                                 int ca_3_0 = 0;
-                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_3_0, ca_3_0, typeof(global::System.Int32), false));
+                                o.@ReadOnlyCollection = global::System.Collections.ObjectModel.ReadOnlyCollection.CreateCollection<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_3_0, ca_3_0, typeof(global::System.Int32), false));
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id249_ImmutableQueue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id249_FrozenSet && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -13938,7 +13956,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     Reader.MoveToElement();
                                 }
                                 global::System.Int32[] a_4_0 = null;
-                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
                                 int ca_4_0 = 0;
                                 if ((Reader.IsEmptyElement)) {
                                     Reader.Skip();
@@ -13973,21 +13991,77 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                                     }
                                 ReadEndElement();
                                 }
-                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_4_0, ca_4_0, typeof(global::System.Int32), false));
+                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_4_0, ca_4_0, typeof(global::System.Int32), false));
                             }
                             else {
                                 global::System.Int32[] a_4_0 = null;
-                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
                                 int ca_4_0 = 0;
-                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_4_0, ca_4_0, typeof(global::System.Int32), false));
+                                o.@FrozenSet = global::System.Collections.Frozen.FrozenSet.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_4_0, ca_4_0, typeof(global::System.Int32), false));
                             }
                             break;
                         }
-                        UnknownNode((object)o, @":ImmutableArray, :ImmutableList, :ReadOnlyCollection, :FrozenSet, :ImmutableQueue");
+                        if (((object) Reader.LocalName == (object)id250_ImmutableQueue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (!ReadNull()) {
+                                if (Reader.HasAttributes) {
+                                    while (Reader.MoveToNextAttribute()) {
+                                        if (!IsXmlnsAttribute(Reader.Name)) {
+                                            UnknownNode(null);
+                                        }
+                                    }
+                                    Reader.MoveToElement();
+                                }
+                                global::System.Int32[] a_5_0 = null;
+                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_5_0 = 0;
+                                if ((Reader.IsEmptyElement)) {
+                                    Reader.Skip();
+                                }
+                                else {
+                                    Reader.ReadStartElement();
+                                    Reader.MoveToContent();
+                                    while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
+                                        if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
+                                            do {
+                                                if (((object) Reader.LocalName == (object)id155_int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                                                    if (Reader.HasAttributes) {
+                                                        while (Reader.MoveToNextAttribute()) {
+                                                            if (!IsXmlnsAttribute(Reader.Name)) {
+                                                                UnknownNode(null);
+                                                            }
+                                                        }
+                                                        Reader.MoveToElement();
+                                                    }
+                                                    {
+                                                        a_5_0 = (global::System.Int32[])EnsureArrayIndex(a_5_0, ca_5_0, typeof(global::System.Int32));a_5_0[ca_5_0++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                                                    }
+                                                    break;
+                                                }
+                                                UnknownNode(null, @":int");
+                                            } while (false);
+                                        }
+                                        else {
+                                            UnknownNode(null, @":int");
+                                        }
+                                        Reader.MoveToContent();
+                                    }
+                                ReadEndElement();
+                                }
+                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_5_0, ca_5_0, typeof(global::System.Int32), false));
+                            }
+                            else {
+                                global::System.Int32[] a_5_0 = null;
+                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(null, 0, typeof(global::System.Int32), false));
+                                int ca_5_0 = 0;
+                                o.@ImmutableQueue = global::System.Collections.Immutable.ImmutableQueue.Create<global::System.Int32>((global::System.ReadOnlySpan<global::System.Int32>)(global::System.Int32[])ShrinkArray(a_5_0, ca_5_0, typeof(global::System.Int32), false));
+                            }
+                            break;
+                        }
+                        UnknownNode((object)o, @":ImmutableArrayField, :ImmutableArray, :ImmutableList, :ReadOnlyCollection, :FrozenSet, :ImmutableQueue");
                     } while (false);
                 }
                 else {
-                    UnknownNode((object)o, @":ImmutableArray, :ImmutableList, :ReadOnlyCollection, :FrozenSet, :ImmutableQueue");
+                    UnknownNode((object)o, @":ImmutableArrayField, :ImmutableArray, :ImmutableList, :ReadOnlyCollection, :FrozenSet, :ImmutableQueue");
                 }
                 Reader.MoveToContent();
             }
@@ -14029,7 +14103,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id250_List && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id251_List && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14077,7 +14151,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id251_Array && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id252_Array && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14174,7 +14248,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id246_ImmutableList && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id247_ImmutableList && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14231,7 +14305,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id247_ReadOnlyCollection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id248_ReadOnlyCollection && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14283,7 +14357,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id245_ImmutableArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id246_ImmutableArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14382,7 +14456,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id252_DateTimeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id253_DateTimeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14397,7 +14471,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id253_CurrentDateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id254_CurrentDateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14462,7 +14536,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id254_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id255_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14501,7 +14575,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id255_F2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id256_F2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14736,7 +14810,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id256_IntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id257_IntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14785,7 +14859,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id257_NIntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id258_NIntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14834,7 +14908,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id258_IntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id259_IntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14882,7 +14956,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id259_NIntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id260_NIntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14934,7 +15008,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id260_IntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id261_IntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14983,7 +15057,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id261_NIntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id262_NIntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15037,7 +15111,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id262_IntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id263_IntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15085,7 +15159,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id263_NIntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id264_NIntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15240,7 +15314,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id264_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id265_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15336,7 +15410,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id264_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id265_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15430,7 +15504,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id254_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id255_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15508,7 +15582,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id266_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15565,12 +15639,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id266_MyStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id267_MyStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyStruct = Read67_DCStruct(true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id267_MyEnum1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id268_MyEnum1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15627,7 +15701,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id268_ByteArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id269_ByteArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15688,7 +15762,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id269_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id270_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15703,7 +15777,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id270_IntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id271_IntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15718,12 +15792,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id271_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id272_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableIntMember = Read70_NullableOfInt32(true);
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id272_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id273_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15776,7 +15850,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id273_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id274_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15889,7 +15963,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id269_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id270_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (ReadNull()) {
                                 o.@StringMember = null;
                             }
@@ -15909,12 +15983,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id271_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id272_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableIntMember = Read70_NullableOfInt32(true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id273_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id274_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15963,7 +16037,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id272_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id273_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16198,7 +16272,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id274_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id275_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16257,7 +16331,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id275_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16272,7 +16346,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16287,7 +16361,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id277_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id278_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16302,7 +16376,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id278_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id279_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16401,7 +16475,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id275_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16416,7 +16490,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16431,7 +16505,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id277_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id278_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16446,7 +16520,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id278_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id279_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16547,7 +16621,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id275_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16562,7 +16636,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16577,7 +16651,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id277_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id278_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16592,7 +16666,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id278_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id279_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16781,7 +16855,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id265_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id266_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16893,7 +16967,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id279_ClassID && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id280_ClassID && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16908,7 +16982,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id280_DisplayName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id281_DisplayName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16923,7 +16997,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id281_Id && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id282_Id && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16938,7 +17012,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id282_IsLoaded && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id283_IsLoaded && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17073,7 +17147,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id283_Some && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id284_Some && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Some = Read86_SomeStruct(true);
                             paramsRead[0] = true;
                             break;
@@ -17120,7 +17194,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id284_Int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id285_Int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17135,7 +17209,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id285_Short && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id286_Short && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17192,32 +17266,32 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id286_Optional && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id287_Optional && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Optional = Read91_NullableOfIntEnum(true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id287_Optionull && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id288_Optionull && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Optionull = Read91_NullableOfIntEnum(true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id288_OptionalInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id289_OptionalInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@OptionalInt = Read70_NullableOfInt32(true);
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id289_OptionullInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id290_OptionullInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@OptionullInt = Read70_NullableOfInt32(true);
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id290_Struct1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id291_Struct1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Struct1 = Read92_NullableOfSomeStruct(true);
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id291_Struct2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id292_Struct2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Struct2 = Read92_NullableOfSomeStruct(true);
                             paramsRead[5] = true;
                             break;
@@ -17280,7 +17354,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_7 = 0;
             System.Span<bool> paramsRead = stackalloc bool[8];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[6] && ((object) Reader.LocalName == (object)id292_XmlAttributeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[6] && ((object) Reader.LocalName == (object)id293_XmlAttributeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@XmlAttributeProperty = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[6] = true;
                 }
@@ -17299,7 +17373,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 string tmp = null;
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id293_Word && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id294_Word && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17315,7 +17389,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id294_Number && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id295_Number && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17331,7 +17405,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id295_DecimalNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id296_DecimalNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17347,12 +17421,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id296_XmlIncludeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id297_XmlIncludeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@XmlIncludeProperty = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id297_XmlEnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id298_XmlEnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17401,7 +17475,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id298_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id299_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17416,7 +17490,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id299_XmlElementPropertyNode && (object) Reader.NamespaceURI == (object)id300_httpelement)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id300_XmlElementPropertyNode && (object) Reader.NamespaceURI == (object)id301_httpelement)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17431,7 +17505,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[5] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id301_CustomXmlArrayProperty && (object) Reader.NamespaceURI == (object)id168_httpmynamespace)) {
+                        if (((object) Reader.LocalName == (object)id302_CustomXmlArrayProperty && (object) Reader.NamespaceURI == (object)id168_httpmynamespace)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17522,7 +17596,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_2 = 0;
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@IntProperty = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[1] = true;
                 }
@@ -17602,12 +17676,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id302_EnumValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id303_EnumValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@EnumValue = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id303_SimpleTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id304_SimpleTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@SimpleTypeValue = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -17654,7 +17728,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id304_StrProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id305_StrProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17711,7 +17785,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id305_MyField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id306_MyField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyFieldSpecified = true;
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -17727,7 +17801,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id306_MyFieldIgnored && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id307_MyFieldIgnored && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyFieldIgnoredSpecified = true;
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -17791,7 +17865,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id307_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id308_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17839,7 +17913,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id308_NoneSchemaFormListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id309_NoneSchemaFormListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17887,7 +17961,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id309_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id310_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17963,7 +18037,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id310_XmlAttributeForm && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id311_XmlAttributeForm && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@XmlAttributeForm = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -18011,7 +18085,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_2 = 0;
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id311_name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id312_name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -18084,7 +18158,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id312_customElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id313_customElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if ((object)(a_0) == null) Reader.Skip(); else a_0.Add(Read108_CustomElement(false, true));
                             break;
                         }
@@ -18196,7 +18270,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id313_DS2Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id314_DS2Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18211,7 +18285,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id314_MetricConfigUrl && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id315_MetricConfigUrl && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18327,7 +18401,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id315_TwoDArrayOfSimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id316_TwoDArrayOfSimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -18443,7 +18517,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id316_EmptyStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id317_EmptyStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18458,7 +18532,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id275_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18473,7 +18547,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id276_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18491,7 +18565,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id317_CharProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id318_CharProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18551,7 +18625,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id318_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18611,7 +18685,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id318_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18671,7 +18745,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18714,7 +18788,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id320_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id321_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Bar = Reader.Value;
                     paramsRead[1] = true;
                 }
@@ -18732,7 +18806,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18777,7 +18851,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.BaseTypeWithShouldSerializeMethod();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id320_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id321_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Bar = Reader.Value;
                     paramsRead[1] = true;
                 }
@@ -18795,7 +18869,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18852,7 +18926,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@FooSpecified = true;
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -18910,12 +18984,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id321_StringArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id322_StringArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@StringArrayValue = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id322_IntArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id323_IntArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@IntArrayValue = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -19009,7 +19083,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id323_DateTimeContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id324_DateTimeContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19024,7 +19098,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id324_QNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id325_QNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19039,7 +19113,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id325_DateContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id326_DateContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19054,7 +19128,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id326_NameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id327_NameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19069,7 +19143,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id327_NCNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id328_NCNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19084,7 +19158,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id328_NMTOKENContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id329_NMTOKENContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19099,7 +19173,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[5] = true;
                             break;
                         }
-                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id329_NMTOKENSContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id330_NMTOKENSContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19114,7 +19188,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[6] = true;
                             break;
                         }
-                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id330_Base64BinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id331_Base64BinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19129,7 +19203,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[7] = true;
                             break;
                         }
-                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id331_HexBinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id332_HexBinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19192,7 +19266,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id332_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id333_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19207,7 +19281,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             choice_a_0 = (global::SerializationTypes.MoreChoices[])EnsureArrayIndex(choice_a_0, cchoice_a_0, typeof(global::SerializationTypes.MoreChoices));choice_a_0[cchoice_a_0++] = global::SerializationTypes.MoreChoices.@Item;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id333_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id334_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19388,12 +19462,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id332_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id333_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             a_0 = (global::System.Object[])EnsureArrayIndex(a_0, ca_0, typeof(global::System.Object));a_0[ca_0++] = Read127_ComplexChoiceA(false, true);
                             choice_a_0 = (global::SerializationTypes.MoreChoices[])EnsureArrayIndex(choice_a_0, cchoice_a_0, typeof(global::SerializationTypes.MoreChoices));choice_a_0[cchoice_a_0++] = global::SerializationTypes.MoreChoices.@Item;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id333_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id334_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19454,7 +19528,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     switch (state) {
                     case 0:
-                        if (((object) Reader.LocalName == (object)id334_IntField2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id335_IntField2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19470,7 +19544,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 1;
                         break;
                     case 1:
-                        if (((object) Reader.LocalName == (object)id335_IntField1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id336_IntField1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19486,7 +19560,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 2;
                         break;
                     case 2:
-                        if (((object) Reader.LocalName == (object)id336_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id337_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19502,7 +19576,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 3;
                         break;
                     case 3:
-                        if (((object) Reader.LocalName == (object)id336_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id337_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19547,7 +19621,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.TypeWithSchemaFormInXmlAttribute();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id337_TestProperty && (object) Reader.NamespaceURI == (object)id338_httptestcom)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id338_TestProperty && (object) Reader.NamespaceURI == (object)id339_httptestcom)) {
                     o.@TestProperty = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -19578,686 +19652,688 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         protected override void InitCallbacks() {
         }
 
-        string id117_TypeWithXmlQualifiedName;
-        string id155_int;
-        string id130_Item;
-        string id29_PurchaseOrder;
-        string id234_Comment2;
-        string id290_Struct1;
-        string id2_Item;
-        string id212_GroupName;
-        string id296_XmlIncludeProperty;
-        string id244_xelements;
-        string id35_DerivedClass1;
-        string id113_CustomDocument;
-        string id173_ArrayOfArrayOfSimpleType;
-        string id330_Base64BinaryContent;
-        string id316_EmptyStringProperty;
-        string id40_Brass;
-        string id308_NoneSchemaFormListProperty;
-        string id57_Item;
-        string id192_NullableDefaultDTO;
-        string id153_ArrayOfOrderedItem;
-        string id39_Instrument;
-        string id236_SingleField;
-        string id176_Value;
-        string id273_ArrayMember;
-        string id63_TypeWithArraylikeMembers;
-        string id52_XElementWrapper;
-        string id320_Bar;
-        string id304_StrProperty;
-        string id237_DoubleProp;
-        string id171_ArrayOfBoolean;
-        string id181_ItemName;
-        string id262_IntLProp;
-        string id144_ContainerType;
-        string id137_TypeClashB;
-        string id206_TimeSpanProperty;
-        string id138_TypeClashA;
-        string id89_ClassImplementsInterface;
-        string id62_TypeWithGetOnlyArrayProperties;
-        string id194_MyDate;
-        string id319_Foo;
-        string id185_LineTotal;
-        string id3_TypeWithXmlDocumentProperty;
-        string id6_Item;
-        string id258_IntLField;
-        string id90_WithStruct;
-        string id76_TypeA;
-        string id300_httpelement;
-        string id301_CustomXmlArrayProperty;
-        string id256_IntAField;
-        string id25_SimpleDerivedClass;
-        string id267_MyEnum1;
-        string id30_httpwwwcontoso1com;
-        string id324_QNameContent;
-        string id158_ArrayOfDouble;
-        string id315_TwoDArrayOfSimpleType;
-        string id175_P2;
-        string id7_DateOnlyWrapper;
-        string id282_IsLoaded;
-        string id280_DisplayName;
-        string id193_Today;
-        string id243_xelement;
-        string id318_EnumProperty;
-        string id314_MetricConfigUrl;
-        string id338_httptestcom;
-        string id305_MyField;
-        string id83_Item;
-        string id202_NullableTime;
-        string id97_IntEnum;
-        string id295_DecimalNumber;
-        string id229_X;
-        string id328_NMTOKENContent;
-        string id99_LongEnum;
-        string id26_BaseIXmlSerializable;
-        string id123_Item;
-        string id302_EnumValue;
-        string id199_Now;
-        string id310_XmlAttributeForm;
-        string id136_Root;
-        string id67_ArrayOfAnyType;
-        string id108_Item;
-        string id102_ItemChoiceType;
-        string id228_TotalCost;
-        string id257_NIntAField;
-        string id32_OrderedItem;
-        string id54_XElementArrayWrapper;
-        string id51_Parameter;
-        string id198_NullableDefaultDate;
-        string id31_Address;
-        string id70_TypeWithEnumMembers;
-        string id265_Data;
-        string id18_DogBreed;
-        string id126_Item;
-        string id227_ShipCost;
-        string id45_Item;
-        string id50_RootClass;
-        string id69_MyEnum;
-        string id279_ClassID;
-        string id75_Item;
-        string id147_Value1;
-        string id13_Item;
-        string id232_Prop;
-        string id252_DateTimeString;
-        string id72_DCClassWithEnumAndStruct;
-        string id225_Items;
-        string id184_Quantity;
-        string id133_ComplexChoiceB;
-        string id101_AttributeTesting;
-        string id254_F1;
-        string id332_Item;
-        string id134_TypeWithFieldsOrdered;
-        string id323_DateTimeContent;
-        string id150_ParameterOfString;
-        string id42_Pet;
-        string id178_Children;
-        string id148_Value2;
-        string id309_Item;
-        string id114_CustomElement;
-        string id110_TypeWithXmlSchemaFormAttribute;
-        string id168_httpmynamespace;
-        string id73_BuiltInTypes;
-        string id255_F2;
-        string id187_Base64Content;
-        string id293_Word;
-        string id269_StringMember;
-        string id259_NIntLField;
-        string id84_TypeWithByteArrayAsXmlText;
-        string id215_value;
-        string id19_Group;
-        string id329_NMTOKENSContent;
-        string id10_DateTimeDateWrapper;
-        string id82_DerivedClassWithSameProperty2;
-        string id322_IntArrayValue;
-        string id238_FloatProp;
-        string id189_DTO2;
-        string id291_Struct2;
-        string id131_MoreChoices;
-        string id116_ServerSettings;
-        string id33_AliasedTestType;
-        string id79_Item;
-        string id210_Breed;
-        string id207_TimeSpanProperty2;
-        string id80_BaseClassWithSamePropertyName;
-        string id217_DateTimeValue;
-        string id146_B;
-        string id245_ImmutableArray;
-        string id248_FrozenSet;
-        string id59_TypeWithDateTimeStringProperty;
-        string id235_DoubleField;
-        string id88_EnumFlags;
-        string id38_Orchestra;
-        string id128_Item;
-        string id170_NoneParameter;
-        string id272_ListMember;
-        string id224_OrderDate;
-        string id22_BaseClass;
-        string id140_FirstName;
-        string id268_ByteArray;
-        string id275_StringProperty;
-        string id327_NCNameContent;
-        string id87_Item;
-        string id167_ArrayOfItemChoiceType;
-        string id58_Item;
-        string id41_Trumpet;
-        string id124_Item;
-        string id141_MiddleName;
-        string id36_ArrayOfDateTime;
-        string id157_string;
-        string id274_Item;
-        string id326_NameContent;
-        string id221_State;
-        string id161_ArrayOfTypeWithLinkedProperty;
-        string id180_Modulation;
-        string id23_DerivedClass;
-        string id34_BaseClass1;
-        string id121_Item;
-        string id9_TimeOnlyAsXsdTimeWrapper;
-        string id27_Item;
-        string id208_ByteProperty;
-        string id298_Item;
-        string id43_DefaultValuesSetToNaN;
-        string id196_NullableDate;
-        string id151_MsgDocumentType;
-        string id115_Item;
-        string id246_ImmutableList;
-        string id169_ArrayOfString1;
-        string id250_List;
-        string id321_StringArrayValue;
-        string id294_Number;
-        string id283_Some;
-        string id125_Item;
-        string id127_Item;
-        string id64_StructNotSerializable;
-        string id74_TypeWithBuiltInTypedMembers;
-        string id48_Document;
-        string id154_ArrayOfInt;
-        string id277_DateTimeProperty;
-        string id71_DCStruct;
-        string id68_anyType;
-        string id231_Z;
-        string id203_NullableTimeWithValue;
-        string id240_id;
-        string id179_IsValved;
-        string id145_A;
-        string id177_Child;
-        string id81_DerivedClassWithSameProperty;
-        string id139_Person;
-        string id247_ReadOnlyCollection;
-        string id174_P1;
         string id241_refs;
-        string id312_customElement;
-        string id289_OptionullInt;
-        string id287_Optionull;
-        string id8_TimeOnlyWrapper;
-        string id337_TestProperty;
-        string id306_MyFieldIgnored;
-        string id85_SimpleDC;
-        string id129_Item;
-        string id183_UnitPrice;
-        string id303_SimpleTypeValue;
-        string id78_TypeHasArrayOfASerializedAsB;
-        string id260_IntAProp;
-        string id37_dateTime;
-        string id107_Item;
-        string id91_SomeStruct;
-        string id95_SByteEnum;
-        string id197_NullableDateWithValue;
-        string id118_TypeWith2DArrayProperty2;
-        string id266_MyStruct;
-        string id214_EmployeeName;
-        string id20_Vehicle;
-        string id94_ByteEnum;
-        string id216_AttributeString;
-        string id92_WithEnums;
-        string id143_Name;
-        string id55_Item;
-        string id334_IntField2;
-        string id44_Item;
-        string id288_OptionalInt;
-        string id190_DefaultDTO;
-        string id122_TypeWithShouldSerializeMethod;
-        string id61_TypeWithGetSetArrayMembers;
-        string id261_NIntAProp;
-        string id205_TestValue;
-        string id253_CurrentDateTime;
-        string id271_NullableIntMember;
-        string id263_NIntLProp;
-        string id299_XmlElementPropertyNode;
-        string id213_GroupVehicle;
-        string id49_httpexamplecom;
-        string id5_Item;
-        string id249_ImmutableQueue;
-        string id223_ShipTo;
-        string id335_IntField1;
-        string id317_CharProperty;
-        string id162_ArrayOfParameter;
-        string id109_TypeWithPropertyNameSpecified;
-        string id165_ArrayOfSimpleType;
-        string id65_TypeWithMyCollectionField;
-        string id297_XmlEnumProperty;
-        string id105_SimpleKnownTypeValue;
-        string id16_Animal;
-        string id156_ArrayOfString;
-        string id142_LastName;
-        string id204_NullableDefaultTime;
-        string id200_MyTime;
-        string id120_Item;
-        string id149_XmlSerializerAttributes;
-        string id17_Dog;
-        string id226_SubTotal;
-        string id135_Item;
-        string id160_ArrayOfInstrument;
-        string id152_Item;
-        string id278_ListProperty;
-        string id201_DefaultTime;
-        string id53_XElementStruct;
-        string id98_UIntEnum;
-        string id182_Description;
-        string id230_Y;
-        string id100_ULongEnum;
-        string id220_City;
-        string id284_Int;
-        string id47_TypeWithLinkedProperty;
-        string id313_DS2Root;
-        string id111_MyXmlType;
-        string id12_TypeWithTimeSpanProperty;
-        string id93_WithNullables;
-        string id211_LicenseNumber;
-        string id307_Item;
-        string id66_Item;
-        string id195_DefaultDate;
-        string id286_Optional;
-        string id106_Item;
-        string id14_TypeWithByteProperty;
-        string id24_SimpleBaseClass;
-        string id276_IntProperty;
-        string id325_DateContent;
-        string id15_TypeWithXmlNodeArrayProperty;
-        string id21_Employee;
-        string id281_Id;
         string id28_DerivedIXmlSerializable;
-        string id292_XmlAttributeName;
-        string id46_RootElement;
-        string id191_NullableDTO;
-        string id4_TypeWithBinaryProperty;
-        string id77_TypeB;
-        string id56_TypeWithReadOnlyCollections;
-        string id222_Zip;
-        string id172_QualifiedParameter;
-        string id86_Item;
-        string id242_Parameters;
-        string id331_HexBinaryContent;
-        string id132_ComplexChoiceA;
-        string id264_Collection;
-        string id119_Item;
-        string id166_ArrayOfTypeA;
-        string id159_double;
-        string id311_name;
-        string id60_SimpleType;
-        string id112_Item;
-        string id164_XElement;
-        string id104_KnownTypesThroughConstructor;
-        string id233_Instruments;
-        string id163_ArrayOfXElement;
-        string id239_IntValue;
-        string id103_TypeWithAnyAttribute;
-        string id11_DateTimeTimeWrapper;
-        string id1_TypeWithXmlElementProperty;
-        string id186_BinaryHexContent;
-        string id336_strfld;
-        string id285_Short;
-        string id270_IntMember;
-        string id333_Amount;
-        string id219_Line1;
         string id209_Age;
-        string id218_BoolValue;
+        string id134_TypeWithFieldsOrdered;
+        string id117_TypeWithXmlQualifiedName;
+        string id48_Document;
+        string id161_ArrayOfTypeWithLinkedProperty;
+        string id75_Item;
+        string id106_Item;
+        string id201_DefaultTime;
+        string id326_DateContent;
+        string id122_TypeWithShouldSerializeMethod;
+        string id74_TypeWithBuiltInTypedMembers;
+        string id226_SubTotal;
+        string id39_Instrument;
+        string id89_ClassImplementsInterface;
+        string id34_BaseClass1;
+        string id133_ComplexChoiceB;
+        string id118_TypeWith2DArrayProperty2;
+        string id108_Item;
+        string id295_Number;
+        string id58_Item;
+        string id328_NCNameContent;
+        string id268_MyEnum1;
+        string id38_Orchestra;
+        string id275_Item;
+        string id311_XmlAttributeForm;
+        string id278_DateTimeProperty;
+        string id195_DefaultDate;
+        string id238_FloatProp;
+        string id68_anyType;
+        string id239_IntValue;
+        string id177_Child;
+        string id153_ArrayOfOrderedItem;
+        string id22_BaseClass;
+        string id3_TypeWithXmlDocumentProperty;
+        string id168_httpmynamespace;
         string id96_ShortEnum;
+        string id216_AttributeString;
+        string id43_DefaultValuesSetToNaN;
+        string id235_DoubleField;
+        string id110_TypeWithXmlSchemaFormAttribute;
+        string id57_Item;
+        string id258_NIntAField;
+        string id59_TypeWithDateTimeStringProperty;
+        string id104_KnownTypesThroughConstructor;
+        string id339_httptestcom;
+        string id301_httpelement;
+        string id91_SomeStruct;
+        string id331_Base64BinaryContent;
+        string id181_ItemName;
+        string id270_StringMember;
+        string id172_QualifiedParameter;
+        string id191_NullableDTO;
+        string id173_ArrayOfArrayOfSimpleType;
+        string id240_id;
+        string id197_NullableDateWithValue;
+        string id165_ArrayOfSimpleType;
+        string id169_ArrayOfString1;
+        string id92_WithEnums;
+        string id32_OrderedItem;
+        string id317_EmptyStringProperty;
+        string id29_PurchaseOrder;
+        string id314_DS2Root;
+        string id101_AttributeTesting;
+        string id266_Data;
+        string id37_dateTime;
+        string id86_Item;
+        string id87_Item;
+        string id157_string;
+        string id113_CustomDocument;
+        string id287_Optional;
+        string id147_Value1;
+        string id263_IntLProp;
+        string id182_Description;
+        string id61_TypeWithGetSetArrayMembers;
+        string id178_Children;
+        string id321_Bar;
+        string id167_ArrayOfItemChoiceType;
+        string id220_City;
+        string id196_NullableDate;
+        string id243_xelement;
+        string id234_Comment2;
+        string id242_Parameters;
+        string id244_xelements;
+        string id85_SimpleDC;
+        string id143_Name;
+        string id208_ByteProperty;
+        string id72_DCClassWithEnumAndStruct;
+        string id88_EnumFlags;
+        string id247_ImmutableList;
+        string id219_Line1;
+        string id26_BaseIXmlSerializable;
+        string id139_Person;
+        string id332_HexBinaryContent;
+        string id84_TypeWithByteArrayAsXmlText;
+        string id49_httpexamplecom;
+        string id176_Value;
+        string id245_ImmutableArrayField;
+        string id337_strfld;
+        string id53_XElementStruct;
+        string id148_Value2;
+        string id69_MyEnum;
+        string id319_EnumProperty;
+        string id260_NIntLField;
+        string id192_NullableDefaultDTO;
+        string id193_Today;
+        string id6_Item;
+        string id200_MyTime;
+        string id185_LineTotal;
+        string id276_StringProperty;
+        string id60_SimpleType;
+        string id180_Modulation;
+        string id16_Animal;
+        string id303_EnumValue;
+        string id151_MsgDocumentType;
+        string id30_httpwwwcontoso1com;
+        string id187_Base64Content;
+        string id162_ArrayOfParameter;
+        string id46_RootElement;
+        string id292_Struct2;
+        string id152_Item;
+        string id308_Item;
+        string id23_DerivedClass;
+        string id159_double;
+        string id56_TypeWithReadOnlyCollections;
+        string id335_IntField2;
+        string id333_Item;
+        string id138_TypeClashA;
+        string id102_ItemChoiceType;
+        string id212_GroupName;
+        string id132_ComplexChoiceA;
+        string id100_ULongEnum;
+        string id194_MyDate;
+        string id203_NullableTimeWithValue;
+        string id98_UIntEnum;
+        string id290_OptionullInt;
+        string id24_SimpleBaseClass;
+        string id233_Instruments;
+        string id279_ListProperty;
+        string id115_Item;
+        string id269_ByteArray;
+        string id207_TimeSpanProperty2;
+        string id137_TypeClashB;
+        string id325_QNameContent;
+        string id107_Item;
+        string id121_Item;
+        string id280_ClassID;
+        string id62_TypeWithGetOnlyArrayProperties;
+        string id155_int;
+        string id77_TypeB;
+        string id257_IntAField;
+        string id154_ArrayOfInt;
+        string id318_CharProperty;
+        string id156_ArrayOfString;
+        string id329_NMTOKENContent;
+        string id284_Some;
+        string id166_ArrayOfTypeA;
+        string id291_Struct1;
+        string id251_List;
+        string id230_Y;
+        string id205_TestValue;
+        string id249_FrozenSet;
+        string id286_Short;
+        string id281_DisplayName;
+        string id183_UnitPrice;
+        string id82_DerivedClassWithSameProperty2;
+        string id254_CurrentDateTime;
+        string id55_Item;
+        string id64_StructNotSerializable;
+        string id320_Foo;
+        string id103_TypeWithAnyAttribute;
+        string id237_DoubleProp;
+        string id184_Quantity;
+        string id232_Prop;
+        string id199_Now;
+        string id145_A;
+        string id246_ImmutableArray;
+        string id256_F2;
+        string id123_Item;
+        string id146_B;
+        string id144_ContainerType;
+        string id94_ByteEnum;
+        string id327_NameContent;
+        string id36_ArrayOfDateTime;
+        string id127_Item;
+        string id99_LongEnum;
+        string id97_IntEnum;
+        string id126_Item;
+        string id19_Group;
+        string id80_BaseClassWithSamePropertyName;
+        string id316_TwoDArrayOfSimpleType;
+        string id330_NMTOKENSContent;
+        string id306_MyField;
+        string id31_Address;
+        string id93_WithNullables;
+        string id307_MyFieldIgnored;
+        string id124_Item;
+        string id73_BuiltInTypes;
+        string id305_StrProperty;
+        string id119_Item;
+        string id174_P1;
+        string id198_NullableDefaultDate;
+        string id217_DateTimeValue;
+        string id294_Word;
+        string id135_Item;
+        string id299_Item;
+        string id289_OptionalInt;
+        string id273_ListMember;
+        string id283_IsLoaded;
+        string id236_SingleField;
+        string id78_TypeHasArrayOfASerializedAsB;
+        string id136_Root;
+        string id141_MiddleName;
+        string id20_Vehicle;
+        string id211_LicenseNumber;
+        string id170_NoneParameter;
+        string id95_SByteEnum;
+        string id272_NullableIntMember;
+        string id114_CustomElement;
+        string id252_Array;
+        string id17_Dog;
+        string id54_XElementArrayWrapper;
+        string id206_TimeSpanProperty;
+        string id42_Pet;
+        string id338_TestProperty;
+        string id76_TypeA;
+        string id262_NIntAProp;
+        string id130_Item;
+        string id158_ArrayOfDouble;
+        string id105_SimpleKnownTypeValue;
+        string id47_TypeWithLinkedProperty;
+        string id163_ArrayOfXElement;
+        string id65_TypeWithMyCollectionField;
+        string id90_WithStruct;
+        string id259_IntLField;
+        string id213_GroupVehicle;
+        string id190_DefaultDTO;
+        string id27_Item;
+        string id70_TypeWithEnumMembers;
+        string id218_BoolValue;
+        string id164_XElement;
+        string id15_TypeWithXmlNodeArrayProperty;
+        string id265_Collection;
+        string id35_DerivedClass1;
+        string id223_ShipTo;
+        string id179_IsValved;
+        string id128_Item;
+        string id310_Item;
+        string id111_MyXmlType;
+        string id221_State;
+        string id1_TypeWithXmlElementProperty;
+        string id261_IntAProp;
+        string id323_IntArrayValue;
+        string id322_StringArrayValue;
+        string id33_AliasedTestType;
+        string id63_TypeWithArraylikeMembers;
+        string id9_TimeOnlyAsXsdTimeWrapper;
+        string id45_Item;
+        string id274_ArrayMember;
+        string id120_Item;
+        string id81_DerivedClassWithSameProperty;
+        string id41_Trumpet;
+        string id67_ArrayOfAnyType;
+        string id297_XmlIncludeProperty;
+        string id282_Id;
+        string id302_CustomXmlArrayProperty;
+        string id324_DateTimeContent;
+        string id112_Item;
+        string id13_Item;
+        string id304_SimpleTypeValue;
+        string id215_value;
+        string id140_FirstName;
+        string id315_MetricConfigUrl;
+        string id5_Item;
+        string id11_DateTimeTimeWrapper;
+        string id250_ImmutableQueue;
+        string id71_DCStruct;
+        string id293_XmlAttributeName;
+        string id7_DateOnlyWrapper;
+        string id253_DateTimeString;
+        string id228_TotalCost;
+        string id214_EmployeeName;
+        string id285_Int;
+        string id150_ParameterOfString;
+        string id66_Item;
+        string id160_ArrayOfInstrument;
+        string id202_NullableTime;
+        string id264_NIntLProp;
+        string id231_Z;
+        string id204_NullableDefaultTime;
+        string id18_DogBreed;
+        string id189_DTO2;
+        string id171_ArrayOfBoolean;
+        string id222_Zip;
+        string id186_BinaryHexContent;
+        string id44_Item;
+        string id50_RootClass;
+        string id129_Item;
+        string id131_MoreChoices;
+        string id10_DateTimeDateWrapper;
+        string id116_ServerSettings;
         string id188_DTO;
-        string id251_Array;
+        string id309_NoneSchemaFormListProperty;
+        string id296_DecimalNumber;
+        string id79_Item;
+        string id336_IntField1;
+        string id227_ShipCost;
+        string id248_ReadOnlyCollection;
+        string id267_MyStruct;
+        string id229_X;
+        string id83_Item;
+        string id2_Item;
+        string id225_Items;
+        string id300_XmlElementPropertyNode;
+        string id125_Item;
+        string id149_XmlSerializerAttributes;
+        string id277_IntProperty;
+        string id4_TypeWithBinaryProperty;
+        string id52_XElementWrapper;
+        string id175_P2;
+        string id12_TypeWithTimeSpanProperty;
+        string id14_TypeWithByteProperty;
+        string id298_XmlEnumProperty;
+        string id312_name;
+        string id334_Amount;
+        string id313_customElement;
+        string id21_Employee;
+        string id25_SimpleDerivedClass;
+        string id224_OrderDate;
+        string id8_TimeOnlyWrapper;
+        string id210_Breed;
+        string id255_F1;
+        string id142_LastName;
+        string id288_Optionull;
+        string id109_TypeWithPropertyNameSpecified;
+        string id51_Parameter;
+        string id40_Brass;
+        string id271_IntMember;
 
         static readonly char[] xmlListSeparators = System.AppContext.TryGetSwitch("Switch.System.Xml.Serialization.UseLegacyXmlListSeparation", out bool useLegacyXmlListSeparation) && useLegacyXmlListSeparation ? null : new char[] { ' ', '\t', '\n', '\r' };
 
         protected override void InitIDs() {
-            id117_TypeWithXmlQualifiedName = Reader.NameTable.Add(@"TypeWithXmlQualifiedName");
-            id155_int = Reader.NameTable.Add(@"int");
-            id130_Item = Reader.NameTable.Add(@"TypeWithPropertyHavingComplexChoice");
-            id29_PurchaseOrder = Reader.NameTable.Add(@"PurchaseOrder");
-            id234_Comment2 = Reader.NameTable.Add(@"Comment2");
-            id290_Struct1 = Reader.NameTable.Add(@"Struct1");
-            id2_Item = Reader.NameTable.Add(@"");
-            id212_GroupName = Reader.NameTable.Add(@"GroupName");
-            id296_XmlIncludeProperty = Reader.NameTable.Add(@"XmlIncludeProperty");
-            id244_xelements = Reader.NameTable.Add(@"xelements");
-            id35_DerivedClass1 = Reader.NameTable.Add(@"DerivedClass1");
-            id113_CustomDocument = Reader.NameTable.Add(@"CustomDocument");
-            id173_ArrayOfArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfArrayOfSimpleType");
-            id330_Base64BinaryContent = Reader.NameTable.Add(@"Base64BinaryContent");
-            id316_EmptyStringProperty = Reader.NameTable.Add(@"EmptyStringProperty");
-            id40_Brass = Reader.NameTable.Add(@"Brass");
-            id308_NoneSchemaFormListProperty = Reader.NameTable.Add(@"NoneSchemaFormListProperty");
-            id57_Item = Reader.NameTable.Add(@"TypeWithMutableCollectionMembers");
-            id192_NullableDefaultDTO = Reader.NameTable.Add(@"NullableDefaultDTO");
-            id153_ArrayOfOrderedItem = Reader.NameTable.Add(@"ArrayOfOrderedItem");
-            id39_Instrument = Reader.NameTable.Add(@"Instrument");
-            id236_SingleField = Reader.NameTable.Add(@"SingleField");
-            id176_Value = Reader.NameTable.Add(@"Value");
-            id273_ArrayMember = Reader.NameTable.Add(@"ArrayMember");
-            id63_TypeWithArraylikeMembers = Reader.NameTable.Add(@"TypeWithArraylikeMembers");
-            id52_XElementWrapper = Reader.NameTable.Add(@"XElementWrapper");
-            id320_Bar = Reader.NameTable.Add(@"Bar");
-            id304_StrProperty = Reader.NameTable.Add(@"StrProperty");
-            id237_DoubleProp = Reader.NameTable.Add(@"DoubleProp");
-            id171_ArrayOfBoolean = Reader.NameTable.Add(@"ArrayOfBoolean");
-            id181_ItemName = Reader.NameTable.Add(@"ItemName");
-            id262_IntLProp = Reader.NameTable.Add(@"IntLProp");
-            id144_ContainerType = Reader.NameTable.Add(@"ContainerType");
-            id137_TypeClashB = Reader.NameTable.Add(@"TypeClashB");
-            id206_TimeSpanProperty = Reader.NameTable.Add(@"TimeSpanProperty");
-            id138_TypeClashA = Reader.NameTable.Add(@"TypeClashA");
-            id89_ClassImplementsInterface = Reader.NameTable.Add(@"ClassImplementsInterface");
-            id62_TypeWithGetOnlyArrayProperties = Reader.NameTable.Add(@"TypeWithGetOnlyArrayProperties");
-            id194_MyDate = Reader.NameTable.Add(@"MyDate");
-            id319_Foo = Reader.NameTable.Add(@"Foo");
-            id185_LineTotal = Reader.NameTable.Add(@"LineTotal");
-            id3_TypeWithXmlDocumentProperty = Reader.NameTable.Add(@"TypeWithXmlDocumentProperty");
-            id6_Item = Reader.NameTable.Add(@"TypeWithDateAndTimeOnlyProperties");
-            id258_IntLField = Reader.NameTable.Add(@"IntLField");
-            id90_WithStruct = Reader.NameTable.Add(@"WithStruct");
-            id76_TypeA = Reader.NameTable.Add(@"TypeA");
-            id300_httpelement = Reader.NameTable.Add(@"http://element");
-            id301_CustomXmlArrayProperty = Reader.NameTable.Add(@"CustomXmlArrayProperty");
-            id256_IntAField = Reader.NameTable.Add(@"IntAField");
-            id25_SimpleDerivedClass = Reader.NameTable.Add(@"SimpleDerivedClass");
-            id267_MyEnum1 = Reader.NameTable.Add(@"MyEnum1");
-            id30_httpwwwcontoso1com = Reader.NameTable.Add(@"http://www.contoso1.com");
-            id324_QNameContent = Reader.NameTable.Add(@"QNameContent");
-            id158_ArrayOfDouble = Reader.NameTable.Add(@"ArrayOfDouble");
-            id315_TwoDArrayOfSimpleType = Reader.NameTable.Add(@"TwoDArrayOfSimpleType");
-            id175_P2 = Reader.NameTable.Add(@"P2");
-            id7_DateOnlyWrapper = Reader.NameTable.Add(@"DateOnlyWrapper");
-            id282_IsLoaded = Reader.NameTable.Add(@"IsLoaded");
-            id280_DisplayName = Reader.NameTable.Add(@"DisplayName");
-            id193_Today = Reader.NameTable.Add(@"Today");
-            id243_xelement = Reader.NameTable.Add(@"xelement");
-            id318_EnumProperty = Reader.NameTable.Add(@"EnumProperty");
-            id314_MetricConfigUrl = Reader.NameTable.Add(@"MetricConfigUrl");
-            id338_httptestcom = Reader.NameTable.Add(@"http://test.com");
-            id305_MyField = Reader.NameTable.Add(@"MyField");
-            id83_Item = Reader.NameTable.Add(@"TypeWithDateTimePropertyAsXmlTime");
-            id202_NullableTime = Reader.NameTable.Add(@"NullableTime");
-            id97_IntEnum = Reader.NameTable.Add(@"IntEnum");
-            id295_DecimalNumber = Reader.NameTable.Add(@"DecimalNumber");
-            id229_X = Reader.NameTable.Add(@"X");
-            id328_NMTOKENContent = Reader.NameTable.Add(@"NMTOKENContent");
-            id99_LongEnum = Reader.NameTable.Add(@"LongEnum");
-            id26_BaseIXmlSerializable = Reader.NameTable.Add(@"BaseIXmlSerializable");
-            id123_Item = Reader.NameTable.Add(@"BaseTypeWithShouldSerializeMethod");
-            id302_EnumValue = Reader.NameTable.Add(@"EnumValue");
-            id199_Now = Reader.NameTable.Add(@"Now");
-            id310_XmlAttributeForm = Reader.NameTable.Add(@"XmlAttributeForm");
-            id136_Root = Reader.NameTable.Add(@"Root");
-            id67_ArrayOfAnyType = Reader.NameTable.Add(@"ArrayOfAnyType");
-            id108_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithParameterlessConstructor");
-            id102_ItemChoiceType = Reader.NameTable.Add(@"ItemChoiceType");
-            id228_TotalCost = Reader.NameTable.Add(@"TotalCost");
-            id257_NIntAField = Reader.NameTable.Add(@"NIntAField");
-            id32_OrderedItem = Reader.NameTable.Add(@"OrderedItem");
-            id54_XElementArrayWrapper = Reader.NameTable.Add(@"XElementArrayWrapper");
-            id51_Parameter = Reader.NameTable.Add(@"Parameter");
-            id198_NullableDefaultDate = Reader.NameTable.Add(@"NullableDefaultDate");
-            id31_Address = Reader.NameTable.Add(@"Address");
-            id70_TypeWithEnumMembers = Reader.NameTable.Add(@"TypeWithEnumMembers");
-            id265_Data = Reader.NameTable.Add(@"Data");
-            id18_DogBreed = Reader.NameTable.Add(@"DogBreed");
-            id126_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithArrayProperties");
-            id227_ShipCost = Reader.NameTable.Add(@"ShipCost");
-            id45_Item = Reader.NameTable.Add(@"DefaultValuesSetToNegativeInfinity");
-            id50_RootClass = Reader.NameTable.Add(@"RootClass");
-            id69_MyEnum = Reader.NameTable.Add(@"MyEnum");
-            id279_ClassID = Reader.NameTable.Add(@"ClassID");
-            id75_Item = Reader.NameTable.Add(@"TypeWithNullableBuiltInTypedMembers");
-            id147_Value1 = Reader.NameTable.Add(@"Value1");
-            id13_Item = Reader.NameTable.Add(@"TypeWithDefaultTimeSpanProperty");
-            id232_Prop = Reader.NameTable.Add(@"Prop");
-            id252_DateTimeString = Reader.NameTable.Add(@"DateTimeString");
-            id72_DCClassWithEnumAndStruct = Reader.NameTable.Add(@"DCClassWithEnumAndStruct");
-            id225_Items = Reader.NameTable.Add(@"Items");
-            id184_Quantity = Reader.NameTable.Add(@"Quantity");
-            id133_ComplexChoiceB = Reader.NameTable.Add(@"ComplexChoiceB");
-            id101_AttributeTesting = Reader.NameTable.Add(@"AttributeTesting");
-            id254_F1 = Reader.NameTable.Add(@"F1");
-            id332_Item = Reader.NameTable.Add(@"Item");
-            id134_TypeWithFieldsOrdered = Reader.NameTable.Add(@"TypeWithFieldsOrdered");
-            id323_DateTimeContent = Reader.NameTable.Add(@"DateTimeContent");
-            id150_ParameterOfString = Reader.NameTable.Add(@"ParameterOfString");
-            id42_Pet = Reader.NameTable.Add(@"Pet");
-            id178_Children = Reader.NameTable.Add(@"Children");
-            id148_Value2 = Reader.NameTable.Add(@"Value2");
-            id309_Item = Reader.NameTable.Add(@"QualifiedSchemaFormListProperty");
-            id114_CustomElement = Reader.NameTable.Add(@"CustomElement");
-            id110_TypeWithXmlSchemaFormAttribute = Reader.NameTable.Add(@"TypeWithXmlSchemaFormAttribute");
-            id168_httpmynamespace = Reader.NameTable.Add(@"http://mynamespace");
-            id73_BuiltInTypes = Reader.NameTable.Add(@"BuiltInTypes");
-            id255_F2 = Reader.NameTable.Add(@"F2");
-            id187_Base64Content = Reader.NameTable.Add(@"Base64Content");
-            id293_Word = Reader.NameTable.Add(@"Word");
-            id269_StringMember = Reader.NameTable.Add(@"StringMember");
-            id259_NIntLField = Reader.NameTable.Add(@"NIntLField");
-            id84_TypeWithByteArrayAsXmlText = Reader.NameTable.Add(@"TypeWithByteArrayAsXmlText");
-            id215_value = Reader.NameTable.Add(@"value");
-            id19_Group = Reader.NameTable.Add(@"Group");
-            id329_NMTOKENSContent = Reader.NameTable.Add(@"NMTOKENSContent");
-            id10_DateTimeDateWrapper = Reader.NameTable.Add(@"DateTimeDateWrapper");
-            id82_DerivedClassWithSameProperty2 = Reader.NameTable.Add(@"DerivedClassWithSameProperty2");
-            id322_IntArrayValue = Reader.NameTable.Add(@"IntArrayValue");
-            id238_FloatProp = Reader.NameTable.Add(@"FloatProp");
-            id189_DTO2 = Reader.NameTable.Add(@"DTO2");
-            id291_Struct2 = Reader.NameTable.Add(@"Struct2");
-            id131_MoreChoices = Reader.NameTable.Add(@"MoreChoices");
-            id116_ServerSettings = Reader.NameTable.Add(@"ServerSettings");
-            id33_AliasedTestType = Reader.NameTable.Add(@"AliasedTestType");
-            id79_Item = Reader.NameTable.Add(@"__TypeNameWithSpecialCharacters漢ñ");
-            id210_Breed = Reader.NameTable.Add(@"Breed");
-            id207_TimeSpanProperty2 = Reader.NameTable.Add(@"TimeSpanProperty2");
-            id80_BaseClassWithSamePropertyName = Reader.NameTable.Add(@"BaseClassWithSamePropertyName");
-            id217_DateTimeValue = Reader.NameTable.Add(@"DateTimeValue");
-            id146_B = Reader.NameTable.Add(@"B");
-            id245_ImmutableArray = Reader.NameTable.Add(@"ImmutableArray");
-            id248_FrozenSet = Reader.NameTable.Add(@"FrozenSet");
-            id59_TypeWithDateTimeStringProperty = Reader.NameTable.Add(@"TypeWithDateTimeStringProperty");
-            id235_DoubleField = Reader.NameTable.Add(@"DoubleField");
-            id88_EnumFlags = Reader.NameTable.Add(@"EnumFlags");
-            id38_Orchestra = Reader.NameTable.Add(@"Orchestra");
-            id128_Item = Reader.NameTable.Add(@"TypeWithTypesHavingCustomFormatter");
-            id170_NoneParameter = Reader.NameTable.Add(@"NoneParameter");
-            id272_ListMember = Reader.NameTable.Add(@"ListMember");
-            id224_OrderDate = Reader.NameTable.Add(@"OrderDate");
-            id22_BaseClass = Reader.NameTable.Add(@"BaseClass");
-            id140_FirstName = Reader.NameTable.Add(@"FirstName");
-            id268_ByteArray = Reader.NameTable.Add(@"ByteArray");
-            id275_StringProperty = Reader.NameTable.Add(@"StringProperty");
-            id327_NCNameContent = Reader.NameTable.Add(@"NCNameContent");
-            id87_Item = Reader.NameTable.Add(@"http://schemas.xmlsoap.org/ws/2005/04/discovery");
-            id167_ArrayOfItemChoiceType = Reader.NameTable.Add(@"ArrayOfItemChoiceType");
-            id58_Item = Reader.NameTable.Add(@"TypeWithGetOnlyReadOnlyCollections");
-            id41_Trumpet = Reader.NameTable.Add(@"Trumpet");
-            id124_Item = Reader.NameTable.Add(@"DerivedTypeWithInheritedShouldSerialize");
-            id141_MiddleName = Reader.NameTable.Add(@"MiddleName");
-            id36_ArrayOfDateTime = Reader.NameTable.Add(@"ArrayOfDateTime");
-            id157_string = Reader.NameTable.Add(@"string");
-            id274_Item = Reader.NameTable.Add(@"PropertyNameWithSpecialCharacters漢ñ");
-            id326_NameContent = Reader.NameTable.Add(@"NameContent");
-            id221_State = Reader.NameTable.Add(@"State");
-            id161_ArrayOfTypeWithLinkedProperty = Reader.NameTable.Add(@"ArrayOfTypeWithLinkedProperty");
-            id180_Modulation = Reader.NameTable.Add(@"Modulation");
-            id23_DerivedClass = Reader.NameTable.Add(@"DerivedClass");
-            id34_BaseClass1 = Reader.NameTable.Add(@"BaseClass1");
-            id121_Item = Reader.NameTable.Add(@"TypeWithEnumFlagPropertyHavingDefaultValue");
-            id9_TimeOnlyAsXsdTimeWrapper = Reader.NameTable.Add(@"TimeOnlyAsXsdTimeWrapper");
-            id27_Item = Reader.NameTable.Add(@"http://example.com/serializer-test-namespace");
-            id208_ByteProperty = Reader.NameTable.Add(@"ByteProperty");
-            id298_Item = Reader.NameTable.Add(@"XmlNamespaceDeclarationsProperty");
-            id43_DefaultValuesSetToNaN = Reader.NameTable.Add(@"DefaultValuesSetToNaN");
-            id196_NullableDate = Reader.NameTable.Add(@"NullableDate");
-            id151_MsgDocumentType = Reader.NameTable.Add(@"MsgDocumentType");
-            id115_Item = Reader.NameTable.Add(@"TypeWithNonPublicDefaultConstructor");
-            id246_ImmutableList = Reader.NameTable.Add(@"ImmutableList");
-            id169_ArrayOfString1 = Reader.NameTable.Add(@"ArrayOfString1");
-            id250_List = Reader.NameTable.Add(@"List");
-            id321_StringArrayValue = Reader.NameTable.Add(@"StringArrayValue");
-            id294_Number = Reader.NameTable.Add(@"Number");
-            id283_Some = Reader.NameTable.Add(@"Some");
-            id125_Item = Reader.NameTable.Add(@"TypeWithFieldBackedSpecifiedMember");
-            id127_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithValue");
-            id64_StructNotSerializable = Reader.NameTable.Add(@"StructNotSerializable");
-            id74_TypeWithBuiltInTypedMembers = Reader.NameTable.Add(@"TypeWithBuiltInTypedMembers");
-            id48_Document = Reader.NameTable.Add(@"Document");
-            id154_ArrayOfInt = Reader.NameTable.Add(@"ArrayOfInt");
-            id277_DateTimeProperty = Reader.NameTable.Add(@"DateTimeProperty");
-            id71_DCStruct = Reader.NameTable.Add(@"DCStruct");
-            id68_anyType = Reader.NameTable.Add(@"anyType");
-            id231_Z = Reader.NameTable.Add(@"Z");
-            id203_NullableTimeWithValue = Reader.NameTable.Add(@"NullableTimeWithValue");
-            id240_id = Reader.NameTable.Add(@"id");
-            id179_IsValved = Reader.NameTable.Add(@"IsValved");
-            id145_A = Reader.NameTable.Add(@"A");
-            id177_Child = Reader.NameTable.Add(@"Child");
-            id81_DerivedClassWithSameProperty = Reader.NameTable.Add(@"DerivedClassWithSameProperty");
-            id139_Person = Reader.NameTable.Add(@"Person");
-            id247_ReadOnlyCollection = Reader.NameTable.Add(@"ReadOnlyCollection");
-            id174_P1 = Reader.NameTable.Add(@"P1");
             id241_refs = Reader.NameTable.Add(@"refs");
-            id312_customElement = Reader.NameTable.Add(@"customElement");
-            id289_OptionullInt = Reader.NameTable.Add(@"OptionullInt");
-            id287_Optionull = Reader.NameTable.Add(@"Optionull");
-            id8_TimeOnlyWrapper = Reader.NameTable.Add(@"TimeOnlyWrapper");
-            id337_TestProperty = Reader.NameTable.Add(@"TestProperty");
-            id306_MyFieldIgnored = Reader.NameTable.Add(@"MyFieldIgnored");
-            id85_SimpleDC = Reader.NameTable.Add(@"SimpleDC");
-            id129_Item = Reader.NameTable.Add(@"TypeWithArrayPropertyHavingChoice");
-            id183_UnitPrice = Reader.NameTable.Add(@"UnitPrice");
-            id303_SimpleTypeValue = Reader.NameTable.Add(@"SimpleTypeValue");
-            id78_TypeHasArrayOfASerializedAsB = Reader.NameTable.Add(@"TypeHasArrayOfASerializedAsB");
-            id260_IntAProp = Reader.NameTable.Add(@"IntAProp");
-            id37_dateTime = Reader.NameTable.Add(@"dateTime");
-            id107_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor");
-            id91_SomeStruct = Reader.NameTable.Add(@"SomeStruct");
-            id95_SByteEnum = Reader.NameTable.Add(@"SByteEnum");
-            id197_NullableDateWithValue = Reader.NameTable.Add(@"NullableDateWithValue");
-            id118_TypeWith2DArrayProperty2 = Reader.NameTable.Add(@"TypeWith2DArrayProperty2");
-            id266_MyStruct = Reader.NameTable.Add(@"MyStruct");
-            id214_EmployeeName = Reader.NameTable.Add(@"EmployeeName");
-            id20_Vehicle = Reader.NameTable.Add(@"Vehicle");
-            id94_ByteEnum = Reader.NameTable.Add(@"ByteEnum");
-            id216_AttributeString = Reader.NameTable.Add(@"AttributeString");
-            id92_WithEnums = Reader.NameTable.Add(@"WithEnums");
-            id143_Name = Reader.NameTable.Add(@"Name");
-            id55_Item = Reader.NameTable.Add(@"DateTimeOffsetIXmlSerializableContainer");
-            id334_IntField2 = Reader.NameTable.Add(@"IntField2");
-            id44_Item = Reader.NameTable.Add(@"DefaultValuesSetToPositiveInfinity");
-            id288_OptionalInt = Reader.NameTable.Add(@"OptionalInt");
-            id190_DefaultDTO = Reader.NameTable.Add(@"DefaultDTO");
-            id122_TypeWithShouldSerializeMethod = Reader.NameTable.Add(@"TypeWithShouldSerializeMethod");
-            id61_TypeWithGetSetArrayMembers = Reader.NameTable.Add(@"TypeWithGetSetArrayMembers");
-            id261_NIntAProp = Reader.NameTable.Add(@"NIntAProp");
-            id205_TestValue = Reader.NameTable.Add(@"TestValue");
-            id253_CurrentDateTime = Reader.NameTable.Add(@"CurrentDateTime");
-            id271_NullableIntMember = Reader.NameTable.Add(@"NullableIntMember");
-            id263_NIntLProp = Reader.NameTable.Add(@"NIntLProp");
-            id299_XmlElementPropertyNode = Reader.NameTable.Add(@"XmlElementPropertyNode");
-            id213_GroupVehicle = Reader.NameTable.Add(@"GroupVehicle");
-            id49_httpexamplecom = Reader.NameTable.Add(@"http://example.com");
-            id5_Item = Reader.NameTable.Add(@"TypeWithDateTimeOffsetProperties");
-            id249_ImmutableQueue = Reader.NameTable.Add(@"ImmutableQueue");
-            id223_ShipTo = Reader.NameTable.Add(@"ShipTo");
-            id335_IntField1 = Reader.NameTable.Add(@"IntField1");
-            id317_CharProperty = Reader.NameTable.Add(@"CharProperty");
-            id162_ArrayOfParameter = Reader.NameTable.Add(@"ArrayOfParameter");
-            id109_TypeWithPropertyNameSpecified = Reader.NameTable.Add(@"TypeWithPropertyNameSpecified");
-            id165_ArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfSimpleType");
-            id65_TypeWithMyCollectionField = Reader.NameTable.Add(@"TypeWithMyCollectionField");
-            id297_XmlEnumProperty = Reader.NameTable.Add(@"XmlEnumProperty");
-            id105_SimpleKnownTypeValue = Reader.NameTable.Add(@"SimpleKnownTypeValue");
-            id16_Animal = Reader.NameTable.Add(@"Animal");
-            id156_ArrayOfString = Reader.NameTable.Add(@"ArrayOfString");
-            id142_LastName = Reader.NameTable.Add(@"LastName");
-            id204_NullableDefaultTime = Reader.NameTable.Add(@"NullableDefaultTime");
-            id200_MyTime = Reader.NameTable.Add(@"MyTime");
-            id120_Item = Reader.NameTable.Add(@"TypeWithEnumPropertyHavingDefaultValue");
-            id149_XmlSerializerAttributes = Reader.NameTable.Add(@"XmlSerializerAttributes");
-            id17_Dog = Reader.NameTable.Add(@"Dog");
-            id226_SubTotal = Reader.NameTable.Add(@"SubTotal");
-            id135_Item = Reader.NameTable.Add(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName");
-            id160_ArrayOfInstrument = Reader.NameTable.Add(@"ArrayOfInstrument");
-            id152_Item = Reader.NameTable.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType");
-            id278_ListProperty = Reader.NameTable.Add(@"ListProperty");
-            id201_DefaultTime = Reader.NameTable.Add(@"DefaultTime");
-            id53_XElementStruct = Reader.NameTable.Add(@"XElementStruct");
-            id98_UIntEnum = Reader.NameTable.Add(@"UIntEnum");
-            id182_Description = Reader.NameTable.Add(@"Description");
-            id230_Y = Reader.NameTable.Add(@"Y");
-            id100_ULongEnum = Reader.NameTable.Add(@"ULongEnum");
-            id220_City = Reader.NameTable.Add(@"City");
-            id284_Int = Reader.NameTable.Add(@"Int");
-            id47_TypeWithLinkedProperty = Reader.NameTable.Add(@"TypeWithLinkedProperty");
-            id313_DS2Root = Reader.NameTable.Add(@"DS2Root");
-            id111_MyXmlType = Reader.NameTable.Add(@"MyXmlType");
-            id12_TypeWithTimeSpanProperty = Reader.NameTable.Add(@"TypeWithTimeSpanProperty");
-            id93_WithNullables = Reader.NameTable.Add(@"WithNullables");
-            id211_LicenseNumber = Reader.NameTable.Add(@"LicenseNumber");
-            id307_Item = Reader.NameTable.Add(@"UnqualifiedSchemaFormListProperty");
-            id66_Item = Reader.NameTable.Add(@"TypeWithReadOnlyMyCollectionProperty");
-            id195_DefaultDate = Reader.NameTable.Add(@"DefaultDate");
-            id286_Optional = Reader.NameTable.Add(@"Optional");
-            id106_Item = Reader.NameTable.Add(@"ClassImplementingIXmlSerializable");
-            id14_TypeWithByteProperty = Reader.NameTable.Add(@"TypeWithByteProperty");
-            id24_SimpleBaseClass = Reader.NameTable.Add(@"SimpleBaseClass");
-            id276_IntProperty = Reader.NameTable.Add(@"IntProperty");
-            id325_DateContent = Reader.NameTable.Add(@"DateContent");
-            id15_TypeWithXmlNodeArrayProperty = Reader.NameTable.Add(@"TypeWithXmlNodeArrayProperty");
-            id21_Employee = Reader.NameTable.Add(@"Employee");
-            id281_Id = Reader.NameTable.Add(@"Id");
             id28_DerivedIXmlSerializable = Reader.NameTable.Add(@"DerivedIXmlSerializable");
-            id292_XmlAttributeName = Reader.NameTable.Add(@"XmlAttributeName");
-            id46_RootElement = Reader.NameTable.Add(@"RootElement");
-            id191_NullableDTO = Reader.NameTable.Add(@"NullableDTO");
-            id4_TypeWithBinaryProperty = Reader.NameTable.Add(@"TypeWithBinaryProperty");
-            id77_TypeB = Reader.NameTable.Add(@"TypeB");
-            id56_TypeWithReadOnlyCollections = Reader.NameTable.Add(@"TypeWithReadOnlyCollections");
-            id222_Zip = Reader.NameTable.Add(@"Zip");
-            id172_QualifiedParameter = Reader.NameTable.Add(@"QualifiedParameter");
-            id86_Item = Reader.NameTable.Add(@"TypeWithXmlTextAttributeOnArray");
-            id242_Parameters = Reader.NameTable.Add(@"Parameters");
-            id331_HexBinaryContent = Reader.NameTable.Add(@"HexBinaryContent");
-            id132_ComplexChoiceA = Reader.NameTable.Add(@"ComplexChoiceA");
-            id264_Collection = Reader.NameTable.Add(@"Collection");
-            id119_Item = Reader.NameTable.Add(@"TypeWithPropertiesHavingDefaultValue");
-            id166_ArrayOfTypeA = Reader.NameTable.Add(@"ArrayOfTypeA");
-            id159_double = Reader.NameTable.Add(@"double");
-            id311_name = Reader.NameTable.Add(@"name");
-            id60_SimpleType = Reader.NameTable.Add(@"SimpleType");
-            id112_Item = Reader.NameTable.Add(@"TypeWithSchemaFormInXmlAttribute");
-            id164_XElement = Reader.NameTable.Add(@"XElement");
-            id104_KnownTypesThroughConstructor = Reader.NameTable.Add(@"KnownTypesThroughConstructor");
-            id233_Instruments = Reader.NameTable.Add(@"Instruments");
-            id163_ArrayOfXElement = Reader.NameTable.Add(@"ArrayOfXElement");
-            id239_IntValue = Reader.NameTable.Add(@"IntValue");
-            id103_TypeWithAnyAttribute = Reader.NameTable.Add(@"TypeWithAnyAttribute");
-            id11_DateTimeTimeWrapper = Reader.NameTable.Add(@"DateTimeTimeWrapper");
-            id1_TypeWithXmlElementProperty = Reader.NameTable.Add(@"TypeWithXmlElementProperty");
-            id186_BinaryHexContent = Reader.NameTable.Add(@"BinaryHexContent");
-            id336_strfld = Reader.NameTable.Add(@"strfld");
-            id285_Short = Reader.NameTable.Add(@"Short");
-            id270_IntMember = Reader.NameTable.Add(@"IntMember");
-            id333_Amount = Reader.NameTable.Add(@"Amount");
-            id219_Line1 = Reader.NameTable.Add(@"Line1");
             id209_Age = Reader.NameTable.Add(@"Age");
-            id218_BoolValue = Reader.NameTable.Add(@"BoolValue");
+            id134_TypeWithFieldsOrdered = Reader.NameTable.Add(@"TypeWithFieldsOrdered");
+            id117_TypeWithXmlQualifiedName = Reader.NameTable.Add(@"TypeWithXmlQualifiedName");
+            id48_Document = Reader.NameTable.Add(@"Document");
+            id161_ArrayOfTypeWithLinkedProperty = Reader.NameTable.Add(@"ArrayOfTypeWithLinkedProperty");
+            id75_Item = Reader.NameTable.Add(@"TypeWithNullableBuiltInTypedMembers");
+            id106_Item = Reader.NameTable.Add(@"ClassImplementingIXmlSerializable");
+            id201_DefaultTime = Reader.NameTable.Add(@"DefaultTime");
+            id326_DateContent = Reader.NameTable.Add(@"DateContent");
+            id122_TypeWithShouldSerializeMethod = Reader.NameTable.Add(@"TypeWithShouldSerializeMethod");
+            id74_TypeWithBuiltInTypedMembers = Reader.NameTable.Add(@"TypeWithBuiltInTypedMembers");
+            id226_SubTotal = Reader.NameTable.Add(@"SubTotal");
+            id39_Instrument = Reader.NameTable.Add(@"Instrument");
+            id89_ClassImplementsInterface = Reader.NameTable.Add(@"ClassImplementsInterface");
+            id34_BaseClass1 = Reader.NameTable.Add(@"BaseClass1");
+            id133_ComplexChoiceB = Reader.NameTable.Add(@"ComplexChoiceB");
+            id118_TypeWith2DArrayProperty2 = Reader.NameTable.Add(@"TypeWith2DArrayProperty2");
+            id108_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithParameterlessConstructor");
+            id295_Number = Reader.NameTable.Add(@"Number");
+            id58_Item = Reader.NameTable.Add(@"TypeWithGetOnlyReadOnlyCollections");
+            id328_NCNameContent = Reader.NameTable.Add(@"NCNameContent");
+            id268_MyEnum1 = Reader.NameTable.Add(@"MyEnum1");
+            id38_Orchestra = Reader.NameTable.Add(@"Orchestra");
+            id275_Item = Reader.NameTable.Add(@"PropertyNameWithSpecialCharacters漢ñ");
+            id311_XmlAttributeForm = Reader.NameTable.Add(@"XmlAttributeForm");
+            id278_DateTimeProperty = Reader.NameTable.Add(@"DateTimeProperty");
+            id195_DefaultDate = Reader.NameTable.Add(@"DefaultDate");
+            id238_FloatProp = Reader.NameTable.Add(@"FloatProp");
+            id68_anyType = Reader.NameTable.Add(@"anyType");
+            id239_IntValue = Reader.NameTable.Add(@"IntValue");
+            id177_Child = Reader.NameTable.Add(@"Child");
+            id153_ArrayOfOrderedItem = Reader.NameTable.Add(@"ArrayOfOrderedItem");
+            id22_BaseClass = Reader.NameTable.Add(@"BaseClass");
+            id3_TypeWithXmlDocumentProperty = Reader.NameTable.Add(@"TypeWithXmlDocumentProperty");
+            id168_httpmynamespace = Reader.NameTable.Add(@"http://mynamespace");
             id96_ShortEnum = Reader.NameTable.Add(@"ShortEnum");
+            id216_AttributeString = Reader.NameTable.Add(@"AttributeString");
+            id43_DefaultValuesSetToNaN = Reader.NameTable.Add(@"DefaultValuesSetToNaN");
+            id235_DoubleField = Reader.NameTable.Add(@"DoubleField");
+            id110_TypeWithXmlSchemaFormAttribute = Reader.NameTable.Add(@"TypeWithXmlSchemaFormAttribute");
+            id57_Item = Reader.NameTable.Add(@"TypeWithMutableCollectionMembers");
+            id258_NIntAField = Reader.NameTable.Add(@"NIntAField");
+            id59_TypeWithDateTimeStringProperty = Reader.NameTable.Add(@"TypeWithDateTimeStringProperty");
+            id104_KnownTypesThroughConstructor = Reader.NameTable.Add(@"KnownTypesThroughConstructor");
+            id339_httptestcom = Reader.NameTable.Add(@"http://test.com");
+            id301_httpelement = Reader.NameTable.Add(@"http://element");
+            id91_SomeStruct = Reader.NameTable.Add(@"SomeStruct");
+            id331_Base64BinaryContent = Reader.NameTable.Add(@"Base64BinaryContent");
+            id181_ItemName = Reader.NameTable.Add(@"ItemName");
+            id270_StringMember = Reader.NameTable.Add(@"StringMember");
+            id172_QualifiedParameter = Reader.NameTable.Add(@"QualifiedParameter");
+            id191_NullableDTO = Reader.NameTable.Add(@"NullableDTO");
+            id173_ArrayOfArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfArrayOfSimpleType");
+            id240_id = Reader.NameTable.Add(@"id");
+            id197_NullableDateWithValue = Reader.NameTable.Add(@"NullableDateWithValue");
+            id165_ArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfSimpleType");
+            id169_ArrayOfString1 = Reader.NameTable.Add(@"ArrayOfString1");
+            id92_WithEnums = Reader.NameTable.Add(@"WithEnums");
+            id32_OrderedItem = Reader.NameTable.Add(@"OrderedItem");
+            id317_EmptyStringProperty = Reader.NameTable.Add(@"EmptyStringProperty");
+            id29_PurchaseOrder = Reader.NameTable.Add(@"PurchaseOrder");
+            id314_DS2Root = Reader.NameTable.Add(@"DS2Root");
+            id101_AttributeTesting = Reader.NameTable.Add(@"AttributeTesting");
+            id266_Data = Reader.NameTable.Add(@"Data");
+            id37_dateTime = Reader.NameTable.Add(@"dateTime");
+            id86_Item = Reader.NameTable.Add(@"TypeWithXmlTextAttributeOnArray");
+            id87_Item = Reader.NameTable.Add(@"http://schemas.xmlsoap.org/ws/2005/04/discovery");
+            id157_string = Reader.NameTable.Add(@"string");
+            id113_CustomDocument = Reader.NameTable.Add(@"CustomDocument");
+            id287_Optional = Reader.NameTable.Add(@"Optional");
+            id147_Value1 = Reader.NameTable.Add(@"Value1");
+            id263_IntLProp = Reader.NameTable.Add(@"IntLProp");
+            id182_Description = Reader.NameTable.Add(@"Description");
+            id61_TypeWithGetSetArrayMembers = Reader.NameTable.Add(@"TypeWithGetSetArrayMembers");
+            id178_Children = Reader.NameTable.Add(@"Children");
+            id321_Bar = Reader.NameTable.Add(@"Bar");
+            id167_ArrayOfItemChoiceType = Reader.NameTable.Add(@"ArrayOfItemChoiceType");
+            id220_City = Reader.NameTable.Add(@"City");
+            id196_NullableDate = Reader.NameTable.Add(@"NullableDate");
+            id243_xelement = Reader.NameTable.Add(@"xelement");
+            id234_Comment2 = Reader.NameTable.Add(@"Comment2");
+            id242_Parameters = Reader.NameTable.Add(@"Parameters");
+            id244_xelements = Reader.NameTable.Add(@"xelements");
+            id85_SimpleDC = Reader.NameTable.Add(@"SimpleDC");
+            id143_Name = Reader.NameTable.Add(@"Name");
+            id208_ByteProperty = Reader.NameTable.Add(@"ByteProperty");
+            id72_DCClassWithEnumAndStruct = Reader.NameTable.Add(@"DCClassWithEnumAndStruct");
+            id88_EnumFlags = Reader.NameTable.Add(@"EnumFlags");
+            id247_ImmutableList = Reader.NameTable.Add(@"ImmutableList");
+            id219_Line1 = Reader.NameTable.Add(@"Line1");
+            id26_BaseIXmlSerializable = Reader.NameTable.Add(@"BaseIXmlSerializable");
+            id139_Person = Reader.NameTable.Add(@"Person");
+            id332_HexBinaryContent = Reader.NameTable.Add(@"HexBinaryContent");
+            id84_TypeWithByteArrayAsXmlText = Reader.NameTable.Add(@"TypeWithByteArrayAsXmlText");
+            id49_httpexamplecom = Reader.NameTable.Add(@"http://example.com");
+            id176_Value = Reader.NameTable.Add(@"Value");
+            id245_ImmutableArrayField = Reader.NameTable.Add(@"ImmutableArrayField");
+            id337_strfld = Reader.NameTable.Add(@"strfld");
+            id53_XElementStruct = Reader.NameTable.Add(@"XElementStruct");
+            id148_Value2 = Reader.NameTable.Add(@"Value2");
+            id69_MyEnum = Reader.NameTable.Add(@"MyEnum");
+            id319_EnumProperty = Reader.NameTable.Add(@"EnumProperty");
+            id260_NIntLField = Reader.NameTable.Add(@"NIntLField");
+            id192_NullableDefaultDTO = Reader.NameTable.Add(@"NullableDefaultDTO");
+            id193_Today = Reader.NameTable.Add(@"Today");
+            id6_Item = Reader.NameTable.Add(@"TypeWithDateAndTimeOnlyProperties");
+            id200_MyTime = Reader.NameTable.Add(@"MyTime");
+            id185_LineTotal = Reader.NameTable.Add(@"LineTotal");
+            id276_StringProperty = Reader.NameTable.Add(@"StringProperty");
+            id60_SimpleType = Reader.NameTable.Add(@"SimpleType");
+            id180_Modulation = Reader.NameTable.Add(@"Modulation");
+            id16_Animal = Reader.NameTable.Add(@"Animal");
+            id303_EnumValue = Reader.NameTable.Add(@"EnumValue");
+            id151_MsgDocumentType = Reader.NameTable.Add(@"MsgDocumentType");
+            id30_httpwwwcontoso1com = Reader.NameTable.Add(@"http://www.contoso1.com");
+            id187_Base64Content = Reader.NameTable.Add(@"Base64Content");
+            id162_ArrayOfParameter = Reader.NameTable.Add(@"ArrayOfParameter");
+            id46_RootElement = Reader.NameTable.Add(@"RootElement");
+            id292_Struct2 = Reader.NameTable.Add(@"Struct2");
+            id152_Item = Reader.NameTable.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType");
+            id308_Item = Reader.NameTable.Add(@"UnqualifiedSchemaFormListProperty");
+            id23_DerivedClass = Reader.NameTable.Add(@"DerivedClass");
+            id159_double = Reader.NameTable.Add(@"double");
+            id56_TypeWithReadOnlyCollections = Reader.NameTable.Add(@"TypeWithReadOnlyCollections");
+            id335_IntField2 = Reader.NameTable.Add(@"IntField2");
+            id333_Item = Reader.NameTable.Add(@"Item");
+            id138_TypeClashA = Reader.NameTable.Add(@"TypeClashA");
+            id102_ItemChoiceType = Reader.NameTable.Add(@"ItemChoiceType");
+            id212_GroupName = Reader.NameTable.Add(@"GroupName");
+            id132_ComplexChoiceA = Reader.NameTable.Add(@"ComplexChoiceA");
+            id100_ULongEnum = Reader.NameTable.Add(@"ULongEnum");
+            id194_MyDate = Reader.NameTable.Add(@"MyDate");
+            id203_NullableTimeWithValue = Reader.NameTable.Add(@"NullableTimeWithValue");
+            id98_UIntEnum = Reader.NameTable.Add(@"UIntEnum");
+            id290_OptionullInt = Reader.NameTable.Add(@"OptionullInt");
+            id24_SimpleBaseClass = Reader.NameTable.Add(@"SimpleBaseClass");
+            id233_Instruments = Reader.NameTable.Add(@"Instruments");
+            id279_ListProperty = Reader.NameTable.Add(@"ListProperty");
+            id115_Item = Reader.NameTable.Add(@"TypeWithNonPublicDefaultConstructor");
+            id269_ByteArray = Reader.NameTable.Add(@"ByteArray");
+            id207_TimeSpanProperty2 = Reader.NameTable.Add(@"TimeSpanProperty2");
+            id137_TypeClashB = Reader.NameTable.Add(@"TypeClashB");
+            id325_QNameContent = Reader.NameTable.Add(@"QNameContent");
+            id107_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor");
+            id121_Item = Reader.NameTable.Add(@"TypeWithEnumFlagPropertyHavingDefaultValue");
+            id280_ClassID = Reader.NameTable.Add(@"ClassID");
+            id62_TypeWithGetOnlyArrayProperties = Reader.NameTable.Add(@"TypeWithGetOnlyArrayProperties");
+            id155_int = Reader.NameTable.Add(@"int");
+            id77_TypeB = Reader.NameTable.Add(@"TypeB");
+            id257_IntAField = Reader.NameTable.Add(@"IntAField");
+            id154_ArrayOfInt = Reader.NameTable.Add(@"ArrayOfInt");
+            id318_CharProperty = Reader.NameTable.Add(@"CharProperty");
+            id156_ArrayOfString = Reader.NameTable.Add(@"ArrayOfString");
+            id329_NMTOKENContent = Reader.NameTable.Add(@"NMTOKENContent");
+            id284_Some = Reader.NameTable.Add(@"Some");
+            id166_ArrayOfTypeA = Reader.NameTable.Add(@"ArrayOfTypeA");
+            id291_Struct1 = Reader.NameTable.Add(@"Struct1");
+            id251_List = Reader.NameTable.Add(@"List");
+            id230_Y = Reader.NameTable.Add(@"Y");
+            id205_TestValue = Reader.NameTable.Add(@"TestValue");
+            id249_FrozenSet = Reader.NameTable.Add(@"FrozenSet");
+            id286_Short = Reader.NameTable.Add(@"Short");
+            id281_DisplayName = Reader.NameTable.Add(@"DisplayName");
+            id183_UnitPrice = Reader.NameTable.Add(@"UnitPrice");
+            id82_DerivedClassWithSameProperty2 = Reader.NameTable.Add(@"DerivedClassWithSameProperty2");
+            id254_CurrentDateTime = Reader.NameTable.Add(@"CurrentDateTime");
+            id55_Item = Reader.NameTable.Add(@"DateTimeOffsetIXmlSerializableContainer");
+            id64_StructNotSerializable = Reader.NameTable.Add(@"StructNotSerializable");
+            id320_Foo = Reader.NameTable.Add(@"Foo");
+            id103_TypeWithAnyAttribute = Reader.NameTable.Add(@"TypeWithAnyAttribute");
+            id237_DoubleProp = Reader.NameTable.Add(@"DoubleProp");
+            id184_Quantity = Reader.NameTable.Add(@"Quantity");
+            id232_Prop = Reader.NameTable.Add(@"Prop");
+            id199_Now = Reader.NameTable.Add(@"Now");
+            id145_A = Reader.NameTable.Add(@"A");
+            id246_ImmutableArray = Reader.NameTable.Add(@"ImmutableArray");
+            id256_F2 = Reader.NameTable.Add(@"F2");
+            id123_Item = Reader.NameTable.Add(@"BaseTypeWithShouldSerializeMethod");
+            id146_B = Reader.NameTable.Add(@"B");
+            id144_ContainerType = Reader.NameTable.Add(@"ContainerType");
+            id94_ByteEnum = Reader.NameTable.Add(@"ByteEnum");
+            id327_NameContent = Reader.NameTable.Add(@"NameContent");
+            id36_ArrayOfDateTime = Reader.NameTable.Add(@"ArrayOfDateTime");
+            id127_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithValue");
+            id99_LongEnum = Reader.NameTable.Add(@"LongEnum");
+            id97_IntEnum = Reader.NameTable.Add(@"IntEnum");
+            id126_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithArrayProperties");
+            id19_Group = Reader.NameTable.Add(@"Group");
+            id80_BaseClassWithSamePropertyName = Reader.NameTable.Add(@"BaseClassWithSamePropertyName");
+            id316_TwoDArrayOfSimpleType = Reader.NameTable.Add(@"TwoDArrayOfSimpleType");
+            id330_NMTOKENSContent = Reader.NameTable.Add(@"NMTOKENSContent");
+            id306_MyField = Reader.NameTable.Add(@"MyField");
+            id31_Address = Reader.NameTable.Add(@"Address");
+            id93_WithNullables = Reader.NameTable.Add(@"WithNullables");
+            id307_MyFieldIgnored = Reader.NameTable.Add(@"MyFieldIgnored");
+            id124_Item = Reader.NameTable.Add(@"DerivedTypeWithInheritedShouldSerialize");
+            id73_BuiltInTypes = Reader.NameTable.Add(@"BuiltInTypes");
+            id305_StrProperty = Reader.NameTable.Add(@"StrProperty");
+            id119_Item = Reader.NameTable.Add(@"TypeWithPropertiesHavingDefaultValue");
+            id174_P1 = Reader.NameTable.Add(@"P1");
+            id198_NullableDefaultDate = Reader.NameTable.Add(@"NullableDefaultDate");
+            id217_DateTimeValue = Reader.NameTable.Add(@"DateTimeValue");
+            id294_Word = Reader.NameTable.Add(@"Word");
+            id135_Item = Reader.NameTable.Add(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName");
+            id299_Item = Reader.NameTable.Add(@"XmlNamespaceDeclarationsProperty");
+            id289_OptionalInt = Reader.NameTable.Add(@"OptionalInt");
+            id273_ListMember = Reader.NameTable.Add(@"ListMember");
+            id283_IsLoaded = Reader.NameTable.Add(@"IsLoaded");
+            id236_SingleField = Reader.NameTable.Add(@"SingleField");
+            id78_TypeHasArrayOfASerializedAsB = Reader.NameTable.Add(@"TypeHasArrayOfASerializedAsB");
+            id136_Root = Reader.NameTable.Add(@"Root");
+            id141_MiddleName = Reader.NameTable.Add(@"MiddleName");
+            id20_Vehicle = Reader.NameTable.Add(@"Vehicle");
+            id211_LicenseNumber = Reader.NameTable.Add(@"LicenseNumber");
+            id170_NoneParameter = Reader.NameTable.Add(@"NoneParameter");
+            id95_SByteEnum = Reader.NameTable.Add(@"SByteEnum");
+            id272_NullableIntMember = Reader.NameTable.Add(@"NullableIntMember");
+            id114_CustomElement = Reader.NameTable.Add(@"CustomElement");
+            id252_Array = Reader.NameTable.Add(@"Array");
+            id17_Dog = Reader.NameTable.Add(@"Dog");
+            id54_XElementArrayWrapper = Reader.NameTable.Add(@"XElementArrayWrapper");
+            id206_TimeSpanProperty = Reader.NameTable.Add(@"TimeSpanProperty");
+            id42_Pet = Reader.NameTable.Add(@"Pet");
+            id338_TestProperty = Reader.NameTable.Add(@"TestProperty");
+            id76_TypeA = Reader.NameTable.Add(@"TypeA");
+            id262_NIntAProp = Reader.NameTable.Add(@"NIntAProp");
+            id130_Item = Reader.NameTable.Add(@"TypeWithPropertyHavingComplexChoice");
+            id158_ArrayOfDouble = Reader.NameTable.Add(@"ArrayOfDouble");
+            id105_SimpleKnownTypeValue = Reader.NameTable.Add(@"SimpleKnownTypeValue");
+            id47_TypeWithLinkedProperty = Reader.NameTable.Add(@"TypeWithLinkedProperty");
+            id163_ArrayOfXElement = Reader.NameTable.Add(@"ArrayOfXElement");
+            id65_TypeWithMyCollectionField = Reader.NameTable.Add(@"TypeWithMyCollectionField");
+            id90_WithStruct = Reader.NameTable.Add(@"WithStruct");
+            id259_IntLField = Reader.NameTable.Add(@"IntLField");
+            id213_GroupVehicle = Reader.NameTable.Add(@"GroupVehicle");
+            id190_DefaultDTO = Reader.NameTable.Add(@"DefaultDTO");
+            id27_Item = Reader.NameTable.Add(@"http://example.com/serializer-test-namespace");
+            id70_TypeWithEnumMembers = Reader.NameTable.Add(@"TypeWithEnumMembers");
+            id218_BoolValue = Reader.NameTable.Add(@"BoolValue");
+            id164_XElement = Reader.NameTable.Add(@"XElement");
+            id15_TypeWithXmlNodeArrayProperty = Reader.NameTable.Add(@"TypeWithXmlNodeArrayProperty");
+            id265_Collection = Reader.NameTable.Add(@"Collection");
+            id35_DerivedClass1 = Reader.NameTable.Add(@"DerivedClass1");
+            id223_ShipTo = Reader.NameTable.Add(@"ShipTo");
+            id179_IsValved = Reader.NameTable.Add(@"IsValved");
+            id128_Item = Reader.NameTable.Add(@"TypeWithTypesHavingCustomFormatter");
+            id310_Item = Reader.NameTable.Add(@"QualifiedSchemaFormListProperty");
+            id111_MyXmlType = Reader.NameTable.Add(@"MyXmlType");
+            id221_State = Reader.NameTable.Add(@"State");
+            id1_TypeWithXmlElementProperty = Reader.NameTable.Add(@"TypeWithXmlElementProperty");
+            id261_IntAProp = Reader.NameTable.Add(@"IntAProp");
+            id323_IntArrayValue = Reader.NameTable.Add(@"IntArrayValue");
+            id322_StringArrayValue = Reader.NameTable.Add(@"StringArrayValue");
+            id33_AliasedTestType = Reader.NameTable.Add(@"AliasedTestType");
+            id63_TypeWithArraylikeMembers = Reader.NameTable.Add(@"TypeWithArraylikeMembers");
+            id9_TimeOnlyAsXsdTimeWrapper = Reader.NameTable.Add(@"TimeOnlyAsXsdTimeWrapper");
+            id45_Item = Reader.NameTable.Add(@"DefaultValuesSetToNegativeInfinity");
+            id274_ArrayMember = Reader.NameTable.Add(@"ArrayMember");
+            id120_Item = Reader.NameTable.Add(@"TypeWithEnumPropertyHavingDefaultValue");
+            id81_DerivedClassWithSameProperty = Reader.NameTable.Add(@"DerivedClassWithSameProperty");
+            id41_Trumpet = Reader.NameTable.Add(@"Trumpet");
+            id67_ArrayOfAnyType = Reader.NameTable.Add(@"ArrayOfAnyType");
+            id297_XmlIncludeProperty = Reader.NameTable.Add(@"XmlIncludeProperty");
+            id282_Id = Reader.NameTable.Add(@"Id");
+            id302_CustomXmlArrayProperty = Reader.NameTable.Add(@"CustomXmlArrayProperty");
+            id324_DateTimeContent = Reader.NameTable.Add(@"DateTimeContent");
+            id112_Item = Reader.NameTable.Add(@"TypeWithSchemaFormInXmlAttribute");
+            id13_Item = Reader.NameTable.Add(@"TypeWithDefaultTimeSpanProperty");
+            id304_SimpleTypeValue = Reader.NameTable.Add(@"SimpleTypeValue");
+            id215_value = Reader.NameTable.Add(@"value");
+            id140_FirstName = Reader.NameTable.Add(@"FirstName");
+            id315_MetricConfigUrl = Reader.NameTable.Add(@"MetricConfigUrl");
+            id5_Item = Reader.NameTable.Add(@"TypeWithDateTimeOffsetProperties");
+            id11_DateTimeTimeWrapper = Reader.NameTable.Add(@"DateTimeTimeWrapper");
+            id250_ImmutableQueue = Reader.NameTable.Add(@"ImmutableQueue");
+            id71_DCStruct = Reader.NameTable.Add(@"DCStruct");
+            id293_XmlAttributeName = Reader.NameTable.Add(@"XmlAttributeName");
+            id7_DateOnlyWrapper = Reader.NameTable.Add(@"DateOnlyWrapper");
+            id253_DateTimeString = Reader.NameTable.Add(@"DateTimeString");
+            id228_TotalCost = Reader.NameTable.Add(@"TotalCost");
+            id214_EmployeeName = Reader.NameTable.Add(@"EmployeeName");
+            id285_Int = Reader.NameTable.Add(@"Int");
+            id150_ParameterOfString = Reader.NameTable.Add(@"ParameterOfString");
+            id66_Item = Reader.NameTable.Add(@"TypeWithReadOnlyMyCollectionProperty");
+            id160_ArrayOfInstrument = Reader.NameTable.Add(@"ArrayOfInstrument");
+            id202_NullableTime = Reader.NameTable.Add(@"NullableTime");
+            id264_NIntLProp = Reader.NameTable.Add(@"NIntLProp");
+            id231_Z = Reader.NameTable.Add(@"Z");
+            id204_NullableDefaultTime = Reader.NameTable.Add(@"NullableDefaultTime");
+            id18_DogBreed = Reader.NameTable.Add(@"DogBreed");
+            id189_DTO2 = Reader.NameTable.Add(@"DTO2");
+            id171_ArrayOfBoolean = Reader.NameTable.Add(@"ArrayOfBoolean");
+            id222_Zip = Reader.NameTable.Add(@"Zip");
+            id186_BinaryHexContent = Reader.NameTable.Add(@"BinaryHexContent");
+            id44_Item = Reader.NameTable.Add(@"DefaultValuesSetToPositiveInfinity");
+            id50_RootClass = Reader.NameTable.Add(@"RootClass");
+            id129_Item = Reader.NameTable.Add(@"TypeWithArrayPropertyHavingChoice");
+            id131_MoreChoices = Reader.NameTable.Add(@"MoreChoices");
+            id10_DateTimeDateWrapper = Reader.NameTable.Add(@"DateTimeDateWrapper");
+            id116_ServerSettings = Reader.NameTable.Add(@"ServerSettings");
             id188_DTO = Reader.NameTable.Add(@"DTO");
-            id251_Array = Reader.NameTable.Add(@"Array");
+            id309_NoneSchemaFormListProperty = Reader.NameTable.Add(@"NoneSchemaFormListProperty");
+            id296_DecimalNumber = Reader.NameTable.Add(@"DecimalNumber");
+            id79_Item = Reader.NameTable.Add(@"__TypeNameWithSpecialCharacters漢ñ");
+            id336_IntField1 = Reader.NameTable.Add(@"IntField1");
+            id227_ShipCost = Reader.NameTable.Add(@"ShipCost");
+            id248_ReadOnlyCollection = Reader.NameTable.Add(@"ReadOnlyCollection");
+            id267_MyStruct = Reader.NameTable.Add(@"MyStruct");
+            id229_X = Reader.NameTable.Add(@"X");
+            id83_Item = Reader.NameTable.Add(@"TypeWithDateTimePropertyAsXmlTime");
+            id2_Item = Reader.NameTable.Add(@"");
+            id225_Items = Reader.NameTable.Add(@"Items");
+            id300_XmlElementPropertyNode = Reader.NameTable.Add(@"XmlElementPropertyNode");
+            id125_Item = Reader.NameTable.Add(@"TypeWithFieldBackedSpecifiedMember");
+            id149_XmlSerializerAttributes = Reader.NameTable.Add(@"XmlSerializerAttributes");
+            id277_IntProperty = Reader.NameTable.Add(@"IntProperty");
+            id4_TypeWithBinaryProperty = Reader.NameTable.Add(@"TypeWithBinaryProperty");
+            id52_XElementWrapper = Reader.NameTable.Add(@"XElementWrapper");
+            id175_P2 = Reader.NameTable.Add(@"P2");
+            id12_TypeWithTimeSpanProperty = Reader.NameTable.Add(@"TypeWithTimeSpanProperty");
+            id14_TypeWithByteProperty = Reader.NameTable.Add(@"TypeWithByteProperty");
+            id298_XmlEnumProperty = Reader.NameTable.Add(@"XmlEnumProperty");
+            id312_name = Reader.NameTable.Add(@"name");
+            id334_Amount = Reader.NameTable.Add(@"Amount");
+            id313_customElement = Reader.NameTable.Add(@"customElement");
+            id21_Employee = Reader.NameTable.Add(@"Employee");
+            id25_SimpleDerivedClass = Reader.NameTable.Add(@"SimpleDerivedClass");
+            id224_OrderDate = Reader.NameTable.Add(@"OrderDate");
+            id8_TimeOnlyWrapper = Reader.NameTable.Add(@"TimeOnlyWrapper");
+            id210_Breed = Reader.NameTable.Add(@"Breed");
+            id255_F1 = Reader.NameTable.Add(@"F1");
+            id142_LastName = Reader.NameTable.Add(@"LastName");
+            id288_Optionull = Reader.NameTable.Add(@"Optionull");
+            id109_TypeWithPropertyNameSpecified = Reader.NameTable.Add(@"TypeWithPropertyNameSpecified");
+            id51_Parameter = Reader.NameTable.Add(@"Parameter");
+            id40_Brass = Reader.NameTable.Add(@"Brass");
+            id271_IntMember = Reader.NameTable.Add(@"IntMember");
         }
     }
 
@@ -22559,139 +22635,139 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             get {
                 if (typedSerializers == null) {
                     System.Collections.Hashtable _tmp = new System.Collections.Hashtable();
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithValue::", new KnownTypesThroughConstructorWithValueSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeA::", new TypeASerializer());
-                    _tmp.Add(@"SerializationTypes.ClassImplementsInterface::", new ClassImplementsInterfaceSerializer());
-                    _tmp.Add(@"TypeWithXmlDocumentProperty::", new TypeWithXmlDocumentPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:", new NamespaceTypeNameClashContainerSerializer());
-                    _tmp.Add(@"SimpleBaseClass::", new SimpleBaseClassSerializer());
-                    _tmp.Add(@"TypeWithTimeSpanProperty::", new TypeWithTimeSpanPropertySerializer());
-                    _tmp.Add(@"DefaultValuesSetToNegativeInfinity::", new DefaultValuesSetToNegativeInfinitySerializer());
-                    _tmp.Add(@"TypeWithXmlElementProperty::", new TypeWithXmlElementPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::", new TypeWithReadOnlyMyCollectionPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.WithEnums::", new WithEnumsSerializer());
-                    _tmp.Add(@"TimeOnlyWrapper::", new TimeOnlyWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::", new TypeWithFieldBackedSpecifiedMemberSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::", new TypeWithTypeNameInXmlTypeAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeNameClashB.TypeNameClash::", new TypeNameClashSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlQualifiedName::", new TypeWithXmlQualifiedNameSerializer());
-                    _tmp.Add(@"TypeWithDateAndTimeOnlyProperties::", new TypeWithDateAndTimeOnlyPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:", new TypeWithXmlSchemaFormAttributeSerializer());
-                    _tmp.Add(@"Vehicle::", new VehicleSerializer());
-                    _tmp.Add(@"SerializationTypes.ShortEnum::", new ShortEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomElement::", new CustomElementSerializer());
-                    _tmp.Add(@"TypeWithReadOnlyCollections::", new TypeWithReadOnlyCollectionsSerializer());
-                    _tmp.Add(@"TypeWithLinkedProperty::", new TypeWithLinkedPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.MyEnum::", new MyEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::", new TypeWithNullableBuiltInTypedMembersSerializer());
-                    _tmp.Add(@"DateTimeTimeWrapper::", new DateTimeTimeWrapperSerializer());
-                    _tmp.Add(@"XElementWrapper::", new XElementWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.ULongEnum::", new ULongEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithDateTimeStringProperty::", new TypeWithDateTimeStringPropertySerializer());
-                    _tmp.Add(@"Outer+Person::", new PersonSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::", new TypeWithDateTimePropertyAsXmlTimeSerializer());
-                    _tmp.Add(@"Employee::", new EmployeeSerializer());
-                    _tmp.Add(@"SerializationTypes.ComplexChoiceA::", new ComplexChoiceASerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleDC::", new SimpleDCSerializer());
-                    _tmp.Add(@"SerializationTypes.UIntEnum::", new UIntEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::", new KnownTypesThroughConstructorWithArrayPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithBuiltInTypedMembers::", new TypeWithBuiltInTypedMembersSerializer());
-                    _tmp.Add(@"Instrument::", new InstrumentSerializer());
-                    _tmp.Add(@"SerializationTypes.EnumFlags::", new EnumFlagsSerializer());
-                    _tmp.Add(@"DerivedClass1::", new DerivedClass1Serializer());
-                    _tmp.Add(@"XElementStruct::", new XElementStructSerializer());
-                    _tmp.Add(@"SerializationTypes.ClassImplementingIXmlSerializable::", new ClassImplementingIXmlSerializableSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWith2DArrayProperty2::", new TypeWith2DArrayProperty2Serializer());
-                    _tmp.Add(@"SerializationTypes.TypeNameClashA.TypeNameClash::", new TypeNameClashSerializer1());
-                    _tmp.Add(@"SerializationTypes.ServerSettings::", new ServerSettingsSerializer());
-                    _tmp.Add(@"AliasedTestType::", new AliasedTestTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.LongEnum::", new LongEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithArrayPropertyHavingChoice::", new TypeWithArrayPropertyHavingChoiceSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomAttribute::", new CustomAttributeSerializer());
-                    _tmp.Add(@"Pet::", new PetSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleKnownTypeValue::", new SimpleKnownTypeValueSerializer());
-                    _tmp.Add(@"SerializationTypes.MoreChoices::", new MoreChoicesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::", new TypeWithPropertiesHavingDefaultValueSerializer());
-                    _tmp.Add(@"OrderedItem::", new OrderedItemSerializer());
-                    _tmp.Add(@"SerializationTypes.ItemChoiceType::", new ItemChoiceTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:", new TypeWithXmlTextAttributeOnArraySerializer());
-                    _tmp.Add(@"SerializationTypes.SomeStruct::", new SomeStructSerializer());
-                    _tmp.Add(@"RootClass::", new RootClassSerializer());
-                    _tmp.Add(@"SerializationTypes.MyList::", new MyListSerializer());
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructor::", new KnownTypesThroughConstructorSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::", new TypeWithSchemaFormInXmlAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumMembers::", new TypeWithEnumMembersSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::", new TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleType::", new SimpleTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.BaseClassWithSamePropertyName::", new BaseClassWithSamePropertyNameSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty::", new DerivedClassWithSamePropertySerializer());
-                    _tmp.Add(@"SerializationTypes.IntEnum::", new IntEnumSerializer());
-                    _tmp.Add(@"BaseClass1::", new BaseClass1Serializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithArraylikeMembers::", new TypeWithArraylikeMembersSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithTypesHavingCustomFormatter::", new TypeWithTypesHavingCustomFormatterSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithGetOnlyArrayProperties::", new TypeWithGetOnlyArrayPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.WithNullables::", new WithNullablesSerializer());
-                    _tmp.Add(@"Address::", new AddressSerializer());
-                    _tmp.Add(@"TypeWithXmlNodeArrayProperty:::True:", new TypeWithXmlNodeArrayPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithMyCollectionField::", new TypeWithMyCollectionFieldSerializer());
-                    _tmp.Add(@"MsgDocumentType:http://example.com:Document:True:", new MsgDocumentTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithAnyAttribute::", new TypeWithAnyAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithFieldsOrdered::", new TypeWithFieldsOrderedSerializer());
-                    _tmp.Add(@"TypeWithMutableCollectionMembers::", new TypeWithMutableCollectionMembersSerializer());
-                    _tmp.Add(@"DogBreed::", new DogBreedSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::", new TypeWithEnumPropertyHavingDefaultValueSerializer());
-                    _tmp.Add(@"TypeWithBinaryProperty::", new TypeWithBinaryPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.ComplexChoiceB::", new ComplexChoiceBSerializer());
-                    _tmp.Add(@"SerializationTypes.DCStruct::", new DCStructSerializer());
-                    _tmp.Add(@"Animal::", new AnimalSerializer());
-                    _tmp.Add(@"XmlSerializableDerivedClass::", new XmlSerializableDerivedClassSerializer());
-                    _tmp.Add(@"SerializationTypes.ByteEnum::", new ByteEnumSerializer());
-                    _tmp.Add(@"Dog::", new DogSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertyHavingComplexChoice::", new TypeWithPropertyHavingComplexChoiceSerializer());
-                    _tmp.Add(@"TypeWithDefaultTimeSpanProperty::", new TypeWithDefaultTimeSpanPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithGetSetArrayMembers::", new TypeWithGetSetArrayMembersSerializer());
-                    _tmp.Add(@"DateTimeOffsetIXmlSerializableContainer::", new DateTimeOffsetIXmlSerializableContainerSerializer());
-                    _tmp.Add(@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:", new XmlSerializerAttributesSerializer());
-                    _tmp.Add(@"BaseClass::", new BaseClassSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::", new TypeWithEnumFlagPropertyHavingDefaultValueSerializer());
-                    _tmp.Add(@"Trumpet::", new TrumpetSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithShouldSerializeMethod::", new TypeWithShouldSerializeMethodSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithByteArrayAsXmlText::", new TypeWithByteArrayAsXmlTextSerializer());
-                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::", new StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer());
-                    _tmp.Add(@"TypeWithByteProperty::", new TypeWithBytePropertySerializer());
-                    _tmp.Add(@"SerializationTypes.BaseTypeWithShouldSerializeMethod::", new BaseTypeWithShouldSerializeMethodSerializer());
-                    _tmp.Add(@"DefaultValuesSetToPositiveInfinity::", new DefaultValuesSetToPositiveInfinitySerializer());
-                    _tmp.Add(@"Parameter::", new ParameterSerializer());
-                    _tmp.Add(@"XElementArrayWrapper::", new XElementArrayWrapperSerializer());
-                    _tmp.Add(@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:", new XmlSerializableBaseClassSerializer());
-                    _tmp.Add(@"TypeWithDateTimeOffsetProperties::", new TypeWithDateTimeOffsetPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.DCClassWithEnumAndStruct::", new DCClassWithEnumAndStructSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertyNameSpecified::", new TypeWithPropertyNameSpecifiedSerializer());
-                    _tmp.Add(@"DerivedClass::", new DerivedClassSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomDocument::", new CustomDocumentSerializer());
-                    _tmp.Add(@"SerializationTypes.SByteEnum::", new SByteEnumSerializer());
-                    _tmp.Add(@"MyCollection1::", new MyCollection1Serializer());
-                    _tmp.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:", new TypeWithMismatchBetweenAttributeAndPropertyTypeSerializer());
-                    _tmp.Add(@"Group::", new GroupSerializer());
-                    _tmp.Add(@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:", new PurchaseOrderSerializer());
-                    _tmp.Add(@"TimeOnlyAsXsdTimeWrapper::", new TimeOnlyAsXsdTimeWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::", new DerivedTypeWithInheritedShouldSerializeSerializer());
-                    _tmp.Add(@"DateTimeDateWrapper::", new DateTimeDateWrapperSerializer());
-                    _tmp.Add(@"TypeWithGetOnlyReadOnlyCollections::", new TypeWithGetOnlyReadOnlyCollectionsSerializer());
-                    _tmp.Add(@"SerializationTypes.BuiltInTypes::", new BuiltInTypesSerializer());
-                    _tmp.Add(@"SimpleDerivedClass::", new SimpleDerivedClassSerializer());
-                    _tmp.Add(@"DefaultValuesSetToNaN::", new DefaultValuesSetToNaNSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithNonPublicDefaultConstructor::", new TypeWithNonPublicDefaultConstructorSerializer());
-                    _tmp.Add(@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::", new __TypeNameWithSpecialCharacters漢ñSerializer());
-                    _tmp.Add(@"SerializationTypes.StructNotSerializable::", new StructNotSerializableSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeHasArrayOfASerializedAsB::", new TypeHasArrayOfASerializedAsBSerializer());
-                    _tmp.Add(@"DateOnlyWrapper::", new DateOnlyWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty2::", new DerivedClassWithSameProperty2Serializer());
-                    _tmp.Add(@"SerializationTypes.WithStruct::", new WithStructSerializer());
-                    _tmp.Add(@"Orchestra::", new OrchestraSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeB::", new TypeBSerializer());
-                    _tmp.Add(@"Brass::", new BrassSerializer());
                     _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::", new StructImplementingIXmlSerializableWithParameterlessConstructorSerializer());
+                    _tmp.Add(@"MsgDocumentType:http://example.com:Document:True:", new MsgDocumentTypeSerializer());
+                    _tmp.Add(@"OrderedItem::", new OrderedItemSerializer());
+                    _tmp.Add(@"DefaultValuesSetToPositiveInfinity::", new DefaultValuesSetToPositiveInfinitySerializer());
+                    _tmp.Add(@"DefaultValuesSetToNaN::", new DefaultValuesSetToNaNSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithBuiltInTypedMembers::", new TypeWithBuiltInTypedMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::", new TypeWithDateTimePropertyAsXmlTimeSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleType::", new SimpleTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertyNameSpecified::", new TypeWithPropertyNameSpecifiedSerializer());
+                    _tmp.Add(@"TypeWithXmlElementProperty::", new TypeWithXmlElementPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::", new TypeWithFieldBackedSpecifiedMemberSerializer());
+                    _tmp.Add(@"Group::", new GroupSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:", new TypeWithXmlTextAttributeOnArraySerializer());
+                    _tmp.Add(@"Parameter::", new ParameterSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeNameClashB.TypeNameClash::", new TypeNameClashSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomElement::", new CustomElementSerializer());
+                    _tmp.Add(@"TimeOnlyAsXsdTimeWrapper::", new TimeOnlyAsXsdTimeWrapperSerializer());
+                    _tmp.Add(@"Orchestra::", new OrchestraSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::", new TypeWithEnumPropertyHavingDefaultValueSerializer());
+                    _tmp.Add(@"SerializationTypes.BaseTypeWithShouldSerializeMethod::", new BaseTypeWithShouldSerializeMethodSerializer());
+                    _tmp.Add(@"SerializationTypes.ClassImplementingIXmlSerializable::", new ClassImplementingIXmlSerializableSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithDateTimeStringProperty::", new TypeWithDateTimeStringPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.LongEnum::", new LongEnumSerializer());
+                    _tmp.Add(@"MyCollection1::", new MyCollection1Serializer());
+                    _tmp.Add(@"TypeWithMutableCollectionMembers::", new TypeWithMutableCollectionMembersSerializer());
+                    _tmp.Add(@"TypeWithDefaultTimeSpanProperty::", new TypeWithDefaultTimeSpanPropertySerializer());
+                    _tmp.Add(@"XElementWrapper::", new XElementWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.UIntEnum::", new UIntEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.WithStruct::", new WithStructSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::", new TypeWithTypeNameInXmlTypeAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.DCStruct::", new DCStructSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeNameClashA.TypeNameClash::", new TypeNameClashSerializer1());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructor::", new KnownTypesThroughConstructorSerializer());
+                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty2::", new DerivedClassWithSameProperty2Serializer());
+                    _tmp.Add(@"SerializationTypes.BuiltInTypes::", new BuiltInTypesSerializer());
+                    _tmp.Add(@"SerializationTypes.ULongEnum::", new ULongEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlQualifiedName::", new TypeWithXmlQualifiedNameSerializer());
+                    _tmp.Add(@"SimpleBaseClass::", new SimpleBaseClassSerializer());
+                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty::", new DerivedClassWithSamePropertySerializer());
+                    _tmp.Add(@"Brass::", new BrassSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithGetOnlyArrayProperties::", new TypeWithGetOnlyArrayPropertiesSerializer());
+                    _tmp.Add(@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:", new XmlSerializerAttributesSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithMyCollectionField::", new TypeWithMyCollectionFieldSerializer());
+                    _tmp.Add(@"TypeWithDateTimeOffsetProperties::", new TypeWithDateTimeOffsetPropertiesSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithShouldSerializeMethod::", new TypeWithShouldSerializeMethodSerializer());
+                    _tmp.Add(@"SerializationTypes.IntEnum::", new IntEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomAttribute::", new CustomAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.ItemChoiceType::", new ItemChoiceTypeSerializer());
+                    _tmp.Add(@"DateTimeTimeWrapper::", new DateTimeTimeWrapperSerializer());
+                    _tmp.Add(@"Outer+Person::", new PersonSerializer());
+                    _tmp.Add(@"TypeWithLinkedProperty::", new TypeWithLinkedPropertySerializer());
+                    _tmp.Add(@"DateTimeOffsetIXmlSerializableContainer::", new DateTimeOffsetIXmlSerializableContainerSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeB::", new TypeBSerializer());
+                    _tmp.Add(@"SerializationTypes.MyEnum::", new MyEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithArraylikeMembers::", new TypeWithArraylikeMembersSerializer());
+                    _tmp.Add(@"TypeWithDateAndTimeOnlyProperties::", new TypeWithDateAndTimeOnlyPropertiesSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithTypesHavingCustomFormatter::", new TypeWithTypesHavingCustomFormatterSerializer());
+                    _tmp.Add(@"SerializationTypes.ShortEnum::", new ShortEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::", new KnownTypesThroughConstructorWithArrayPropertiesSerializer());
+                    _tmp.Add(@"TimeOnlyWrapper::", new TimeOnlyWrapperSerializer());
+                    _tmp.Add(@"TypeWithXmlNodeArrayProperty:::True:", new TypeWithXmlNodeArrayPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeA::", new TypeASerializer());
+                    _tmp.Add(@"XElementArrayWrapper::", new XElementArrayWrapperSerializer());
+                    _tmp.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:", new TypeWithMismatchBetweenAttributeAndPropertyTypeSerializer());
+                    _tmp.Add(@"DateTimeDateWrapper::", new DateTimeDateWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleKnownTypeValue::", new SimpleKnownTypeValueSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::", new TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer());
+                    _tmp.Add(@"TypeWithReadOnlyCollections::", new TypeWithReadOnlyCollectionsSerializer());
+                    _tmp.Add(@"Vehicle::", new VehicleSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertyHavingComplexChoice::", new TypeWithPropertyHavingComplexChoiceSerializer());
+                    _tmp.Add(@"SerializationTypes.ComplexChoiceB::", new ComplexChoiceBSerializer());
+                    _tmp.Add(@"SerializationTypes.MyList::", new MyListSerializer());
+                    _tmp.Add(@"Instrument::", new InstrumentSerializer());
+                    _tmp.Add(@"BaseClass1::", new BaseClass1Serializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithNonPublicDefaultConstructor::", new TypeWithNonPublicDefaultConstructorSerializer());
+                    _tmp.Add(@"SerializationTypes.EnumFlags::", new EnumFlagsSerializer());
+                    _tmp.Add(@"XmlSerializableDerivedClass::", new XmlSerializableDerivedClassSerializer());
+                    _tmp.Add(@"SerializationTypes.StructNotSerializable::", new StructNotSerializableSerializer());
+                    _tmp.Add(@"DerivedClass::", new DerivedClassSerializer());
+                    _tmp.Add(@"SerializationTypes.SomeStruct::", new SomeStructSerializer());
+                    _tmp.Add(@"AliasedTestType::", new AliasedTestTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:", new NamespaceTypeNameClashContainerSerializer());
+                    _tmp.Add(@"SerializationTypes.ComplexChoiceA::", new ComplexChoiceASerializer());
+                    _tmp.Add(@"SerializationTypes.WithNullables::", new WithNullablesSerializer());
+                    _tmp.Add(@"Employee::", new EmployeeSerializer());
+                    _tmp.Add(@"SimpleDerivedClass::", new SimpleDerivedClassSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithFieldsOrdered::", new TypeWithFieldsOrderedSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithAnyAttribute::", new TypeWithAnyAttributeSerializer());
+                    _tmp.Add(@"Animal::", new AnimalSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithByteArrayAsXmlText::", new TypeWithByteArrayAsXmlTextSerializer());
+                    _tmp.Add(@"XElementStruct::", new XElementStructSerializer());
+                    _tmp.Add(@"TypeWithTimeSpanProperty::", new TypeWithTimeSpanPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::", new TypeWithSchemaFormInXmlAttributeSerializer());
+                    _tmp.Add(@"Address::", new AddressSerializer());
+                    _tmp.Add(@"Pet::", new PetSerializer());
+                    _tmp.Add(@"SerializationTypes.MoreChoices::", new MoreChoicesSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::", new TypeWithEnumFlagPropertyHavingDefaultValueSerializer());
+                    _tmp.Add(@"DogBreed::", new DogBreedSerializer());
+                    _tmp.Add(@"SerializationTypes.ClassImplementsInterface::", new ClassImplementsInterfaceSerializer());
+                    _tmp.Add(@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::", new DerivedTypeWithInheritedShouldSerializeSerializer());
+                    _tmp.Add(@"DateOnlyWrapper::", new DateOnlyWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithGetSetArrayMembers::", new TypeWithGetSetArrayMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomDocument::", new CustomDocumentSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:", new TypeWithXmlSchemaFormAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumMembers::", new TypeWithEnumMembersSerializer());
+                    _tmp.Add(@"Dog::", new DogSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWith2DArrayProperty2::", new TypeWith2DArrayProperty2Serializer());
+                    _tmp.Add(@"SerializationTypes.ByteEnum::", new ByteEnumSerializer());
+                    _tmp.Add(@"DefaultValuesSetToNegativeInfinity::", new DefaultValuesSetToNegativeInfinitySerializer());
+                    _tmp.Add(@"TypeWithBinaryProperty::", new TypeWithBinaryPropertySerializer());
+                    _tmp.Add(@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:", new XmlSerializableBaseClassSerializer());
+                    _tmp.Add(@"TypeWithByteProperty::", new TypeWithBytePropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithArrayPropertyHavingChoice::", new TypeWithArrayPropertyHavingChoiceSerializer());
+                    _tmp.Add(@"SerializationTypes.BaseClassWithSamePropertyName::", new BaseClassWithSamePropertyNameSerializer());
+                    _tmp.Add(@"TypeWithXmlDocumentProperty::", new TypeWithXmlDocumentPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::", new TypeWithPropertiesHavingDefaultValueSerializer());
+                    _tmp.Add(@"RootClass::", new RootClassSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleDC::", new SimpleDCSerializer());
+                    _tmp.Add(@"BaseClass::", new BaseClassSerializer());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithValue::", new KnownTypesThroughConstructorWithValueSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::", new TypeWithNullableBuiltInTypedMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::", new TypeWithReadOnlyMyCollectionPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::", new __TypeNameWithSpecialCharacters漢ñSerializer());
+                    _tmp.Add(@"SerializationTypes.WithEnums::", new WithEnumsSerializer());
+                    _tmp.Add(@"SerializationTypes.SByteEnum::", new SByteEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.ServerSettings::", new ServerSettingsSerializer());
+                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::", new StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer());
+                    _tmp.Add(@"DerivedClass1::", new DerivedClass1Serializer());
+                    _tmp.Add(@"SerializationTypes.TypeHasArrayOfASerializedAsB::", new TypeHasArrayOfASerializedAsBSerializer());
+                    _tmp.Add(@"SerializationTypes.DCClassWithEnumAndStruct::", new DCClassWithEnumAndStructSerializer());
+                    _tmp.Add(@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:", new PurchaseOrderSerializer());
+                    _tmp.Add(@"TypeWithGetOnlyReadOnlyCollections::", new TypeWithGetOnlyReadOnlyCollectionsSerializer());
+                    _tmp.Add(@"Trumpet::", new TrumpetSerializer());
                     if (typedSerializers == null) typedSerializers = _tmp;
                 }
                 return typedSerializers;

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Expected.SerializableAssembly.XmlSerializers.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Expected.SerializableAssembly.XmlSerializers.cs
@@ -3832,6 +3832,14 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                     WriteEndElement();
                 }
             }
+            {
+                global::System.Collections.Immutable.ImmutableList<global::System.Int32> a = (global::System.Collections.Immutable.ImmutableList<global::System.Int32>)o.@Flat;
+                if (a != null) {
+                    for (int ia = 0; ia < ((System.Collections.ICollection)a).Count; ia++) {
+                        WriteElementStringRaw(@"Flat", @"", System.Xml.XmlConvert.ToString((global::System.Int32)((global::System.Int32)a[ia])));
+                    }
+                }
+            }
             WriteEndElement(o);
         }
 
@@ -14232,7 +14240,9 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_1 = 0;
             global::System.String[] a_2 = null;
             int ca_2 = 0;
-            System.Span<bool> paramsRead = stackalloc bool[3];
+            global::System.Int32[] a_3 = null;
+            int ca_3 = 0;
+            System.Span<bool> paramsRead = stackalloc bool[4];
             while (Reader.MoveToNextAttribute()) {
                 if (!IsXmlnsAttribute(Reader.Name)) {
                     UnknownNode((object)o);
@@ -14414,11 +14424,25 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        UnknownNode((object)o, @":ImmutableList, :ReadOnlyCollection, :ImmutableArray");
+                        if (((object) Reader.LocalName == (object)id253_Flat && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                            if (Reader.HasAttributes) {
+                                while (Reader.MoveToNextAttribute()) {
+                                    if (!IsXmlnsAttribute(Reader.Name)) {
+                                        UnknownNode(null);
+                                    }
+                                }
+                                Reader.MoveToElement();
+                            }
+                            {
+                                a_3 = (global::System.Int32[])EnsureArrayIndex(a_3, ca_3, typeof(global::System.Int32));a_3[ca_3++] = System.Xml.XmlConvert.ToInt32(Reader.ReadElementString());
+                            }
+                            break;
+                        }
+                        UnknownNode((object)o, @":ImmutableList, :ReadOnlyCollection, :ImmutableArray, :Flat");
                     } while (false);
                 }
                 else {
-                    UnknownNode((object)o, @":ImmutableList, :ReadOnlyCollection, :ImmutableArray");
+                    UnknownNode((object)o, @":ImmutableList, :ReadOnlyCollection, :ImmutableArray, :Flat");
                 }
                 Reader.MoveToContent();
             }
@@ -14456,7 +14480,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id253_DateTimeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id254_DateTimeString && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14471,7 +14495,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id254_CurrentDateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id255_CurrentDateTime && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -14536,7 +14560,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id255_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id256_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14575,7 +14599,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id256_F2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id257_F2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14810,7 +14834,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id257_IntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id258_IntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14859,7 +14883,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id258_NIntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id259_NIntAField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14908,7 +14932,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id259_IntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id260_IntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -14956,7 +14980,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id260_NIntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id261_NIntLField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15008,7 +15032,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id261_IntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id262_IntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15057,7 +15081,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id262_NIntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id263_NIntAProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15111,7 +15135,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id263_IntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id264_IntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15159,7 +15183,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id264_NIntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id265_NIntLProp && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15314,7 +15338,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id265_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id266_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15410,7 +15434,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id265_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id266_Collection && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15504,7 +15528,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id255_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id256_F1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15582,7 +15606,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id266_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id267_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15639,12 +15663,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id267_MyStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id268_MyStruct && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyStruct = Read67_DCStruct(true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id268_MyEnum1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id269_MyEnum1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15701,7 +15725,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id269_ByteArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id270_ByteArray && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15762,7 +15786,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id270_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id271_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15777,7 +15801,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id271_IntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id272_IntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -15792,12 +15816,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id272_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id273_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableIntMember = Read70_NullableOfInt32(true);
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id273_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id274_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15850,7 +15874,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id274_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id275_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -15963,7 +15987,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id270_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id271_StringMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (ReadNull()) {
                                 o.@StringMember = null;
                             }
@@ -15983,12 +16007,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id272_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id273_NullableIntMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@NullableIntMember = Read70_NullableOfInt32(true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id274_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id275_ArrayMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16037,7 +16061,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id273_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id274_ListMember && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16272,7 +16296,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id275_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16331,7 +16355,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id277_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16346,7 +16370,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id278_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16361,7 +16385,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id278_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id279_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16376,7 +16400,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id279_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id280_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16475,7 +16499,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id277_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16490,7 +16514,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id278_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16505,7 +16529,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id278_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id279_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16520,7 +16544,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id279_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id280_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16621,7 +16645,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id276_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id277_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16636,7 +16660,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id278_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16651,7 +16675,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id278_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id279_DateTimeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16666,7 +16690,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id279_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id280_ListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -16855,7 +16879,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id266_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id267_Data && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16967,7 +16991,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id280_ClassID && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id281_ClassID && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16982,7 +17006,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id281_DisplayName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id282_DisplayName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -16997,7 +17021,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id282_Id && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id283_Id && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17012,7 +17036,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id283_IsLoaded && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id284_IsLoaded && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17147,7 +17171,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id284_Some && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id285_Some && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Some = Read86_SomeStruct(true);
                             paramsRead[0] = true;
                             break;
@@ -17194,7 +17218,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id285_Int && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id286_Int && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17209,7 +17233,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id286_Short && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id287_Short && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17266,32 +17290,32 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id287_Optional && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id288_Optional && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Optional = Read91_NullableOfIntEnum(true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id288_Optionull && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id289_Optionull && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Optionull = Read91_NullableOfIntEnum(true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id289_OptionalInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id290_OptionalInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@OptionalInt = Read70_NullableOfInt32(true);
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id290_OptionullInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id291_OptionullInt && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@OptionullInt = Read70_NullableOfInt32(true);
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id291_Struct1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id292_Struct1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Struct1 = Read92_NullableOfSomeStruct(true);
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id292_Struct2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id293_Struct2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@Struct2 = Read92_NullableOfSomeStruct(true);
                             paramsRead[5] = true;
                             break;
@@ -17354,7 +17378,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_7 = 0;
             System.Span<bool> paramsRead = stackalloc bool[8];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[6] && ((object) Reader.LocalName == (object)id293_XmlAttributeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[6] && ((object) Reader.LocalName == (object)id294_XmlAttributeName && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@XmlAttributeProperty = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[6] = true;
                 }
@@ -17373,7 +17397,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 string tmp = null;
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id294_Word && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id295_Word && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17389,7 +17413,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id295_Number && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id296_Number && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17405,7 +17429,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id296_DecimalNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id297_DecimalNumber && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17421,12 +17445,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id297_XmlIncludeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id298_XmlIncludeProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@XmlIncludeProperty = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id298_XmlEnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id299_XmlEnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17475,7 +17499,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id299_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id300_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17490,7 +17514,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id300_XmlElementPropertyNode && (object) Reader.NamespaceURI == (object)id301_httpelement)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id301_XmlElementPropertyNode && (object) Reader.NamespaceURI == (object)id302_httpelement)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17505,7 +17529,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[5] = true;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id302_CustomXmlArrayProperty && (object) Reader.NamespaceURI == (object)id168_httpmynamespace)) {
+                        if (((object) Reader.LocalName == (object)id303_CustomXmlArrayProperty && (object) Reader.NamespaceURI == (object)id168_httpmynamespace)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17596,7 +17620,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_2 = 0;
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id278_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@IntProperty = System.Xml.XmlConvert.ToInt32(Reader.Value);
                     paramsRead[1] = true;
                 }
@@ -17676,12 +17700,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id303_EnumValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id304_EnumValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@EnumValue = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id304_SimpleTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id305_SimpleTypeValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@SimpleTypeValue = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -17728,7 +17752,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id305_StrProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id306_StrProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -17785,7 +17809,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id306_MyField && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id307_MyField && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyFieldSpecified = true;
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -17801,7 +17825,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id307_MyFieldIgnored && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id308_MyFieldIgnored && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@MyFieldIgnoredSpecified = true;
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -17865,7 +17889,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id308_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id309_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17913,7 +17937,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id309_NoneSchemaFormListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id310_NoneSchemaFormListProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -17961,7 +17985,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             }
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id310_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id311_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -18037,7 +18061,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.TypeWithTypeNameInXmlTypeAttribute();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id311_XmlAttributeForm && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id312_XmlAttributeForm && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@XmlAttributeForm = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -18085,7 +18109,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             int ca_2 = 0;
             System.Span<bool> paramsRead = stackalloc bool[3];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id312_name && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id313_name && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Name = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -18158,7 +18182,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id313_customElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id314_customElement && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if ((object)(a_0) == null) Reader.Skip(); else a_0.Add(Read108_CustomElement(false, true));
                             break;
                         }
@@ -18270,7 +18294,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id314_DS2Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id315_DS2Root && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18285,7 +18309,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id315_MetricConfigUrl && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id316_MetricConfigUrl && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18401,7 +18425,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id316_TwoDArrayOfSimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id317_TwoDArrayOfSimpleType && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (!ReadNull()) {
                                 if (Reader.HasAttributes) {
                                     while (Reader.MoveToNextAttribute()) {
@@ -18517,7 +18541,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id317_EmptyStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id318_EmptyStringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18532,7 +18556,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id276_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id277_StringProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18547,7 +18571,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id277_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id278_IntProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18565,7 +18589,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id318_CharProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id319_CharProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18625,7 +18649,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18685,7 +18709,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id319_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_EnumProperty && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18745,7 +18769,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id321_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18788,7 +18812,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.DerivedTypeWithInheritedShouldSerialize();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id321_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id322_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Bar = Reader.Value;
                     paramsRead[1] = true;
                 }
@@ -18806,7 +18830,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id321_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18851,7 +18875,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.BaseTypeWithShouldSerializeMethod();
             System.Span<bool> paramsRead = stackalloc bool[2];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id321_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                if (!paramsRead[1] && ((object) Reader.LocalName == (object)id322_Bar && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Bar = Reader.Value;
                     paramsRead[1] = true;
                 }
@@ -18869,7 +18893,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id321_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -18926,7 +18950,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id320_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id321_Foo && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@FooSpecified = true;
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
@@ -18984,12 +19008,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id322_StringArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id323_StringArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@StringArrayValue = Read1_Object(false, true);
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id323_IntArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id324_IntArrayValue && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             o.@IntArrayValue = Read1_Object(false, true);
                             paramsRead[1] = true;
                             break;
@@ -19083,7 +19107,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id324_DateTimeContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[0] && ((object) Reader.LocalName == (object)id325_DateTimeContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19098,7 +19122,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[0] = true;
                             break;
                         }
-                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id325_QNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[1] && ((object) Reader.LocalName == (object)id326_QNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19113,7 +19137,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[1] = true;
                             break;
                         }
-                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id326_DateContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[2] && ((object) Reader.LocalName == (object)id327_DateContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19128,7 +19152,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[2] = true;
                             break;
                         }
-                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id327_NameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[3] && ((object) Reader.LocalName == (object)id328_NameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19143,7 +19167,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[3] = true;
                             break;
                         }
-                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id328_NCNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[4] && ((object) Reader.LocalName == (object)id329_NCNameContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19158,7 +19182,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[4] = true;
                             break;
                         }
-                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id329_NMTOKENContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[5] && ((object) Reader.LocalName == (object)id330_NMTOKENContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19173,7 +19197,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[5] = true;
                             break;
                         }
-                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id330_NMTOKENSContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[6] && ((object) Reader.LocalName == (object)id331_NMTOKENSContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19188,7 +19212,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[6] = true;
                             break;
                         }
-                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id331_Base64BinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[7] && ((object) Reader.LocalName == (object)id332_Base64BinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19203,7 +19227,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             paramsRead[7] = true;
                             break;
                         }
-                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id332_HexBinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (!paramsRead[8] && ((object) Reader.LocalName == (object)id333_HexBinaryContent && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19266,7 +19290,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id333_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id334_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19281,7 +19305,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                             choice_a_0 = (global::SerializationTypes.MoreChoices[])EnsureArrayIndex(choice_a_0, cchoice_a_0, typeof(global::SerializationTypes.MoreChoices));choice_a_0[cchoice_a_0++] = global::SerializationTypes.MoreChoices.@Item;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id334_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id335_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19462,12 +19486,12 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             while (Reader.NodeType != System.Xml.XmlNodeType.EndElement && Reader.NodeType != System.Xml.XmlNodeType.None) {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     do {
-                        if (((object) Reader.LocalName == (object)id333_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id334_Item && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             a_0 = (global::System.Object[])EnsureArrayIndex(a_0, ca_0, typeof(global::System.Object));a_0[ca_0++] = Read127_ComplexChoiceA(false, true);
                             choice_a_0 = (global::SerializationTypes.MoreChoices[])EnsureArrayIndex(choice_a_0, cchoice_a_0, typeof(global::SerializationTypes.MoreChoices));choice_a_0[cchoice_a_0++] = global::SerializationTypes.MoreChoices.@Item;
                             break;
                         }
-                        if (((object) Reader.LocalName == (object)id334_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id335_Amount && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19528,7 +19552,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                 if (Reader.NodeType == System.Xml.XmlNodeType.Element) {
                     switch (state) {
                     case 0:
-                        if (((object) Reader.LocalName == (object)id335_IntField2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id336_IntField2 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19544,7 +19568,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 1;
                         break;
                     case 1:
-                        if (((object) Reader.LocalName == (object)id336_IntField1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id337_IntField1 && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19560,7 +19584,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 2;
                         break;
                     case 2:
-                        if (((object) Reader.LocalName == (object)id337_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id338_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19576,7 +19600,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
                         state = 3;
                         break;
                     case 3:
-                        if (((object) Reader.LocalName == (object)id337_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
+                        if (((object) Reader.LocalName == (object)id338_strfld && (object) Reader.NamespaceURI == (object)id2_Item)) {
                             if (Reader.HasAttributes) {
                                 while (Reader.MoveToNextAttribute()) {
                                     if (!IsXmlnsAttribute(Reader.Name)) {
@@ -19621,7 +19645,7 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             o = new global::SerializationTypes.TypeWithSchemaFormInXmlAttribute();
             System.Span<bool> paramsRead = stackalloc bool[1];
             while (Reader.MoveToNextAttribute()) {
-                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id338_TestProperty && (object) Reader.NamespaceURI == (object)id339_httptestcom)) {
+                if (!paramsRead[0] && ((object) Reader.LocalName == (object)id339_TestProperty && (object) Reader.NamespaceURI == (object)id340_httptestcom)) {
                     o.@TestProperty = Reader.Value;
                     paramsRead[0] = true;
                 }
@@ -19652,688 +19676,690 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
         protected override void InitCallbacks() {
         }
 
-        string id241_refs;
-        string id28_DerivedIXmlSerializable;
-        string id209_Age;
-        string id134_TypeWithFieldsOrdered;
-        string id117_TypeWithXmlQualifiedName;
-        string id48_Document;
-        string id161_ArrayOfTypeWithLinkedProperty;
-        string id75_Item;
-        string id106_Item;
-        string id201_DefaultTime;
-        string id326_DateContent;
-        string id122_TypeWithShouldSerializeMethod;
-        string id74_TypeWithBuiltInTypedMembers;
-        string id226_SubTotal;
-        string id39_Instrument;
-        string id89_ClassImplementsInterface;
-        string id34_BaseClass1;
-        string id133_ComplexChoiceB;
-        string id118_TypeWith2DArrayProperty2;
-        string id108_Item;
-        string id295_Number;
-        string id58_Item;
-        string id328_NCNameContent;
-        string id268_MyEnum1;
-        string id38_Orchestra;
-        string id275_Item;
-        string id311_XmlAttributeForm;
-        string id278_DateTimeProperty;
-        string id195_DefaultDate;
-        string id238_FloatProp;
-        string id68_anyType;
-        string id239_IntValue;
-        string id177_Child;
-        string id153_ArrayOfOrderedItem;
-        string id22_BaseClass;
-        string id3_TypeWithXmlDocumentProperty;
-        string id168_httpmynamespace;
-        string id96_ShortEnum;
-        string id216_AttributeString;
-        string id43_DefaultValuesSetToNaN;
-        string id235_DoubleField;
-        string id110_TypeWithXmlSchemaFormAttribute;
-        string id57_Item;
-        string id258_NIntAField;
-        string id59_TypeWithDateTimeStringProperty;
-        string id104_KnownTypesThroughConstructor;
-        string id339_httptestcom;
-        string id301_httpelement;
-        string id91_SomeStruct;
-        string id331_Base64BinaryContent;
-        string id181_ItemName;
-        string id270_StringMember;
-        string id172_QualifiedParameter;
-        string id191_NullableDTO;
-        string id173_ArrayOfArrayOfSimpleType;
-        string id240_id;
-        string id197_NullableDateWithValue;
-        string id165_ArrayOfSimpleType;
-        string id169_ArrayOfString1;
-        string id92_WithEnums;
-        string id32_OrderedItem;
-        string id317_EmptyStringProperty;
-        string id29_PurchaseOrder;
-        string id314_DS2Root;
-        string id101_AttributeTesting;
-        string id266_Data;
-        string id37_dateTime;
         string id86_Item;
-        string id87_Item;
-        string id157_string;
-        string id113_CustomDocument;
-        string id287_Optional;
-        string id147_Value1;
-        string id263_IntLProp;
-        string id182_Description;
-        string id61_TypeWithGetSetArrayMembers;
-        string id178_Children;
-        string id321_Bar;
-        string id167_ArrayOfItemChoiceType;
         string id220_City;
-        string id196_NullableDate;
-        string id243_xelement;
-        string id234_Comment2;
-        string id242_Parameters;
-        string id244_xelements;
-        string id85_SimpleDC;
-        string id143_Name;
-        string id208_ByteProperty;
-        string id72_DCClassWithEnumAndStruct;
-        string id88_EnumFlags;
-        string id247_ImmutableList;
-        string id219_Line1;
-        string id26_BaseIXmlSerializable;
-        string id139_Person;
-        string id332_HexBinaryContent;
-        string id84_TypeWithByteArrayAsXmlText;
-        string id49_httpexamplecom;
-        string id176_Value;
-        string id245_ImmutableArrayField;
-        string id337_strfld;
-        string id53_XElementStruct;
-        string id148_Value2;
+        string id273_NullableIntMember;
+        string id335_Amount;
+        string id314_customElement;
+        string id299_XmlEnumProperty;
         string id69_MyEnum;
-        string id319_EnumProperty;
-        string id260_NIntLField;
-        string id192_NullableDefaultDTO;
-        string id193_Today;
-        string id6_Item;
-        string id200_MyTime;
-        string id185_LineTotal;
-        string id276_StringProperty;
-        string id60_SimpleType;
-        string id180_Modulation;
-        string id16_Animal;
-        string id303_EnumValue;
+        string id221_State;
+        string id149_XmlSerializerAttributes;
+        string id280_ListProperty;
+        string id12_TypeWithTimeSpanProperty;
+        string id279_DateTimeProperty;
+        string id108_Item;
+        string id140_FirstName;
+        string id136_Root;
+        string id122_TypeWithShouldSerializeMethod;
+        string id209_Age;
+        string id1_TypeWithXmlElementProperty;
+        string id289_Optionull;
+        string id188_DTO;
+        string id118_TypeWith2DArrayProperty2;
+        string id17_Dog;
+        string id33_AliasedTestType;
+        string id298_XmlIncludeProperty;
+        string id250_ImmutableQueue;
+        string id5_Item;
+        string id316_MetricConfigUrl;
+        string id18_DogBreed;
+        string id43_DefaultValuesSetToNaN;
+        string id47_TypeWithLinkedProperty;
+        string id154_ArrayOfInt;
+        string id219_Line1;
+        string id64_StructNotSerializable;
+        string id168_httpmynamespace;
+        string id251_List;
+        string id179_IsValved;
+        string id286_Int;
+        string id307_MyField;
+        string id290_OptionalInt;
+        string id125_Item;
         string id151_MsgDocumentType;
-        string id30_httpwwwcontoso1com;
-        string id187_Base64Content;
-        string id162_ArrayOfParameter;
-        string id46_RootElement;
-        string id292_Struct2;
+        string id263_NIntAProp;
+        string id145_A;
+        string id77_TypeB;
+        string id135_Item;
+        string id331_NMTOKENSContent;
+        string id297_DecimalNumber;
+        string id58_Item;
+        string id338_strfld;
+        string id126_Item;
+        string id189_DTO2;
+        string id241_refs;
+        string id312_XmlAttributeForm;
         string id152_Item;
-        string id308_Item;
-        string id23_DerivedClass;
-        string id159_double;
-        string id56_TypeWithReadOnlyCollections;
-        string id335_IntField2;
-        string id333_Item;
+        string id235_DoubleField;
+        string id165_ArrayOfSimpleType;
+        string id239_IntValue;
+        string id79_Item;
+        string id243_xelement;
+        string id211_LicenseNumber;
+        string id20_Vehicle;
+        string id65_TypeWithMyCollectionField;
+        string id54_XElementArrayWrapper;
+        string id166_ArrayOfTypeA;
+        string id29_PurchaseOrder;
+        string id223_ShipTo;
+        string id271_StringMember;
+        string id117_TypeWithXmlQualifiedName;
+        string id36_ArrayOfDateTime;
+        string id142_LastName;
+        string id6_Item;
+        string id89_ClassImplementsInterface;
+        string id88_EnumFlags;
+        string id124_Item;
+        string id8_TimeOnlyWrapper;
+        string id180_Modulation;
+        string id147_Value1;
+        string id237_DoubleProp;
+        string id315_DS2Root;
+        string id144_ContainerType;
+        string id52_XElementWrapper;
+        string id190_DefaultDTO;
+        string id153_ArrayOfOrderedItem;
+        string id57_Item;
+        string id288_Optional;
+        string id291_OptionullInt;
+        string id53_XElementStruct;
+        string id334_Item;
+        string id25_SimpleDerivedClass;
+        string id133_ComplexChoiceB;
+        string id231_Z;
+        string id44_Item;
+        string id319_CharProperty;
+        string id28_DerivedIXmlSerializable;
+        string id156_ArrayOfString;
+        string id246_ImmutableArray;
+        string id247_ImmutableList;
+        string id38_Orchestra;
+        string id322_Bar;
+        string id98_UIntEnum;
+        string id41_Trumpet;
+        string id248_ReadOnlyCollection;
+        string id177_Child;
+        string id107_Item;
+        string id55_Item;
+        string id205_TestValue;
+        string id32_OrderedItem;
+        string id195_DefaultDate;
+        string id30_httpwwwcontoso1com;
+        string id230_Y;
+        string id253_Flat;
+        string id183_UnitPrice;
+        string id224_OrderDate;
+        string id175_P2;
+        string id83_Item;
+        string id70_TypeWithEnumMembers;
+        string id225_Items;
+        string id325_DateTimeContent;
+        string id194_MyDate;
+        string id264_IntLProp;
+        string id16_Animal;
+        string id104_KnownTypesThroughConstructor;
+        string id24_SimpleBaseClass;
+        string id324_IntArrayValue;
+        string id327_DateContent;
+        string id160_ArrayOfInstrument;
+        string id11_DateTimeTimeWrapper;
+        string id170_NoneParameter;
+        string id80_BaseClassWithSamePropertyName;
+        string id249_FrozenSet;
+        string id101_AttributeTesting;
+        string id161_ArrayOfTypeWithLinkedProperty;
+        string id49_httpexamplecom;
+        string id226_SubTotal;
+        string id113_CustomDocument;
+        string id328_NameContent;
+        string id150_ParameterOfString;
+        string id163_ArrayOfXElement;
+        string id191_NullableDTO;
+        string id19_Group;
+        string id320_EnumProperty;
+        string id97_IntEnum;
+        string id148_Value2;
+        string id200_MyTime;
+        string id111_MyXmlType;
+        string id72_DCClassWithEnumAndStruct;
+        string id214_EmployeeName;
+        string id114_CustomElement;
+        string id100_ULongEnum;
+        string id266_Collection;
+        string id265_NIntLProp;
+        string id158_ArrayOfDouble;
+        string id67_ArrayOfAnyType;
+        string id78_TypeHasArrayOfASerializedAsB;
+        string id34_BaseClass1;
+        string id284_IsLoaded;
+        string id285_Some;
+        string id45_Item;
+        string id258_IntAField;
+        string id208_ByteProperty;
+        string id85_SimpleDC;
+        string id196_NullableDate;
+        string id261_NIntLField;
+        string id216_AttributeString;
+        string id15_TypeWithXmlNodeArrayProperty;
+        string id96_ShortEnum;
+        string id277_StringProperty;
+        string id197_NullableDateWithValue;
+        string id283_Id;
+        string id238_FloatProp;
+        string id301_XmlElementPropertyNode;
+        string id233_Instruments;
+        string id294_XmlAttributeName;
+        string id91_SomeStruct;
+        string id201_DefaultTime;
+        string id172_QualifiedParameter;
+        string id210_Breed;
+        string id256_F1;
+        string id275_ArrayMember;
+        string id3_TypeWithXmlDocumentProperty;
+        string id198_NullableDefaultDate;
+        string id48_Document;
+        string id103_TypeWithAnyAttribute;
+        string id129_Item;
+        string id81_DerivedClassWithSameProperty;
+        string id27_Item;
+        string id106_Item;
+        string id229_X;
+        string id50_RootClass;
+        string id74_TypeWithBuiltInTypedMembers;
+        string id242_Parameters;
+        string id22_BaseClass;
+        string id213_GroupVehicle;
+        string id333_HexBinaryContent;
+        string id173_ArrayOfArrayOfSimpleType;
+        string id110_TypeWithXmlSchemaFormAttribute;
+        string id276_Item;
+        string id146_B;
+        string id14_TypeWithByteProperty;
+        string id94_ByteEnum;
+        string id171_ArrayOfBoolean;
+        string id240_id;
+        string id128_Item;
+        string id305_SimpleTypeValue;
+        string id84_TypeWithByteArrayAsXmlText;
+        string id185_LineTotal;
+        string id178_Children;
+        string id143_Name;
+        string id141_MiddleName;
         string id138_TypeClashA;
         string id102_ItemChoiceType;
-        string id212_GroupName;
-        string id132_ComplexChoiceA;
-        string id100_ULongEnum;
-        string id194_MyDate;
-        string id203_NullableTimeWithValue;
-        string id98_UIntEnum;
-        string id290_OptionullInt;
-        string id24_SimpleBaseClass;
-        string id233_Instruments;
-        string id279_ListProperty;
-        string id115_Item;
-        string id269_ByteArray;
-        string id207_TimeSpanProperty2;
-        string id137_TypeClashB;
-        string id325_QNameContent;
-        string id107_Item;
-        string id121_Item;
-        string id280_ClassID;
-        string id62_TypeWithGetOnlyArrayProperties;
-        string id155_int;
-        string id77_TypeB;
-        string id257_IntAField;
-        string id154_ArrayOfInt;
-        string id318_CharProperty;
-        string id156_ArrayOfString;
-        string id329_NMTOKENContent;
-        string id284_Some;
-        string id166_ArrayOfTypeA;
-        string id291_Struct1;
-        string id251_List;
-        string id230_Y;
-        string id205_TestValue;
-        string id249_FrozenSet;
-        string id286_Short;
-        string id281_DisplayName;
-        string id183_UnitPrice;
-        string id82_DerivedClassWithSameProperty2;
-        string id254_CurrentDateTime;
-        string id55_Item;
-        string id64_StructNotSerializable;
-        string id320_Foo;
-        string id103_TypeWithAnyAttribute;
-        string id237_DoubleProp;
-        string id184_Quantity;
-        string id232_Prop;
-        string id199_Now;
-        string id145_A;
-        string id246_ImmutableArray;
-        string id256_F2;
-        string id123_Item;
-        string id146_B;
-        string id144_ContainerType;
-        string id94_ByteEnum;
-        string id327_NameContent;
-        string id36_ArrayOfDateTime;
-        string id127_Item;
-        string id99_LongEnum;
-        string id97_IntEnum;
-        string id126_Item;
-        string id19_Group;
-        string id80_BaseClassWithSamePropertyName;
-        string id316_TwoDArrayOfSimpleType;
-        string id330_NMTOKENSContent;
-        string id306_MyField;
-        string id31_Address;
-        string id93_WithNullables;
-        string id307_MyFieldIgnored;
-        string id124_Item;
-        string id73_BuiltInTypes;
-        string id305_StrProperty;
-        string id119_Item;
-        string id174_P1;
-        string id198_NullableDefaultDate;
-        string id217_DateTimeValue;
-        string id294_Word;
-        string id135_Item;
-        string id299_Item;
-        string id289_OptionalInt;
-        string id273_ListMember;
-        string id283_IsLoaded;
-        string id236_SingleField;
-        string id78_TypeHasArrayOfASerializedAsB;
-        string id136_Root;
-        string id141_MiddleName;
-        string id20_Vehicle;
-        string id211_LicenseNumber;
-        string id170_NoneParameter;
-        string id95_SByteEnum;
-        string id272_NullableIntMember;
-        string id114_CustomElement;
-        string id252_Array;
-        string id17_Dog;
-        string id54_XElementArrayWrapper;
-        string id206_TimeSpanProperty;
-        string id42_Pet;
-        string id338_TestProperty;
-        string id76_TypeA;
-        string id262_NIntAProp;
-        string id130_Item;
-        string id158_ArrayOfDouble;
-        string id105_SimpleKnownTypeValue;
-        string id47_TypeWithLinkedProperty;
-        string id163_ArrayOfXElement;
-        string id65_TypeWithMyCollectionField;
-        string id90_WithStruct;
-        string id259_IntLField;
-        string id213_GroupVehicle;
-        string id190_DefaultDTO;
-        string id27_Item;
-        string id70_TypeWithEnumMembers;
-        string id218_BoolValue;
+        string id274_ListMember;
         string id164_XElement;
-        string id15_TypeWithXmlNodeArrayProperty;
-        string id265_Collection;
-        string id35_DerivedClass1;
-        string id223_ShipTo;
-        string id179_IsValved;
-        string id128_Item;
-        string id310_Item;
-        string id111_MyXmlType;
-        string id221_State;
-        string id1_TypeWithXmlElementProperty;
-        string id261_IntAProp;
-        string id323_IntArrayValue;
-        string id322_StringArrayValue;
-        string id33_AliasedTestType;
-        string id63_TypeWithArraylikeMembers;
-        string id9_TimeOnlyAsXsdTimeWrapper;
-        string id45_Item;
-        string id274_ArrayMember;
-        string id120_Item;
-        string id81_DerivedClassWithSameProperty;
-        string id41_Trumpet;
-        string id67_ArrayOfAnyType;
-        string id297_XmlIncludeProperty;
-        string id282_Id;
-        string id302_CustomXmlArrayProperty;
-        string id324_DateTimeContent;
-        string id112_Item;
+        string id267_Data;
+        string id56_TypeWithReadOnlyCollections;
+        string id31_Address;
         string id13_Item;
-        string id304_SimpleTypeValue;
-        string id215_value;
-        string id140_FirstName;
-        string id315_MetricConfigUrl;
-        string id5_Item;
-        string id11_DateTimeTimeWrapper;
-        string id250_ImmutableQueue;
+        string id252_Array;
+        string id39_Instrument;
+        string id92_WithEnums;
+        string id119_Item;
+        string id157_string;
+        string id193_Today;
+        string id62_TypeWithGetOnlyArrayProperties;
         string id71_DCStruct;
-        string id293_XmlAttributeName;
-        string id7_DateOnlyWrapper;
-        string id253_DateTimeString;
-        string id228_TotalCost;
-        string id214_EmployeeName;
-        string id285_Int;
-        string id150_ParameterOfString;
-        string id66_Item;
-        string id160_ArrayOfInstrument;
-        string id202_NullableTime;
-        string id264_NIntLProp;
-        string id231_Z;
-        string id204_NullableDefaultTime;
-        string id18_DogBreed;
-        string id189_DTO2;
-        string id171_ArrayOfBoolean;
-        string id222_Zip;
-        string id186_BinaryHexContent;
-        string id44_Item;
-        string id50_RootClass;
-        string id129_Item;
-        string id131_MoreChoices;
-        string id10_DateTimeDateWrapper;
-        string id116_ServerSettings;
-        string id188_DTO;
-        string id309_NoneSchemaFormListProperty;
-        string id296_DecimalNumber;
-        string id79_Item;
-        string id336_IntField1;
-        string id227_ShipCost;
-        string id248_ReadOnlyCollection;
-        string id267_MyStruct;
-        string id229_X;
-        string id83_Item;
-        string id2_Item;
-        string id225_Items;
-        string id300_XmlElementPropertyNode;
-        string id125_Item;
-        string id149_XmlSerializerAttributes;
-        string id277_IntProperty;
+        string id63_TypeWithArraylikeMembers;
         string id4_TypeWithBinaryProperty;
-        string id52_XElementWrapper;
-        string id175_P2;
-        string id12_TypeWithTimeSpanProperty;
-        string id14_TypeWithByteProperty;
-        string id298_XmlEnumProperty;
-        string id312_name;
-        string id334_Amount;
-        string id313_customElement;
-        string id21_Employee;
-        string id25_SimpleDerivedClass;
-        string id224_OrderDate;
-        string id8_TimeOnlyWrapper;
-        string id210_Breed;
-        string id255_F1;
-        string id142_LastName;
-        string id288_Optionull;
-        string id109_TypeWithPropertyNameSpecified;
+        string id10_DateTimeDateWrapper;
+        string id270_ByteArray;
+        string id131_MoreChoices;
+        string id87_Item;
+        string id302_httpelement;
+        string id134_TypeWithFieldsOrdered;
+        string id295_Word;
+        string id310_NoneSchemaFormListProperty;
+        string id132_ComplexChoiceA;
+        string id337_IntField1;
+        string id162_ArrayOfParameter;
+        string id257_F2;
+        string id112_Item;
+        string id269_MyEnum1;
+        string id68_anyType;
+        string id26_BaseIXmlSerializable;
+        string id254_DateTimeString;
+        string id255_CurrentDateTime;
+        string id303_CustomXmlArrayProperty;
+        string id236_SingleField;
+        string id204_NullableDefaultTime;
+        string id330_NMTOKENContent;
+        string id321_Foo;
+        string id155_int;
+        string id95_SByteEnum;
+        string id313_name;
+        string id186_BinaryHexContent;
+        string id116_ServerSettings;
+        string id2_Item;
+        string id212_GroupName;
+        string id59_TypeWithDateTimeStringProperty;
+        string id304_EnumValue;
+        string id203_NullableTimeWithValue;
+        string id309_Item;
+        string id46_RootElement;
+        string id207_TimeSpanProperty2;
+        string id192_NullableDefaultDTO;
+        string id187_Base64Content;
+        string id137_TypeClashB;
+        string id317_TwoDArrayOfSimpleType;
+        string id278_IntProperty;
+        string id306_StrProperty;
+        string id123_Item;
+        string id130_Item;
+        string id259_NIntAField;
         string id51_Parameter;
+        string id336_IntField2;
+        string id234_Comment2;
+        string id182_Description;
+        string id215_value;
+        string id282_DisplayName;
+        string id184_Quantity;
+        string id61_TypeWithGetSetArrayMembers;
+        string id199_Now;
         string id40_Brass;
-        string id271_IntMember;
+        string id167_ArrayOfItemChoiceType;
+        string id308_MyFieldIgnored;
+        string id217_DateTimeValue;
+        string id37_dateTime;
+        string id218_BoolValue;
+        string id260_IntLField;
+        string id232_Prop;
+        string id105_SimpleKnownTypeValue;
+        string id7_DateOnlyWrapper;
+        string id121_Item;
+        string id99_LongEnum;
+        string id159_double;
+        string id35_DerivedClass1;
+        string id66_Item;
+        string id300_Item;
+        string id176_Value;
+        string id139_Person;
+        string id329_NCNameContent;
+        string id109_TypeWithPropertyNameSpecified;
+        string id127_Item;
+        string id169_ArrayOfString1;
+        string id181_ItemName;
+        string id93_WithNullables;
+        string id244_xelements;
+        string id272_IntMember;
+        string id76_TypeA;
+        string id174_P1;
+        string id90_WithStruct;
+        string id75_Item;
+        string id262_IntAProp;
+        string id339_TestProperty;
+        string id281_ClassID;
+        string id323_StringArrayValue;
+        string id115_Item;
+        string id23_DerivedClass;
+        string id340_httptestcom;
+        string id228_TotalCost;
+        string id292_Struct1;
+        string id73_BuiltInTypes;
+        string id9_TimeOnlyAsXsdTimeWrapper;
+        string id326_QNameContent;
+        string id21_Employee;
+        string id296_Number;
+        string id42_Pet;
+        string id222_Zip;
+        string id206_TimeSpanProperty;
+        string id332_Base64BinaryContent;
+        string id287_Short;
+        string id318_EmptyStringProperty;
+        string id227_ShipCost;
+        string id311_Item;
+        string id60_SimpleType;
+        string id202_NullableTime;
+        string id82_DerivedClassWithSameProperty2;
+        string id120_Item;
+        string id293_Struct2;
+        string id268_MyStruct;
+        string id245_ImmutableArrayField;
 
         static readonly char[] xmlListSeparators = System.AppContext.TryGetSwitch("Switch.System.Xml.Serialization.UseLegacyXmlListSeparation", out bool useLegacyXmlListSeparation) && useLegacyXmlListSeparation ? null : new char[] { ' ', '\t', '\n', '\r' };
 
         protected override void InitIDs() {
-            id241_refs = Reader.NameTable.Add(@"refs");
-            id28_DerivedIXmlSerializable = Reader.NameTable.Add(@"DerivedIXmlSerializable");
-            id209_Age = Reader.NameTable.Add(@"Age");
-            id134_TypeWithFieldsOrdered = Reader.NameTable.Add(@"TypeWithFieldsOrdered");
-            id117_TypeWithXmlQualifiedName = Reader.NameTable.Add(@"TypeWithXmlQualifiedName");
-            id48_Document = Reader.NameTable.Add(@"Document");
-            id161_ArrayOfTypeWithLinkedProperty = Reader.NameTable.Add(@"ArrayOfTypeWithLinkedProperty");
-            id75_Item = Reader.NameTable.Add(@"TypeWithNullableBuiltInTypedMembers");
-            id106_Item = Reader.NameTable.Add(@"ClassImplementingIXmlSerializable");
-            id201_DefaultTime = Reader.NameTable.Add(@"DefaultTime");
-            id326_DateContent = Reader.NameTable.Add(@"DateContent");
-            id122_TypeWithShouldSerializeMethod = Reader.NameTable.Add(@"TypeWithShouldSerializeMethod");
-            id74_TypeWithBuiltInTypedMembers = Reader.NameTable.Add(@"TypeWithBuiltInTypedMembers");
-            id226_SubTotal = Reader.NameTable.Add(@"SubTotal");
-            id39_Instrument = Reader.NameTable.Add(@"Instrument");
-            id89_ClassImplementsInterface = Reader.NameTable.Add(@"ClassImplementsInterface");
-            id34_BaseClass1 = Reader.NameTable.Add(@"BaseClass1");
-            id133_ComplexChoiceB = Reader.NameTable.Add(@"ComplexChoiceB");
-            id118_TypeWith2DArrayProperty2 = Reader.NameTable.Add(@"TypeWith2DArrayProperty2");
-            id108_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithParameterlessConstructor");
-            id295_Number = Reader.NameTable.Add(@"Number");
-            id58_Item = Reader.NameTable.Add(@"TypeWithGetOnlyReadOnlyCollections");
-            id328_NCNameContent = Reader.NameTable.Add(@"NCNameContent");
-            id268_MyEnum1 = Reader.NameTable.Add(@"MyEnum1");
-            id38_Orchestra = Reader.NameTable.Add(@"Orchestra");
-            id275_Item = Reader.NameTable.Add(@"PropertyNameWithSpecialCharacters漢ñ");
-            id311_XmlAttributeForm = Reader.NameTable.Add(@"XmlAttributeForm");
-            id278_DateTimeProperty = Reader.NameTable.Add(@"DateTimeProperty");
-            id195_DefaultDate = Reader.NameTable.Add(@"DefaultDate");
-            id238_FloatProp = Reader.NameTable.Add(@"FloatProp");
-            id68_anyType = Reader.NameTable.Add(@"anyType");
-            id239_IntValue = Reader.NameTable.Add(@"IntValue");
-            id177_Child = Reader.NameTable.Add(@"Child");
-            id153_ArrayOfOrderedItem = Reader.NameTable.Add(@"ArrayOfOrderedItem");
-            id22_BaseClass = Reader.NameTable.Add(@"BaseClass");
-            id3_TypeWithXmlDocumentProperty = Reader.NameTable.Add(@"TypeWithXmlDocumentProperty");
-            id168_httpmynamespace = Reader.NameTable.Add(@"http://mynamespace");
-            id96_ShortEnum = Reader.NameTable.Add(@"ShortEnum");
-            id216_AttributeString = Reader.NameTable.Add(@"AttributeString");
-            id43_DefaultValuesSetToNaN = Reader.NameTable.Add(@"DefaultValuesSetToNaN");
-            id235_DoubleField = Reader.NameTable.Add(@"DoubleField");
-            id110_TypeWithXmlSchemaFormAttribute = Reader.NameTable.Add(@"TypeWithXmlSchemaFormAttribute");
-            id57_Item = Reader.NameTable.Add(@"TypeWithMutableCollectionMembers");
-            id258_NIntAField = Reader.NameTable.Add(@"NIntAField");
-            id59_TypeWithDateTimeStringProperty = Reader.NameTable.Add(@"TypeWithDateTimeStringProperty");
-            id104_KnownTypesThroughConstructor = Reader.NameTable.Add(@"KnownTypesThroughConstructor");
-            id339_httptestcom = Reader.NameTable.Add(@"http://test.com");
-            id301_httpelement = Reader.NameTable.Add(@"http://element");
-            id91_SomeStruct = Reader.NameTable.Add(@"SomeStruct");
-            id331_Base64BinaryContent = Reader.NameTable.Add(@"Base64BinaryContent");
-            id181_ItemName = Reader.NameTable.Add(@"ItemName");
-            id270_StringMember = Reader.NameTable.Add(@"StringMember");
-            id172_QualifiedParameter = Reader.NameTable.Add(@"QualifiedParameter");
-            id191_NullableDTO = Reader.NameTable.Add(@"NullableDTO");
-            id173_ArrayOfArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfArrayOfSimpleType");
-            id240_id = Reader.NameTable.Add(@"id");
-            id197_NullableDateWithValue = Reader.NameTable.Add(@"NullableDateWithValue");
-            id165_ArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfSimpleType");
-            id169_ArrayOfString1 = Reader.NameTable.Add(@"ArrayOfString1");
-            id92_WithEnums = Reader.NameTable.Add(@"WithEnums");
-            id32_OrderedItem = Reader.NameTable.Add(@"OrderedItem");
-            id317_EmptyStringProperty = Reader.NameTable.Add(@"EmptyStringProperty");
-            id29_PurchaseOrder = Reader.NameTable.Add(@"PurchaseOrder");
-            id314_DS2Root = Reader.NameTable.Add(@"DS2Root");
-            id101_AttributeTesting = Reader.NameTable.Add(@"AttributeTesting");
-            id266_Data = Reader.NameTable.Add(@"Data");
-            id37_dateTime = Reader.NameTable.Add(@"dateTime");
             id86_Item = Reader.NameTable.Add(@"TypeWithXmlTextAttributeOnArray");
-            id87_Item = Reader.NameTable.Add(@"http://schemas.xmlsoap.org/ws/2005/04/discovery");
-            id157_string = Reader.NameTable.Add(@"string");
-            id113_CustomDocument = Reader.NameTable.Add(@"CustomDocument");
-            id287_Optional = Reader.NameTable.Add(@"Optional");
-            id147_Value1 = Reader.NameTable.Add(@"Value1");
-            id263_IntLProp = Reader.NameTable.Add(@"IntLProp");
-            id182_Description = Reader.NameTable.Add(@"Description");
-            id61_TypeWithGetSetArrayMembers = Reader.NameTable.Add(@"TypeWithGetSetArrayMembers");
-            id178_Children = Reader.NameTable.Add(@"Children");
-            id321_Bar = Reader.NameTable.Add(@"Bar");
-            id167_ArrayOfItemChoiceType = Reader.NameTable.Add(@"ArrayOfItemChoiceType");
             id220_City = Reader.NameTable.Add(@"City");
-            id196_NullableDate = Reader.NameTable.Add(@"NullableDate");
-            id243_xelement = Reader.NameTable.Add(@"xelement");
-            id234_Comment2 = Reader.NameTable.Add(@"Comment2");
-            id242_Parameters = Reader.NameTable.Add(@"Parameters");
-            id244_xelements = Reader.NameTable.Add(@"xelements");
-            id85_SimpleDC = Reader.NameTable.Add(@"SimpleDC");
-            id143_Name = Reader.NameTable.Add(@"Name");
-            id208_ByteProperty = Reader.NameTable.Add(@"ByteProperty");
-            id72_DCClassWithEnumAndStruct = Reader.NameTable.Add(@"DCClassWithEnumAndStruct");
-            id88_EnumFlags = Reader.NameTable.Add(@"EnumFlags");
-            id247_ImmutableList = Reader.NameTable.Add(@"ImmutableList");
-            id219_Line1 = Reader.NameTable.Add(@"Line1");
-            id26_BaseIXmlSerializable = Reader.NameTable.Add(@"BaseIXmlSerializable");
-            id139_Person = Reader.NameTable.Add(@"Person");
-            id332_HexBinaryContent = Reader.NameTable.Add(@"HexBinaryContent");
-            id84_TypeWithByteArrayAsXmlText = Reader.NameTable.Add(@"TypeWithByteArrayAsXmlText");
-            id49_httpexamplecom = Reader.NameTable.Add(@"http://example.com");
-            id176_Value = Reader.NameTable.Add(@"Value");
-            id245_ImmutableArrayField = Reader.NameTable.Add(@"ImmutableArrayField");
-            id337_strfld = Reader.NameTable.Add(@"strfld");
-            id53_XElementStruct = Reader.NameTable.Add(@"XElementStruct");
-            id148_Value2 = Reader.NameTable.Add(@"Value2");
+            id273_NullableIntMember = Reader.NameTable.Add(@"NullableIntMember");
+            id335_Amount = Reader.NameTable.Add(@"Amount");
+            id314_customElement = Reader.NameTable.Add(@"customElement");
+            id299_XmlEnumProperty = Reader.NameTable.Add(@"XmlEnumProperty");
             id69_MyEnum = Reader.NameTable.Add(@"MyEnum");
-            id319_EnumProperty = Reader.NameTable.Add(@"EnumProperty");
-            id260_NIntLField = Reader.NameTable.Add(@"NIntLField");
-            id192_NullableDefaultDTO = Reader.NameTable.Add(@"NullableDefaultDTO");
-            id193_Today = Reader.NameTable.Add(@"Today");
-            id6_Item = Reader.NameTable.Add(@"TypeWithDateAndTimeOnlyProperties");
-            id200_MyTime = Reader.NameTable.Add(@"MyTime");
-            id185_LineTotal = Reader.NameTable.Add(@"LineTotal");
-            id276_StringProperty = Reader.NameTable.Add(@"StringProperty");
-            id60_SimpleType = Reader.NameTable.Add(@"SimpleType");
-            id180_Modulation = Reader.NameTable.Add(@"Modulation");
-            id16_Animal = Reader.NameTable.Add(@"Animal");
-            id303_EnumValue = Reader.NameTable.Add(@"EnumValue");
+            id221_State = Reader.NameTable.Add(@"State");
+            id149_XmlSerializerAttributes = Reader.NameTable.Add(@"XmlSerializerAttributes");
+            id280_ListProperty = Reader.NameTable.Add(@"ListProperty");
+            id12_TypeWithTimeSpanProperty = Reader.NameTable.Add(@"TypeWithTimeSpanProperty");
+            id279_DateTimeProperty = Reader.NameTable.Add(@"DateTimeProperty");
+            id108_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithParameterlessConstructor");
+            id140_FirstName = Reader.NameTable.Add(@"FirstName");
+            id136_Root = Reader.NameTable.Add(@"Root");
+            id122_TypeWithShouldSerializeMethod = Reader.NameTable.Add(@"TypeWithShouldSerializeMethod");
+            id209_Age = Reader.NameTable.Add(@"Age");
+            id1_TypeWithXmlElementProperty = Reader.NameTable.Add(@"TypeWithXmlElementProperty");
+            id289_Optionull = Reader.NameTable.Add(@"Optionull");
+            id188_DTO = Reader.NameTable.Add(@"DTO");
+            id118_TypeWith2DArrayProperty2 = Reader.NameTable.Add(@"TypeWith2DArrayProperty2");
+            id17_Dog = Reader.NameTable.Add(@"Dog");
+            id33_AliasedTestType = Reader.NameTable.Add(@"AliasedTestType");
+            id298_XmlIncludeProperty = Reader.NameTable.Add(@"XmlIncludeProperty");
+            id250_ImmutableQueue = Reader.NameTable.Add(@"ImmutableQueue");
+            id5_Item = Reader.NameTable.Add(@"TypeWithDateTimeOffsetProperties");
+            id316_MetricConfigUrl = Reader.NameTable.Add(@"MetricConfigUrl");
+            id18_DogBreed = Reader.NameTable.Add(@"DogBreed");
+            id43_DefaultValuesSetToNaN = Reader.NameTable.Add(@"DefaultValuesSetToNaN");
+            id47_TypeWithLinkedProperty = Reader.NameTable.Add(@"TypeWithLinkedProperty");
+            id154_ArrayOfInt = Reader.NameTable.Add(@"ArrayOfInt");
+            id219_Line1 = Reader.NameTable.Add(@"Line1");
+            id64_StructNotSerializable = Reader.NameTable.Add(@"StructNotSerializable");
+            id168_httpmynamespace = Reader.NameTable.Add(@"http://mynamespace");
+            id251_List = Reader.NameTable.Add(@"List");
+            id179_IsValved = Reader.NameTable.Add(@"IsValved");
+            id286_Int = Reader.NameTable.Add(@"Int");
+            id307_MyField = Reader.NameTable.Add(@"MyField");
+            id290_OptionalInt = Reader.NameTable.Add(@"OptionalInt");
+            id125_Item = Reader.NameTable.Add(@"TypeWithFieldBackedSpecifiedMember");
             id151_MsgDocumentType = Reader.NameTable.Add(@"MsgDocumentType");
-            id30_httpwwwcontoso1com = Reader.NameTable.Add(@"http://www.contoso1.com");
-            id187_Base64Content = Reader.NameTable.Add(@"Base64Content");
-            id162_ArrayOfParameter = Reader.NameTable.Add(@"ArrayOfParameter");
-            id46_RootElement = Reader.NameTable.Add(@"RootElement");
-            id292_Struct2 = Reader.NameTable.Add(@"Struct2");
+            id263_NIntAProp = Reader.NameTable.Add(@"NIntAProp");
+            id145_A = Reader.NameTable.Add(@"A");
+            id77_TypeB = Reader.NameTable.Add(@"TypeB");
+            id135_Item = Reader.NameTable.Add(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName");
+            id331_NMTOKENSContent = Reader.NameTable.Add(@"NMTOKENSContent");
+            id297_DecimalNumber = Reader.NameTable.Add(@"DecimalNumber");
+            id58_Item = Reader.NameTable.Add(@"TypeWithGetOnlyReadOnlyCollections");
+            id338_strfld = Reader.NameTable.Add(@"strfld");
+            id126_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithArrayProperties");
+            id189_DTO2 = Reader.NameTable.Add(@"DTO2");
+            id241_refs = Reader.NameTable.Add(@"refs");
+            id312_XmlAttributeForm = Reader.NameTable.Add(@"XmlAttributeForm");
             id152_Item = Reader.NameTable.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType");
-            id308_Item = Reader.NameTable.Add(@"UnqualifiedSchemaFormListProperty");
-            id23_DerivedClass = Reader.NameTable.Add(@"DerivedClass");
-            id159_double = Reader.NameTable.Add(@"double");
-            id56_TypeWithReadOnlyCollections = Reader.NameTable.Add(@"TypeWithReadOnlyCollections");
-            id335_IntField2 = Reader.NameTable.Add(@"IntField2");
-            id333_Item = Reader.NameTable.Add(@"Item");
+            id235_DoubleField = Reader.NameTable.Add(@"DoubleField");
+            id165_ArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfSimpleType");
+            id239_IntValue = Reader.NameTable.Add(@"IntValue");
+            id79_Item = Reader.NameTable.Add(@"__TypeNameWithSpecialCharacters漢ñ");
+            id243_xelement = Reader.NameTable.Add(@"xelement");
+            id211_LicenseNumber = Reader.NameTable.Add(@"LicenseNumber");
+            id20_Vehicle = Reader.NameTable.Add(@"Vehicle");
+            id65_TypeWithMyCollectionField = Reader.NameTable.Add(@"TypeWithMyCollectionField");
+            id54_XElementArrayWrapper = Reader.NameTable.Add(@"XElementArrayWrapper");
+            id166_ArrayOfTypeA = Reader.NameTable.Add(@"ArrayOfTypeA");
+            id29_PurchaseOrder = Reader.NameTable.Add(@"PurchaseOrder");
+            id223_ShipTo = Reader.NameTable.Add(@"ShipTo");
+            id271_StringMember = Reader.NameTable.Add(@"StringMember");
+            id117_TypeWithXmlQualifiedName = Reader.NameTable.Add(@"TypeWithXmlQualifiedName");
+            id36_ArrayOfDateTime = Reader.NameTable.Add(@"ArrayOfDateTime");
+            id142_LastName = Reader.NameTable.Add(@"LastName");
+            id6_Item = Reader.NameTable.Add(@"TypeWithDateAndTimeOnlyProperties");
+            id89_ClassImplementsInterface = Reader.NameTable.Add(@"ClassImplementsInterface");
+            id88_EnumFlags = Reader.NameTable.Add(@"EnumFlags");
+            id124_Item = Reader.NameTable.Add(@"DerivedTypeWithInheritedShouldSerialize");
+            id8_TimeOnlyWrapper = Reader.NameTable.Add(@"TimeOnlyWrapper");
+            id180_Modulation = Reader.NameTable.Add(@"Modulation");
+            id147_Value1 = Reader.NameTable.Add(@"Value1");
+            id237_DoubleProp = Reader.NameTable.Add(@"DoubleProp");
+            id315_DS2Root = Reader.NameTable.Add(@"DS2Root");
+            id144_ContainerType = Reader.NameTable.Add(@"ContainerType");
+            id52_XElementWrapper = Reader.NameTable.Add(@"XElementWrapper");
+            id190_DefaultDTO = Reader.NameTable.Add(@"DefaultDTO");
+            id153_ArrayOfOrderedItem = Reader.NameTable.Add(@"ArrayOfOrderedItem");
+            id57_Item = Reader.NameTable.Add(@"TypeWithMutableCollectionMembers");
+            id288_Optional = Reader.NameTable.Add(@"Optional");
+            id291_OptionullInt = Reader.NameTable.Add(@"OptionullInt");
+            id53_XElementStruct = Reader.NameTable.Add(@"XElementStruct");
+            id334_Item = Reader.NameTable.Add(@"Item");
+            id25_SimpleDerivedClass = Reader.NameTable.Add(@"SimpleDerivedClass");
+            id133_ComplexChoiceB = Reader.NameTable.Add(@"ComplexChoiceB");
+            id231_Z = Reader.NameTable.Add(@"Z");
+            id44_Item = Reader.NameTable.Add(@"DefaultValuesSetToPositiveInfinity");
+            id319_CharProperty = Reader.NameTable.Add(@"CharProperty");
+            id28_DerivedIXmlSerializable = Reader.NameTable.Add(@"DerivedIXmlSerializable");
+            id156_ArrayOfString = Reader.NameTable.Add(@"ArrayOfString");
+            id246_ImmutableArray = Reader.NameTable.Add(@"ImmutableArray");
+            id247_ImmutableList = Reader.NameTable.Add(@"ImmutableList");
+            id38_Orchestra = Reader.NameTable.Add(@"Orchestra");
+            id322_Bar = Reader.NameTable.Add(@"Bar");
+            id98_UIntEnum = Reader.NameTable.Add(@"UIntEnum");
+            id41_Trumpet = Reader.NameTable.Add(@"Trumpet");
+            id248_ReadOnlyCollection = Reader.NameTable.Add(@"ReadOnlyCollection");
+            id177_Child = Reader.NameTable.Add(@"Child");
+            id107_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor");
+            id55_Item = Reader.NameTable.Add(@"DateTimeOffsetIXmlSerializableContainer");
+            id205_TestValue = Reader.NameTable.Add(@"TestValue");
+            id32_OrderedItem = Reader.NameTable.Add(@"OrderedItem");
+            id195_DefaultDate = Reader.NameTable.Add(@"DefaultDate");
+            id30_httpwwwcontoso1com = Reader.NameTable.Add(@"http://www.contoso1.com");
+            id230_Y = Reader.NameTable.Add(@"Y");
+            id253_Flat = Reader.NameTable.Add(@"Flat");
+            id183_UnitPrice = Reader.NameTable.Add(@"UnitPrice");
+            id224_OrderDate = Reader.NameTable.Add(@"OrderDate");
+            id175_P2 = Reader.NameTable.Add(@"P2");
+            id83_Item = Reader.NameTable.Add(@"TypeWithDateTimePropertyAsXmlTime");
+            id70_TypeWithEnumMembers = Reader.NameTable.Add(@"TypeWithEnumMembers");
+            id225_Items = Reader.NameTable.Add(@"Items");
+            id325_DateTimeContent = Reader.NameTable.Add(@"DateTimeContent");
+            id194_MyDate = Reader.NameTable.Add(@"MyDate");
+            id264_IntLProp = Reader.NameTable.Add(@"IntLProp");
+            id16_Animal = Reader.NameTable.Add(@"Animal");
+            id104_KnownTypesThroughConstructor = Reader.NameTable.Add(@"KnownTypesThroughConstructor");
+            id24_SimpleBaseClass = Reader.NameTable.Add(@"SimpleBaseClass");
+            id324_IntArrayValue = Reader.NameTable.Add(@"IntArrayValue");
+            id327_DateContent = Reader.NameTable.Add(@"DateContent");
+            id160_ArrayOfInstrument = Reader.NameTable.Add(@"ArrayOfInstrument");
+            id11_DateTimeTimeWrapper = Reader.NameTable.Add(@"DateTimeTimeWrapper");
+            id170_NoneParameter = Reader.NameTable.Add(@"NoneParameter");
+            id80_BaseClassWithSamePropertyName = Reader.NameTable.Add(@"BaseClassWithSamePropertyName");
+            id249_FrozenSet = Reader.NameTable.Add(@"FrozenSet");
+            id101_AttributeTesting = Reader.NameTable.Add(@"AttributeTesting");
+            id161_ArrayOfTypeWithLinkedProperty = Reader.NameTable.Add(@"ArrayOfTypeWithLinkedProperty");
+            id49_httpexamplecom = Reader.NameTable.Add(@"http://example.com");
+            id226_SubTotal = Reader.NameTable.Add(@"SubTotal");
+            id113_CustomDocument = Reader.NameTable.Add(@"CustomDocument");
+            id328_NameContent = Reader.NameTable.Add(@"NameContent");
+            id150_ParameterOfString = Reader.NameTable.Add(@"ParameterOfString");
+            id163_ArrayOfXElement = Reader.NameTable.Add(@"ArrayOfXElement");
+            id191_NullableDTO = Reader.NameTable.Add(@"NullableDTO");
+            id19_Group = Reader.NameTable.Add(@"Group");
+            id320_EnumProperty = Reader.NameTable.Add(@"EnumProperty");
+            id97_IntEnum = Reader.NameTable.Add(@"IntEnum");
+            id148_Value2 = Reader.NameTable.Add(@"Value2");
+            id200_MyTime = Reader.NameTable.Add(@"MyTime");
+            id111_MyXmlType = Reader.NameTable.Add(@"MyXmlType");
+            id72_DCClassWithEnumAndStruct = Reader.NameTable.Add(@"DCClassWithEnumAndStruct");
+            id214_EmployeeName = Reader.NameTable.Add(@"EmployeeName");
+            id114_CustomElement = Reader.NameTable.Add(@"CustomElement");
+            id100_ULongEnum = Reader.NameTable.Add(@"ULongEnum");
+            id266_Collection = Reader.NameTable.Add(@"Collection");
+            id265_NIntLProp = Reader.NameTable.Add(@"NIntLProp");
+            id158_ArrayOfDouble = Reader.NameTable.Add(@"ArrayOfDouble");
+            id67_ArrayOfAnyType = Reader.NameTable.Add(@"ArrayOfAnyType");
+            id78_TypeHasArrayOfASerializedAsB = Reader.NameTable.Add(@"TypeHasArrayOfASerializedAsB");
+            id34_BaseClass1 = Reader.NameTable.Add(@"BaseClass1");
+            id284_IsLoaded = Reader.NameTable.Add(@"IsLoaded");
+            id285_Some = Reader.NameTable.Add(@"Some");
+            id45_Item = Reader.NameTable.Add(@"DefaultValuesSetToNegativeInfinity");
+            id258_IntAField = Reader.NameTable.Add(@"IntAField");
+            id208_ByteProperty = Reader.NameTable.Add(@"ByteProperty");
+            id85_SimpleDC = Reader.NameTable.Add(@"SimpleDC");
+            id196_NullableDate = Reader.NameTable.Add(@"NullableDate");
+            id261_NIntLField = Reader.NameTable.Add(@"NIntLField");
+            id216_AttributeString = Reader.NameTable.Add(@"AttributeString");
+            id15_TypeWithXmlNodeArrayProperty = Reader.NameTable.Add(@"TypeWithXmlNodeArrayProperty");
+            id96_ShortEnum = Reader.NameTable.Add(@"ShortEnum");
+            id277_StringProperty = Reader.NameTable.Add(@"StringProperty");
+            id197_NullableDateWithValue = Reader.NameTable.Add(@"NullableDateWithValue");
+            id283_Id = Reader.NameTable.Add(@"Id");
+            id238_FloatProp = Reader.NameTable.Add(@"FloatProp");
+            id301_XmlElementPropertyNode = Reader.NameTable.Add(@"XmlElementPropertyNode");
+            id233_Instruments = Reader.NameTable.Add(@"Instruments");
+            id294_XmlAttributeName = Reader.NameTable.Add(@"XmlAttributeName");
+            id91_SomeStruct = Reader.NameTable.Add(@"SomeStruct");
+            id201_DefaultTime = Reader.NameTable.Add(@"DefaultTime");
+            id172_QualifiedParameter = Reader.NameTable.Add(@"QualifiedParameter");
+            id210_Breed = Reader.NameTable.Add(@"Breed");
+            id256_F1 = Reader.NameTable.Add(@"F1");
+            id275_ArrayMember = Reader.NameTable.Add(@"ArrayMember");
+            id3_TypeWithXmlDocumentProperty = Reader.NameTable.Add(@"TypeWithXmlDocumentProperty");
+            id198_NullableDefaultDate = Reader.NameTable.Add(@"NullableDefaultDate");
+            id48_Document = Reader.NameTable.Add(@"Document");
+            id103_TypeWithAnyAttribute = Reader.NameTable.Add(@"TypeWithAnyAttribute");
+            id129_Item = Reader.NameTable.Add(@"TypeWithArrayPropertyHavingChoice");
+            id81_DerivedClassWithSameProperty = Reader.NameTable.Add(@"DerivedClassWithSameProperty");
+            id27_Item = Reader.NameTable.Add(@"http://example.com/serializer-test-namespace");
+            id106_Item = Reader.NameTable.Add(@"ClassImplementingIXmlSerializable");
+            id229_X = Reader.NameTable.Add(@"X");
+            id50_RootClass = Reader.NameTable.Add(@"RootClass");
+            id74_TypeWithBuiltInTypedMembers = Reader.NameTable.Add(@"TypeWithBuiltInTypedMembers");
+            id242_Parameters = Reader.NameTable.Add(@"Parameters");
+            id22_BaseClass = Reader.NameTable.Add(@"BaseClass");
+            id213_GroupVehicle = Reader.NameTable.Add(@"GroupVehicle");
+            id333_HexBinaryContent = Reader.NameTable.Add(@"HexBinaryContent");
+            id173_ArrayOfArrayOfSimpleType = Reader.NameTable.Add(@"ArrayOfArrayOfSimpleType");
+            id110_TypeWithXmlSchemaFormAttribute = Reader.NameTable.Add(@"TypeWithXmlSchemaFormAttribute");
+            id276_Item = Reader.NameTable.Add(@"PropertyNameWithSpecialCharacters漢ñ");
+            id146_B = Reader.NameTable.Add(@"B");
+            id14_TypeWithByteProperty = Reader.NameTable.Add(@"TypeWithByteProperty");
+            id94_ByteEnum = Reader.NameTable.Add(@"ByteEnum");
+            id171_ArrayOfBoolean = Reader.NameTable.Add(@"ArrayOfBoolean");
+            id240_id = Reader.NameTable.Add(@"id");
+            id128_Item = Reader.NameTable.Add(@"TypeWithTypesHavingCustomFormatter");
+            id305_SimpleTypeValue = Reader.NameTable.Add(@"SimpleTypeValue");
+            id84_TypeWithByteArrayAsXmlText = Reader.NameTable.Add(@"TypeWithByteArrayAsXmlText");
+            id185_LineTotal = Reader.NameTable.Add(@"LineTotal");
+            id178_Children = Reader.NameTable.Add(@"Children");
+            id143_Name = Reader.NameTable.Add(@"Name");
+            id141_MiddleName = Reader.NameTable.Add(@"MiddleName");
             id138_TypeClashA = Reader.NameTable.Add(@"TypeClashA");
             id102_ItemChoiceType = Reader.NameTable.Add(@"ItemChoiceType");
-            id212_GroupName = Reader.NameTable.Add(@"GroupName");
-            id132_ComplexChoiceA = Reader.NameTable.Add(@"ComplexChoiceA");
-            id100_ULongEnum = Reader.NameTable.Add(@"ULongEnum");
-            id194_MyDate = Reader.NameTable.Add(@"MyDate");
-            id203_NullableTimeWithValue = Reader.NameTable.Add(@"NullableTimeWithValue");
-            id98_UIntEnum = Reader.NameTable.Add(@"UIntEnum");
-            id290_OptionullInt = Reader.NameTable.Add(@"OptionullInt");
-            id24_SimpleBaseClass = Reader.NameTable.Add(@"SimpleBaseClass");
-            id233_Instruments = Reader.NameTable.Add(@"Instruments");
-            id279_ListProperty = Reader.NameTable.Add(@"ListProperty");
-            id115_Item = Reader.NameTable.Add(@"TypeWithNonPublicDefaultConstructor");
-            id269_ByteArray = Reader.NameTable.Add(@"ByteArray");
-            id207_TimeSpanProperty2 = Reader.NameTable.Add(@"TimeSpanProperty2");
-            id137_TypeClashB = Reader.NameTable.Add(@"TypeClashB");
-            id325_QNameContent = Reader.NameTable.Add(@"QNameContent");
-            id107_Item = Reader.NameTable.Add(@"StructImplementingIXmlSerializableWithoutParameterlessConstructor");
-            id121_Item = Reader.NameTable.Add(@"TypeWithEnumFlagPropertyHavingDefaultValue");
-            id280_ClassID = Reader.NameTable.Add(@"ClassID");
-            id62_TypeWithGetOnlyArrayProperties = Reader.NameTable.Add(@"TypeWithGetOnlyArrayProperties");
-            id155_int = Reader.NameTable.Add(@"int");
-            id77_TypeB = Reader.NameTable.Add(@"TypeB");
-            id257_IntAField = Reader.NameTable.Add(@"IntAField");
-            id154_ArrayOfInt = Reader.NameTable.Add(@"ArrayOfInt");
-            id318_CharProperty = Reader.NameTable.Add(@"CharProperty");
-            id156_ArrayOfString = Reader.NameTable.Add(@"ArrayOfString");
-            id329_NMTOKENContent = Reader.NameTable.Add(@"NMTOKENContent");
-            id284_Some = Reader.NameTable.Add(@"Some");
-            id166_ArrayOfTypeA = Reader.NameTable.Add(@"ArrayOfTypeA");
-            id291_Struct1 = Reader.NameTable.Add(@"Struct1");
-            id251_List = Reader.NameTable.Add(@"List");
-            id230_Y = Reader.NameTable.Add(@"Y");
-            id205_TestValue = Reader.NameTable.Add(@"TestValue");
-            id249_FrozenSet = Reader.NameTable.Add(@"FrozenSet");
-            id286_Short = Reader.NameTable.Add(@"Short");
-            id281_DisplayName = Reader.NameTable.Add(@"DisplayName");
-            id183_UnitPrice = Reader.NameTable.Add(@"UnitPrice");
-            id82_DerivedClassWithSameProperty2 = Reader.NameTable.Add(@"DerivedClassWithSameProperty2");
-            id254_CurrentDateTime = Reader.NameTable.Add(@"CurrentDateTime");
-            id55_Item = Reader.NameTable.Add(@"DateTimeOffsetIXmlSerializableContainer");
-            id64_StructNotSerializable = Reader.NameTable.Add(@"StructNotSerializable");
-            id320_Foo = Reader.NameTable.Add(@"Foo");
-            id103_TypeWithAnyAttribute = Reader.NameTable.Add(@"TypeWithAnyAttribute");
-            id237_DoubleProp = Reader.NameTable.Add(@"DoubleProp");
-            id184_Quantity = Reader.NameTable.Add(@"Quantity");
-            id232_Prop = Reader.NameTable.Add(@"Prop");
-            id199_Now = Reader.NameTable.Add(@"Now");
-            id145_A = Reader.NameTable.Add(@"A");
-            id246_ImmutableArray = Reader.NameTable.Add(@"ImmutableArray");
-            id256_F2 = Reader.NameTable.Add(@"F2");
-            id123_Item = Reader.NameTable.Add(@"BaseTypeWithShouldSerializeMethod");
-            id146_B = Reader.NameTable.Add(@"B");
-            id144_ContainerType = Reader.NameTable.Add(@"ContainerType");
-            id94_ByteEnum = Reader.NameTable.Add(@"ByteEnum");
-            id327_NameContent = Reader.NameTable.Add(@"NameContent");
-            id36_ArrayOfDateTime = Reader.NameTable.Add(@"ArrayOfDateTime");
-            id127_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithValue");
-            id99_LongEnum = Reader.NameTable.Add(@"LongEnum");
-            id97_IntEnum = Reader.NameTable.Add(@"IntEnum");
-            id126_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithArrayProperties");
-            id19_Group = Reader.NameTable.Add(@"Group");
-            id80_BaseClassWithSamePropertyName = Reader.NameTable.Add(@"BaseClassWithSamePropertyName");
-            id316_TwoDArrayOfSimpleType = Reader.NameTable.Add(@"TwoDArrayOfSimpleType");
-            id330_NMTOKENSContent = Reader.NameTable.Add(@"NMTOKENSContent");
-            id306_MyField = Reader.NameTable.Add(@"MyField");
-            id31_Address = Reader.NameTable.Add(@"Address");
-            id93_WithNullables = Reader.NameTable.Add(@"WithNullables");
-            id307_MyFieldIgnored = Reader.NameTable.Add(@"MyFieldIgnored");
-            id124_Item = Reader.NameTable.Add(@"DerivedTypeWithInheritedShouldSerialize");
-            id73_BuiltInTypes = Reader.NameTable.Add(@"BuiltInTypes");
-            id305_StrProperty = Reader.NameTable.Add(@"StrProperty");
-            id119_Item = Reader.NameTable.Add(@"TypeWithPropertiesHavingDefaultValue");
-            id174_P1 = Reader.NameTable.Add(@"P1");
-            id198_NullableDefaultDate = Reader.NameTable.Add(@"NullableDefaultDate");
-            id217_DateTimeValue = Reader.NameTable.Add(@"DateTimeValue");
-            id294_Word = Reader.NameTable.Add(@"Word");
-            id135_Item = Reader.NameTable.Add(@"TypeWithKnownTypesOfCollectionsWithConflictingXmlName");
-            id299_Item = Reader.NameTable.Add(@"XmlNamespaceDeclarationsProperty");
-            id289_OptionalInt = Reader.NameTable.Add(@"OptionalInt");
-            id273_ListMember = Reader.NameTable.Add(@"ListMember");
-            id283_IsLoaded = Reader.NameTable.Add(@"IsLoaded");
-            id236_SingleField = Reader.NameTable.Add(@"SingleField");
-            id78_TypeHasArrayOfASerializedAsB = Reader.NameTable.Add(@"TypeHasArrayOfASerializedAsB");
-            id136_Root = Reader.NameTable.Add(@"Root");
-            id141_MiddleName = Reader.NameTable.Add(@"MiddleName");
-            id20_Vehicle = Reader.NameTable.Add(@"Vehicle");
-            id211_LicenseNumber = Reader.NameTable.Add(@"LicenseNumber");
-            id170_NoneParameter = Reader.NameTable.Add(@"NoneParameter");
-            id95_SByteEnum = Reader.NameTable.Add(@"SByteEnum");
-            id272_NullableIntMember = Reader.NameTable.Add(@"NullableIntMember");
-            id114_CustomElement = Reader.NameTable.Add(@"CustomElement");
-            id252_Array = Reader.NameTable.Add(@"Array");
-            id17_Dog = Reader.NameTable.Add(@"Dog");
-            id54_XElementArrayWrapper = Reader.NameTable.Add(@"XElementArrayWrapper");
-            id206_TimeSpanProperty = Reader.NameTable.Add(@"TimeSpanProperty");
-            id42_Pet = Reader.NameTable.Add(@"Pet");
-            id338_TestProperty = Reader.NameTable.Add(@"TestProperty");
-            id76_TypeA = Reader.NameTable.Add(@"TypeA");
-            id262_NIntAProp = Reader.NameTable.Add(@"NIntAProp");
-            id130_Item = Reader.NameTable.Add(@"TypeWithPropertyHavingComplexChoice");
-            id158_ArrayOfDouble = Reader.NameTable.Add(@"ArrayOfDouble");
-            id105_SimpleKnownTypeValue = Reader.NameTable.Add(@"SimpleKnownTypeValue");
-            id47_TypeWithLinkedProperty = Reader.NameTable.Add(@"TypeWithLinkedProperty");
-            id163_ArrayOfXElement = Reader.NameTable.Add(@"ArrayOfXElement");
-            id65_TypeWithMyCollectionField = Reader.NameTable.Add(@"TypeWithMyCollectionField");
-            id90_WithStruct = Reader.NameTable.Add(@"WithStruct");
-            id259_IntLField = Reader.NameTable.Add(@"IntLField");
-            id213_GroupVehicle = Reader.NameTable.Add(@"GroupVehicle");
-            id190_DefaultDTO = Reader.NameTable.Add(@"DefaultDTO");
-            id27_Item = Reader.NameTable.Add(@"http://example.com/serializer-test-namespace");
-            id70_TypeWithEnumMembers = Reader.NameTable.Add(@"TypeWithEnumMembers");
-            id218_BoolValue = Reader.NameTable.Add(@"BoolValue");
+            id274_ListMember = Reader.NameTable.Add(@"ListMember");
             id164_XElement = Reader.NameTable.Add(@"XElement");
-            id15_TypeWithXmlNodeArrayProperty = Reader.NameTable.Add(@"TypeWithXmlNodeArrayProperty");
-            id265_Collection = Reader.NameTable.Add(@"Collection");
-            id35_DerivedClass1 = Reader.NameTable.Add(@"DerivedClass1");
-            id223_ShipTo = Reader.NameTable.Add(@"ShipTo");
-            id179_IsValved = Reader.NameTable.Add(@"IsValved");
-            id128_Item = Reader.NameTable.Add(@"TypeWithTypesHavingCustomFormatter");
-            id310_Item = Reader.NameTable.Add(@"QualifiedSchemaFormListProperty");
-            id111_MyXmlType = Reader.NameTable.Add(@"MyXmlType");
-            id221_State = Reader.NameTable.Add(@"State");
-            id1_TypeWithXmlElementProperty = Reader.NameTable.Add(@"TypeWithXmlElementProperty");
-            id261_IntAProp = Reader.NameTable.Add(@"IntAProp");
-            id323_IntArrayValue = Reader.NameTable.Add(@"IntArrayValue");
-            id322_StringArrayValue = Reader.NameTable.Add(@"StringArrayValue");
-            id33_AliasedTestType = Reader.NameTable.Add(@"AliasedTestType");
-            id63_TypeWithArraylikeMembers = Reader.NameTable.Add(@"TypeWithArraylikeMembers");
-            id9_TimeOnlyAsXsdTimeWrapper = Reader.NameTable.Add(@"TimeOnlyAsXsdTimeWrapper");
-            id45_Item = Reader.NameTable.Add(@"DefaultValuesSetToNegativeInfinity");
-            id274_ArrayMember = Reader.NameTable.Add(@"ArrayMember");
-            id120_Item = Reader.NameTable.Add(@"TypeWithEnumPropertyHavingDefaultValue");
-            id81_DerivedClassWithSameProperty = Reader.NameTable.Add(@"DerivedClassWithSameProperty");
-            id41_Trumpet = Reader.NameTable.Add(@"Trumpet");
-            id67_ArrayOfAnyType = Reader.NameTable.Add(@"ArrayOfAnyType");
-            id297_XmlIncludeProperty = Reader.NameTable.Add(@"XmlIncludeProperty");
-            id282_Id = Reader.NameTable.Add(@"Id");
-            id302_CustomXmlArrayProperty = Reader.NameTable.Add(@"CustomXmlArrayProperty");
-            id324_DateTimeContent = Reader.NameTable.Add(@"DateTimeContent");
-            id112_Item = Reader.NameTable.Add(@"TypeWithSchemaFormInXmlAttribute");
+            id267_Data = Reader.NameTable.Add(@"Data");
+            id56_TypeWithReadOnlyCollections = Reader.NameTable.Add(@"TypeWithReadOnlyCollections");
+            id31_Address = Reader.NameTable.Add(@"Address");
             id13_Item = Reader.NameTable.Add(@"TypeWithDefaultTimeSpanProperty");
-            id304_SimpleTypeValue = Reader.NameTable.Add(@"SimpleTypeValue");
-            id215_value = Reader.NameTable.Add(@"value");
-            id140_FirstName = Reader.NameTable.Add(@"FirstName");
-            id315_MetricConfigUrl = Reader.NameTable.Add(@"MetricConfigUrl");
-            id5_Item = Reader.NameTable.Add(@"TypeWithDateTimeOffsetProperties");
-            id11_DateTimeTimeWrapper = Reader.NameTable.Add(@"DateTimeTimeWrapper");
-            id250_ImmutableQueue = Reader.NameTable.Add(@"ImmutableQueue");
+            id252_Array = Reader.NameTable.Add(@"Array");
+            id39_Instrument = Reader.NameTable.Add(@"Instrument");
+            id92_WithEnums = Reader.NameTable.Add(@"WithEnums");
+            id119_Item = Reader.NameTable.Add(@"TypeWithPropertiesHavingDefaultValue");
+            id157_string = Reader.NameTable.Add(@"string");
+            id193_Today = Reader.NameTable.Add(@"Today");
+            id62_TypeWithGetOnlyArrayProperties = Reader.NameTable.Add(@"TypeWithGetOnlyArrayProperties");
             id71_DCStruct = Reader.NameTable.Add(@"DCStruct");
-            id293_XmlAttributeName = Reader.NameTable.Add(@"XmlAttributeName");
-            id7_DateOnlyWrapper = Reader.NameTable.Add(@"DateOnlyWrapper");
-            id253_DateTimeString = Reader.NameTable.Add(@"DateTimeString");
-            id228_TotalCost = Reader.NameTable.Add(@"TotalCost");
-            id214_EmployeeName = Reader.NameTable.Add(@"EmployeeName");
-            id285_Int = Reader.NameTable.Add(@"Int");
-            id150_ParameterOfString = Reader.NameTable.Add(@"ParameterOfString");
-            id66_Item = Reader.NameTable.Add(@"TypeWithReadOnlyMyCollectionProperty");
-            id160_ArrayOfInstrument = Reader.NameTable.Add(@"ArrayOfInstrument");
-            id202_NullableTime = Reader.NameTable.Add(@"NullableTime");
-            id264_NIntLProp = Reader.NameTable.Add(@"NIntLProp");
-            id231_Z = Reader.NameTable.Add(@"Z");
-            id204_NullableDefaultTime = Reader.NameTable.Add(@"NullableDefaultTime");
-            id18_DogBreed = Reader.NameTable.Add(@"DogBreed");
-            id189_DTO2 = Reader.NameTable.Add(@"DTO2");
-            id171_ArrayOfBoolean = Reader.NameTable.Add(@"ArrayOfBoolean");
-            id222_Zip = Reader.NameTable.Add(@"Zip");
-            id186_BinaryHexContent = Reader.NameTable.Add(@"BinaryHexContent");
-            id44_Item = Reader.NameTable.Add(@"DefaultValuesSetToPositiveInfinity");
-            id50_RootClass = Reader.NameTable.Add(@"RootClass");
-            id129_Item = Reader.NameTable.Add(@"TypeWithArrayPropertyHavingChoice");
-            id131_MoreChoices = Reader.NameTable.Add(@"MoreChoices");
-            id10_DateTimeDateWrapper = Reader.NameTable.Add(@"DateTimeDateWrapper");
-            id116_ServerSettings = Reader.NameTable.Add(@"ServerSettings");
-            id188_DTO = Reader.NameTable.Add(@"DTO");
-            id309_NoneSchemaFormListProperty = Reader.NameTable.Add(@"NoneSchemaFormListProperty");
-            id296_DecimalNumber = Reader.NameTable.Add(@"DecimalNumber");
-            id79_Item = Reader.NameTable.Add(@"__TypeNameWithSpecialCharacters漢ñ");
-            id336_IntField1 = Reader.NameTable.Add(@"IntField1");
-            id227_ShipCost = Reader.NameTable.Add(@"ShipCost");
-            id248_ReadOnlyCollection = Reader.NameTable.Add(@"ReadOnlyCollection");
-            id267_MyStruct = Reader.NameTable.Add(@"MyStruct");
-            id229_X = Reader.NameTable.Add(@"X");
-            id83_Item = Reader.NameTable.Add(@"TypeWithDateTimePropertyAsXmlTime");
-            id2_Item = Reader.NameTable.Add(@"");
-            id225_Items = Reader.NameTable.Add(@"Items");
-            id300_XmlElementPropertyNode = Reader.NameTable.Add(@"XmlElementPropertyNode");
-            id125_Item = Reader.NameTable.Add(@"TypeWithFieldBackedSpecifiedMember");
-            id149_XmlSerializerAttributes = Reader.NameTable.Add(@"XmlSerializerAttributes");
-            id277_IntProperty = Reader.NameTable.Add(@"IntProperty");
+            id63_TypeWithArraylikeMembers = Reader.NameTable.Add(@"TypeWithArraylikeMembers");
             id4_TypeWithBinaryProperty = Reader.NameTable.Add(@"TypeWithBinaryProperty");
-            id52_XElementWrapper = Reader.NameTable.Add(@"XElementWrapper");
-            id175_P2 = Reader.NameTable.Add(@"P2");
-            id12_TypeWithTimeSpanProperty = Reader.NameTable.Add(@"TypeWithTimeSpanProperty");
-            id14_TypeWithByteProperty = Reader.NameTable.Add(@"TypeWithByteProperty");
-            id298_XmlEnumProperty = Reader.NameTable.Add(@"XmlEnumProperty");
-            id312_name = Reader.NameTable.Add(@"name");
-            id334_Amount = Reader.NameTable.Add(@"Amount");
-            id313_customElement = Reader.NameTable.Add(@"customElement");
-            id21_Employee = Reader.NameTable.Add(@"Employee");
-            id25_SimpleDerivedClass = Reader.NameTable.Add(@"SimpleDerivedClass");
-            id224_OrderDate = Reader.NameTable.Add(@"OrderDate");
-            id8_TimeOnlyWrapper = Reader.NameTable.Add(@"TimeOnlyWrapper");
-            id210_Breed = Reader.NameTable.Add(@"Breed");
-            id255_F1 = Reader.NameTable.Add(@"F1");
-            id142_LastName = Reader.NameTable.Add(@"LastName");
-            id288_Optionull = Reader.NameTable.Add(@"Optionull");
-            id109_TypeWithPropertyNameSpecified = Reader.NameTable.Add(@"TypeWithPropertyNameSpecified");
+            id10_DateTimeDateWrapper = Reader.NameTable.Add(@"DateTimeDateWrapper");
+            id270_ByteArray = Reader.NameTable.Add(@"ByteArray");
+            id131_MoreChoices = Reader.NameTable.Add(@"MoreChoices");
+            id87_Item = Reader.NameTable.Add(@"http://schemas.xmlsoap.org/ws/2005/04/discovery");
+            id302_httpelement = Reader.NameTable.Add(@"http://element");
+            id134_TypeWithFieldsOrdered = Reader.NameTable.Add(@"TypeWithFieldsOrdered");
+            id295_Word = Reader.NameTable.Add(@"Word");
+            id310_NoneSchemaFormListProperty = Reader.NameTable.Add(@"NoneSchemaFormListProperty");
+            id132_ComplexChoiceA = Reader.NameTable.Add(@"ComplexChoiceA");
+            id337_IntField1 = Reader.NameTable.Add(@"IntField1");
+            id162_ArrayOfParameter = Reader.NameTable.Add(@"ArrayOfParameter");
+            id257_F2 = Reader.NameTable.Add(@"F2");
+            id112_Item = Reader.NameTable.Add(@"TypeWithSchemaFormInXmlAttribute");
+            id269_MyEnum1 = Reader.NameTable.Add(@"MyEnum1");
+            id68_anyType = Reader.NameTable.Add(@"anyType");
+            id26_BaseIXmlSerializable = Reader.NameTable.Add(@"BaseIXmlSerializable");
+            id254_DateTimeString = Reader.NameTable.Add(@"DateTimeString");
+            id255_CurrentDateTime = Reader.NameTable.Add(@"CurrentDateTime");
+            id303_CustomXmlArrayProperty = Reader.NameTable.Add(@"CustomXmlArrayProperty");
+            id236_SingleField = Reader.NameTable.Add(@"SingleField");
+            id204_NullableDefaultTime = Reader.NameTable.Add(@"NullableDefaultTime");
+            id330_NMTOKENContent = Reader.NameTable.Add(@"NMTOKENContent");
+            id321_Foo = Reader.NameTable.Add(@"Foo");
+            id155_int = Reader.NameTable.Add(@"int");
+            id95_SByteEnum = Reader.NameTable.Add(@"SByteEnum");
+            id313_name = Reader.NameTable.Add(@"name");
+            id186_BinaryHexContent = Reader.NameTable.Add(@"BinaryHexContent");
+            id116_ServerSettings = Reader.NameTable.Add(@"ServerSettings");
+            id2_Item = Reader.NameTable.Add(@"");
+            id212_GroupName = Reader.NameTable.Add(@"GroupName");
+            id59_TypeWithDateTimeStringProperty = Reader.NameTable.Add(@"TypeWithDateTimeStringProperty");
+            id304_EnumValue = Reader.NameTable.Add(@"EnumValue");
+            id203_NullableTimeWithValue = Reader.NameTable.Add(@"NullableTimeWithValue");
+            id309_Item = Reader.NameTable.Add(@"UnqualifiedSchemaFormListProperty");
+            id46_RootElement = Reader.NameTable.Add(@"RootElement");
+            id207_TimeSpanProperty2 = Reader.NameTable.Add(@"TimeSpanProperty2");
+            id192_NullableDefaultDTO = Reader.NameTable.Add(@"NullableDefaultDTO");
+            id187_Base64Content = Reader.NameTable.Add(@"Base64Content");
+            id137_TypeClashB = Reader.NameTable.Add(@"TypeClashB");
+            id317_TwoDArrayOfSimpleType = Reader.NameTable.Add(@"TwoDArrayOfSimpleType");
+            id278_IntProperty = Reader.NameTable.Add(@"IntProperty");
+            id306_StrProperty = Reader.NameTable.Add(@"StrProperty");
+            id123_Item = Reader.NameTable.Add(@"BaseTypeWithShouldSerializeMethod");
+            id130_Item = Reader.NameTable.Add(@"TypeWithPropertyHavingComplexChoice");
+            id259_NIntAField = Reader.NameTable.Add(@"NIntAField");
             id51_Parameter = Reader.NameTable.Add(@"Parameter");
+            id336_IntField2 = Reader.NameTable.Add(@"IntField2");
+            id234_Comment2 = Reader.NameTable.Add(@"Comment2");
+            id182_Description = Reader.NameTable.Add(@"Description");
+            id215_value = Reader.NameTable.Add(@"value");
+            id282_DisplayName = Reader.NameTable.Add(@"DisplayName");
+            id184_Quantity = Reader.NameTable.Add(@"Quantity");
+            id61_TypeWithGetSetArrayMembers = Reader.NameTable.Add(@"TypeWithGetSetArrayMembers");
+            id199_Now = Reader.NameTable.Add(@"Now");
             id40_Brass = Reader.NameTable.Add(@"Brass");
-            id271_IntMember = Reader.NameTable.Add(@"IntMember");
+            id167_ArrayOfItemChoiceType = Reader.NameTable.Add(@"ArrayOfItemChoiceType");
+            id308_MyFieldIgnored = Reader.NameTable.Add(@"MyFieldIgnored");
+            id217_DateTimeValue = Reader.NameTable.Add(@"DateTimeValue");
+            id37_dateTime = Reader.NameTable.Add(@"dateTime");
+            id218_BoolValue = Reader.NameTable.Add(@"BoolValue");
+            id260_IntLField = Reader.NameTable.Add(@"IntLField");
+            id232_Prop = Reader.NameTable.Add(@"Prop");
+            id105_SimpleKnownTypeValue = Reader.NameTable.Add(@"SimpleKnownTypeValue");
+            id7_DateOnlyWrapper = Reader.NameTable.Add(@"DateOnlyWrapper");
+            id121_Item = Reader.NameTable.Add(@"TypeWithEnumFlagPropertyHavingDefaultValue");
+            id99_LongEnum = Reader.NameTable.Add(@"LongEnum");
+            id159_double = Reader.NameTable.Add(@"double");
+            id35_DerivedClass1 = Reader.NameTable.Add(@"DerivedClass1");
+            id66_Item = Reader.NameTable.Add(@"TypeWithReadOnlyMyCollectionProperty");
+            id300_Item = Reader.NameTable.Add(@"XmlNamespaceDeclarationsProperty");
+            id176_Value = Reader.NameTable.Add(@"Value");
+            id139_Person = Reader.NameTable.Add(@"Person");
+            id329_NCNameContent = Reader.NameTable.Add(@"NCNameContent");
+            id109_TypeWithPropertyNameSpecified = Reader.NameTable.Add(@"TypeWithPropertyNameSpecified");
+            id127_Item = Reader.NameTable.Add(@"KnownTypesThroughConstructorWithValue");
+            id169_ArrayOfString1 = Reader.NameTable.Add(@"ArrayOfString1");
+            id181_ItemName = Reader.NameTable.Add(@"ItemName");
+            id93_WithNullables = Reader.NameTable.Add(@"WithNullables");
+            id244_xelements = Reader.NameTable.Add(@"xelements");
+            id272_IntMember = Reader.NameTable.Add(@"IntMember");
+            id76_TypeA = Reader.NameTable.Add(@"TypeA");
+            id174_P1 = Reader.NameTable.Add(@"P1");
+            id90_WithStruct = Reader.NameTable.Add(@"WithStruct");
+            id75_Item = Reader.NameTable.Add(@"TypeWithNullableBuiltInTypedMembers");
+            id262_IntAProp = Reader.NameTable.Add(@"IntAProp");
+            id339_TestProperty = Reader.NameTable.Add(@"TestProperty");
+            id281_ClassID = Reader.NameTable.Add(@"ClassID");
+            id323_StringArrayValue = Reader.NameTable.Add(@"StringArrayValue");
+            id115_Item = Reader.NameTable.Add(@"TypeWithNonPublicDefaultConstructor");
+            id23_DerivedClass = Reader.NameTable.Add(@"DerivedClass");
+            id340_httptestcom = Reader.NameTable.Add(@"http://test.com");
+            id228_TotalCost = Reader.NameTable.Add(@"TotalCost");
+            id292_Struct1 = Reader.NameTable.Add(@"Struct1");
+            id73_BuiltInTypes = Reader.NameTable.Add(@"BuiltInTypes");
+            id9_TimeOnlyAsXsdTimeWrapper = Reader.NameTable.Add(@"TimeOnlyAsXsdTimeWrapper");
+            id326_QNameContent = Reader.NameTable.Add(@"QNameContent");
+            id21_Employee = Reader.NameTable.Add(@"Employee");
+            id296_Number = Reader.NameTable.Add(@"Number");
+            id42_Pet = Reader.NameTable.Add(@"Pet");
+            id222_Zip = Reader.NameTable.Add(@"Zip");
+            id206_TimeSpanProperty = Reader.NameTable.Add(@"TimeSpanProperty");
+            id332_Base64BinaryContent = Reader.NameTable.Add(@"Base64BinaryContent");
+            id287_Short = Reader.NameTable.Add(@"Short");
+            id318_EmptyStringProperty = Reader.NameTable.Add(@"EmptyStringProperty");
+            id227_ShipCost = Reader.NameTable.Add(@"ShipCost");
+            id311_Item = Reader.NameTable.Add(@"QualifiedSchemaFormListProperty");
+            id60_SimpleType = Reader.NameTable.Add(@"SimpleType");
+            id202_NullableTime = Reader.NameTable.Add(@"NullableTime");
+            id82_DerivedClassWithSameProperty2 = Reader.NameTable.Add(@"DerivedClassWithSameProperty2");
+            id120_Item = Reader.NameTable.Add(@"TypeWithEnumPropertyHavingDefaultValue");
+            id293_Struct2 = Reader.NameTable.Add(@"Struct2");
+            id268_MyStruct = Reader.NameTable.Add(@"MyStruct");
+            id245_ImmutableArrayField = Reader.NameTable.Add(@"ImmutableArrayField");
         }
     }
 
@@ -22635,139 +22661,139 @@ namespace Microsoft.Xml.Serialization.GeneratedAssembly {
             get {
                 if (typedSerializers == null) {
                     System.Collections.Hashtable _tmp = new System.Collections.Hashtable();
-                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::", new StructImplementingIXmlSerializableWithParameterlessConstructorSerializer());
-                    _tmp.Add(@"MsgDocumentType:http://example.com:Document:True:", new MsgDocumentTypeSerializer());
-                    _tmp.Add(@"OrderedItem::", new OrderedItemSerializer());
-                    _tmp.Add(@"DefaultValuesSetToPositiveInfinity::", new DefaultValuesSetToPositiveInfinitySerializer());
-                    _tmp.Add(@"DefaultValuesSetToNaN::", new DefaultValuesSetToNaNSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithBuiltInTypedMembers::", new TypeWithBuiltInTypedMembersSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::", new TypeWithDateTimePropertyAsXmlTimeSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleType::", new SimpleTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertyNameSpecified::", new TypeWithPropertyNameSpecifiedSerializer());
-                    _tmp.Add(@"TypeWithXmlElementProperty::", new TypeWithXmlElementPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::", new TypeWithFieldBackedSpecifiedMemberSerializer());
-                    _tmp.Add(@"Group::", new GroupSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:", new TypeWithXmlTextAttributeOnArraySerializer());
-                    _tmp.Add(@"Parameter::", new ParameterSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeNameClashB.TypeNameClash::", new TypeNameClashSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomElement::", new CustomElementSerializer());
-                    _tmp.Add(@"TimeOnlyAsXsdTimeWrapper::", new TimeOnlyAsXsdTimeWrapperSerializer());
-                    _tmp.Add(@"Orchestra::", new OrchestraSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::", new TypeWithEnumPropertyHavingDefaultValueSerializer());
-                    _tmp.Add(@"SerializationTypes.BaseTypeWithShouldSerializeMethod::", new BaseTypeWithShouldSerializeMethodSerializer());
-                    _tmp.Add(@"SerializationTypes.ClassImplementingIXmlSerializable::", new ClassImplementingIXmlSerializableSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithDateTimeStringProperty::", new TypeWithDateTimeStringPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.LongEnum::", new LongEnumSerializer());
-                    _tmp.Add(@"MyCollection1::", new MyCollection1Serializer());
-                    _tmp.Add(@"TypeWithMutableCollectionMembers::", new TypeWithMutableCollectionMembersSerializer());
-                    _tmp.Add(@"TypeWithDefaultTimeSpanProperty::", new TypeWithDefaultTimeSpanPropertySerializer());
-                    _tmp.Add(@"XElementWrapper::", new XElementWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.UIntEnum::", new UIntEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.WithStruct::", new WithStructSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::", new TypeWithTypeNameInXmlTypeAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.DCStruct::", new DCStructSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeNameClashA.TypeNameClash::", new TypeNameClashSerializer1());
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructor::", new KnownTypesThroughConstructorSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty2::", new DerivedClassWithSameProperty2Serializer());
-                    _tmp.Add(@"SerializationTypes.BuiltInTypes::", new BuiltInTypesSerializer());
-                    _tmp.Add(@"SerializationTypes.ULongEnum::", new ULongEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlQualifiedName::", new TypeWithXmlQualifiedNameSerializer());
-                    _tmp.Add(@"SimpleBaseClass::", new SimpleBaseClassSerializer());
-                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty::", new DerivedClassWithSamePropertySerializer());
-                    _tmp.Add(@"Brass::", new BrassSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithGetOnlyArrayProperties::", new TypeWithGetOnlyArrayPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:", new XmlSerializerAttributesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithMyCollectionField::", new TypeWithMyCollectionFieldSerializer());
-                    _tmp.Add(@"TypeWithDateTimeOffsetProperties::", new TypeWithDateTimeOffsetPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithShouldSerializeMethod::", new TypeWithShouldSerializeMethodSerializer());
-                    _tmp.Add(@"SerializationTypes.IntEnum::", new IntEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomAttribute::", new CustomAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.ItemChoiceType::", new ItemChoiceTypeSerializer());
-                    _tmp.Add(@"DateTimeTimeWrapper::", new DateTimeTimeWrapperSerializer());
-                    _tmp.Add(@"Outer+Person::", new PersonSerializer());
-                    _tmp.Add(@"TypeWithLinkedProperty::", new TypeWithLinkedPropertySerializer());
-                    _tmp.Add(@"DateTimeOffsetIXmlSerializableContainer::", new DateTimeOffsetIXmlSerializableContainerSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeB::", new TypeBSerializer());
-                    _tmp.Add(@"SerializationTypes.MyEnum::", new MyEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithArraylikeMembers::", new TypeWithArraylikeMembersSerializer());
-                    _tmp.Add(@"TypeWithDateAndTimeOnlyProperties::", new TypeWithDateAndTimeOnlyPropertiesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithTypesHavingCustomFormatter::", new TypeWithTypesHavingCustomFormatterSerializer());
-                    _tmp.Add(@"SerializationTypes.ShortEnum::", new ShortEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::", new KnownTypesThroughConstructorWithArrayPropertiesSerializer());
-                    _tmp.Add(@"TimeOnlyWrapper::", new TimeOnlyWrapperSerializer());
-                    _tmp.Add(@"TypeWithXmlNodeArrayProperty:::True:", new TypeWithXmlNodeArrayPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeA::", new TypeASerializer());
-                    _tmp.Add(@"XElementArrayWrapper::", new XElementArrayWrapperSerializer());
-                    _tmp.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:", new TypeWithMismatchBetweenAttributeAndPropertyTypeSerializer());
-                    _tmp.Add(@"DateTimeDateWrapper::", new DateTimeDateWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleKnownTypeValue::", new SimpleKnownTypeValueSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::", new TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer());
-                    _tmp.Add(@"TypeWithReadOnlyCollections::", new TypeWithReadOnlyCollectionsSerializer());
-                    _tmp.Add(@"Vehicle::", new VehicleSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertyHavingComplexChoice::", new TypeWithPropertyHavingComplexChoiceSerializer());
-                    _tmp.Add(@"SerializationTypes.ComplexChoiceB::", new ComplexChoiceBSerializer());
-                    _tmp.Add(@"SerializationTypes.MyList::", new MyListSerializer());
-                    _tmp.Add(@"Instrument::", new InstrumentSerializer());
-                    _tmp.Add(@"BaseClass1::", new BaseClass1Serializer());
                     _tmp.Add(@"SerializationTypes.TypeWithNonPublicDefaultConstructor::", new TypeWithNonPublicDefaultConstructorSerializer());
-                    _tmp.Add(@"SerializationTypes.EnumFlags::", new EnumFlagsSerializer());
-                    _tmp.Add(@"XmlSerializableDerivedClass::", new XmlSerializableDerivedClassSerializer());
-                    _tmp.Add(@"SerializationTypes.StructNotSerializable::", new StructNotSerializableSerializer());
-                    _tmp.Add(@"DerivedClass::", new DerivedClassSerializer());
-                    _tmp.Add(@"SerializationTypes.SomeStruct::", new SomeStructSerializer());
+                    _tmp.Add(@"RootClass::", new RootClassSerializer());
+                    _tmp.Add(@"Parameter::", new ParameterSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeA::", new TypeASerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithFieldBackedSpecifiedMember::", new TypeWithFieldBackedSpecifiedMemberSerializer());
+                    _tmp.Add(@"Dog::", new DogSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithBuiltInTypedMembers::", new TypeWithBuiltInTypedMembersSerializer());
+                    _tmp.Add(@"TypeWithDateTimeOffsetProperties::", new TypeWithDateTimeOffsetPropertiesSerializer());
+                    _tmp.Add(@"Brass::", new BrassSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::", new TypeWithNullableBuiltInTypedMembersSerializer());
+                    _tmp.Add(@"DefaultValuesSetToNegativeInfinity::", new DefaultValuesSetToNegativeInfinitySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumMembers::", new TypeWithEnumMembersSerializer());
+                    _tmp.Add(@"TypeWithXmlElementProperty::", new TypeWithXmlElementPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithParameterlessConstructor::", new StructImplementingIXmlSerializableWithParameterlessConstructorSerializer());
+                    _tmp.Add(@"SerializationTypes.ComplexChoiceB::", new ComplexChoiceBSerializer());
                     _tmp.Add(@"AliasedTestType::", new AliasedTestTypeSerializer());
-                    _tmp.Add(@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:", new NamespaceTypeNameClashContainerSerializer());
-                    _tmp.Add(@"SerializationTypes.ComplexChoiceA::", new ComplexChoiceASerializer());
-                    _tmp.Add(@"SerializationTypes.WithNullables::", new WithNullablesSerializer());
-                    _tmp.Add(@"Employee::", new EmployeeSerializer());
-                    _tmp.Add(@"SimpleDerivedClass::", new SimpleDerivedClassSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithFieldsOrdered::", new TypeWithFieldsOrderedSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithAnyAttribute::", new TypeWithAnyAttributeSerializer());
-                    _tmp.Add(@"Animal::", new AnimalSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithByteArrayAsXmlText::", new TypeWithByteArrayAsXmlTextSerializer());
-                    _tmp.Add(@"XElementStruct::", new XElementStructSerializer());
-                    _tmp.Add(@"TypeWithTimeSpanProperty::", new TypeWithTimeSpanPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::", new TypeWithSchemaFormInXmlAttributeSerializer());
-                    _tmp.Add(@"Address::", new AddressSerializer());
-                    _tmp.Add(@"Pet::", new PetSerializer());
+                    _tmp.Add(@"MsgDocumentType:http://example.com:Document:True:", new MsgDocumentTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithArraylikeMembers::", new TypeWithArraylikeMembersSerializer());
+                    _tmp.Add(@"TypeWithReadOnlyCollections::", new TypeWithReadOnlyCollectionsSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlQualifiedName::", new TypeWithXmlQualifiedNameSerializer());
+                    _tmp.Add(@"DefaultValuesSetToNaN::", new DefaultValuesSetToNaNSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomDocument::", new CustomDocumentSerializer());
+                    _tmp.Add(@"TypeWithLinkedProperty::", new TypeWithLinkedPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithMyCollectionField::", new TypeWithMyCollectionFieldSerializer());
+                    _tmp.Add(@"SerializationTypes.BaseClassWithSamePropertyName::", new BaseClassWithSamePropertyNameSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithGetOnlyArrayProperties::", new TypeWithGetOnlyArrayPropertiesSerializer());
+                    _tmp.Add(@"TypeWithBinaryProperty::", new TypeWithBinaryPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.DCClassWithEnumAndStruct::", new DCClassWithEnumAndStructSerializer());
+                    _tmp.Add(@"SerializationTypes.ShortEnum::", new ShortEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.BaseTypeWithShouldSerializeMethod::", new BaseTypeWithShouldSerializeMethodSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleDC::", new SimpleDCSerializer());
+                    _tmp.Add(@"TypeWithXmlDocumentProperty::", new TypeWithXmlDocumentPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.XmlSerializerAttributes::AttributeTesting:False:", new XmlSerializerAttributesSerializer());
                     _tmp.Add(@"SerializationTypes.MoreChoices::", new MoreChoicesSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::", new TypeWithEnumFlagPropertyHavingDefaultValueSerializer());
-                    _tmp.Add(@"DogBreed::", new DogBreedSerializer());
+                    _tmp.Add(@"DefaultValuesSetToPositiveInfinity::", new DefaultValuesSetToPositiveInfinitySerializer());
+                    _tmp.Add(@"SerializationTypes.MyList::", new MyListSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithSchemaFormInXmlAttribute::", new TypeWithSchemaFormInXmlAttributeSerializer());
                     _tmp.Add(@"SerializationTypes.ClassImplementsInterface::", new ClassImplementsInterfaceSerializer());
                     _tmp.Add(@"SerializationTypes.DerivedTypeWithInheritedShouldSerialize::", new DerivedTypeWithInheritedShouldSerializeSerializer());
-                    _tmp.Add(@"DateOnlyWrapper::", new DateOnlyWrapperSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithGetSetArrayMembers::", new TypeWithGetSetArrayMembersSerializer());
-                    _tmp.Add(@"SerializationTypes.CustomDocument::", new CustomDocumentSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:", new TypeWithXmlSchemaFormAttributeSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithEnumMembers::", new TypeWithEnumMembersSerializer());
-                    _tmp.Add(@"Dog::", new DogSerializer());
+                    _tmp.Add(@"DerivedClass::", new DerivedClassSerializer());
+                    _tmp.Add(@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::", new __TypeNameWithSpecialCharacters漢ñSerializer());
                     _tmp.Add(@"SerializationTypes.TypeWith2DArrayProperty2::", new TypeWith2DArrayProperty2Serializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlSchemaFormAttribute:::True:", new TypeWithXmlSchemaFormAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumPropertyHavingDefaultValue::", new TypeWithEnumPropertyHavingDefaultValueSerializer());
+                    _tmp.Add(@"DateTimeTimeWrapper::", new DateTimeTimeWrapperSerializer());
+                    _tmp.Add(@"Animal::", new AnimalSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomElement::", new CustomElementSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithTypesHavingCustomFormatter::", new TypeWithTypesHavingCustomFormatterSerializer());
                     _tmp.Add(@"SerializationTypes.ByteEnum::", new ByteEnumSerializer());
-                    _tmp.Add(@"DefaultValuesSetToNegativeInfinity::", new DefaultValuesSetToNegativeInfinitySerializer());
-                    _tmp.Add(@"TypeWithBinaryProperty::", new TypeWithBinaryPropertySerializer());
-                    _tmp.Add(@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:", new XmlSerializableBaseClassSerializer());
-                    _tmp.Add(@"TypeWithByteProperty::", new TypeWithBytePropertySerializer());
+                    _tmp.Add(@"TypeWithGetOnlyReadOnlyCollections::", new TypeWithGetOnlyReadOnlyCollectionsSerializer());
+                    _tmp.Add(@"SerializationTypes.LongEnum::", new LongEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithDateTimePropertyAsXmlTime::", new TypeWithDateTimePropertyAsXmlTimeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithFieldsOrdered::", new TypeWithFieldsOrderedSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithDateTimeStringProperty::", new TypeWithDateTimeStringPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.EnumFlags::", new EnumFlagsSerializer());
+                    _tmp.Add(@"Instrument::", new InstrumentSerializer());
+                    _tmp.Add(@"SerializationTypes.UIntEnum::", new UIntEnumSerializer());
+                    _tmp.Add(@"SerializationTypes.ItemChoiceType::", new ItemChoiceTypeSerializer());
+                    _tmp.Add(@"SerializationTypes.SomeStruct::", new SomeStructSerializer());
+                    _tmp.Add(@"XElementStruct::", new XElementStructSerializer());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructor::", new KnownTypesThroughConstructorSerializer());
+                    _tmp.Add(@"DateOnlyWrapper::", new DateOnlyWrapperSerializer());
+                    _tmp.Add(@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:", new PurchaseOrderSerializer());
+                    _tmp.Add(@"Outer+Person::", new PersonSerializer());
+                    _tmp.Add(@"SerializationTypes.ClassImplementingIXmlSerializable::", new ClassImplementingIXmlSerializableSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleType::", new SimpleTypeSerializer());
+                    _tmp.Add(@"TypeWithMismatchBetweenAttributeAndPropertyType::RootElement:True:", new TypeWithMismatchBetweenAttributeAndPropertyTypeSerializer());
+                    _tmp.Add(@"Vehicle::", new VehicleSerializer());
+                    _tmp.Add(@"SerializationTypes.SimpleKnownTypeValue::", new SimpleKnownTypeValueSerializer());
+                    _tmp.Add(@"SimpleBaseClass::", new SimpleBaseClassSerializer());
+                    _tmp.Add(@"SerializationTypes.DCStruct::", new DCStructSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeHasArrayOfASerializedAsB::", new TypeHasArrayOfASerializedAsBSerializer());
+                    _tmp.Add(@"SerializationTypes.WithStruct::", new WithStructSerializer());
+                    _tmp.Add(@"SerializationTypes.WithEnums::", new WithEnumsSerializer());
                     _tmp.Add(@"SerializationTypes.TypeWithArrayPropertyHavingChoice::", new TypeWithArrayPropertyHavingChoiceSerializer());
-                    _tmp.Add(@"SerializationTypes.BaseClassWithSamePropertyName::", new BaseClassWithSamePropertyNameSerializer());
-                    _tmp.Add(@"TypeWithXmlDocumentProperty::", new TypeWithXmlDocumentPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::", new TypeWithPropertiesHavingDefaultValueSerializer());
-                    _tmp.Add(@"RootClass::", new RootClassSerializer());
-                    _tmp.Add(@"SerializationTypes.SimpleDC::", new SimpleDCSerializer());
+                    _tmp.Add(@"TimeOnlyWrapper::", new TimeOnlyWrapperSerializer());
+                    _tmp.Add(@"DateTimeOffsetIXmlSerializableContainer::", new DateTimeOffsetIXmlSerializableContainerSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithKnownTypesOfCollectionsWithConflictingXmlName::", new TypeWithKnownTypesOfCollectionsWithConflictingXmlNameSerializer());
+                    _tmp.Add(@"Orchestra::", new OrchestraSerializer());
+                    _tmp.Add(@"SerializationTypes.MyEnum::", new MyEnumSerializer());
+                    _tmp.Add(@"TimeOnlyAsXsdTimeWrapper::", new TimeOnlyAsXsdTimeWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithTypeNameInXmlTypeAttribute::", new TypeWithTypeNameInXmlTypeAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithEnumFlagPropertyHavingDefaultValue::", new TypeWithEnumFlagPropertyHavingDefaultValueSerializer());
+                    _tmp.Add(@"SerializationTypes.SByteEnum::", new SByteEnumSerializer());
+                    _tmp.Add(@"DateTimeDateWrapper::", new DateTimeDateWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeNameClashA.TypeNameClash::", new TypeNameClashSerializer1());
                     _tmp.Add(@"BaseClass::", new BaseClassSerializer());
                     _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithValue::", new KnownTypesThroughConstructorWithValueSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithNullableBuiltInTypedMembers::", new TypeWithNullableBuiltInTypedMembersSerializer());
-                    _tmp.Add(@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::", new TypeWithReadOnlyMyCollectionPropertySerializer());
-                    _tmp.Add(@"SerializationTypes.__TypeNameWithSpecialCharacters漢ñ::", new __TypeNameWithSpecialCharacters漢ñSerializer());
-                    _tmp.Add(@"SerializationTypes.WithEnums::", new WithEnumsSerializer());
-                    _tmp.Add(@"SerializationTypes.SByteEnum::", new SByteEnumSerializer());
-                    _tmp.Add(@"SerializationTypes.ServerSettings::", new ServerSettingsSerializer());
-                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::", new StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer());
+                    _tmp.Add(@"DogBreed::", new DogBreedSerializer());
+                    _tmp.Add(@"TypeWithByteProperty::", new TypeWithBytePropertySerializer());
+                    _tmp.Add(@"OrderedItem::", new OrderedItemSerializer());
                     _tmp.Add(@"DerivedClass1::", new DerivedClass1Serializer());
-                    _tmp.Add(@"SerializationTypes.TypeHasArrayOfASerializedAsB::", new TypeHasArrayOfASerializedAsBSerializer());
-                    _tmp.Add(@"SerializationTypes.DCClassWithEnumAndStruct::", new DCClassWithEnumAndStructSerializer());
-                    _tmp.Add(@"PurchaseOrder:http://www.contoso1.com:PurchaseOrder:False:", new PurchaseOrderSerializer());
-                    _tmp.Add(@"TypeWithGetOnlyReadOnlyCollections::", new TypeWithGetOnlyReadOnlyCollectionsSerializer());
+                    _tmp.Add(@"MyCollection1::", new MyCollection1Serializer());
+                    _tmp.Add(@"SerializationTypes.TypeB::", new TypeBSerializer());
+                    _tmp.Add(@"SerializationTypes.IntEnum::", new IntEnumSerializer());
+                    _tmp.Add(@"Address::", new AddressSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithXmlTextAttributeOnArray:http://schemas.xmlsoap.org/ws/2005/04/discovery::False:", new TypeWithXmlTextAttributeOnArraySerializer());
+                    _tmp.Add(@"Group::", new GroupSerializer());
+                    _tmp.Add(@"Pet::", new PetSerializer());
+                    _tmp.Add(@"XElementWrapper::", new XElementWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.ComplexChoiceA::", new ComplexChoiceASerializer());
+                    _tmp.Add(@"SerializationTypes.StructNotSerializable::", new StructNotSerializableSerializer());
+                    _tmp.Add(@"SerializationTypes.ServerSettings::", new ServerSettingsSerializer());
+                    _tmp.Add(@"BaseClass1::", new BaseClass1Serializer());
+                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty2::", new DerivedClassWithSameProperty2Serializer());
+                    _tmp.Add(@"SerializationTypes.NamespaceTypeNameClashContainer::Root:True:", new NamespaceTypeNameClashContainerSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertyNameSpecified::", new TypeWithPropertyNameSpecifiedSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeNameClashB.TypeNameClash::", new TypeNameClashSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithAnyAttribute::", new TypeWithAnyAttributeSerializer());
+                    _tmp.Add(@"TypeWithDefaultTimeSpanProperty::", new TypeWithDefaultTimeSpanPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithByteArrayAsXmlText::", new TypeWithByteArrayAsXmlTextSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertyHavingComplexChoice::", new TypeWithPropertyHavingComplexChoiceSerializer());
+                    _tmp.Add(@"TypeWithDateAndTimeOnlyProperties::", new TypeWithDateAndTimeOnlyPropertiesSerializer());
+                    _tmp.Add(@"SimpleDerivedClass::", new SimpleDerivedClassSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithShouldSerializeMethod::", new TypeWithShouldSerializeMethodSerializer());
+                    _tmp.Add(@"TypeWithTimeSpanProperty::", new TypeWithTimeSpanPropertySerializer());
+                    _tmp.Add(@"XmlSerializableBaseClass:http://example.com/serializer-test-namespace::True:", new XmlSerializableBaseClassSerializer());
+                    _tmp.Add(@"SerializationTypes.WithNullables::", new WithNullablesSerializer());
+                    _tmp.Add(@"TypeWithMutableCollectionMembers::", new TypeWithMutableCollectionMembersSerializer());
+                    _tmp.Add(@"TypeWithXmlNodeArrayProperty:::True:", new TypeWithXmlNodeArrayPropertySerializer());
+                    _tmp.Add(@"XElementArrayWrapper::", new XElementArrayWrapperSerializer());
+                    _tmp.Add(@"SerializationTypes.CustomAttribute::", new CustomAttributeSerializer());
+                    _tmp.Add(@"SerializationTypes.StructImplementingIXmlSerializableWithoutParameterlessConstructor::", new StructImplementingIXmlSerializableWithoutParameterlessConstructorSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithPropertiesHavingDefaultValue::", new TypeWithPropertiesHavingDefaultValueSerializer());
+                    _tmp.Add(@"SerializationTypes.DerivedClassWithSameProperty::", new DerivedClassWithSamePropertySerializer());
+                    _tmp.Add(@"SerializationTypes.BuiltInTypes::", new BuiltInTypesSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithReadOnlyMyCollectionProperty::", new TypeWithReadOnlyMyCollectionPropertySerializer());
+                    _tmp.Add(@"SerializationTypes.KnownTypesThroughConstructorWithArrayProperties::", new KnownTypesThroughConstructorWithArrayPropertiesSerializer());
+                    _tmp.Add(@"XmlSerializableDerivedClass::", new XmlSerializableDerivedClassSerializer());
                     _tmp.Add(@"Trumpet::", new TrumpetSerializer());
+                    _tmp.Add(@"SerializationTypes.TypeWithGetSetArrayMembers::", new TypeWithGetSetArrayMembersSerializer());
+                    _tmp.Add(@"SerializationTypes.ULongEnum::", new ULongEnumSerializer());
+                    _tmp.Add(@"Employee::", new EmployeeSerializer());
                     if (typedSerializers == null) typedSerializers = _tmp;
                 }
                 return typedSerializers;

--- a/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
@@ -439,6 +439,7 @@
     <Compile Include="System\Xml\Serialization\CodeGenerator.cs" />
     <Compile Include="System\Xml\Serialization\CodeIdentifier.cs" />
     <Compile Include="System\Xml\Serialization\CodeIdentifiers.cs" />
+    <Compile Include="System\Xml\Serialization\CollectionBuilderInfo.cs" />
     <Compile Include="System\Xml\Serialization\Compilation.cs" />
     <Compile Include="System\Xml\Serialization\Compiler.cs" />
     <Compile Include="System\Xml\Serialization\ContextAwareTables.cs" />

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CollectionBuilderInfo.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CollectionBuilderInfo.cs
@@ -1,0 +1,307 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace System.Xml.Serialization
+{
+    /// <summary>
+    /// Describes the factory method named by a <see cref="CollectionBuilderAttribute"/> on a collection type.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="XmlSerializer"/> normally fills a collection in place, by constructing it and then calling
+    /// <c>Add</c> or assigning through its default indexer. Read-only and immutable collections cannot be
+    /// populated that way. When such a type opts in to a collection builder, the readers instead accumulate
+    /// elements in a temporary array and create the real collection from that array once the whole collection
+    /// has been read.
+    /// </remarks>
+    internal sealed class CollectionBuilderInfo
+    {
+        private const string CollectionBuilderAttributeFullName = "System.Runtime.CompilerServices.CollectionBuilderAttribute";
+
+        private CollectionBuilderInvoker? _invoker;
+
+        private CollectionBuilderInfo(Type elementType, MethodInfo? spanFactory, MethodInfo? arrayFactory, MethodInfo? spanConversion)
+        {
+            ElementType = elementType;
+            SpanFactory = spanFactory;
+            ArrayFactory = arrayFactory;
+            SpanConversion = spanConversion;
+        }
+
+        /// <summary>The type of the elements the factory method accepts.</summary>
+        internal Type ElementType { get; }
+
+        /// <summary>
+        /// The <c>Create(ReadOnlySpan&lt;T&gt;)</c> overload. This is the shape the
+        /// <see cref="CollectionBuilderAttribute"/> contract documents, so it is always preferred.
+        /// </summary>
+        internal MethodInfo? SpanFactory { get; }
+
+        /// <summary>
+        /// The <c>Create(T[])</c> overload, when the builder offers one. Only used by the reflection-based
+        /// serializer when dynamic code is unavailable, because invoking the span overload requires closing
+        /// a generic type over the element type.
+        /// </summary>
+        internal MethodInfo? ArrayFactory { get; }
+
+        /// <summary>The factory method the IL and source generating serializers should call.</summary>
+        internal MethodInfo Factory => SpanFactory ?? ArrayFactory!;
+
+        /// <summary>Whether <see cref="Factory"/> accepts a <see cref="ReadOnlySpan{T}"/> rather than an array.</summary>
+        [MemberNotNullWhen(true, nameof(SpanConversion))]
+        internal bool FactoryTakesSpan => SpanFactory != null;
+
+        /// <summary>
+        /// The implicit conversion from the element array the readers accumulate into to the
+        /// <see cref="ReadOnlySpan{T}"/> that <see cref="Factory"/> takes. Null when the factory takes an array.
+        /// </summary>
+        internal MethodInfo? SpanConversion { get; }
+
+        /// <summary>
+        /// The C# expression the source generating serializer emits to create the collection, up to but not
+        /// including the argument that supplies its elements.
+        /// </summary>
+        internal string GetCSharpFactoryCall()
+        {
+            string name = $"{CodeIdentifier.GetCSharpName(Factory.DeclaringType!)}.{Factory.Name}";
+
+            if (Factory.IsGenericMethod)
+            {
+                Type[] arguments = Factory.GetGenericArguments();
+                string[] names = new string[arguments.Length];
+                for (int i = 0; i < arguments.Length; i++)
+                {
+                    names[i] = CodeIdentifier.GetCSharpName(arguments[i]);
+                }
+
+                name = $"{name}<{string.Join(", ", names)}>";
+            }
+
+            // The builders that take a span usually offer a params array overload too, so the argument is cast
+            // to make the call unambiguous.
+            return FactoryTakesSpan
+                ? $"{name}((global::System.ReadOnlySpan<{CodeIdentifier.GetCSharpName(ElementType)}>)"
+                : $"{name}(";
+        }
+
+        /// <summary>
+        /// Looks for a usable collection builder on <paramref name="collectionType"/>, returning <see langword="null"/>
+        /// when the type is not attributed or no factory method matching the attribute could be resolved.
+        /// </summary>
+        [RequiresUnreferencedCode("Resolves the factory method named by CollectionBuilderAttribute.")]
+        internal static CollectionBuilderInfo? Find(Type collectionType)
+        {
+            if (!TryGetBuilderAttribute(collectionType, out Type? builderType, out string? methodName))
+            {
+                return null;
+            }
+
+            Type[] typeArguments = collectionType.IsGenericType ? collectionType.GetGenericArguments() : Type.EmptyTypes;
+            MethodInfo? spanFactory = null;
+            MethodInfo? arrayFactory = null;
+
+            foreach (MethodInfo candidate in builderType.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (!candidate.Name.Equals(methodName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                MethodInfo? factory = Close(candidate, typeArguments);
+                if (factory == null || !collectionType.IsAssignableFrom(factory.ReturnType))
+                {
+                    continue;
+                }
+
+                ParameterInfo[] parameters = factory.GetParameters();
+                if (parameters.Length != 1)
+                {
+                    continue;
+                }
+
+                Type parameterType = parameters[0].ParameterType;
+                if (parameterType.IsGenericType && parameterType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>))
+                {
+                    spanFactory ??= factory;
+                }
+                else if (parameterType.IsArray && parameterType.GetArrayRank() == 1)
+                {
+                    arrayFactory ??= factory;
+                }
+            }
+
+            Type? elementType = spanFactory != null
+                ? spanFactory.GetParameters()[0].ParameterType.GetGenericArguments()[0]
+                : arrayFactory?.GetParameters()[0].ParameterType.GetElementType();
+
+            if (elementType == null || elementType.IsPointer || elementType.IsByRef || elementType.ContainsGenericParameters)
+            {
+                return null;
+            }
+
+            // Only keep the array overload when it agrees with the span overload, so that the two paths
+            // cannot disagree about what the collection contains.
+            if (spanFactory != null && arrayFactory != null && arrayFactory.GetParameters()[0].ParameterType.GetElementType() != elementType)
+            {
+                arrayFactory = null;
+            }
+
+            MethodInfo? spanConversion = null;
+            if (spanFactory != null)
+            {
+                spanConversion = FindSpanConversion(spanFactory.GetParameters()[0].ParameterType, elementType);
+
+                if (spanConversion == null)
+                {
+                    // Without the conversion the span overload cannot be called from generated code.
+                    if (arrayFactory == null)
+                    {
+                        return null;
+                    }
+
+                    spanFactory = null;
+                }
+            }
+
+            return new CollectionBuilderInfo(elementType, spanFactory, arrayFactory, spanConversion);
+        }
+
+        /// <summary>
+        /// Finds the implicit conversion from the element array the readers accumulate into to the span the
+        /// factory method takes.
+        /// </summary>
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "Every XmlSerializer entry point that can reach this code is annotated with RequiresDynamicCode. " +
+                            "The array type is only used to look the conversion up; failing to find it leaves the collection " +
+                            "unsupported, which is the behavior that predates collection builder support.")]
+        private static MethodInfo? FindSpanConversion(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type spanType,
+            Type elementType) =>
+            spanType.GetMethod(
+                "op_Implicit",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                new Type[] { elementType.MakeArrayType() },
+                modifiers: null);
+
+        /// <summary>Creates the collection described by this builder from the accumulated elements.</summary>
+        [RequiresUnreferencedCode("Invokes the factory method named by CollectionBuilderAttribute.")]
+        internal object Build(Array elements) => (_invoker ??= CreateInvoker()).Build(elements);
+
+        /// <summary>Creates the empty array the readers accumulate elements into.</summary>
+        [RequiresUnreferencedCode("Creates an array of the collection's element type.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "Every XmlSerializer entry point that can reach this code is annotated with RequiresDynamicCode.")]
+        internal Array CreateAccumulator(int length) => Array.CreateInstance(ElementType, length);
+
+        private static bool TryGetBuilderAttribute(
+            Type type,
+            [NotNullWhen(true)] out Type? builderType,
+            [NotNullWhen(true)] out string? methodName)
+        {
+            builderType = null;
+            methodName = null;
+
+            // CollectionBuilderAttribute is not inherited, and reading it through CustomAttributeData avoids
+            // instantiating the attribute or forcing types to load just to answer the question.
+            foreach (CustomAttributeData attribute in type.GetCustomAttributesData())
+            {
+                if (attribute.AttributeType.FullName != CollectionBuilderAttributeFullName)
+                {
+                    continue;
+                }
+
+                IList<CustomAttributeTypedArgument> arguments = attribute.ConstructorArguments;
+                if (arguments.Count != 2)
+                {
+                    continue;
+                }
+
+                builderType = arguments[0].Value as Type;
+                methodName = arguments[1].Value as string;
+                return builderType != null && !string.IsNullOrEmpty(methodName);
+            }
+
+            return false;
+        }
+
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "Every XmlSerializer entry point that can reach this code is annotated with RequiresDynamicCode. " +
+                            "A failure to resolve the factory method is caught here and simply leaves the collection unsupported, " +
+                            "which is the behavior that predates collection builder support.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
+            Justification = "Every XmlSerializer entry point that can reach this code is annotated with RequiresUnreferencedCode. " +
+                            "A failure to resolve the factory method is caught here and simply leaves the collection unsupported, " +
+                            "which is the behavior that predates collection builder support.")]
+        private static MethodInfo? Close(MethodInfo candidate, Type[] typeArguments)
+        {
+            if (!candidate.IsGenericMethodDefinition)
+            {
+                return typeArguments.Length == 0 ? candidate : null;
+            }
+
+            if (typeArguments.Length == 0 || candidate.GetGenericArguments().Length != typeArguments.Length)
+            {
+                return null;
+            }
+
+            try
+            {
+                return candidate.MakeGenericMethod(typeArguments);
+            }
+            catch (Exception e) when (e is ArgumentException or NotSupportedException or InvalidOperationException)
+            {
+                // The builder method's constraints reject the collection's type arguments, or this
+                // instantiation is not available without dynamic code.
+                return null;
+            }
+        }
+
+        [RequiresUnreferencedCode("Invokes the factory method named by CollectionBuilderAttribute.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "The generic instantiation is only created when dynamic code is supported, or when the builder " +
+                            "offers no array overload to fall back to.")]
+        private CollectionBuilderInvoker CreateInvoker()
+        {
+            // The span overload is preferred, but invoking it means closing a generic type over the element
+            // type. Where that is not possible, an array overload lets the reflection-based serializer keep
+            // working without emitting or instantiating any generic code.
+            if (SpanFactory != null && (ArrayFactory == null || RuntimeFeature.IsDynamicCodeSupported))
+            {
+                Type invokerType = typeof(SpanInvoker<,>).MakeGenericType(ElementType, SpanFactory.ReturnType);
+                return (CollectionBuilderInvoker)Activator.CreateInstance(invokerType, SpanFactory)!;
+            }
+
+            return new ArrayInvoker(ArrayFactory!);
+        }
+
+        private delegate TCollection SpanBuilder<TElement, TCollection>(ReadOnlySpan<TElement> values);
+
+        private abstract class CollectionBuilderInvoker
+        {
+            internal abstract object Build(Array elements);
+        }
+
+        private sealed class ArrayInvoker : CollectionBuilderInvoker
+        {
+            private readonly MethodInfo _factory;
+
+            internal ArrayInvoker(MethodInfo factory) => _factory = factory;
+
+            internal override object Build(Array elements) => _factory.Invoke(null, new object?[] { elements })!;
+        }
+
+        private sealed class SpanInvoker<TElement, TCollection> : CollectionBuilderInvoker
+        {
+            private readonly SpanBuilder<TElement, TCollection> _factory;
+
+            public SpanInvoker(MethodInfo factory) => _factory = factory.CreateDelegate<SpanBuilder<TElement, TCollection>>();
+
+            internal override object Build(Array elements) => _factory((TElement[])elements)!;
+        }
+    }
+}

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CollectionBuilderInfo.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CollectionBuilderInfo.cs
@@ -8,70 +8,50 @@ using System.Runtime.CompilerServices;
 
 namespace System.Xml.Serialization
 {
-    /// <summary>
-    /// Describes the factory method named by a <see cref="CollectionBuilderAttribute"/> on a collection type.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="XmlSerializer"/> normally fills a collection in place, by constructing it and then calling
-    /// <c>Add</c> or assigning through its default indexer. Read-only and immutable collections cannot be
-    /// populated that way. When such a type opts in to a collection builder, the readers instead accumulate
-    /// elements in a temporary array and create the real collection from that array once the whole collection
-    /// has been read.
-    /// </remarks>
+    // The factory method named by a CollectionBuilderAttribute on a collection type.
+    //
+    // XmlSerializer normally fills a collection in place, by constructing it and then calling Add or assigning
+    // through its default indexer. Read-only and immutable collections cannot be populated that way. When such a
+    // type opts in to a collection builder, the readers accumulate elements into a temporary array and create the
+    // real collection from that array once the whole collection has been read.
+    //
+    // The attribute's contract requires a Create(ReadOnlySpan<T>) overload, so that is the one used. Builders
+    // commonly offer a Create(T[]) overload too, which the reflection-based reader falls back to when dynamic code
+    // is unavailable and it therefore cannot close a generic type over the element type.
     internal sealed class CollectionBuilderInfo
     {
         private const string CollectionBuilderAttributeFullName = "System.Runtime.CompilerServices.CollectionBuilderAttribute";
 
-        private CollectionBuilderInvoker? _invoker;
+        private readonly MethodInfo? _arrayFactory;
+        private Func<Array, object>? _build;
 
-        private CollectionBuilderInfo(Type elementType, MethodInfo? spanFactory, MethodInfo? arrayFactory, MethodInfo? spanConversion)
+        private CollectionBuilderInfo(Type elementType, MethodInfo spanFactory, MethodInfo spanConversion, MethodInfo? arrayFactory)
         {
             ElementType = elementType;
+            _arrayFactory = arrayFactory;
             SpanFactory = spanFactory;
-            ArrayFactory = arrayFactory;
             SpanConversion = spanConversion;
         }
 
-        /// <summary>The type of the elements the factory method accepts.</summary>
+        // The element type the factory method accepts.
         internal Type ElementType { get; }
 
-        /// <summary>
-        /// The <c>Create(ReadOnlySpan&lt;T&gt;)</c> overload. This is the shape the
-        /// <see cref="CollectionBuilderAttribute"/> contract documents, so it is always preferred.
-        /// </summary>
-        internal MethodInfo? SpanFactory { get; }
+        // Create(ReadOnlySpan<T>).
+        internal MethodInfo SpanFactory { get; }
 
-        /// <summary>
-        /// The <c>Create(T[])</c> overload, when the builder offers one. Only used by the reflection-based
-        /// serializer when dynamic code is unavailable, because invoking the span overload requires closing
-        /// a generic type over the element type.
-        /// </summary>
-        internal MethodInfo? ArrayFactory { get; }
+        // The implicit T[] to ReadOnlySpan<T> conversion, which gets the generating readers from the array they
+        // accumulate into to the span SpanFactory takes.
+        internal MethodInfo SpanConversion { get; }
 
-        /// <summary>The factory method the IL and source generating serializers should call.</summary>
-        internal MethodInfo Factory => SpanFactory ?? ArrayFactory!;
-
-        /// <summary>Whether <see cref="Factory"/> accepts a <see cref="ReadOnlySpan{T}"/> rather than an array.</summary>
-        [MemberNotNullWhen(true, nameof(SpanConversion))]
-        internal bool FactoryTakesSpan => SpanFactory != null;
-
-        /// <summary>
-        /// The implicit conversion from the element array the readers accumulate into to the
-        /// <see cref="ReadOnlySpan{T}"/> that <see cref="Factory"/> takes. Null when the factory takes an array.
-        /// </summary>
-        internal MethodInfo? SpanConversion { get; }
-
-        /// <summary>
-        /// The C# expression the source generating serializer emits to create the collection, up to but not
-        /// including the argument that supplies its elements.
-        /// </summary>
+        // The C# expression the source generating reader emits to create the collection, up to but not including
+        // the argument that supplies its elements.
         internal string GetCSharpFactoryCall()
         {
-            string name = $"{CodeIdentifier.GetCSharpName(Factory.DeclaringType!)}.{Factory.Name}";
+            string name = $"{CodeIdentifier.GetCSharpName(SpanFactory.DeclaringType!)}.{SpanFactory.Name}";
 
-            if (Factory.IsGenericMethod)
+            if (SpanFactory.IsGenericMethod)
             {
-                Type[] arguments = Factory.GetGenericArguments();
+                Type[] arguments = SpanFactory.GetGenericArguments();
                 string[] names = new string[arguments.Length];
                 for (int i = 0; i < arguments.Length; i++)
                 {
@@ -81,17 +61,14 @@ namespace System.Xml.Serialization
                 name = $"{name}<{string.Join(", ", names)}>";
             }
 
-            // The builders that take a span usually offer a params array overload too, so the argument is cast
-            // to make the call unambiguous.
-            return FactoryTakesSpan
-                ? $"{name}((global::System.ReadOnlySpan<{CodeIdentifier.GetCSharpName(ElementType)}>)"
-                : $"{name}(";
+            // Builders that take a span usually offer a params array overload too, so the argument is cast to make
+            // the call unambiguous.
+            return $"{name}((global::System.ReadOnlySpan<{CodeIdentifier.GetCSharpName(ElementType)}>)";
         }
 
-        /// <summary>
-        /// Looks for a usable collection builder on <paramref name="collectionType"/>, returning <see langword="null"/>
-        /// when the type is not attributed or no factory method matching the attribute could be resolved.
-        /// </summary>
+        // Returns null when the type is not attributed, or when no factory method matching the attribute and the
+        // shape the readers need could be resolved. Either way the collection stays unsupported, which is the
+        // behavior that predates collection builder support.
         [RequiresUnreferencedCode("Resolves the factory method named by CollectionBuilderAttribute.")]
         internal static CollectionBuilderInfo? Find(Type collectionType)
         {
@@ -134,46 +111,33 @@ namespace System.Xml.Serialization
                 }
             }
 
-            Type? elementType = spanFactory != null
-                ? spanFactory.GetParameters()[0].ParameterType.GetGenericArguments()[0]
-                : arrayFactory?.GetParameters()[0].ParameterType.GetElementType();
-
-            if (elementType == null || elementType.IsPointer || elementType.IsByRef || elementType.ContainsGenericParameters)
+            if (spanFactory == null)
             {
                 return null;
             }
 
-            // Only keep the array overload when it agrees with the span overload, so that the two paths
-            // cannot disagree about what the collection contains.
-            if (spanFactory != null && arrayFactory != null && arrayFactory.GetParameters()[0].ParameterType.GetElementType() != elementType)
+            Type elementType = spanFactory.GetParameters()[0].ParameterType.GetGenericArguments()[0];
+            if (elementType.IsPointer || elementType.IsByRef || elementType.ContainsGenericParameters)
+            {
+                return null;
+            }
+
+            MethodInfo? spanConversion = FindSpanConversion(spanFactory.GetParameters()[0].ParameterType, elementType);
+            if (spanConversion == null)
+            {
+                return null;
+            }
+
+            // Only keep the array overload when it agrees with the span overload, so the two paths cannot disagree
+            // about what the collection contains.
+            if (arrayFactory != null && arrayFactory.GetParameters()[0].ParameterType.GetElementType() != elementType)
             {
                 arrayFactory = null;
             }
 
-            MethodInfo? spanConversion = null;
-            if (spanFactory != null)
-            {
-                spanConversion = FindSpanConversion(spanFactory.GetParameters()[0].ParameterType, elementType);
-
-                if (spanConversion == null)
-                {
-                    // Without the conversion the span overload cannot be called from generated code.
-                    if (arrayFactory == null)
-                    {
-                        return null;
-                    }
-
-                    spanFactory = null;
-                }
-            }
-
-            return new CollectionBuilderInfo(elementType, spanFactory, arrayFactory, spanConversion);
+            return new CollectionBuilderInfo(elementType, spanFactory, spanConversion, arrayFactory);
         }
 
-        /// <summary>
-        /// Finds the implicit conversion from the element array the readers accumulate into to the span the
-        /// factory method takes.
-        /// </summary>
         [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
             Justification = "Every XmlSerializer entry point that can reach this code is annotated with RequiresDynamicCode. " +
                             "The array type is only used to look the conversion up; failing to find it leaves the collection " +
@@ -188,15 +152,34 @@ namespace System.Xml.Serialization
                 new Type[] { elementType.MakeArrayType() },
                 modifiers: null);
 
-        /// <summary>Creates the collection described by this builder from the accumulated elements.</summary>
-        [RequiresUnreferencedCode("Invokes the factory method named by CollectionBuilderAttribute.")]
-        internal object Build(Array elements) => (_invoker ??= CreateInvoker()).Build(elements);
-
-        /// <summary>Creates the empty array the readers accumulate elements into.</summary>
+        // Creates the array the readers accumulate elements into.
         [RequiresUnreferencedCode("Creates an array of the collection's element type.")]
         [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
             Justification = "Every XmlSerializer entry point that can reach this code is annotated with RequiresDynamicCode.")]
         internal Array CreateAccumulator(int length) => Array.CreateInstance(ElementType, length);
+
+        // Creates the collection from the accumulated elements.
+        [RequiresUnreferencedCode("Invokes the factory method named by CollectionBuilderAttribute.")]
+        internal object Build(Array elements) => (_build ??= CreateBuilder())(elements);
+
+        [RequiresUnreferencedCode("Invokes the factory method named by CollectionBuilderAttribute.")]
+        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "The generic instantiation is only created when dynamic code is supported, or when the builder " +
+                            "offers no array overload to fall back to.")]
+        private Func<Array, object> CreateBuilder()
+        {
+            // Calling the span overload means closing a generic type over the element type. Where that is not
+            // possible, an array overload lets the reflection-based reader keep working without instantiating any
+            // generic code.
+            if (_arrayFactory is MethodInfo arrayFactory && !RuntimeFeature.IsDynamicCodeSupported)
+            {
+                return elements => arrayFactory.Invoke(null, new object?[] { elements })!;
+            }
+
+            var invoker = (SpanInvoker)Activator.CreateInstance(
+                typeof(SpanInvoker<,>).MakeGenericType(ElementType, SpanFactory.ReturnType), SpanFactory)!;
+            return invoker.Build;
+        }
 
         private static bool TryGetBuilderAttribute(
             Type type,
@@ -255,47 +238,20 @@ namespace System.Xml.Serialization
             }
             catch (Exception e) when (e is ArgumentException or NotSupportedException or InvalidOperationException)
             {
-                // The builder method's constraints reject the collection's type arguments, or this
-                // instantiation is not available without dynamic code.
+                // The builder method's constraints reject the collection's type arguments, or this instantiation is
+                // not available without dynamic code.
                 return null;
             }
         }
 
-        [RequiresUnreferencedCode("Invokes the factory method named by CollectionBuilderAttribute.")]
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-            Justification = "The generic instantiation is only created when dynamic code is supported, or when the builder " +
-                            "offers no array overload to fall back to.")]
-        private CollectionBuilderInvoker CreateInvoker()
-        {
-            // The span overload is preferred, but invoking it means closing a generic type over the element
-            // type. Where that is not possible, an array overload lets the reflection-based serializer keep
-            // working without emitting or instantiating any generic code.
-            if (SpanFactory != null && (ArrayFactory == null || RuntimeFeature.IsDynamicCodeSupported))
-            {
-                Type invokerType = typeof(SpanInvoker<,>).MakeGenericType(ElementType, SpanFactory.ReturnType);
-                return (CollectionBuilderInvoker)Activator.CreateInstance(invokerType, SpanFactory)!;
-            }
-
-            return new ArrayInvoker(ArrayFactory!);
-        }
-
         private delegate TCollection SpanBuilder<TElement, TCollection>(ReadOnlySpan<TElement> values);
 
-        private abstract class CollectionBuilderInvoker
+        private abstract class SpanInvoker
         {
             internal abstract object Build(Array elements);
         }
 
-        private sealed class ArrayInvoker : CollectionBuilderInvoker
-        {
-            private readonly MethodInfo _factory;
-
-            internal ArrayInvoker(MethodInfo factory) => _factory = factory;
-
-            internal override object Build(Array elements) => _factory.Invoke(null, new object?[] { elements })!;
-        }
-
-        private sealed class SpanInvoker<TElement, TCollection> : CollectionBuilderInvoker
+        private sealed class SpanInvoker<TElement, TCollection> : SpanInvoker
         {
             private readonly SpanBuilder<TElement, TCollection> _factory;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -1871,9 +1871,17 @@ namespace System.Xml.Serialization
                         // This is an odd legacy behavior, but it's what the old serializers did.
                         if (isList && member.Source != null)
                         {
+                            // A collection that is a struct, such as ImmutableArray<T>, is uninitialized when it holds its
+                            // default value rather than when it is null, and a boxed default is never null. Capture that
+                            // default so an absent member ends up empty here too, matching the other serializers.
+                            object? uninitialized = mapping.TypeDesc.UsesCollectionBuilder && mapping.TypeDesc.Type!.IsValueType
+                                ? RuntimeHelpers.GetUninitializedObject(mapping.TypeDesc.Type)
+                                : null;
+
                             member.EnsureCollection = (obj) =>
                             {
-                                if (GetMemberValue(obj, mapping.MemberInfo!) == null)
+                                object? current = GetMemberValue(obj, mapping.MemberInfo!);
+                                if (current == null || current.Equals(uninitialized))
                                 {
                                     var empty = ReflectionCreateCollection(mapping.TypeDesc);
                                     member.Source(empty);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -1600,14 +1600,10 @@ namespace System.Xml.Serialization
             object? memberSource = getSource();
             if (memberSource == null)
             {
-                if (readOnly)
-                {
-                    throw CreateReadOnlyCollectionException(typeDesc.CSharpName);
-                }
-
-                // Encoded serialization populates collections through a fixup once the referenced items have
-                // been read, which a collection that has to be created from its complete contents cannot do.
-                if (typeDesc.UsesCollectionBuilder)
+                // Encoded serialization populates a collection through a fixup once the referenced items have been
+                // read, which neither a read-only member nor a collection that has to be created from its complete
+                // contents can do.
+                if (readOnly || typeDesc.UsesCollectionBuilder)
                 {
                     throw CreateReadOnlyCollectionException(typeDesc.CSharpName);
                 }
@@ -1964,10 +1960,10 @@ namespace System.Xml.Serialization
                         // collection instance returned by the getter. This matches what the IL-based serializer does.
                         if (memberInfo is PropertyInfo pi && pi.GetSetMethod(nonPublic: true) == null)
                         {
-                            // A collection built from its complete contents cannot be added to, and with no setter
-                            // there is nowhere to put the collection we would create. Leave whatever the getter
-                            // returns alone, which is how a get-only collection that cannot be added to has always
-                            // behaved.
+                            // A collection built from its complete contents cannot be added to: the Add below would
+                            // throw for it, or silently discard the new collection it returns. With no setter there
+                            // is nowhere to put a collection we created either, so the elements read are dropped and
+                            // the getter's value survives, as it does for any collection that cannot be added to.
                             if (member.Mapping.TypeDesc!.UsesCollectionBuilder)
                             {
                                 continue;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -280,14 +280,14 @@ namespace System.Xml.Serialization
             foreach (Member member in textOrArrayMembers)
             {
                 object? value = null;
-                SetCollectionObjectWithCollectionMember(ref value, member.Collection!, member.Mapping.TypeDesc!.Type!);
+                SetCollectionObjectWithCollectionMember(ref value, member.Collection!, member.Mapping.TypeDesc!.Type!, member.Mapping.TypeDesc.CollectionBuilder);
                 member.Source!(value);
             }
 
             if (anyAttribute != null)
             {
                 object? value = null;
-                SetCollectionObjectWithCollectionMember(ref value, anyAttribute.Collection!, anyAttribute.Mapping.TypeDesc!.Type!);
+                SetCollectionObjectWithCollectionMember(ref value, anyAttribute.Collection!, anyAttribute.Mapping.TypeDesc!.Type!, anyAttribute.Mapping.TypeDesc.CollectionBuilder);
                 anyAttribute.ArraySource!(value);
             }
 
@@ -547,7 +547,7 @@ namespace System.Xml.Serialization
         }
 
         private static void SetCollectionObjectWithCollectionMember([NotNull] ref object? collection, CollectionMember collectionMember,
-            [DynamicallyAccessedMembers(TrimmerConstants.AllMethods)] Type collectionType)
+            [DynamicallyAccessedMembers(TrimmerConstants.AllMethods)] Type collectionType, CollectionBuilderInfo? collectionBuilder)
         {
             if (collectionType.IsArray)
             {
@@ -568,12 +568,44 @@ namespace System.Xml.Serialization
 
                 collection = a;
             }
+            else if (collectionBuilder != null)
+            {
+                // The collection cannot be populated in place, so anything read into an already assigned
+                // instance would be lost. The whole collection is created from the elements read instead.
+                collection = BuildCollection(collectionBuilder, collectionMember);
+            }
             else
             {
                 collection ??= ReflectionCreateObject(collectionType)!;
 
                 AddObjectsIntoTargetCollection(collection, collectionMember, collectionType);
             }
+        }
+
+        [RequiresUnreferencedCode(XmlSerializer.TrimSerializationWarning)]
+        private static object BuildCollection(CollectionBuilderInfo collectionBuilder, List<object?> elements)
+        {
+            Array accumulator = collectionBuilder.CreateAccumulator(elements.Count);
+            for (int i = 0; i < elements.Count; i++)
+            {
+                accumulator.SetValue(elements[i], i);
+            }
+
+            return collectionBuilder.Build(accumulator);
+        }
+
+        /// <summary>
+        /// Creates an empty instance of a collection, whether or not it can be constructed directly.
+        /// </summary>
+        [RequiresUnreferencedCode(XmlSerializer.TrimSerializationWarning)]
+        private static object? ReflectionCreateCollection(TypeDesc typeDesc)
+        {
+            if (typeDesc.CollectionBuilder is CollectionBuilderInfo collectionBuilder)
+            {
+                return collectionBuilder.Build(collectionBuilder.CreateAccumulator(0));
+            }
+
+            return ReflectionCreateObject(typeDesc.Type!);
         }
 
         private static void AddObjectsIntoTargetCollection(object targetCollection, List<object?> sourceCollection,
@@ -1237,7 +1269,7 @@ namespace System.Xml.Serialization
                     };
 
                     Type collectionType = memberMapping.TypeDesc!.Type!;
-                    o = ReflectionCreateObject(memberMapping.TypeDesc.Type!);
+                    o = ReflectionCreateCollection(memberMapping.TypeDesc);
 
                     // When this array is the value of a member that carries an [XmlChoiceIdentifier]
                     // (e.g. one of the choice element types is itself an array), the parallel choice
@@ -1263,7 +1295,14 @@ namespace System.Xml.Serialization
                         ReadEndElement();
                     }
 
-                    SetCollectionObjectWithCollectionMember(ref o, arrayMember.Collection, collectionType);
+                    SetCollectionObjectWithCollectionMember(ref o, arrayMember.Collection, collectionType, memberMapping.TypeDesc.CollectionBuilder);
+                }
+                else if (arrayMapping.TypeDesc!.UsesCollectionBuilder)
+                {
+                    // A collection that is created from its contents is always created, even when the element is
+                    // nil, which is how a collection populated in place has always behaved. Collections that are
+                    // value types are never nillable, so without this they would be left at their default value.
+                    o = ReflectionCreateCollection(arrayMapping.TypeDesc);
                 }
             }
 
@@ -1566,6 +1605,13 @@ namespace System.Xml.Serialization
                     throw CreateReadOnlyCollectionException(typeDesc.CSharpName);
                 }
 
+                // Encoded serialization populates collections through a fixup once the referenced items have
+                // been read, which a collection that has to be created from its complete contents cannot do.
+                if (typeDesc.UsesCollectionBuilder)
+                {
+                    throw CreateReadOnlyCollectionException(typeDesc.CSharpName);
+                }
+
                 memberSource = ReflectionCreateObject(typeDesc.Type!);
                 setSource(memberSource);
             }
@@ -1775,7 +1821,11 @@ namespace System.Xml.Serialization
                         // first before we make noise about not being able to set a list property.
                         else if (isList && pi != null && (pi.SetMethod == null || !pi.SetMethod.IsPublic))
                         {
-                            var addMethod = mapping.TypeDesc.Type!.GetMethod("Add");
+                            // A collection built from its complete contents cannot be populated in place, so there is
+                            // nothing an Add method could usefully do here: it either throws or returns a new collection
+                            // that would be discarded. Leaving the source null keeps whatever the getter returns, which
+                            // matches the other serializers and how a collection with no Add method already behaves.
+                            MethodInfo? addMethod = mapping.TypeDesc.UsesCollectionBuilder ? null : mapping.TypeDesc.Type!.GetMethod("Add");
 
                             if (addMethod != null)
                             {
@@ -1825,7 +1875,7 @@ namespace System.Xml.Serialization
                             {
                                 if (GetMemberValue(obj, mapping.MemberInfo!) == null)
                                 {
-                                    var empty = ReflectionCreateObject(mapping.TypeDesc.Type!);
+                                    var empty = ReflectionCreateCollection(mapping.TypeDesc);
                                     member.Source(empty);
                                 }
                             };
@@ -1906,6 +1956,15 @@ namespace System.Xml.Serialization
                         // collection instance returned by the getter. This matches what the IL-based serializer does.
                         if (memberInfo is PropertyInfo pi && pi.GetSetMethod(nonPublic: true) == null)
                         {
+                            // A collection built from its complete contents cannot be added to, and with no setter
+                            // there is nowhere to put the collection we would create. Leave whatever the getter
+                            // returns alone, which is how a get-only collection that cannot be added to has always
+                            // behaved.
+                            if (member.Mapping.TypeDesc!.UsesCollectionBuilder)
+                            {
+                                continue;
+                            }
+
                             object? existingCollection = pi.GetValue(o);
                             if (existingCollection != null)
                             {
@@ -1915,7 +1974,7 @@ namespace System.Xml.Serialization
                         else
                         {
                             object? collection = null;
-                            SetCollectionObjectWithCollectionMember(ref collection, member.Collection, member.Mapping.TypeDesc!.Type!);
+                            SetCollectionObjectWithCollectionMember(ref collection, member.Collection, member.Mapping.TypeDesc!.Type!, member.Mapping.TypeDesc.CollectionBuilder);
                             var setMemberValue = GetSetMemberValueDelegate(o, memberInfo.Name);
                             setMemberValue(o, collection);
                         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -96,6 +96,7 @@ namespace System.Xml.Serialization
         private bool _isMixed;
         private int _weight;
         private Exception? _exception;
+        private CollectionBuilderInfo? _collectionBuilder;
 
         internal TypeDesc(string name, string fullName, XmlSchemaType? dataType, TypeKind kind, TypeDesc? baseTypeDesc, TypeFlags flags, string? formatterName)
         {
@@ -273,6 +274,21 @@ namespace System.Xml.Serialization
             get { return !HasDefaultConstructor || ConstructorInaccessible; }
         }
 
+        /// <summary>
+        /// The collection builder to create this collection with, for collections that cannot be
+        /// populated in place. Null for every other type.
+        /// </summary>
+        internal CollectionBuilderInfo? CollectionBuilder
+        {
+            get { return _collectionBuilder; }
+            set { _collectionBuilder = value; }
+        }
+
+        internal bool UsesCollectionBuilder
+        {
+            get { return _collectionBuilder != null; }
+        }
+
         internal bool IsAbstract
         {
             get { return (_flags & TypeFlags.Abstract) != 0; }
@@ -387,7 +403,7 @@ namespace System.Xml.Serialization
 
         internal void CheckNeedConstructor()
         {
-            if (!IsValueType && !IsAbstract && !HasDefaultConstructor)
+            if (!IsValueType && !IsAbstract && !HasDefaultConstructor && !UsesCollectionBuilder)
             {
                 _flags |= TypeFlags.Unsupported;
                 _exception = new InvalidOperationException(SR.Format(SR.XmlConstructorInaccessible, FullName));
@@ -822,6 +838,7 @@ namespace System.Xml.Serialization
             Type? baseType = null;
             TypeFlags flags = 0;
             Exception? exception = null;
+            CollectionBuilderInfo? collectionBuilder = null;
 
             if (!type.IsVisible)
             {
@@ -875,8 +892,51 @@ namespace System.Xml.Serialization
             else if (typeof(ICollection).IsAssignableFrom(type) && !IsArraySegment(type))
             {
                 kind = TypeKind.Collection;
-                arrayElementType = GetCollectionElementType(type, memberInfo == null ? null : $"{memberInfo.DeclaringType!.FullName}.{memberInfo.Name}");
                 flags |= GetConstructorFlags(type);
+
+                string? memberName = memberInfo == null ? null : $"{memberInfo.DeclaringType!.FullName}.{memberInfo.Name}";
+                ThrowIfUnsupportedDictionary(type, memberName);
+
+                PropertyInfo? indexer = FindDefaultIndexer(type);
+                bool canAppend = indexer != null && type.GetMethod("Add", new Type[] { indexer.PropertyType }) != null;
+                bool cannotNew = CannotNew(flags);
+
+                // A collection we cannot construct, or cannot append to, may still be deserializable if it
+                // opts in to a collection builder. Elements are then accumulated separately and the real
+                // collection is created from them once it has been read in full.
+                if (cannotNew || !canAppend)
+                {
+                    collectionBuilder = GetCollectionBuilder(type);
+                }
+
+                if (collectionBuilder != null)
+                {
+                    arrayElementType = collectionBuilder.ElementType;
+
+                    if (indexer == null)
+                    {
+                        // Collections are written through their default indexer, which a type like
+                        // ImmutableHashSet<T> does not have. Those are written through their enumerator instead.
+                        if (FindEnumeratorMethod(type, ref flags) == null)
+                        {
+                            throw new InvalidOperationException(SR.Format(SR.XmlNoDefaultAccessors, type.FullName));
+                        }
+
+                        kind = TypeKind.Enumerable;
+                    }
+                }
+                else if (indexer == null)
+                {
+                    throw new InvalidOperationException(SR.Format(SR.XmlNoDefaultAccessors, type.FullName));
+                }
+                else if (!canAppend)
+                {
+                    throw new InvalidOperationException(SR.Format(SR.XmlNoAddMethod, type.FullName, indexer.PropertyType, "ICollection"));
+                }
+                else
+                {
+                    arrayElementType = indexer.PropertyType;
+                }
             }
             else if (type == typeof(XmlQualifiedName))
             {
@@ -966,16 +1026,18 @@ namespace System.Xml.Serialization
             {
                 if (typeof(IEnumerable).IsAssignableFrom(type) && !IsArraySegment(type))
                 {
-                    arrayElementType = GetEnumeratorElementType(type, ref flags);
-                    kind = TypeKind.Enumerable;
-
                     // GetEnumeratorElementType checks for the security attributes on the GetEnumerator(), Add() methods and Current property,
                     // we need to check the MoveNext() and ctor methods for the security attribues
                     flags |= GetConstructorFlags(type);
+
+                    bool cannotNew = CannotNew(flags);
+                    arrayElementType = GetEnumeratorElementType(type, ref flags, cannotNew, out collectionBuilder);
+                    kind = TypeKind.Enumerable;
                 }
             }
             typeDesc = new TypeDesc(type, CodeIdentifier.MakeValid(TypeName(type)), type.ToString(), kind, null, flags, null);
             typeDesc.Exception = exception;
+            typeDesc.CollectionBuilder = collectionBuilder;
 
             if (directReference && (typeDesc.IsClass || kind == TypeKind.Serializable))
                 typeDesc.CheckNeedConstructor();
@@ -1079,7 +1141,8 @@ namespace System.Xml.Serialization
             else if (typeof(IEnumerable).IsAssignableFrom(type))
             {
                 TypeFlags flags = TypeFlags.None;
-                return GetEnumeratorElementType(type, ref flags);
+                // The same test ImportTypeDesc applies, so that both paths agree on the element type.
+                return GetEnumeratorElementType(type, ref flags, CannotNew(GetConstructorFlags(type)), out _);
             }
             else
                 return null;
@@ -1329,69 +1392,135 @@ namespace System.Xml.Serialization
             return 0;
         }
 
+        /// <summary>
+        /// Whether the constructor flags describe a type <see cref="XmlSerializer"/> cannot create an
+        /// instance of, which is one of the reasons a collection needs a collection builder.
+        /// </summary>
+        private static bool CannotNew(TypeFlags flags) =>
+            (flags & TypeFlags.HasDefaultConstructor) == 0 || (flags & TypeFlags.CtorInaccessible) != 0;
+
+        /// <summary>
+        /// Locates the <c>GetEnumerator</c> method to walk <paramref name="type"/> with, setting the flags
+        /// that describe how it needs to be called. Returns null when the type cannot be enumerated.
+        /// </summary>
         [RequiresUnreferencedCode("Needs to mark members on the return type of the GetEnumerator method")]
-        private static Type? GetEnumeratorElementType(Type type, ref TypeFlags flags)
+        private static MethodInfo? FindEnumeratorMethod(Type type, ref TypeFlags flags)
         {
-            if (typeof(IEnumerable).IsAssignableFrom(type))
-            {
-                MethodInfo? enumerator = type.GetMethod("GetEnumerator", Type.EmptyTypes);
-
-                if (enumerator == null || !typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))
-                {
-                    // try generic implementation
-                    enumerator = null;
-                    foreach (MemberInfo member in type.GetMember("System.Collections.Generic.IEnumerable<*", BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic))
-                    {
-                        enumerator = member as MethodInfo;
-                        if (enumerator != null && typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))
-                        {
-                            // use the first one we find
-                            flags |= TypeFlags.GenericInterface;
-                            break;
-                        }
-                        else
-                        {
-                            enumerator = null;
-                        }
-                    }
-                    if (enumerator == null)
-                    {
-                        // and finally private interface implementation
-                        flags |= TypeFlags.UsePrivateImplementation;
-                        enumerator = type.GetMethod("System.Collections.IEnumerable.GetEnumerator", BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, Type.EmptyTypes);
-                    }
-                }
-                if (enumerator == null || !typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))
-                {
-                    return null;
-                }
-                XmlAttributes methodAttrs = new XmlAttributes(enumerator);
-                if (methodAttrs.XmlIgnore) return null;
-
-                PropertyInfo? p = enumerator.ReturnType.GetProperty("Current");
-                Type currentType = (p == null ? typeof(object) : p.PropertyType);
-
-                MethodInfo? addMethod = type.GetMethod("Add", new Type[] { currentType });
-
-                if (addMethod == null && currentType != typeof(object))
-                {
-                    currentType = typeof(object);
-                    addMethod = type.GetMethod("Add", new Type[] { currentType });
-                }
-                if (addMethod == null)
-                {
-                    throw new InvalidOperationException(SR.Format(SR.XmlNoAddMethod, type.FullName, currentType, "IEnumerable"));
-                }
-                return currentType;
-            }
-            else
+            if (!typeof(IEnumerable).IsAssignableFrom(type))
             {
                 return null;
             }
+
+            MethodInfo? enumerator = type.GetMethod("GetEnumerator", Type.EmptyTypes);
+
+            if (enumerator == null || !typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))
+            {
+                // try generic implementation
+                enumerator = null;
+                foreach (MemberInfo member in type.GetMember("System.Collections.Generic.IEnumerable<*", BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic))
+                {
+                    enumerator = member as MethodInfo;
+                    if (enumerator != null && typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))
+                    {
+                        // use the first one we find
+                        flags |= TypeFlags.GenericInterface;
+                        break;
+                    }
+                    else
+                    {
+                        enumerator = null;
+                    }
+                }
+                if (enumerator == null)
+                {
+                    // and finally private interface implementation
+                    flags |= TypeFlags.UsePrivateImplementation;
+                    enumerator = type.GetMethod("System.Collections.IEnumerable.GetEnumerator", BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, Type.EmptyTypes);
+                }
+            }
+            if (enumerator == null || !typeof(IEnumerator).IsAssignableFrom(enumerator.ReturnType))
+            {
+                return null;
+            }
+            XmlAttributes methodAttrs = new XmlAttributes(enumerator);
+            if (methodAttrs.XmlIgnore) return null;
+
+            return enumerator;
         }
 
-        internal static PropertyInfo GetDefaultIndexer(
-            [DynamicallyAccessedMembers(TrimmerConstants.PublicMembers)] Type type, string? memberInfo)
+        [RequiresUnreferencedCode("Needs to mark members on the return type of the GetEnumerator method")]
+        private static Type? GetEnumeratorElementType(Type type, ref TypeFlags flags, bool cannotNew, out CollectionBuilderInfo? collectionBuilder)
+        {
+            collectionBuilder = null;
+
+            MethodInfo? enumerator = FindEnumeratorMethod(type, ref flags);
+            if (enumerator == null)
+            {
+                return null;
+            }
+
+            PropertyInfo? p = enumerator.ReturnType.GetProperty("Current");
+            Type currentType = (p == null ? typeof(object) : p.PropertyType);
+
+            MethodInfo? addMethod = type.GetMethod("Add", new Type[] { currentType });
+
+            if (addMethod == null && currentType != typeof(object))
+            {
+                currentType = typeof(object);
+                addMethod = type.GetMethod("Add", new Type[] { currentType });
+            }
+
+            // A collection builder creates the collection from elements gathered elsewhere, so neither an
+            // accessible constructor nor an Add method is needed. Immutable collections in particular do
+            // often have an Add, but one that returns a new collection instead of modifying this one.
+            if (addMethod == null || cannotNew)
+            {
+                collectionBuilder = GetCollectionBuilder(type);
+                if (collectionBuilder != null)
+                {
+                    return collectionBuilder.ElementType;
+                }
+            }
+
+            if (addMethod == null)
+            {
+                throw new InvalidOperationException(SR.Format(SR.XmlNoAddMethod, type.FullName, currentType, "IEnumerable"));
+            }
+
+            return currentType;
+        }
+
+        /// <summary>
+        /// Returns the collection builder <paramref name="type"/> opts in to, or null when it has none that
+        /// XmlSerializer can use.
+        /// </summary>
+        [RequiresUnreferencedCode("Resolves the factory method named by CollectionBuilderAttribute.")]
+        private static CollectionBuilderInfo? GetCollectionBuilder(Type type)
+        {
+            // Dictionaries are not serializable by XmlSerializer, and a collection builder does not change that.
+            if (typeof(IDictionary).IsAssignableFrom(type) || ImplementsGenericDictionary(type))
+            {
+                return null;
+            }
+
+            return CollectionBuilderInfo.Find(type);
+        }
+
+        [RequiresUnreferencedCode("Enumerates the interfaces implemented by the type.")]
+        private static bool ImplementsGenericDictionary(Type type)
+        {
+            foreach (Type interfaceType in type.GetInterfaces())
+            {
+                if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void ThrowIfUnsupportedDictionary(Type type, string? memberInfo)
         {
             if (typeof(IDictionary).IsAssignableFrom(type))
             {
@@ -1404,7 +1533,15 @@ namespace System.Xml.Serialization
                     throw new NotSupportedException(SR.Format(SR.XmlUnsupportedIDictionaryDetails, memberInfo, type.FullName));
                 }
             }
+        }
 
+        /// <summary>
+        /// Locates the <c>this[int]</c> indexer that collections are read and written through, or null when
+        /// <paramref name="type"/> does not have one.
+        /// </summary>
+        private static PropertyInfo? FindDefaultIndexer(
+            [DynamicallyAccessedMembers(TrimmerConstants.PublicMembers)] Type type)
+        {
             MemberInfo[] defaultMembers = type.GetDefaultMembers();
             PropertyInfo? indexer = null;
             if (defaultMembers != null && defaultMembers.Length > 0)
@@ -1429,6 +1566,16 @@ namespace System.Xml.Serialization
                     if (indexer != null) break;
                 }
             }
+
+            return indexer;
+        }
+
+        internal static PropertyInfo GetDefaultIndexer(
+            [DynamicallyAccessedMembers(TrimmerConstants.PublicMembers)] Type type, string? memberInfo)
+        {
+            ThrowIfUnsupportedDictionary(type, memberInfo);
+
+            PropertyInfo? indexer = FindDefaultIndexer(type);
             if (indexer == null)
             {
                 throw new InvalidOperationException(SR.Format(SR.XmlNoDefaultAccessors, type.FullName));
@@ -1440,11 +1587,42 @@ namespace System.Xml.Serialization
             }
             return indexer;
         }
+        /// <summary>
+        /// Returns the type of the elements of a collection, which is normally the type its default indexer
+        /// exposes. A collection that has to be created through a collection builder takes its element type
+        /// from the builder's factory method instead, the same way <see cref="ImportTypeDesc"/> does.
+        /// </summary>
+        [RequiresUnreferencedCode("Resolves the factory method named by CollectionBuilderAttribute.")]
         private static Type GetCollectionElementType(
             [DynamicallyAccessedMembers(TrimmerConstants.PublicMembers)] Type type,
             string? memberInfo)
         {
-            return GetDefaultIndexer(type, memberInfo).PropertyType;
+            ThrowIfUnsupportedDictionary(type, memberInfo);
+
+            PropertyInfo? indexer = FindDefaultIndexer(type);
+            bool canAppend = indexer != null && type.GetMethod("Add", new Type[] { indexer.PropertyType }) != null;
+
+            if (canAppend && !CannotNew(GetConstructorFlags(type)))
+            {
+                return indexer!.PropertyType;
+            }
+
+            CollectionBuilderInfo? collectionBuilder = GetCollectionBuilder(type);
+            if (collectionBuilder != null)
+            {
+                return collectionBuilder.ElementType;
+            }
+
+            if (indexer == null)
+            {
+                throw new InvalidOperationException(SR.Format(SR.XmlNoDefaultAccessors, type.FullName));
+            }
+            if (!canAppend)
+            {
+                throw new InvalidOperationException(SR.Format(SR.XmlNoAddMethod, type.FullName, indexer.PropertyType, "ICollection"));
+            }
+
+            return indexer.PropertyType;
         }
 
         internal static XmlQualifiedName ParseWsdlArrayType(string type, out string dims, XmlSchemaObject? parent)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -2171,7 +2171,9 @@ namespace System.Xml.Serialization
                         _arraySource = arraySource;
                     else
                         _arraySource = outerClass.GetArraySource(mapping.TypeDesc, _arrayName, multiRef);
-                    _isArray = mapping.TypeDesc.IsArray;
+                    // A collection built from its complete contents accumulates into an array first, so from
+                    // here on it is read exactly like one.
+                    _isArray = mapping.TypeDesc.IsArray || mapping.TypeDesc.UsesCollectionBuilder;
                     _isList = !_isArray;
                     if (mapping.ChoiceIdentifier != null)
                     {
@@ -3180,7 +3182,7 @@ namespace System.Xml.Serialization
                     }
                     else if (m is ArrayMapping arrayMapping)
                     {
-                        if (arrayMapping.TypeDesc!.HasDefaultConstructor)
+                        if (arrayMapping.TypeDesc!.HasDefaultConstructor || arrayMapping.TypeDesc.UsesCollectionBuilder)
                         {
                             Writer.Write("if (");
                             WriteQNameEqual("xsiType", arrayMapping.TypeName, arrayMapping.Namespace);
@@ -3622,6 +3624,11 @@ namespace System.Xml.Serialization
 
         private void WriteAddCollectionFixup(TypeDesc typeDesc, bool readOnly, string memberSource, string targetSource)
         {
+            // Encoded serialization populates a collection after the fact, through a fixup, which a collection
+            // that has to be created from its complete contents cannot support.
+            if (typeDesc.UsesCollectionBuilder)
+                throw new InvalidOperationException(SR.Format(SR.XmlReadOnlyCollection, typeDesc.CSharpName));
+
             Writer.WriteLine("// get array of the collection items");
             CreateCollectionInfo? create = (CreateCollectionInfo?)_createMethods[typeDesc];
             if (create == null)
@@ -3979,10 +3986,32 @@ namespace System.Xml.Serialization
                     TypeDesc typeDesc = member.Mapping.TypeDesc!;
                     string typeDescFullName = typeDesc.CSharpName;
 
-                    if (member.Mapping.TypeDesc!.IsArray)
+                    if (member.Mapping.TypeDesc!.IsArray || typeDesc.UsesCollectionBuilder)
                     {
-                        WriteArrayLocalDecl(typeDesc.CSharpName,
-                                            a, "null", typeDesc);
+                        if (typeDesc.IsArray)
+                        {
+                            WriteArrayLocalDecl(typeDesc.CSharpName,
+                                                a, "null", typeDesc);
+                        }
+                        else
+                        {
+                            // The collection is created from the elements once they have all been read, so
+                            // they accumulate in an array of the element type in the meantime.
+                            WriteArrayLocalDecl($"{typeDesc.ArrayElementTypeDesc!.CSharpName}[]",
+                                                a, "null", typeDesc.ArrayElementTypeDesc);
+
+                            // The collection is also created up front, the way one that is populated in place
+                            // is, so that a member the document never mentions still comes back as an empty
+                            // collection rather than as null.
+                            if (!member.Mapping.ReadOnly && !member.Source.EndsWith('(') && !member.Source.EndsWith('{'))
+                            {
+                                WriteSourceBegin(member.Source);
+                                WriteBuildCollection(typeDesc, null);
+                                WriteSourceEnd(member.Source);
+                                Writer.WriteLine(";");
+                            }
+                        }
+
                         Writer.Write("int ");
                         Writer.Write(c);
                         Writer.WriteLine(" = 0;");
@@ -4484,7 +4513,7 @@ namespace System.Xml.Serialization
                 init = $"soap = (System.Object[])EnsureArrayIndex(soap, {c}+2, typeof(System.Object)); ";
             }
             bool useReflection = typeDesc.UseReflection;
-            if (typeDesc.IsArray)
+            if (typeDesc.IsArray || typeDesc.UsesCollectionBuilder)
             {
                 string arrayTypeFullName = typeDesc.ArrayElementTypeDesc!.CSharpName;
                 bool arrayUseReflection = typeDesc.ArrayElementTypeDesc.UseReflection;
@@ -4510,6 +4539,29 @@ namespace System.Xml.Serialization
             WriteMemberEnd(members, false);
         }
 
+        /// <summary>
+        /// Writes the expression that creates a collection from the elements accumulated in
+        /// <paramref name="arrayName"/>, or an empty collection when <paramref name="arrayName"/> is null.
+        /// </summary>
+        private void WriteBuildCollection(TypeDesc typeDesc, string? arrayName)
+        {
+            bool arrayUseReflection = typeDesc.ArrayElementTypeDesc!.UseReflection;
+            string arrayTypeFullName = typeDesc.ArrayElementTypeDesc.CSharpName;
+
+            Writer.Write(typeDesc.CollectionBuilder!.GetCSharpFactoryCall());
+            if (!arrayUseReflection)
+                Writer.Write($"({arrayTypeFullName}[])");
+            Writer.Write("ShrinkArray(");
+            Writer.Write(arrayName ?? "null");
+            Writer.Write(", ");
+            Writer.Write(arrayName == null ? "0" : $"c{arrayName}");
+            Writer.Write(", ");
+            Writer.Write(RaCodeGen.GetStringForTypeof(arrayTypeFullName, arrayUseReflection));
+            // A collection built from its contents is never left null: a nil collection hydrates to an empty
+            // one, which is how a collection populated in place has always behaved.
+            Writer.Write(", false))");
+        }
+
         private void WriteMemberEnd(Member[] members, bool soapRefs)
         {
             for (int i = 0; i < members.Length; i++)
@@ -4520,7 +4572,14 @@ namespace System.Xml.Serialization
                 {
                     TypeDesc typeDesc = member.Mapping.TypeDesc!;
 
-                    if (typeDesc.IsArray)
+                    // A collection built from its complete contents cannot be populated in place, so a member
+                    // with no setter has nowhere to put the collection that would be created. Leave whatever the
+                    // getter returns alone, which is how a get-only collection that cannot be added to has
+                    // always behaved.
+                    if (typeDesc.UsesCollectionBuilder && member.Mapping.ReadOnly)
+                        continue;
+
+                    if (typeDesc.IsArray || typeDesc.UsesCollectionBuilder)
                     {
                         WriteSourceBegin(member.Source);
 
@@ -4532,17 +4591,24 @@ namespace System.Xml.Serialization
 
                         bool arrayUseReflection = typeDesc.ArrayElementTypeDesc!.UseReflection;
                         string arrayTypeFullName = typeDesc.ArrayElementTypeDesc.CSharpName;
-                        if (!arrayUseReflection)
-                            Writer.Write($"({arrayTypeFullName}[])");
-                        Writer.Write("ShrinkArray(");
-                        Writer.Write(a);
-                        Writer.Write(", ");
-                        Writer.Write(c);
-                        Writer.Write(", ");
-                        Writer.Write(RaCodeGen.GetStringForTypeof(arrayTypeFullName, arrayUseReflection));
-                        Writer.Write(", ");
-                        WriteBooleanValue(member.IsNullable);
-                        Writer.Write(")");
+                        if (typeDesc.IsArray)
+                        {
+                            if (!arrayUseReflection)
+                                Writer.Write($"({arrayTypeFullName}[])");
+                            Writer.Write("ShrinkArray(");
+                            Writer.Write(a);
+                            Writer.Write(", ");
+                            Writer.Write(c);
+                            Writer.Write(", ");
+                            Writer.Write(RaCodeGen.GetStringForTypeof(arrayTypeFullName, arrayUseReflection));
+                            Writer.Write(", ");
+                            WriteBooleanValue(member.IsNullable);
+                            Writer.Write(")");
+                        }
+                        else
+                        {
+                            WriteBuildCollection(typeDesc, a);
+                        }
                         WriteSourceEnd(member.Source);
                         Writer.WriteLine(";");
 
@@ -4721,8 +4787,11 @@ namespace System.Xml.Serialization
 
                 Writer.Indent--;
                 Writer.WriteLine("}");
-                if (isNullable)
+                if (isNullable || arrayMapping.TypeDesc!.UsesCollectionBuilder)
                 {
+                    // A collection that is created from its contents is always created, even when the element is
+                    // nil, which is how a collection populated in place has always behaved. Collections that are
+                    // value types are never nillable, so without this they would be left at their default value.
                     Writer.WriteLine("else {");
                     Writer.Indent++;
                     member.IsNullable = true;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -90,7 +90,9 @@ namespace System.Xml.Serialization
                         _arraySource = arraySource;
                     else
                         _arraySource = XmlSerializationReaderILGen.GetArraySource(mapping.TypeDesc, _arrayName, multiRef);
-                    _isArray = mapping.TypeDesc.IsArray;
+                    // A collection built from its complete contents accumulates into an array first, so from
+                    // here on it is read exactly like one.
+                    _isArray = mapping.TypeDesc.IsArray || mapping.TypeDesc.UsesCollectionBuilder;
                     _isList = !_isArray;
                     if (mapping.ChoiceIdentifier != null)
                     {
@@ -1312,7 +1314,7 @@ namespace System.Xml.Serialization
                     }
                     else if (m is ArrayMapping arrayMapping)
                     {
-                        if (arrayMapping.TypeDesc!.HasDefaultConstructor)
+                        if (arrayMapping.TypeDesc!.HasDefaultConstructor || arrayMapping.TypeDesc.UsesCollectionBuilder)
                         {
                             ilg.InitElseIf();
                             WriteQNameEqual("xsiType", arrayMapping.TypeName, arrayMapping.Namespace);
@@ -2208,10 +2210,31 @@ namespace System.Xml.Serialization
 
                     TypeDesc typeDesc = member.Mapping.TypeDesc!;
 
-                    if (member.Mapping.TypeDesc!.IsArray)
+                    if (member.Mapping.TypeDesc!.IsArray || typeDesc.UsesCollectionBuilder)
                     {
-                        WriteArrayLocalDecl(typeDesc.CSharpName,
-                                            a, "null", typeDesc);
+                        if (typeDesc.IsArray)
+                        {
+                            WriteArrayLocalDecl(typeDesc.CSharpName,
+                                                a, "null", typeDesc);
+                        }
+                        else
+                        {
+                            // The collection is created from the elements once they have all been read, so
+                            // they accumulate in an array of the element type in the meantime.
+                            WriteArrayLocalDecl($"{typeDesc.ArrayElementTypeDesc!.CSharpName}[]",
+                                                a, "null", typeDesc.ArrayElementTypeDesc);
+
+                            // The collection is also created up front, the way one that is populated in place
+                            // is, so that a member the document never mentions still comes back as an empty
+                            // collection rather than as null.
+                            if (!member.Mapping.ReadOnly && !member.Source.EndsWith('(') && !member.Source.EndsWith('{'))
+                            {
+                                WriteSourceBegin(member.Source);
+                                WriteBuildCollection(typeDesc, null);
+                                WriteSourceEnd(member.Source, typeDesc.Type!);
+                            }
+                        }
+
                         ilg.Ldc(0);
                         ilg.Stloc(typeof(int), c);
 
@@ -2707,7 +2730,7 @@ namespace System.Xml.Serialization
             {
                 init = $"soap = (System.Object[])EnsureArrayIndex(soap, {c}+2, typeof(System.Object)); ";
             }
-            if (typeDesc.IsArray)
+            if (typeDesc.IsArray || typeDesc.UsesCollectionBuilder)
             {
                 string arrayTypeFullName = typeDesc.ArrayElementTypeDesc!.CSharpName;
                 init = $"{init}{a} = ({arrayTypeFullName}[])EnsureArrayIndex({a}, {c}, {ReflectionAwareILGen.GetStringForTypeof(arrayTypeFullName)});";
@@ -2740,7 +2763,14 @@ namespace System.Xml.Serialization
                 {
                     TypeDesc typeDesc = member.Mapping.TypeDesc!;
 
-                    if (typeDesc.IsArray)
+                    // A collection built from its complete contents cannot be populated in place, so a member
+                    // with no setter has nowhere to put the collection that would be created. Leave whatever the
+                    // getter returns alone, which is how a get-only collection that cannot be added to has
+                    // always behaved.
+                    if (typeDesc.UsesCollectionBuilder && member.Mapping.ReadOnly)
+                        continue;
+
+                    if (typeDesc.IsArray || typeDesc.UsesCollectionBuilder)
                     {
                         WriteSourceBegin(member.Source);
 
@@ -2749,22 +2779,35 @@ namespace System.Xml.Serialization
                         string a = member.ArrayName;
                         string c = $"c{a}";
 
-                        MethodInfo XmlSerializationReader_ShrinkArray = typeof(XmlSerializationReader).GetMethod(
-                            "ShrinkArray",
-                            CodeGenerator.InstanceBindingFlags,
-                            new Type[] { typeof(Array), typeof(int), typeof(Type), typeof(bool) }
-                            )!;
-                        ilg.Ldarg(0);
-                        ilg.Ldloc(ilg.GetLocal(a));
-                        ilg.Ldloc(ilg.GetLocal(c));
-                        ilg.Ldc(typeDesc.ArrayElementTypeDesc!.Type!);
-                        ilg.Ldc(member.IsNullable);
-                        ilg.Call(XmlSerializationReader_ShrinkArray);
-                        ilg.ConvertValue(XmlSerializationReader_ShrinkArray.ReturnType, typeDesc.Type!);
+                        if (typeDesc.IsArray)
+                        {
+                            MethodInfo XmlSerializationReader_ShrinkArray = typeof(XmlSerializationReader).GetMethod(
+                                "ShrinkArray",
+                                CodeGenerator.InstanceBindingFlags,
+                                new Type[] { typeof(Array), typeof(int), typeof(Type), typeof(bool) }
+                                )!;
+                            ilg.Ldarg(0);
+                            ilg.Ldloc(ilg.GetLocal(a));
+                            ilg.Ldloc(ilg.GetLocal(c));
+                            ilg.Ldc(typeDesc.ArrayElementTypeDesc!.Type!);
+                            ilg.Ldc(member.IsNullable);
+                            ilg.Call(XmlSerializationReader_ShrinkArray);
+                            ilg.ConvertValue(XmlSerializationReader_ShrinkArray.ReturnType, typeDesc.Type!);
+                        }
+                        else
+                        {
+                            WriteBuildCollection(typeDesc, a);
+                        }
+
                         WriteSourceEnd(member.Source, typeDesc.Type!);
 
                         if (member.Mapping.ChoiceIdentifier != null)
                         {
+                            MethodInfo XmlSerializationReader_ShrinkArray = typeof(XmlSerializationReader).GetMethod(
+                                "ShrinkArray",
+                                CodeGenerator.InstanceBindingFlags,
+                                new Type[] { typeof(Array), typeof(int), typeof(Type), typeof(bool) }
+                                )!;
                             WriteSourceBegin(member.ChoiceSource!);
                             a = member.ChoiceArrayName;
                             c = $"c{a}";
@@ -2788,6 +2831,46 @@ namespace System.Xml.Serialization
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Emits the creation of a collection from the elements accumulated in the local named by
+        /// <paramref name="arrayName"/>, or an empty collection when <paramref name="arrayName"/> is null.
+        /// </summary>
+        private void WriteBuildCollection(TypeDesc typeDesc, string? arrayName)
+        {
+            CollectionBuilderInfo collectionBuilder = typeDesc.CollectionBuilder!;
+            Type elementType = typeDesc.ArrayElementTypeDesc!.Type!;
+
+            MethodInfo XmlSerializationReader_ShrinkArray = typeof(XmlSerializationReader).GetMethod(
+                "ShrinkArray",
+                CodeGenerator.InstanceBindingFlags,
+                new Type[] { typeof(Array), typeof(int), typeof(Type), typeof(bool) }
+                )!;
+            ilg.Ldarg(0);
+            if (arrayName == null)
+            {
+                ilg.Load(null);
+                ilg.Ldc(0);
+            }
+            else
+            {
+                ilg.Ldloc(ilg.GetLocal(arrayName));
+                ilg.Ldloc(ilg.GetLocal($"c{arrayName}"));
+            }
+            ilg.Ldc(elementType);
+            // A collection built from its contents is never left null: a nil collection hydrates to an empty
+            // one, which is how a collection populated in place has always behaved.
+            ilg.Ldc(false);
+            ilg.Call(XmlSerializationReader_ShrinkArray);
+            ilg.ConvertValue(XmlSerializationReader_ShrinkArray.ReturnType, elementType.MakeArrayType());
+
+            if (collectionBuilder.FactoryTakesSpan)
+            {
+                ilg.Call(collectionBuilder.SpanConversion);
+            }
+            ilg.Call(collectionBuilder.Factory);
+            ilg.ConvertValue(collectionBuilder.Factory.ReturnType, typeDesc.Type!);
         }
 
         private void WriteSourceBeginTyped(string source)
@@ -3047,6 +3130,11 @@ namespace System.Xml.Serialization
 
         private void WriteArray(string source, string? arrayName, ArrayMapping arrayMapping, bool readOnly, bool isNullable, int elementIndex)
         {
+            // A collection that is created from its contents is always created, even when the element is nil,
+            // which is how a collection populated in place has always behaved. Collections that are value types
+            // are never nillable, so without this they would be left at their uninitialized default value.
+            bool alwaysCreate = isNullable || arrayMapping.TypeDesc!.UsesCollectionBuilder;
+
             MethodInfo XmlSerializationReader_ReadNull = typeof(XmlSerializationReader).GetMethod(
                 "ReadNull",
                 CodeGenerator.InstanceBindingFlags,
@@ -3153,7 +3241,7 @@ namespace System.Xml.Serialization
 
             WriteMemberEnd(members, false);
 
-            if (isNullable)
+            if (alwaysCreate)
             {
                 ilg.ExitScope();    // if (!ReadNull()) { ExitScope
                 ilg.Else();         // } else { EnterScope

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -2865,12 +2865,9 @@ namespace System.Xml.Serialization
             ilg.Call(XmlSerializationReader_ShrinkArray);
             ilg.ConvertValue(XmlSerializationReader_ShrinkArray.ReturnType, elementType.MakeArrayType());
 
-            if (collectionBuilder.FactoryTakesSpan)
-            {
-                ilg.Call(collectionBuilder.SpanConversion);
-            }
-            ilg.Call(collectionBuilder.Factory);
-            ilg.ConvertValue(collectionBuilder.Factory.ReturnType, typeDesc.Type!);
+            ilg.Call(collectionBuilder.SpanConversion);
+            ilg.Call(collectionBuilder.SpanFactory);
+            ilg.ConvertValue(collectionBuilder.SpanFactory.ReturnType, typeDesc.Type!);
         }
 
         private void WriteSourceBeginTyped(string source)

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
@@ -342,100 +343,203 @@ public static partial class XmlSerializerTests
         Assert.Equal((string)x[1], (string)y[1]);
     }
 
-    // ROC and Immutable types are not types from 'SerializableAssembly.dll', so they were not included in the
-    // pregenerated serializers for the sgen tests. We could wrap them in a type that does exist there...
-    // but I think the RO/Immutable story is wonky enough and RefEmit vs Reflection is near enough on the
-    // horizon that it's not worth the trouble.
 #if !XMLSERIALIZERGENERATORTESTS
-    [Fact]
-    public static void Xml_ReadOnlyCollection()
+    [Theory]
+    [MemberData(nameof(Xml_ReadOnlyCollectionAsRoot_MemberData))]
+    public static void Xml_ReadOnlyCollectionAsRoot(Type type, object collection, string expectedXml, object[] expectedItems)
     {
-        ReadOnlyCollection<string> roc = new ReadOnlyCollection<string>(new string[] { "one", "two" });
+        var serializer = new XmlSerializer(type);
+        string actualXml = Serialize(collection, expectedXml, () => serializer, skipStringCompare: expectedXml == null);
+        object roundTripped = Deserialize(serializer, actualXml);
 
-#if ReflectionOnly
-        // Expect exception when _using_ the serializer
-        var serializer = new XmlSerializer(typeof(ReadOnlyCollection<string>));
-        var ex = Assert.Throws<InvalidOperationException>(() => Serialize(roc, null, () => serializer));
-        Assert.Equal("There was an error generating the XML document.", ex.Message);
-        Assert.NotNull(ex.InnerException);
-        Assert.IsType<InvalidOperationException>(ex.InnerException);
-        Assert.StartsWith("To be XML serializable, types which inherit from ICollection must have an implementation of Add(System.String) at all levels of their inheritance hierarchy.", ex.InnerException.Message);
-#else
-        // Expect exception when _creating_ the serializer
-        var ex = Assert.Throws<InvalidOperationException>(() => new XmlSerializer(typeof(ReadOnlyCollection<string>)));
-        Assert.StartsWith("To be XML serializable, types which inherit from ICollection must have an implementation of Add(System.String) at all levels of their inheritance hierarchy.", ex.Message);
-#endif
+        Assert.NotNull(roundTripped);
+        Assert.IsAssignableFrom(type, roundTripped);
+        // Not every read-only collection overrides Equals, so compare contents rather than instances.
+        Assert.Equal(expectedItems, ((IEnumerable)roundTripped).Cast<object>());
+    }
+    public static IEnumerable<object[]> Xml_ReadOnlyCollectionAsRoot_MemberData()
+    {
+        static string ArrayOfInt(params int[] values) => WithXmlHeader(
+            $"<ArrayOfInt xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">{string.Concat(values.Select(v => $"<int>{v}</int>"))}</ArrayOfInt>");
+
+        object[] oneTwoThree = new object[] { 1, 2, 3 };
+
+        yield return new object[] { typeof(ImmutableArray<int>), ImmutableArray.Create(1, 2, 3), ArrayOfInt(1, 2, 3), oneTwoThree };
+        yield return new object[] { typeof(ImmutableList<int>), ImmutableList.Create(1, 2, 3), ArrayOfInt(1, 2, 3), oneTwoThree };
+        yield return new object[] { typeof(ImmutableSortedSet<int>), ImmutableSortedSet.Create(1, 2, 3), ArrayOfInt(1, 2, 3), oneTwoThree };
+        yield return new object[] { typeof(ImmutableQueue<int>), ImmutableQueue.Create(1, 2, 3), ArrayOfInt(1, 2, 3), oneTwoThree };
+        yield return new object[] { typeof(ReadOnlyCollection<int>), new ReadOnlyCollection<int>(new int[] { 1, 2, 3 }), ArrayOfInt(1, 2, 3), oneTwoThree };
+
+        // A stack enumerates newest-first, so writing one out and reading it back reverses it. This matches how a
+        // C# collection expression builds a stack, and is the same round-trip a caller would get from
+        // ImmutableStack.CreateRange(stack).
+        yield return new object[] { typeof(ImmutableStack<int>), ImmutableStack.Create(1, 2, 3), ArrayOfInt(3, 2, 1), oneTwoThree };
+
+        // Sets have no ordering guarantee, so their serialized form isn't compared against a baseline.
+        yield return new object[] { typeof(ImmutableHashSet<int>), ImmutableHashSet.Create(1), ArrayOfInt(1), new object[] { 1 } };
+        yield return new object[] { typeof(FrozenSet<int>), FrozenSet.Create(1), ArrayOfInt(1), new object[] { 1 } };
+        yield return new object[] { typeof(ReadOnlySet<int>), new ReadOnlySet<int>(new HashSet<int>() { 1 }), ArrayOfInt(1), new object[] { 1 } };
+
+        yield return new object[] { typeof(ReadOnlyCollection<string>),
+            new ReadOnlyCollection<string>(new string[] { "one", "two" }),
+            WithXmlHeader("<ArrayOfString xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><string>one</string><string>two</string></ArrayOfString>"),
+            new object[] { "one", "two" } };
+
+        // Nullable enum elements used to fail outright. (dotnet/runtime#66264)
+        yield return new object[] { typeof(ImmutableArray<ConsoleColor?>),
+            ImmutableArray.Create<ConsoleColor?>(ConsoleColor.Blue, null, ConsoleColor.Red),
+            null,
+            new object[] { ConsoleColor.Blue, null, ConsoleColor.Red } };
+
+        yield return new object[] { typeof(ImmutableArray<object>), ImmutableArray.Create<object>(), null, Array.Empty<object>() };
     }
 
     [Theory]
-    [MemberData(nameof(Xml_ImmutableCollections_MemberData))]
-    public static void Xml_ImmutableCollections(Type type, object collection, Type createException, Type addException, string expectedXml, string exMsg = null)
+    [InlineData(true)]
+    [InlineData(false)]
+    public static void Xml_ReadOnlyCollectionAsRoot_EmptyAndNil(bool nil)
     {
-        XmlSerializer serializer;
+        var serializer = new XmlSerializer(typeof(ImmutableArray<int>));
+        string xml = WithXmlHeader(nil
+            ? "<ArrayOfInt xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xsi:nil=\"true\" />"
+            : "<ArrayOfInt xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" />");
 
-        // Some collections implement the required enumerator/Add combo (ImmutableList, ImmutableArray) and some don't (ImmutableStack,
-        // ImmutableQueue). If they do not, they will throw upon serializer construction in RefEmit mode. They should throw when
-        // first using the serializer in Reflection mode.
-#if ReflectionOnly
-        serializer = new XmlSerializer(type);
-        if (createException != null)
-        {
-            var ex = Assert.Throws(createException, () => Serialize(collection, expectedXml, () => serializer));
-            if (exMsg != null)
-                Assert.Contains(exMsg, $"{ex.Message} : {ex.InnerException?.Message}");
-            return;
-        }
-#else
-        if (createException != null)
-        {
-            var ex = Assert.Throws(createException, () => serializer = new XmlSerializer(type));
-            if (exMsg != null)
-                Assert.Contains(exMsg, $"{ex.Message} : {ex.InnerException?.Message}");
-            return;
-        }
-        serializer = new XmlSerializer(type);
-#endif
+        var roundTripped = (ImmutableArray<int>)Deserialize(serializer, xml);
 
-        // If they do meet the signature requirement, they may succeed or fail depending on whether their Add/Indexer explicitly throw
-        // or not. (ImmutableArray throws. ImmutableList does not - it returns a new copy instead... which gets ignored and is thus
-        // essentially a silent failure.) Serializing out to a string first should work though.
-        string serializedValue = Serialize(collection, expectedXml, () => serializer);
-
-        if (addException != null)
-        {
-            var ex = Assert.Throws(addException, () => Deserialize(serializer, serializedValue));
-            if (exMsg != null)
-                Assert.Contains(exMsg, $"{ex.Message} : {ex.InnerException?.Message}");
-            return;
-        }
-
-        // In this case, we can execute everything without exception. But since our calls to '.Add()' do nothing, we end up
-        // with an empty collection
-        var rttCollection = Deserialize(serializer, serializedValue);
-        Assert.NotNull(rttCollection);
-        Assert.Empty((IEnumerable)rttCollection);
+        Assert.False(roundTripped.IsDefault);
+        Assert.Empty(roundTripped);
     }
-    public static IEnumerable<object[]> Xml_ImmutableCollections_MemberData()
-    {
-        string arrayOfInt = WithXmlHeader("<ArrayOfInt xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><int>42</int></ArrayOfInt>");
-        string arrayOfAny = WithXmlHeader("<ArrayOfAnyType xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><anyType /></ArrayOfAnyType>");
 
-#if ReflectionOnly
-        yield return new object[] { typeof(ImmutableArray<int>), ImmutableArray.Create(42), null, typeof(InvalidOperationException), arrayOfInt, "Specified method is not supported." };
-        yield return new object[] { typeof(ImmutableArray<object>), ImmutableArray.Create(new object()), null, typeof(InvalidOperationException), arrayOfAny, "Specified method is not supported." };
-        yield return new object[] { typeof(ImmutableList<int>), ImmutableList.Create(42), null, typeof(InvalidOperationException), arrayOfInt, "Specified method is not supported." };
-        yield return new object[] { typeof(ImmutableStack<int>), ImmutableStack.Create(42), typeof(InvalidOperationException), null, arrayOfInt, "To be XML serializable, types which inherit from IEnumerable must have an implementation of Add" };
-        yield return new object[] { typeof(ImmutableQueue<int>), ImmutableQueue.Create(42), typeof(InvalidOperationException), null, arrayOfInt, "To be XML serializable, types which inherit from IEnumerable must have an implementation of Add" };
-        yield return new object[] { typeof(ImmutableDictionary<string, int>), new Dictionary<string, int>() { { "one", 1 } }.ToImmutableDictionary(), typeof(InvalidOperationException), null, null, "is not supported because it implements IDictionary." };
-#else
-        yield return new object[] { typeof(ImmutableArray<int>), ImmutableArray.Create(42), null, typeof(InvalidOperationException), arrayOfInt, "Parameterless constructor is required for collections and enumerators." };
-        yield return new object[] { typeof(ImmutableArray<object>), ImmutableArray.Create(new object()), null, typeof(InvalidOperationException), arrayOfAny, "Parameterless constructor is required for collections and enumerators." };
-        yield return new object[] { typeof(ImmutableList<int>), ImmutableList.Create(42), null, null, arrayOfInt };
-        yield return new object[] { typeof(ImmutableStack<int>), ImmutableStack.Create(42), typeof(InvalidOperationException), null, arrayOfInt, "To be XML serializable, types which inherit from IEnumerable must have an implementation of Add" };
-        yield return new object[] { typeof(ImmutableQueue<int>), ImmutableQueue.Create(42), typeof(InvalidOperationException), null, arrayOfInt, "To be XML serializable, types which inherit from IEnumerable must have an implementation of Add" };
-        // IDictionary types are denied right from the start with a NotSupportedExcpetion
-        yield return new object[] { typeof(ImmutableDictionary<string, int>), new Dictionary<string, int>() { { "one", 1 } }.ToImmutableDictionary(), typeof(NotSupportedException), null, null, "is not supported because it implements IDictionary." };
+    // A nil collection deserializes to an empty collection rather than to null, which is how XmlSerializer has
+    // always treated the collections it populates in place. List<int> is here as the control.
+    [Theory]
+#if !ReflectionOnly
+    // The reflection based reader leaves a nil root level mutable collection null. That is a pre-existing
+    // difference from the IL generating reader which this change deliberately leaves alone.
+    [InlineData(typeof(List<int>))]
 #endif
+    [InlineData(typeof(ImmutableList<int>))]
+    [InlineData(typeof(ImmutableArray<int>))]
+    [InlineData(typeof(ReadOnlyCollection<int>))]
+    [InlineData(typeof(FrozenSet<int>))]
+    public static void Xml_NilCollectionAsRoot_BecomesEmpty(Type type)
+    {
+        var serializer = new XmlSerializer(type);
+        object roundTripped = Deserialize(serializer, WithXmlHeader(
+            "<ArrayOfInt xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\" />"));
+
+        Assert.NotNull(roundTripped);
+        Assert.Empty((IEnumerable)roundTripped);
+    }
+#endif  // !XMLSERIALIZERGENERATORTESTS
+
+    [Fact]
+    public static void Xml_ReadOnlyCollectionAsMember()
+    {
+        var value = new TypeWithReadOnlyCollections()
+        {
+            ImmutableArray = ImmutableArray.Create(1, 2, 3),
+            ImmutableList = ImmutableList.Create("one", "two"),
+            ReadOnlyCollection = new ReadOnlyCollection<int>(new int[] { 4, 5 }),
+            FrozenSet = FrozenSet.Create(6),
+            ImmutableQueue = ImmutableQueue.Create(7, 8),
+        };
+
+        var roundTripped = SerializeAndDeserialize(value, null, skipStringCompare: true);
+
+        Assert.Equal(value.ImmutableArray, roundTripped.ImmutableArray);
+        Assert.Equal(value.ImmutableList, roundTripped.ImmutableList);
+        Assert.Equal(value.ReadOnlyCollection, roundTripped.ReadOnlyCollection);
+        Assert.Equal(value.FrozenSet, roundTripped.FrozenSet);
+        Assert.Equal(value.ImmutableQueue, roundTripped.ImmutableQueue);
+    }
+
+    [Fact]
+    public static void Xml_ReadOnlyCollectionAsMember_NilBecomesEmpty()
+    {
+        // A collection that is absent or nil in the document still comes back as an empty collection, which is how
+        // XmlSerializer has always treated collections it populates in place.
+        var serializer = new XmlSerializer(typeof(TypeWithReadOnlyCollections));
+        var roundTripped = (TypeWithReadOnlyCollections)Deserialize(serializer, WithXmlHeader(
+            "<TypeWithReadOnlyCollections xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><ImmutableArray xsi:nil=\"true\" /></TypeWithReadOnlyCollections>"));
+
+        Assert.False(roundTripped.ImmutableArray.IsDefault);
+        Assert.Empty(roundTripped.ImmutableArray);
+        Assert.Empty(roundTripped.ImmutableList);
+        Assert.Empty(roundTripped.ReadOnlyCollection);
+        Assert.Empty(roundTripped.FrozenSet);
+        Assert.Empty(roundTripped.ImmutableQueue);
+    }
+
+    [Fact]
+    public static void Xml_MutableCollectionAsMember_NilOrAbsentBecomesEmpty()
+    {
+        // The behavior that read-only collections are expected to match. A collection member is never left null,
+        // but an array member is.
+        var serializer = new XmlSerializer(typeof(TypeWithMutableCollectionMembers));
+        const string Ns = " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"";
+
+        var nil = (TypeWithMutableCollectionMembers)Deserialize(serializer, WithXmlHeader(
+            $"<TypeWithMutableCollectionMembers{Ns}><List xsi:nil=\"true\" /><Array xsi:nil=\"true\" /></TypeWithMutableCollectionMembers>"));
+        Assert.Empty(nil.List);
+        Assert.Null(nil.Array);
+
+        var absent = (TypeWithMutableCollectionMembers)Deserialize(serializer, WithXmlHeader(
+            $"<TypeWithMutableCollectionMembers{Ns} />"));
+        Assert.Empty(absent.List);
+        Assert.Null(absent.Array);
+    }
+
+    [Fact]
+    public static void Xml_GetOnlyReadOnlyCollectionAsMember_KeepsGetterValue()
+    {
+        // A collection created from its complete contents cannot be added to, and a get-only member has nowhere
+        // to store a new instance, so the elements read are dropped and the getter's value survives. This matches
+        // how a get-only collection that cannot be added to has always behaved.
+        var serializer = new XmlSerializer(typeof(TypeWithGetOnlyReadOnlyCollections));
+        var roundTripped = (TypeWithGetOnlyReadOnlyCollections)Deserialize(serializer, WithXmlHeader(
+            "<TypeWithGetOnlyReadOnlyCollections><ImmutableList><string>read</string></ImmutableList>" +
+            "<ReadOnlyCollection><int>7</int></ReadOnlyCollection>" +
+            "<ImmutableArray><string>read</string></ImmutableArray></TypeWithGetOnlyReadOnlyCollections>"));
+
+        Assert.Equal(new[] { "initial" }, roundTripped.ImmutableList);
+        Assert.Equal(new[] { 42 }, roundTripped.ReadOnlyCollection);
+        Assert.True(roundTripped.ImmutableArray.IsDefault);
+    }
+
+#if !XMLSERIALIZERGENERATORTESTS
+    [Theory]
+    [MemberData(nameof(Xml_UnsupportedReadOnlyCollections_MemberData))]
+    public static void Xml_UnsupportedReadOnlyCollections(Type type, Type expectedException, string expectedMessage)
+    {
+#if ReflectionOnly
+        // The reflection based serializer defers the failure until the serializer is first used. Deserializing
+        // avoids needing an instance of a type that cannot be constructed in the first place.
+        var serializer = new XmlSerializer(type);
+        var ex = Assert.Throws(expectedException, () => Deserialize(serializer, WithXmlHeader("<Root />")));
+#else
+        var ex = Assert.Throws(expectedException, () => new XmlSerializer(type));
+#endif
+        Assert.Contains(expectedMessage, $"{ex.Message} : {ex.InnerException?.Message}");
+    }
+    public static IEnumerable<object[]> Xml_UnsupportedReadOnlyCollections_MemberData()
+    {
+        // Dictionaries stay unsupported whether or not they carry a collection builder.
+#if ReflectionOnly
+        yield return new object[] { typeof(ImmutableDictionary<string, int>), typeof(InvalidOperationException), "is not supported because it implements IDictionary." };
+        yield return new object[] { typeof(FrozenDictionary<string, int>), typeof(InvalidOperationException), "is not supported because it implements IDictionary." };
+#else
+        yield return new object[] { typeof(ImmutableDictionary<string, int>), typeof(NotSupportedException), "is not supported because it implements IDictionary." };
+        yield return new object[] { typeof(FrozenDictionary<string, int>), typeof(NotSupportedException), "is not supported because it implements IDictionary." };
+#endif
+        // ImmutableSortedDictionary is doubly unsupported: it is a dictionary, and it has no collection builder.
+        yield return new object[] { typeof(ImmutableSortedDictionary<string, int>),
+#if ReflectionOnly
+            typeof(InvalidOperationException),
+#else
+            typeof(NotSupportedException),
+#endif
+            "is not supported because it implements IDictionary." };
     }
 #endif  // !XMLSERIALIZERGENERATORTESTS
 

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -443,6 +443,7 @@ public static partial class XmlSerializerTests
             ReadOnlyCollection = new ReadOnlyCollection<int>(new int[] { 4, 5 }),
             FrozenSet = FrozenSet.Create(6),
             ImmutableQueue = ImmutableQueue.Create(7, 8),
+            ImmutableArrayField = ImmutableArray.Create("nine", "ten"),
         };
 
         var roundTripped = SerializeAndDeserialize(value, null, skipStringCompare: true);
@@ -452,6 +453,7 @@ public static partial class XmlSerializerTests
         Assert.Equal(value.ReadOnlyCollection, roundTripped.ReadOnlyCollection);
         Assert.Equal(value.FrozenSet, roundTripped.FrozenSet);
         Assert.Equal(value.ImmutableQueue, roundTripped.ImmutableQueue);
+        Assert.Equal(value.ImmutableArrayField, roundTripped.ImmutableArrayField);
     }
 
     [Fact]
@@ -469,6 +471,8 @@ public static partial class XmlSerializerTests
         Assert.Empty(roundTripped.ReadOnlyCollection);
         Assert.Empty(roundTripped.FrozenSet);
         Assert.Empty(roundTripped.ImmutableQueue);
+        Assert.False(roundTripped.ImmutableArrayField.IsDefault);
+        Assert.Empty(roundTripped.ImmutableArrayField);
     }
 
     [Fact]

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -456,42 +456,44 @@ public static partial class XmlSerializerTests
         Assert.Equal(value.ImmutableArrayField, roundTripped.ImmutableArrayField);
     }
 
-    [Fact]
-    public static void Xml_ReadOnlyCollectionAsMember_NilBecomesEmpty()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public static void Xml_CollectionAsMember_NilOrAbsentBecomesEmpty(bool nil)
     {
-        // A collection that is absent or nil in the document still comes back as an empty collection, which is how
-        // XmlSerializer has always treated collections it populates in place.
-        var serializer = new XmlSerializer(typeof(TypeWithReadOnlyCollections));
-        var roundTripped = (TypeWithReadOnlyCollections)Deserialize(serializer, WithXmlHeader(
-            "<TypeWithReadOnlyCollections xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><ImmutableArray xsi:nil=\"true\" /></TypeWithReadOnlyCollections>"));
-
-        Assert.False(roundTripped.ImmutableArray.IsDefault);
-        Assert.Empty(roundTripped.ImmutableArray);
-        Assert.Empty(roundTripped.ImmutableList);
-        Assert.Empty(roundTripped.ReadOnlyCollection);
-        Assert.Empty(roundTripped.FrozenSet);
-        Assert.Empty(roundTripped.ImmutableQueue);
-        Assert.False(roundTripped.ImmutableArrayField.IsDefault);
-        Assert.Empty(roundTripped.ImmutableArrayField);
-    }
-
-    [Fact]
-    public static void Xml_MutableCollectionAsMember_NilOrAbsentBecomesEmpty()
-    {
-        // The behavior that read-only collections are expected to match. A collection member is never left null,
-        // but an array member is.
-        var serializer = new XmlSerializer(typeof(TypeWithMutableCollectionMembers));
+        // A collection member is never left null, whether the document says it is nil or leaves it out entirely,
+        // which is how XmlSerializer has always treated the collections it populates in place. Collections created
+        // from their complete contents have to match that.
         const string Ns = " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"";
 
-        var nil = (TypeWithMutableCollectionMembers)Deserialize(serializer, WithXmlHeader(
-            $"<TypeWithMutableCollectionMembers{Ns}><List xsi:nil=\"true\" /><Array xsi:nil=\"true\" /></TypeWithMutableCollectionMembers>"));
-        Assert.Empty(nil.List);
-        Assert.Null(nil.Array);
+        string readOnlyBody = nil
+            ? "<ImmutableArray xsi:nil=\"true\" /><ImmutableList xsi:nil=\"true\" /><ReadOnlyCollection xsi:nil=\"true\" />" +
+              "<FrozenSet xsi:nil=\"true\" /><ImmutableQueue xsi:nil=\"true\" /><ImmutableArrayField xsi:nil=\"true\" />"
+            : "";
 
-        var absent = (TypeWithMutableCollectionMembers)Deserialize(serializer, WithXmlHeader(
-            $"<TypeWithMutableCollectionMembers{Ns} />"));
-        Assert.Empty(absent.List);
-        Assert.Null(absent.Array);
+        var readOnly = (TypeWithReadOnlyCollections)Deserialize(
+            new XmlSerializer(typeof(TypeWithReadOnlyCollections)),
+            WithXmlHeader($"<TypeWithReadOnlyCollections{Ns}>{readOnlyBody}</TypeWithReadOnlyCollections>"));
+
+        Assert.False(readOnly.ImmutableArray.IsDefault);
+        Assert.Empty(readOnly.ImmutableArray);
+        Assert.Empty(readOnly.ImmutableList);
+        Assert.Empty(readOnly.ReadOnlyCollection);
+        Assert.Empty(readOnly.FrozenSet);
+        Assert.Empty(readOnly.ImmutableQueue);
+        Assert.False(readOnly.ImmutableArrayField.IsDefault);
+        Assert.Empty(readOnly.ImmutableArrayField);
+
+        // The mutable behavior above is expected to match. A collection member is never left null, but an array
+        // member is.
+        string mutableBody = nil ? "<List xsi:nil=\"true\" /><Array xsi:nil=\"true\" />" : "";
+
+        var mutable = (TypeWithMutableCollectionMembers)Deserialize(
+            new XmlSerializer(typeof(TypeWithMutableCollectionMembers)),
+            WithXmlHeader($"<TypeWithMutableCollectionMembers{Ns}>{mutableBody}</TypeWithMutableCollectionMembers>"));
+
+        Assert.Empty(mutable.List);
+        Assert.Null(mutable.Array);
     }
 
     [Fact]
@@ -504,11 +506,13 @@ public static partial class XmlSerializerTests
         var roundTripped = (TypeWithGetOnlyReadOnlyCollections)Deserialize(serializer, WithXmlHeader(
             "<TypeWithGetOnlyReadOnlyCollections><ImmutableList><string>read</string></ImmutableList>" +
             "<ReadOnlyCollection><int>7</int></ReadOnlyCollection>" +
-            "<ImmutableArray><string>read</string></ImmutableArray></TypeWithGetOnlyReadOnlyCollections>"));
+            "<ImmutableArray><string>read</string></ImmutableArray>" +
+            "<Flat>21</Flat><Flat>22</Flat></TypeWithGetOnlyReadOnlyCollections>"));
 
         Assert.Equal(new[] { "initial" }, roundTripped.ImmutableList);
         Assert.Equal(new[] { 42 }, roundTripped.ReadOnlyCollection);
         Assert.True(roundTripped.ImmutableArray.IsDefault);
+        Assert.Equal(new[] { 13 }, roundTripped.Flat);
     }
 
 #if !XMLSERIALIZERGENERATORTESTS

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
@@ -1816,4 +1819,35 @@ public class DateTimeOffsetIXmlSerializableContainer : IXmlSerializable
         Date = (DateTimeOffset)innerSerializer.ReadObject(reader);
         reader.ReadEndElement();
     }
+}
+
+// Collections that cannot be populated in place, and so are created from their complete contents by the
+// collection builder their type declares.
+public class TypeWithReadOnlyCollections
+{
+    public ImmutableArray<int> ImmutableArray { get; set; }
+    public ImmutableList<string> ImmutableList { get; set; }
+    public ReadOnlyCollection<int> ReadOnlyCollection { get; set; }
+    public FrozenSet<int> FrozenSet { get; set; }
+    public ImmutableQueue<int> ImmutableQueue { get; set; }
+}
+
+// The mutable counterpart of TypeWithReadOnlyCollections, used to verify that collections created from their
+// contents observe the same nil and absent element behavior as collections populated in place.
+public class TypeWithMutableCollectionMembers
+{
+    public List<int> List { get; set; }
+    public int[] Array { get; set; }
+}
+
+// Get-only collection properties are imported, but a collection created from its complete contents has nowhere
+// to be stored without a setter, so the value the getter returns is left alone.
+public class TypeWithGetOnlyReadOnlyCollections
+{
+    public ImmutableList<string> ImmutableList { get; } = System.Collections.Immutable.ImmutableList.Create("initial");
+    public ReadOnlyCollection<int> ReadOnlyCollection { get; } = new ReadOnlyCollection<int>(new int[] { 42 });
+
+    // Left uninitialized so the getter returns a default struct, which no collection built from its complete
+    // contents can be added to.
+    public ImmutableArray<string> ImmutableArray { get; }
 }

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1830,6 +1830,9 @@ public class TypeWithReadOnlyCollections
     public ReadOnlyCollection<int> ReadOnlyCollection { get; set; }
     public FrozenSet<int> FrozenSet { get; set; }
     public ImmutableQueue<int> ImmutableQueue { get; set; }
+
+    // A field rather than a property, which the serializers assign through a different path.
+    public ImmutableArray<string> ImmutableArrayField;
 }
 
 // The mutable counterpart of TypeWithReadOnlyCollections, used to verify that collections created from their

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -1853,4 +1853,9 @@ public class TypeWithGetOnlyReadOnlyCollections
     // Left uninitialized so the getter returns a default struct, which no collection built from its complete
     // contents can be added to.
     public ImmutableArray<string> ImmutableArray { get; }
+
+    // Repeated elements rather than a wrapped array, which the reflection based reader accumulates and assigns
+    // through a different path than the wrapped shape above.
+    [XmlElement("Flat")]
+    public ImmutableList<int> Flat { get; } = System.Collections.Immutable.ImmutableList.Create(13);
 }


### PR DESCRIPTION
Fixes: #66264

Supersedes #130455, which took a narrower approach. This branch is a fresh implementation.

## Problem

`XmlSerializer` populates a collection by constructing it and then calling `Add()` (or `this[int]`) once per element. Read-only and immutable collections cannot be populated that way, so today they fall into one of three buckets:

| Bucket | Types | Symptom |
|---|---|---|
| Throw at import | `ImmutableHashSet<T>`, `FrozenSet<T>`, `ReadOnlySet<T>`, `ReadOnlyCollection<T>`, `ImmutableStack<T>`, `ImmutableQueue<T>` | `InvalidOperationException`, "...does not implement Add(System.Object)" / "...does not have a default accessor" |
| Silently lose data | `ImmutableList<T>`, `ImmutableSortedSet<T>` | `Add` returns a *new* instance which is discarded, so the member always deserializes **empty** |
| Throw at runtime | `ImmutableArray<T>` | `NotSupportedException` from `IList.Add`, or an NRE for a nil root |

## Approach

This adds a secondary construction path driven by `System.Runtime.CompilerServices.CollectionBuilderAttribute`. When a collection type carries the attribute *and* cannot be constructed or populated the normal way, the readers accumulate elements into an ephemeral `T[]`, exactly like the existing array path, and at end-of-collection hydrate the real instance by calling the builder factory method.

This is deliberately not an "Immutable-namespace" special case. It is a generic fallback for any type that opts in via the attribute, including user-defined ones.

### Gating

The builder path is used only when **both** hold:

1. The type has `[CollectionBuilder]` and a usable factory method resolves; and
2. The type fails today's requirements, meaning `TypeDesc.CannotNew`, or no usable `this[int]` indexer, or no matching `Add`.

Types that work today are untouched: with no attribute present, behavior is byte-identical to before.

Attribute discovery uses `GetCustomAttributesData()` rather than `GetCustomAttribute<T>()`, so no attribute is instantiated and no extra types or assemblies are loaded during import.

### Factory resolution and invocation

`[CollectionBuilder]` requires a `Create(ReadOnlySpan<T>)` overload and permits a `T[]` overload, so `CollectionBuilderInfo` requires the span overload and treats the array overload as optional. The ILGen and sgen backends always emit the span call directly.

Because `MethodInfo.Invoke` cannot pass a `ReadOnlySpan<T>`, the reflection reader binds the closed `MethodInfo` to a private delegate type via `MethodInfo.CreateDelegate` (no expression trees). When `!RuntimeFeature.IsDynamicCodeSupported` it cannot close that generic delegate, so it falls back to the `T[]` overload with a plain `Invoke`. Note that `ReadOnlyCollection.CreateCollection<T>`, `ReadOnlyCollection.CreateSet<T>` and `FrozenSet.Create<T>` are span-only, so there is no fallback for those three.

## Types that begin working

`ImmutableArray<T>`, `ImmutableList<T>`, `ImmutableHashSet<T>`, `ImmutableSortedSet<T>`, `ImmutableStack<T>`, `ImmutableQueue<T>`, `FrozenSet<T>`, `ReadOnlyCollection<T>`, `ReadOnlySet<T>`.

## Behavioral changes

These are the observable differences for code that compiles today:

- **`ImmutableList<T>` and `ImmutableSortedSet<T>` members previously deserialized silently empty and now round-trip with their content.** Anyone relying on the empty result was relying on data loss, but it is a behavior change nonetheless.
- **`ImmutableArray<T>` previously threw `NotSupportedException`** during deserialization and now succeeds.

Everything else here turns a thrown exception into working serialization, which is additive.

## Known limitations

- **`ImmutableStack<T>` and `ImmutableQueue<T>` reverse element order on round-trip.** Their builders match C# collection-expression semantics (`ImmutableStack.Create(a, b, c)` enumerates as `c, b, a`). This is documented in the tests rather than worked around, so the behavior stays consistent with the language. Reversing on hydration is a reasonable follow-up.
- **Dictionaries remain unsupported.** `XmlSerializer` rejects `IDictionary` up front and that guard is unchanged, so `ImmutableDictionary<,>` and `FrozenDictionary<,>` still throw. `ImmutableSortedDictionary<,>` has no `[CollectionBuilder]` at all.
- **Interfaces** such as `IImmutableList<T>` are still rejected earlier as interfaces.
- **Get-only collection properties do not round-trip.** A collection created from its complete contents cannot be added to, and a member with no setter has nowhere to store the new instance, so the elements read are dropped and the getter's value survives. This is the same thing that happens today for a get-only `ImmutableList<T>`, and it is why the fix skips the assignment rather than throwing: such a property imports, serializes, *and* deserializes (as empty) today, so throwing at deserialize would regress it, and throwing at import would break serialize-only scenarios since import is shared by both directions. All three readers agree on this, including for a get-only `ImmutableArray<T>` whose getter returns an uninitialized struct.
- **SOAP / encoded mode is out of scope.** Its `CollectionFixup` / `WriteAddCollectionFixup` model defers population until after the object graph is read, which is fundamentally incompatible with hydrate-once construction. Builder-backed types are explicitly guarded there so they throw a clear error rather than producing garbage.

## Notes for reviewers

- **`UsesCollectionBuilder` is not a `TypeFlags` bit.** It is derived from whether the resolved `CollectionBuilderInfo` is non-null. `GetNullableTypeDesc` and `CreateArrayTypeDesc` copy `_flags` but not the builder object, so a flag bit would leak the capability onto derived `TypeDesc`s that have no builder.
- **`CannotNew` is not redefined.** A builder has no bearing on whether a type can be `new`-ed; every downstream site that cares checks `UsesCollectionBuilder` explicitly. `CheckNeedConstructor()` is itself builder-aware rather than each call site being patched.
- **Nil and absent semantics are preserved exactly.** The legacy quirk is that a non-array collection always comes back empty, never `null`, whether the XML says `xsi:nil="true"` or omits the element entirely, while arrays come back `null`. That "absent means empty" behavior comes from `WriteMemberBegin` pre-creating the collection, not from `WriteMemberEnd`, so builder-backed members do both: create empty up front and hydrate at the end. `ShrinkArray` is called with `isNullable: false` so a nil collection yields an empty array and therefore an empty hydrated collection. `Xml_CollectionAsMember_NilOrAbsentBecomesEmpty` pins this against a mutable control type.
- **There are two independent element-type resolution paths**, `TypeScope.ImportTypeDesc` for classification and `TypeScope.GetArrayElementType` -> `GetCollectionElementType` used by `ArrayModel.Element` and `XmlReflectionImporter.ImportAccessorMapping`. Both had to be taught the same rule or they disagree and the second one re-throws.
- **`[UnconditionalSuppressMessage]` rather than `[RequiresDynamicCode]`** on the `MakeGenericMethod` choke point. Propagating `RequiresDynamicCode` would cascade across every caller of `TypeScope.GetTypeDesc`, and every `XmlSerializer` public entry point is already annotated `[RequiresDynamicCode(XmlSerializer.AotSerializationWarning)]`.
- **`Expected.SerializableAssembly.XmlSerializers.cs` is machine-generated** and was regenerated from sgen output. Adding a type to `SerializationTypes.cs` renumbers every `Write##_`/`Read##_` method, which is why that part of the diff is large. The `%%ParentAssemblyId%%` placeholder is preserved.
- No new resource strings; this reuses `SR.XmlReadOnlyCollection`.

## Testing

New tests live in `XmlSerializerTests.cs` so they run in **all three** flavors. They cover root-level and member-level usage, empty and nil collections, `ImmutableArray<ConsoleColor?>` (the original AV repro from the issue), and sequence-equality comparisons since `ReadOnlyCollection<T>` does not override `Equals`. Member-level coverage includes a field as well as properties, since the readers assign fields through a different path. Unsupported shapes are covered by negative tests asserting they still throw.

| Suite | Result |
|---|---|
| `System.Private.Xml.Tests` (ILGen) | 49,058 passed, 0 failed, 0 skipped |
| `System.Xml.XmlSerializer.ReflectionOnly.Tests` | 366 passed, 0 failed |
| `Microsoft.XmlSerializer.Generator.Tests` (sgen) | 139 passed, 0 failed |
| `System.Runtime.Serialization.Xml.Tests` (shares `SerializationTypes.cs`) | 361 passed, 0 failed |

Three divergences between the backends were found by tests rather than by inspection, and are worth knowing about when reviewing this area:

1. `Xml_GetOnlyReadOnlyCollectionAsMember_KeepsGetterValue` failed without the fix in two distinct ways. The ILGen reader hit `Debug.Assert(setMethod != null)` in `CodeGenerator.StoreMember` and took the test host down, because `Member._isArray` is now `IsArray || UsesCollectionBuilder` and get-only *collection* properties are admitted at import (`Models.cs:238`) where get-only *array* properties are not. The reflection reader failed separately with a `NullReferenceException`: for the `[XmlArray]`-wrapped shape it never takes the `member.Collection` path and instead installed a reflective `Add` delegate that called `ImmutableArray<T>.Add` on an uninitialized struct. The regenerated sgen output was inspected directly to confirm the read method for that type contains zero member assignments.

2. Adding a **field** to `TypeWithReadOnlyCollections` exposed the reflection reader's `EnsureCollection` finalizer, the thing that guarantees a collection member is never left uninitialized, testing `GetMemberValue(...) == null`. A struct collection such as `ImmutableArray<T>` boxes to a non-null default, so an *absent* member kept its default value where the other two readers produced an empty collection. `EnsureCollection` now also treats a boxed default as uninitialized.

3. The reflection reader's flat `[XmlElement]` shape reaches `AddObjectsIntoTargetCollection` and its `IList.Add`, which throws `NotSupportedException` for a builder-backed type. The guard that skips it was verified by adding a repeated-element get-only member and confirming the test fails when the guard is removed.

The `!RuntimeFeature.IsDynamicCodeSupported` array fallback in `CollectionBuilderInfo.CreateBuilder` is not covered by an executed test. It was verified by inspection only, as the libraries test suites all run with dynamic code available.

Unrelated pre-existing behavior worth knowing: the reflection reader cannot deserialize into a `readonly` **field** of any collection type, failing with `ArgumentException: Expression must be writeable` from the `Expression.Assign` it builds. This reproduces identically with a plain `readonly List<int>` field, so it is not caused by this change and is not addressed here. Filed separately as #132357.

> [!NOTE]
> This pull request description was drafted with GitHub Copilot.