### PR TITLE
Adds metadata reference validation to ILVerify.

### DIFF
--- a/src/coreclr/tools/ILVerification.Tests/ILMetadataReferenceTester.cs
+++ b/src/coreclr/tools/ILVerification.Tests/ILMetadataReferenceTester.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Reflection.Metadata;
+using ILVerify;
+using Internal.TypeSystem.Ecma;
+using Xunit;
+
+namespace ILVerification.Tests
+{
+    public class ILMetadataReferenceTester
+    {
+        [Fact]
+        public static void ReportsUnusedMetadataReferences()
+        {
+            (EcmaModule module, VerificationResult[] results) =
+                VerifyMetadataReferences("UnusedMetadataReferenceTests.dll");
+
+            var verifier = new Verifier((ILVerifyTypeSystemContext)module.Context, new VerifierOptions());
+            Assert.Empty(verifier.Verify(module.PEReader));
+
+            AssertResult(results, HandleKind.AssemblyReference, "ILVerifyAssemblyThatDoesNotExist");
+            AssertResult(results, HandleKind.ModuleReference, "ILVerifyManagedModuleThatDoesNotExist.netmodule");
+            AssertResult(results, HandleKind.ExportedType, "ILVerifyAssemblyThatDoesNotExist");
+
+            // The P/Invoke ModuleRef and resolvable references should not produce additional errors.
+            Assert.Equal(3, results.Length);
+        }
+
+        [Fact]
+        public static void ReportsInvalidMetadataReferenceKinds()
+        {
+            (_, VerificationResult[] results) =
+                VerifyMetadataReferences("InvalidMetadataReferenceTests.dll");
+
+            Assert.Equal(13, results.Length);
+            Assert.Equal(1, results.Count(result => result.MetadataHandle.Kind == HandleKind.AssemblyReference));
+            Assert.Equal(6, results.Count(result => result.MetadataHandle.Kind == HandleKind.TypeReference));
+            Assert.Equal(2, results.Count(result => result.MetadataHandle.Kind == HandleKind.MemberReference));
+            Assert.Equal(1, results.Count(result => result.MetadataHandle.Kind == HandleKind.TypeSpecification));
+            Assert.Equal(1, results.Count(result => result.MetadataHandle.Kind == HandleKind.MethodSpecification));
+            Assert.Equal(2, results.Count(result => result.MetadataHandle.Kind == HandleKind.StandaloneSignature));
+
+            AssertResult(results, HandleKind.AssemblyReference, "ILVerifyAssemblyThatDoesNotExist");
+            AssertResult(results, HandleKind.TypeReference, "ILVerifyAssemblyThatDoesNotExist");
+            AssertResult(results, HandleKind.TypeReference, "ILVerifyTypeThatDoesNotExist");
+            AssertResult(results, HandleKind.MemberReference, "ILVerifyMethodThatDoesNotExist");
+            AssertResult(results, HandleKind.MemberReference, "ILVerifyFieldThatDoesNotExist");
+            AssertResult(results, HandleKind.TypeSpecification, "ILVerifyTypeSpecTypeThatDoesNotExist");
+            AssertResult(results, HandleKind.MethodSpecification, "ILVerifyMethodSpecTypeThatDoesNotExist");
+            AssertResult(results, HandleKind.StandaloneSignature, "ILVerifyStandaloneMethodTypeThatDoesNotExist");
+            AssertResult(results, HandleKind.StandaloneSignature, "ILVerifyStandaloneLocalTypeThatDoesNotExist");
+
+            Assert.All(results, result =>
+            {
+                Assert.False(result.MetadataHandle.IsNil);
+                Assert.True(result.Code != VerifierError.None || result.ExceptionID != null);
+            });
+        }
+
+        private static (EcmaModule Module, VerificationResult[] Results) VerifyMetadataReferences(string assemblyName)
+        {
+            EcmaModule module = TestDataLoader.GetModuleForTestAssembly(assemblyName);
+            var verifier = new Verifier((ILVerifyTypeSystemContext)module.Context, new VerifierOptions());
+
+            return (module, verifier.VerifyMetadataReferences(module.PEReader).ToArray());
+        }
+
+        private static void AssertResult(
+            VerificationResult[] results,
+            HandleKind kind,
+            string messagePart)
+        {
+            Assert.Single(results, result =>
+                result.MetadataHandle.Kind == kind &&
+                result.Message.Contains(messagePart, StringComparison.Ordinal));
+        }
+    }
+}

--- a/src/coreclr/tools/ILVerification.Tests/ILMetadataReferenceTester.cs
+++ b/src/coreclr/tools/ILVerification.Tests/ILMetadataReferenceTester.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Reflection.Metadata;
 using ILVerify;
+using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using Xunit;
 
@@ -52,6 +53,13 @@ namespace ILVerification.Tests
             AssertResult(results, HandleKind.MethodSpecification, "ILVerifyMethodSpecTypeThatDoesNotExist");
             AssertResult(results, HandleKind.StandaloneSignature, "ILVerifyStandaloneMethodTypeThatDoesNotExist");
             AssertResult(results, HandleKind.StandaloneSignature, "ILVerifyStandaloneLocalTypeThatDoesNotExist");
+
+            VerificationResult missingAssembly = Assert.Single(results, result =>
+                result.MetadataHandle.Kind == HandleKind.AssemblyReference &&
+                result.ExceptionID == ExceptionStringID.FileLoadErrorGeneric);
+            Assert.Equal(
+                new[] { "ILVerifyAssemblyThatDoesNotExist" },
+                missingAssembly.GetArgumentValue<string[]>(nameof(TypeSystemException.Arguments)));
 
             Assert.All(results, result =>
             {

--- a/src/coreclr/tools/ILVerification.Tests/ILTests/InvalidMetadataReferenceTests.il
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/InvalidMetadataReferenceTests.il
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Private.CoreLib
+{
+}
+
+.assembly extern ILVerifyAssemblyThatDoesNotExist
+{
+}
+
+.assembly InvalidMetadataReferenceTests
+{
+}
+
+.class public auto ansi abstract sealed beforefieldinit InvalidMetadataReferenceTestsType
+       extends [System.Private.CoreLib]System.Object
+{
+    .method private static void MissingTypeInMissingAssembly() cil managed
+    {
+        ldnull
+        castclass [ILVerifyAssemblyThatDoesNotExist]ILVerifyTypeInMissingAssembly
+        pop
+        ret
+    }
+
+    .method private static void MissingTypeInResolvedAssembly() cil managed
+    {
+        ldnull
+        castclass [System.Private.CoreLib]ILVerifyTypeThatDoesNotExist
+        pop
+        ret
+    }
+
+    .method private static void MissingMethodReference() cil managed
+    {
+        call void [System.Private.CoreLib]System.Object::ILVerifyMethodThatDoesNotExist()
+        ret
+    }
+
+    .method private static void MissingFieldReference() cil managed
+    {
+        ldsfld int32 [System.Private.CoreLib]System.String::ILVerifyFieldThatDoesNotExist
+        pop
+        ret
+    }
+
+    .method private static void MissingTypeSpecification() cil managed
+    {
+        ldnull
+        castclass class [System.Private.CoreLib]System.Collections.Generic.List`1<
+            class [System.Private.CoreLib]ILVerifyTypeSpecTypeThatDoesNotExist>
+        pop
+        ret
+    }
+
+    .method private static void GenericMethod<T>() cil managed
+    {
+        ret
+    }
+
+    .method private static void MissingMethodSpecification() cil managed
+    {
+        call void InvalidMetadataReferenceTestsType::GenericMethod<
+            class [System.Private.CoreLib]ILVerifyMethodSpecTypeThatDoesNotExist>()
+        ret
+    }
+
+    .method private static void MissingStandaloneMethodSignature() cil managed
+    {
+        ldnull
+        calli void(class [System.Private.CoreLib]ILVerifyStandaloneMethodTypeThatDoesNotExist)
+        ret
+    }
+
+    .method private static void MissingStandaloneLocalSignature() cil managed
+    {
+        .locals init (
+            [0] class [System.Private.CoreLib]ILVerifyStandaloneLocalTypeThatDoesNotExist
+        )
+
+        ret
+    }
+}

--- a/src/coreclr/tools/ILVerification.Tests/ILTests/InvalidMetadataReferenceTests.ilproj
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/InvalidMetadataReferenceTests.ilproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tools/ILVerification.Tests/ILTests/UnusedMetadataReferenceTests.il
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/UnusedMetadataReferenceTests.il
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Private.CoreLib
+{
+}
+
+// Deliberately unresolved. This AssemblyRef is also used by the ExportedType below.
+.assembly extern ILVerifyAssemblyThatDoesNotExist
+{
+}
+
+.assembly UnusedMetadataReferenceTests
+{
+}
+
+.module extern ILVerifyManagedModuleThatDoesNotExist.netmodule
+.module extern ValidMetadataReferenceModule.netmodule
+
+.file ValidMetadataReferenceModule.netmodule
+
+.class extern forwarder MissingForwardedType
+{
+    .assembly extern ILVerifyAssemblyThatDoesNotExist
+}
+
+// Provides a resolvable TypeRef to System.Object and contains the P/Invoke method whose
+// native-library ModuleRef must not be treated as a managed netmodule dependency.
+.class public auto ansi beforefieldinit UnusedMetadataReferenceTestsType
+       extends [System.Private.CoreLib]System.Object
+{
+    .method public static pinvokeimpl("ILVerifyNativeLibraryThatDoesNotExist" as "NativeMethod")
+            void NativeMethod() cil managed preservesig
+    {
+    }
+}

--- a/src/coreclr/tools/ILVerification.Tests/ILTests/UnusedMetadataReferenceTests.ilproj
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/UnusedMetadataReferenceTests.ilproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tools/ILVerification.Tests/ILTests/ValidMetadataReferenceModule.il
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/ValidMetadataReferenceModule.il
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Private.CoreLib
+{
+}
+
+.module ValidMetadataReferenceModule.netmodule
+
+.class public auto ansi beforefieldinit ValidMetadataReferenceModuleType
+       extends [System.Private.CoreLib]System.Object
+{
+}

--- a/src/coreclr/tools/ILVerification.Tests/ILTests/ValidMetadataReferenceModule.ilproj
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/ValidMetadataReferenceModule.ilproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <TargetExt>.netmodule</TargetExt>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tools/ILVerification.Tests/ILVerification.Tests.csproj
+++ b/src/coreclr/tools/ILVerification.Tests/ILVerification.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="ILMethodTester.cs" />
+    <Compile Include="ILMetadataReferenceTester.cs" />
     <Compile Include="ILTypeVerificationTester.cs" />
     <Compile Include="TestDataLoader.cs" />
     <Compile Include="JsonContext.cs" />
@@ -20,6 +21,10 @@
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>Tests\%(Filename).dll</TargetPath>
+    </ProjectReference>
+
+    <ProjectReference Update="ILTests\ValidMetadataReferenceModule.ilproj">
+      <TargetPath>Tests\%(Filename).netmodule</TargetPath>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/coreclr/tools/ILVerification.Tests/TestDataLoader.cs
+++ b/src/coreclr/tools/ILVerification.Tests/TestDataLoader.cs
@@ -251,9 +251,13 @@ namespace ILVerification.Tests
         {
             var simpleNameToPathMap = new Dictionary<string, string>();
 
-            foreach (var fileName in GetAllTestDlls())
+            foreach (var fileName in Directory.GetFiles(TestAssemblyPath))
             {
-                simpleNameToPathMap.Add(Path.GetFileNameWithoutExtension(fileName), Path.Combine(TestAssemblyPath, fileName));
+                string name = fileName.ToLower();
+                if (name.EndsWith(".dll") || name.EndsWith(".netmodule"))
+                {
+                    simpleNameToPathMap.Add(Path.GetFileNameWithoutExtension(fileName), fileName);
+                }
             }
 
             Assembly coreAssembly = typeof(object).GetTypeInfo().Assembly;

--- a/src/coreclr/tools/ILVerification/VerificationResult.cs
+++ b/src/coreclr/tools/ILVerification/VerificationResult.cs
@@ -12,6 +12,7 @@ namespace ILVerify
         public ExceptionStringID? ExceptionID { get; internal set; }
         public TypeDefinitionHandle Type { get; internal set; }
         public MethodDefinitionHandle Method { get; internal set; }
+        internal EntityHandle MetadataHandle { get; set; }
         public string Message { get; internal set; }
         public object[] Args { get; internal set; }
         public ErrorArgument[] ErrorArguments { get; set; }

--- a/src/coreclr/tools/ILVerification/Verifier.cs
+++ b/src/coreclr/tools/ILVerification/Verifier.cs
@@ -279,7 +279,10 @@ namespace ILVerify
             }
             catch (TypeSystemException e)
             {
-                return createVerificationResult(e.Message, e.StringID);
+                return createVerificationResult(
+                    e.Message,
+                    e.StringID,
+                    exceptionArguments: e.Arguments);
             }
             catch (BadImageFormatException e)
             {
@@ -307,7 +310,8 @@ namespace ILVerify
             VerificationResult createVerificationResult(
                 string message,
                 ExceptionStringID? exceptionID = null,
-                VerifierError code = VerifierError.None)
+                VerifierError code = VerifierError.None,
+                IReadOnlyList<string> exceptionArguments = null)
             {
                 if (code == VerifierError.None && exceptionID == null)
                 {
@@ -319,7 +323,12 @@ namespace ILVerify
                     Code = code,
                     ExceptionID = exceptionID,
                     MetadataHandle = handle,
-                    ErrorArguments = Array.Empty<ErrorArgument>(),
+                    ErrorArguments = exceptionArguments == null ? Array.Empty<ErrorArgument>()
+                        : new[]
+                        {
+                            new ErrorArgument(nameof(TypeSystemException.Arguments),
+                                exceptionArguments.ToArray())
+                        },
                     Message = $"Unable to resolve metadata reference ({handle.Kind}): {message}"
                 };
             }
@@ -538,9 +547,7 @@ namespace ILVerify
             TypeSystemException exception,
             IReadOnlyCollection<VerificationResult> metadataErrors)
         {
-            if (exception is not TypeSystemException.TypeLoadException &&
-                exception is not TypeSystemException.MissingMemberException &&
-                exception is not TypeSystemException.FileNotFoundException)
+            if (!CanDeduplicateMetadataResolutionException(exception.StringID))
             {
                 return false;
             }
@@ -556,6 +563,23 @@ namespace ILVerify
 
             return false;
         }
+
+        internal static bool CanDeduplicateMetadataResolutionException(ExceptionStringID exceptionID)
+            => exceptionID is ExceptionStringID.ClassLoadGeneral
+                or ExceptionStringID.ClassLoadExplicitGeneric
+                or ExceptionStringID.ClassLoadBadFormat
+                or ExceptionStringID.ClassLoadExplicitLayout
+                or ExceptionStringID.ClassLoadValueClassTooLarge
+                or ExceptionStringID.ClassLoadRankTooLarge
+                or ExceptionStringID.ClassLoadInlineArrayFieldCount
+                or ExceptionStringID.ClassLoadInlineArrayLength
+                or ExceptionStringID.ClassLoadInlineArrayExplicit
+                or ExceptionStringID.ClassLoadInlineArrayExplicitSize
+
+                or ExceptionStringID.MissingMethod
+                or ExceptionStringID.MissingField
+
+                or ExceptionStringID.FileLoadErrorGeneric;
 
         private void ThrowMissingSystemModule()
         {

--- a/src/coreclr/tools/ILVerification/Verifier.cs
+++ b/src/coreclr/tools/ILVerification/Verifier.cs
@@ -51,6 +51,9 @@ namespace ILVerify
         }
 
         public IEnumerable<VerificationResult> Verify(PEReader peReader)
+            => Verify(peReader, true);
+
+        internal IEnumerable<VerificationResult> Verify(PEReader peReader, bool reportMetadataResolutionErrors)
         {
             if (peReader == null)
             {
@@ -66,7 +69,7 @@ namespace ILVerify
             try
             {
                 EcmaModule module = GetModule(peReader);
-                results = VerifyMethods(module, module.MetadataReader.MethodDefinitions);
+                results = VerifyMethods(module, module.MetadataReader.MethodDefinitions, reportMetadataResolutionErrors);
             }
             catch (VerifierException e)
             {
@@ -80,6 +83,13 @@ namespace ILVerify
         }
 
         public IEnumerable<VerificationResult> Verify(PEReader peReader, TypeDefinitionHandle typeHandle, bool verifyMethods = false)
+            => Verify(peReader, typeHandle, verifyMethods, true);
+
+        internal IEnumerable<VerificationResult> Verify(
+            PEReader peReader,
+            TypeDefinitionHandle typeHandle,
+            bool verifyMethods,
+            bool reportMetadataResolutionErrors)
         {
             if (peReader == null)
             {
@@ -102,12 +112,12 @@ namespace ILVerify
                 EcmaModule module = GetModule(peReader);
                 MetadataReader metadataReader = peReader.GetMetadataReader();
 
-                results = VerifyType(module, typeHandle);
+                results = VerifyType(module, typeHandle, reportMetadataResolutionErrors);
 
                 if (verifyMethods)
                 {
                     TypeDefinition typeDef = metadataReader.GetTypeDefinition(typeHandle);
-                    results = results.Union(VerifyMethods(module, typeDef.GetMethods()));
+                    results = results.Union(VerifyMethods(module, typeDef.GetMethods(), reportMetadataResolutionErrors));
                 }
             }
             catch (VerifierException e)
@@ -122,6 +132,12 @@ namespace ILVerify
         }
 
         public IEnumerable<VerificationResult> Verify(PEReader peReader, MethodDefinitionHandle methodHandle)
+            => Verify(peReader, methodHandle, true);
+
+        internal IEnumerable<VerificationResult> Verify(
+            PEReader peReader,
+            MethodDefinitionHandle methodHandle,
+            bool reportMetadataResolutionErrors)
         {
             if (peReader == null)
             {
@@ -142,7 +158,7 @@ namespace ILVerify
             try
             {
                 EcmaModule module = GetModule(peReader);
-                results = VerifyMethods(module, new[] { methodHandle });
+                results = VerifyMethods(module, new[] { methodHandle }, reportMetadataResolutionErrors);
             }
             catch (VerifierException e)
             {
@@ -326,7 +342,10 @@ namespace ILVerify
         }
 
 
-        private IEnumerable<VerificationResult> VerifyMethods(EcmaModule module, IEnumerable<MethodDefinitionHandle> methodHandles)
+        private IEnumerable<VerificationResult> VerifyMethods(
+            EcmaModule module,
+            IEnumerable<MethodDefinitionHandle> methodHandles,
+            bool reportMetadataResolutionErrors)
         {
             foreach (var methodHandle in methodHandles)
             {
@@ -335,7 +354,7 @@ namespace ILVerify
 
                 if (methodIL != null)
                 {
-                    var results = VerifyMethod(module, methodIL, methodHandle);
+                    var results = VerifyMethod(module, methodIL, methodHandle, reportMetadataResolutionErrors);
                     foreach (var result in results)
                     {
                         yield return result;
@@ -344,7 +363,11 @@ namespace ILVerify
             }
         }
 
-        private IEnumerable<VerificationResult> VerifyMethod(EcmaModule module, MethodIL methodIL, MethodDefinitionHandle methodHandle)
+        private IEnumerable<VerificationResult> VerifyMethod(
+            EcmaModule module,
+            MethodIL methodIL,
+            MethodDefinitionHandle methodHandle,
+            bool reportMetadataResolutionErrors)
         {
             var builder = new ArrayBuilder<VerificationResult>();
             MethodDesc method = methodIL.OwningMethod;
@@ -407,7 +430,10 @@ namespace ILVerify
             }
             catch (TypeSystemException e)
             {
-                reportTypeSystemException(e);
+                if (reportMetadataResolutionErrors)
+                {
+                    reportTypeSystemException(e);
+                }
             }
 
             return builder.ToArray();
@@ -432,7 +458,10 @@ namespace ILVerify
             }
         }
 
-        private IEnumerable<VerificationResult> VerifyType(EcmaModule module, TypeDefinitionHandle typeHandle)
+        private IEnumerable<VerificationResult> VerifyType(
+            EcmaModule module,
+            TypeDefinitionHandle typeHandle,
+            bool reportMetadataResolutionErrors)
         {
             var builder = new ArrayBuilder<VerificationResult>();
 
@@ -485,7 +514,10 @@ namespace ILVerify
             }
             catch (TypeSystemException e)
             {
-                reportException(e);
+                if (reportMetadataResolutionErrors)
+                {
+                    reportException(e);
+                }
             }
 
             return builder.ToArray();

--- a/src/coreclr/tools/ILVerification/Verifier.cs
+++ b/src/coreclr/tools/ILVerification/Verifier.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Resources;
 using Internal.IL;
@@ -153,6 +154,177 @@ namespace ILVerify
                 yield return result;
             }
         }
+
+        internal IEnumerable<VerificationResult> VerifyMetadataReferences(PEReader peReader)
+        {
+            EcmaModule module = GetModule(peReader);
+            MetadataReader reader = module.MetadataReader;
+
+            foreach (EntityHandle handle in EnumerateReferenceHandles(reader))
+            {
+                VerificationResult result = TryResolveMetadataHandle(module, handle);
+                if (result != null)
+                {
+                    yield return result;
+                }
+            }
+        }
+
+        private static IEnumerable<EntityHandle> EnumerateReferenceHandles(MetadataReader reader)
+        {
+            foreach (AssemblyReferenceHandle handle in reader.AssemblyReferences)
+            {
+                yield return handle;
+            }
+
+            // ModuleRef is also used as ImplMap.ImportScope to store unmanaged library names for
+            // P/Invoke. Do not try to resolve those entries as managed netmodules.
+            HashSet<ModuleReferenceHandle> pInvokeModuleReferences = GetPInvokeModuleReferences(reader);
+            for (int row = 1;
+                 row <= reader.GetTableRowCount(TableIndex.ModuleRef);
+                 row++)
+            {
+                ModuleReferenceHandle handle = MetadataTokens.ModuleReferenceHandle(row);
+                if (!pInvokeModuleReferences.Contains(handle))
+                {
+                    yield return handle;
+                }
+            }
+
+            foreach (TypeReferenceHandle handle in reader.TypeReferences)
+            {
+                yield return handle;
+            }
+
+            foreach (MemberReferenceHandle handle in reader.MemberReferences)
+            {
+                yield return handle;
+            }
+
+            foreach (ExportedTypeHandle handle in reader.ExportedTypes)
+            {
+                yield return handle;
+            }
+
+            for (int row = 1;
+                 row <= reader.GetTableRowCount(TableIndex.TypeSpec);
+                 row++)
+            {
+                yield return MetadataTokens.TypeSpecificationHandle(row);
+            }
+
+            for (int row = 1;
+                 row <= reader.GetTableRowCount(TableIndex.MethodSpec);
+                 row++)
+            {
+                yield return MetadataTokens.MethodSpecificationHandle(row);
+            }
+
+            for (int row = 1;
+                 row <= reader.GetTableRowCount(TableIndex.StandAloneSig);
+                 row++)
+            {
+                yield return MetadataTokens.StandaloneSignatureHandle(row);
+            }
+        }
+
+        private static HashSet<ModuleReferenceHandle> GetPInvokeModuleReferences(MetadataReader reader)
+        {
+            var moduleReferences = new HashSet<ModuleReferenceHandle>();
+
+            foreach (MethodDefinitionHandle handle in reader.MethodDefinitions)
+            {
+                ModuleReferenceHandle module = reader.GetMethodDefinition(handle).GetImport().Module;
+                if (!module.IsNil)
+                {
+                    moduleReferences.Add(module);
+                }
+            }
+
+            return moduleReferences;
+        }
+
+        private static VerificationResult TryResolveMetadataHandle(EcmaModule module, EntityHandle handle)
+        {
+            try
+            {
+                if (handle.Kind == HandleKind.StandaloneSignature)
+                {
+                    ResolveStandaloneSignature(module, (StandaloneSignatureHandle)handle);
+                }
+                else
+                {
+                    module.GetObject(handle);
+                }
+
+                return null;
+            }
+            catch (TypeSystemException e)
+            {
+                return createVerificationResult(e.Message, e.StringID);
+            }
+            catch (BadImageFormatException e)
+            {
+                return createVerificationResult(e.Message);
+            }
+            catch (InvalidProgramException e)
+            {
+                return createVerificationResult(e.Message);
+            }
+            catch (VerifierException e)
+            {
+                return createVerificationResult(e.Message, code: e.Code);
+            }
+            catch (NotImplementedException e)
+            {
+                return new VerificationResult
+                {
+                    Code = VerifierError.TokenResolve,
+                    MetadataHandle = handle,
+                    ErrorArguments = Array.Empty<ErrorArgument>(),
+                    Message = $"Unable to validate metadata reference ({handle.Kind}) because this metadata form is not supported: {e.Message}"
+                };
+            }
+
+            VerificationResult createVerificationResult(
+                string message,
+                ExceptionStringID? exceptionID = null,
+                VerifierError code = VerifierError.None)
+            {
+                if (code == VerifierError.None && exceptionID == null)
+                {
+                    code = VerifierError.TokenResolve;
+                }
+
+                return new VerificationResult
+                {
+                    Code = code,
+                    ExceptionID = exceptionID,
+                    MetadataHandle = handle,
+                    ErrorArguments = Array.Empty<ErrorArgument>(),
+                    Message = $"Unable to resolve metadata reference ({handle.Kind}): {message}"
+                };
+            }
+        }
+
+        private static void ResolveStandaloneSignature(EcmaModule module, StandaloneSignatureHandle handle)
+        {
+            MetadataReader reader = module.MetadataReader;
+            StandaloneSignature signature = reader.GetStandaloneSignature(handle);
+
+            if (signature.GetKind() == StandaloneSignatureKind.LocalVariables)
+            {
+                // Local-variable signature
+                var parser = new EcmaSignatureParser(module, reader.GetBlobReader(signature.Signature), NotFoundBehavior.Throw);
+                parser.ParseLocalsSignature();
+            }
+            else
+            {
+                // Method signature (calli)
+                module.GetObject(handle);
+            }
+        }
+
 
         private IEnumerable<VerificationResult> VerifyMethods(EcmaModule module, IEnumerable<MethodDefinitionHandle> methodHandles)
         {

--- a/src/coreclr/tools/ILVerification/Verifier.cs
+++ b/src/coreclr/tools/ILVerification/Verifier.cs
@@ -51,9 +51,11 @@ namespace ILVerify
         }
 
         public IEnumerable<VerificationResult> Verify(PEReader peReader)
-            => Verify(peReader, true);
+            => Verify(peReader, Array.Empty<VerificationResult>());
 
-        internal IEnumerable<VerificationResult> Verify(PEReader peReader, bool reportMetadataResolutionErrors)
+        internal IEnumerable<VerificationResult> Verify(
+            PEReader peReader,
+            IReadOnlyCollection<VerificationResult> metadataErrors)
         {
             if (peReader == null)
             {
@@ -69,7 +71,7 @@ namespace ILVerify
             try
             {
                 EcmaModule module = GetModule(peReader);
-                results = VerifyMethods(module, module.MetadataReader.MethodDefinitions, reportMetadataResolutionErrors);
+                results = VerifyMethods(module, module.MetadataReader.MethodDefinitions, metadataErrors);
             }
             catch (VerifierException e)
             {
@@ -83,13 +85,13 @@ namespace ILVerify
         }
 
         public IEnumerable<VerificationResult> Verify(PEReader peReader, TypeDefinitionHandle typeHandle, bool verifyMethods = false)
-            => Verify(peReader, typeHandle, verifyMethods, true);
+            => Verify(peReader, typeHandle, verifyMethods, Array.Empty<VerificationResult>());
 
         internal IEnumerable<VerificationResult> Verify(
             PEReader peReader,
             TypeDefinitionHandle typeHandle,
             bool verifyMethods,
-            bool reportMetadataResolutionErrors)
+            IReadOnlyCollection<VerificationResult> metadataErrors)
         {
             if (peReader == null)
             {
@@ -112,12 +114,12 @@ namespace ILVerify
                 EcmaModule module = GetModule(peReader);
                 MetadataReader metadataReader = peReader.GetMetadataReader();
 
-                results = VerifyType(module, typeHandle, reportMetadataResolutionErrors);
+                results = VerifyType(module, typeHandle, metadataErrors);
 
                 if (verifyMethods)
                 {
                     TypeDefinition typeDef = metadataReader.GetTypeDefinition(typeHandle);
-                    results = results.Union(VerifyMethods(module, typeDef.GetMethods(), reportMetadataResolutionErrors));
+                    results = results.Union(VerifyMethods(module, typeDef.GetMethods(), metadataErrors));
                 }
             }
             catch (VerifierException e)
@@ -132,12 +134,12 @@ namespace ILVerify
         }
 
         public IEnumerable<VerificationResult> Verify(PEReader peReader, MethodDefinitionHandle methodHandle)
-            => Verify(peReader, methodHandle, true);
+            => Verify(peReader, methodHandle, Array.Empty<VerificationResult>());
 
         internal IEnumerable<VerificationResult> Verify(
             PEReader peReader,
             MethodDefinitionHandle methodHandle,
-            bool reportMetadataResolutionErrors)
+            IReadOnlyCollection<VerificationResult> metadataErrors)
         {
             if (peReader == null)
             {
@@ -158,7 +160,7 @@ namespace ILVerify
             try
             {
                 EcmaModule module = GetModule(peReader);
-                results = VerifyMethods(module, new[] { methodHandle }, reportMetadataResolutionErrors);
+                results = VerifyMethods(module, new[] { methodHandle }, metadataErrors);
             }
             catch (VerifierException e)
             {
@@ -345,7 +347,7 @@ namespace ILVerify
         private IEnumerable<VerificationResult> VerifyMethods(
             EcmaModule module,
             IEnumerable<MethodDefinitionHandle> methodHandles,
-            bool reportMetadataResolutionErrors)
+            IReadOnlyCollection<VerificationResult> metadataErrors)
         {
             foreach (var methodHandle in methodHandles)
             {
@@ -354,7 +356,7 @@ namespace ILVerify
 
                 if (methodIL != null)
                 {
-                    var results = VerifyMethod(module, methodIL, methodHandle, reportMetadataResolutionErrors);
+                    var results = VerifyMethod(module, methodIL, methodHandle, metadataErrors);
                     foreach (var result in results)
                     {
                         yield return result;
@@ -367,7 +369,7 @@ namespace ILVerify
             EcmaModule module,
             MethodIL methodIL,
             MethodDefinitionHandle methodHandle,
-            bool reportMetadataResolutionErrors)
+            IReadOnlyCollection<VerificationResult> metadataErrors)
         {
             var builder = new ArrayBuilder<VerificationResult>();
             MethodDesc method = methodIL.OwningMethod;
@@ -430,7 +432,7 @@ namespace ILVerify
             }
             catch (TypeSystemException e)
             {
-                if (reportMetadataResolutionErrors)
+                if (!IsDuplicateMetadataResolutionError(e, metadataErrors))
                 {
                     reportTypeSystemException(e);
                 }
@@ -461,7 +463,7 @@ namespace ILVerify
         private IEnumerable<VerificationResult> VerifyType(
             EcmaModule module,
             TypeDefinitionHandle typeHandle,
-            bool reportMetadataResolutionErrors)
+            IReadOnlyCollection<VerificationResult> metadataErrors)
         {
             var builder = new ArrayBuilder<VerificationResult>();
 
@@ -514,7 +516,7 @@ namespace ILVerify
             }
             catch (TypeSystemException e)
             {
-                if (reportMetadataResolutionErrors)
+                if (!IsDuplicateMetadataResolutionError(e, metadataErrors))
                 {
                     reportException(e);
                 }
@@ -530,6 +532,29 @@ namespace ILVerify
                     Message = e.Message
                 });
             }
+        }
+
+        private static bool IsDuplicateMetadataResolutionError(
+            TypeSystemException exception,
+            IReadOnlyCollection<VerificationResult> metadataErrors)
+        {
+            if (exception is not TypeSystemException.TypeLoadException &&
+                exception is not TypeSystemException.MissingMemberException &&
+                exception is not TypeSystemException.FileNotFoundException)
+            {
+                return false;
+            }
+
+            foreach (VerificationResult metadataError in metadataErrors)
+            {
+                if (metadataError.ExceptionID == exception.StringID &&
+                    metadataError.Message.EndsWith(exception.Message, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void ThrowMissingSystemModule()

--- a/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
+++ b/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
@@ -36,7 +36,7 @@ namespace ILVerify
             new("--verbose") { Description = "Verbose output" };
         public Option<bool> Tokens { get; } =
             new("--tokens", "-t") { Description = "Include metadata tokens in error messages" };
-        public Option<bool> MetadataOnly { get; } =
+        public Option<bool> MetadataReferencesOnly { get; } =
             new("--metadata-references-only") { Description = "Only validate metadata references" };
 
         public ParseResult Result;
@@ -57,7 +57,7 @@ namespace ILVerify
             Options.Add(Statistics);
             Options.Add(Verbose);
             Options.Add(Tokens);
-            Options.Add(MetadataOnly);
+            Options.Add(MetadataReferencesOnly);
 
             this.SetAction(result =>
             {

--- a/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
+++ b/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
@@ -36,6 +36,8 @@ namespace ILVerify
             new("--verbose") { Description = "Verbose output" };
         public Option<bool> Tokens { get; } =
             new("--tokens", "-t") { Description = "Include metadata tokens in error messages" };
+        public Option<bool> VerifyAllDependencies { get; } =
+            new("--verify-all-dependencies") { Description = "Resolve all metadata reference tokens and report errors for unresolvable ones" };
 
         public ParseResult Result;
 
@@ -55,6 +57,7 @@ namespace ILVerify
             Options.Add(Statistics);
             Options.Add(Verbose);
             Options.Add(Tokens);
+            Options.Add(VerifyAllDependencies);
 
             this.SetAction(result =>
             {

--- a/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
+++ b/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
@@ -37,7 +37,7 @@ namespace ILVerify
         public Option<bool> Tokens { get; } =
             new("--tokens", "-t") { Description = "Include metadata tokens in error messages" };
         public Option<bool> MetadataOnly { get; } =
-            new("--metadata-only") { Description = "Only validate metadata references" };
+            new("--metadata-references-only") { Description = "Only validate metadata references" };
 
         public ParseResult Result;
 

--- a/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
+++ b/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
@@ -36,8 +36,8 @@ namespace ILVerify
             new("--verbose") { Description = "Verbose output" };
         public Option<bool> Tokens { get; } =
             new("--tokens", "-t") { Description = "Include metadata tokens in error messages" };
-        public Option<bool> VerifyAllDependencies { get; } =
-            new("--verify-all-dependencies") { Description = "Resolve all metadata reference tokens and report errors for unresolvable ones" };
+        public Option<bool> MetadataOnly { get; } =
+            new("--metadata-only") { Description = "Only validate metadata references" };
 
         public ParseResult Result;
 
@@ -57,7 +57,7 @@ namespace ILVerify
             Options.Add(Statistics);
             Options.Add(Verbose);
             Options.Add(Tokens);
-            Options.Add(VerifyAllDependencies);
+            Options.Add(MetadataOnly);
 
             this.SetAction(result =>
             {

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -5,12 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Text.RegularExpressions;
+using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
 using static System.Console;
@@ -281,8 +283,15 @@ namespace ILVerify
             string path,
             ref int numErrors)
         {
+            var reportedMetadataResolutionErrors = new Dictionary<ExceptionStringID, List<string[]>>();
+
             foreach (VerificationResult result in metadataErrors)
             {
+                if (IsDuplicateMetadataResolutionError(result, reportedMetadataResolutionErrors))
+                {
+                    continue;
+                }
+
                 if (ShouldIgnoreVerificationResult(result))
                 {
                     if (_verbose)
@@ -297,6 +306,35 @@ namespace ILVerify
                     numErrors++;
                 }
             }
+        }
+
+        private static bool IsDuplicateMetadataResolutionError(
+            VerificationResult result,
+            Dictionary<ExceptionStringID, List<string[]>> reportedErrors)
+        {
+            if (result.ExceptionID is not ExceptionStringID exceptionID ||
+                !Verifier.CanDeduplicateMetadataResolutionException(exceptionID) ||
+                !result.TryGetArgumentValue(nameof(TypeSystemException.Arguments), out string[] arguments))
+            {
+                return false;
+            }
+
+            if (!reportedErrors.TryGetValue(exceptionID, out List<string[]> reportedArguments))
+            {
+                reportedArguments = new List<string[]>();
+                reportedErrors.Add(exceptionID, reportedArguments);
+            }
+
+            foreach (string[] previousArguments in reportedArguments)
+            {
+                if (arguments.SequenceEqual(previousArguments))
+                {
+                    return true;
+                }
+            }
+
+            reportedArguments.Add(arguments);
+            return false;
         }
 
         private void PrintVerifyMetadataReferencesResult(VerificationResult result, string path)

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -242,15 +242,16 @@ namespace ILVerify
             int typeCounter = 0;
             bool metadataOnly = Get(_command.MetadataOnly);
 
+            List<VerificationResult> metadataErrors = new(_verifier.VerifyMetadataReferences(peReader));
             int metadataErrorCounter = VerifyMetadataReferences(
-                _verifier.VerifyMetadataReferences(peReader),
+                metadataErrors,
                 path,
                 ref numErrors);
 
             if (!metadataOnly)
             {
-                VerifyMethods(peReader, module, path, ref numErrors, ref verifiedMethodCounter, ref methodCounter);
-                VerifyTypes(peReader, module, path, ref numErrors, ref verifiedTypeCounter, ref typeCounter);
+                VerifyMethods(peReader, module, metadataErrors, path, ref numErrors, ref verifiedMethodCounter, ref methodCounter);
+                VerifyTypes(peReader, module, metadataErrors, path, ref numErrors, ref verifiedTypeCounter, ref typeCounter);
             }
 
             if (numErrors > 0)
@@ -258,12 +259,10 @@ namespace ILVerify
             else if (metadataOnly)
                 WriteLine("All metadata references in " + path + " resolved.");
             else
-                WriteLine("All Classes and Methods in " + path + " Verified.");
+                WriteLine("All Classes and Methods in " + path + " verified.");
 
             if (Get(_command.Statistics))
             {
-                WriteLine($"Metadata errors: {metadataErrorCounter}");
-
                 if (!metadataOnly)
                 {
                     WriteLine($"Types found: {typeCounter}");
@@ -331,7 +330,14 @@ namespace ILVerify
             WriteLine(result.Message);
         }
 
-        private void VerifyMethods(PEReader peReader, EcmaModule module, string path, ref int numErrors, ref int verifiedMethodCounter, ref int methodCounter)
+        private void VerifyMethods(
+            PEReader peReader,
+            EcmaModule module,
+            IReadOnlyCollection<VerificationResult> metadataErrors,
+            string path,
+            ref int numErrors,
+            ref int verifiedMethodCounter,
+            ref int methodCounter)
         {
             verifiedMethodCounter = 0;
             methodCounter = 0;
@@ -351,7 +357,7 @@ namespace ILVerify
 
                 if (verifying)
                 {
-                    var results = _verifier.Verify(peReader, methodHandle, false);
+                    var results = _verifier.Verify(peReader, methodHandle, metadataErrors);
                     foreach (var result in results)
                     {
                         if (ShouldIgnoreVerificationResult(result))
@@ -376,7 +382,14 @@ namespace ILVerify
             }
         }
 
-        private void VerifyTypes(PEReader peReader, EcmaModule module, string path, ref int numErrors, ref int verifiedTypeCounter, ref int typeCounter)
+        private void VerifyTypes(
+            PEReader peReader,
+            EcmaModule module,
+            IReadOnlyCollection<VerificationResult> metadataErrors,
+            string path,
+            ref int numErrors,
+            ref int verifiedTypeCounter,
+            ref int typeCounter)
         {
             MetadataReader metadataReader = peReader.GetMetadataReader();
 
@@ -392,7 +405,7 @@ namespace ILVerify
                 }
                 if (verifying)
                 {
-                    var results = _verifier.Verify(peReader, typeHandle, false, false);
+                    var results = _verifier.Verify(peReader, typeHandle, false, metadataErrors);
                     foreach (VerificationResult result in results)
                     {
                         if (ShouldIgnoreVerificationResult(result))

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -259,7 +259,7 @@ namespace ILVerify
             else if (metadataOnly)
                 WriteLine("All metadata references in " + path + " resolved.");
             else
-                WriteLine("All Classes and Methods in " + path + " verified.");
+                WriteLine("All types and methods in " + path + " verified.");
 
             if (Get(_command.Statistics))
             {

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -7,6 +7,7 @@ using System.CommandLine;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -243,6 +244,9 @@ namespace ILVerify
             VerifyMethods(peReader, module, path, ref numErrors, ref verifiedMethodCounter, ref methodCounter);
             VerifyTypes(peReader, module, path, ref numErrors, ref verifiedTypeCounter, ref typeCounter);
 
+            if (Get(_command.VerifyAllDependencies))
+                VerifyMetadataReferences(peReader, path, ref numErrors);
+
             if (numErrors > 0)
                 WriteLine(numErrors + " Error(s) Verifying " + path);
             else
@@ -258,6 +262,52 @@ namespace ILVerify
             }
 
             return numErrors;
+        }
+
+        private void VerifyMetadataReferences(PEReader peReader, string path, ref int numErrors)
+        {
+            foreach (VerificationResult result in _verifier.VerifyMetadataReferences(peReader))
+            {
+                if (ShouldIgnoreVerificationResult(result))
+                {
+                    if (_verbose)
+                    {
+                        Write("Ignoring ");
+                        PrintVerifyMetadataReferencesResult(result, path);
+                    }
+                }
+                else
+                {
+                    PrintVerifyMetadataReferencesResult(result, path);
+                    numErrors++;
+                }
+            }
+        }
+
+        private void PrintVerifyMetadataReferencesResult(VerificationResult result, string path)
+        {
+            Write("[MD]: Error [");
+            if (result.Code != VerifierError.None)
+            {
+                Write(result.Code);
+            }
+            else
+            {
+                Write(result.ExceptionID);
+            }
+            Write("]: [");
+            Write(path);
+            Write("]");
+
+            if (Get(_command.Tokens))
+            {
+                Write("[token 0x");
+                Write(MetadataTokens.GetToken(result.MetadataHandle).ToString("X8"));
+                Write("]");
+            }
+
+            Write(" ");
+            WriteLine(result.Message);
         }
 
         private void VerifyMethods(PEReader peReader, EcmaModule module, string path, ref int numErrors, ref int verifiedMethodCounter, ref int methodCounter)

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -240,15 +240,15 @@ namespace ILVerify
             int methodCounter = 0;
             int verifiedTypeCounter = 0;
             int typeCounter = 0;
-            bool metadataOnly = Get(_command.MetadataOnly);
+            bool metadataReferencesOnly = Get(_command.MetadataReferencesOnly);
 
             List<VerificationResult> metadataErrors = new(_verifier.VerifyMetadataReferences(peReader));
-            int metadataErrorCounter = VerifyMetadataReferences(
+            VerifyMetadataReferences(
                 metadataErrors,
                 path,
                 ref numErrors);
 
-            if (!metadataOnly)
+            if (!metadataReferencesOnly)
             {
                 VerifyMethods(peReader, module, metadataErrors, path, ref numErrors, ref verifiedMethodCounter, ref methodCounter);
                 VerifyTypes(peReader, module, metadataErrors, path, ref numErrors, ref verifiedTypeCounter, ref typeCounter);
@@ -256,14 +256,14 @@ namespace ILVerify
 
             if (numErrors > 0)
                 WriteLine(numErrors + " Error(s) Verifying " + path);
-            else if (metadataOnly)
+            else if (metadataReferencesOnly)
                 WriteLine("All metadata references in " + path + " resolved.");
             else
                 WriteLine("All types and methods in " + path + " verified.");
 
             if (Get(_command.Statistics))
             {
-                if (!metadataOnly)
+                if (!metadataReferencesOnly)
                 {
                     WriteLine($"Types found: {typeCounter}");
                     WriteLine($"Types verified: {verifiedTypeCounter}");
@@ -276,13 +276,11 @@ namespace ILVerify
             return numErrors;
         }
 
-        private int VerifyMetadataReferences(
+        private void VerifyMetadataReferences(
             IEnumerable<VerificationResult> metadataErrors,
             string path,
             ref int numErrors)
         {
-            int metadataErrorCounter = 0;
-
             foreach (VerificationResult result in metadataErrors)
             {
                 if (ShouldIgnoreVerificationResult(result))
@@ -297,11 +295,8 @@ namespace ILVerify
                 {
                     PrintVerifyMetadataReferencesResult(result, path);
                     numErrors++;
-                    metadataErrorCounter++;
                 }
             }
-
-            return metadataErrorCounter;
         }
 
         private void PrintVerifyMetadataReferencesResult(VerificationResult result, string path)

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -240,33 +240,51 @@ namespace ILVerify
             int methodCounter = 0;
             int verifiedTypeCounter = 0;
             int typeCounter = 0;
+            bool metadataOnly = Get(_command.MetadataOnly);
 
-            VerifyMethods(peReader, module, path, ref numErrors, ref verifiedMethodCounter, ref methodCounter);
-            VerifyTypes(peReader, module, path, ref numErrors, ref verifiedTypeCounter, ref typeCounter);
+            int metadataErrorCounter = VerifyMetadataReferences(
+                _verifier.VerifyMetadataReferences(peReader),
+                path,
+                ref numErrors);
 
-            if (Get(_command.VerifyAllDependencies))
-                VerifyMetadataReferences(peReader, path, ref numErrors);
+            if (!metadataOnly)
+            {
+                VerifyMethods(peReader, module, path, ref numErrors, ref verifiedMethodCounter, ref methodCounter);
+                VerifyTypes(peReader, module, path, ref numErrors, ref verifiedTypeCounter, ref typeCounter);
+            }
 
             if (numErrors > 0)
                 WriteLine(numErrors + " Error(s) Verifying " + path);
+            else if (metadataOnly)
+                WriteLine("All metadata references in " + path + " resolved.");
             else
                 WriteLine("All Classes and Methods in " + path + " Verified.");
 
             if (Get(_command.Statistics))
             {
-                WriteLine($"Types found: {typeCounter}");
-                WriteLine($"Types verified: {verifiedTypeCounter}");
+                WriteLine($"Metadata errors: {metadataErrorCounter}");
 
-                WriteLine($"Methods found: {methodCounter}");
-                WriteLine($"Methods verified: {verifiedMethodCounter}");
+                if (!metadataOnly)
+                {
+                    WriteLine($"Types found: {typeCounter}");
+                    WriteLine($"Types verified: {verifiedTypeCounter}");
+
+                    WriteLine($"Methods found: {methodCounter}");
+                    WriteLine($"Methods verified: {verifiedMethodCounter}");
+                }
             }
 
             return numErrors;
         }
 
-        private void VerifyMetadataReferences(PEReader peReader, string path, ref int numErrors)
+        private int VerifyMetadataReferences(
+            IEnumerable<VerificationResult> metadataErrors,
+            string path,
+            ref int numErrors)
         {
-            foreach (VerificationResult result in _verifier.VerifyMetadataReferences(peReader))
+            int metadataErrorCounter = 0;
+
+            foreach (VerificationResult result in metadataErrors)
             {
                 if (ShouldIgnoreVerificationResult(result))
                 {
@@ -280,8 +298,11 @@ namespace ILVerify
                 {
                     PrintVerifyMetadataReferencesResult(result, path);
                     numErrors++;
+                    metadataErrorCounter++;
                 }
             }
+
+            return metadataErrorCounter;
         }
 
         private void PrintVerifyMetadataReferencesResult(VerificationResult result, string path)
@@ -312,7 +333,6 @@ namespace ILVerify
 
         private void VerifyMethods(PEReader peReader, EcmaModule module, string path, ref int numErrors, ref int verifiedMethodCounter, ref int methodCounter)
         {
-            numErrors = 0;
             verifiedMethodCounter = 0;
             methodCounter = 0;
 
@@ -331,7 +351,7 @@ namespace ILVerify
 
                 if (verifying)
                 {
-                    var results = _verifier.Verify(peReader, methodHandle);
+                    var results = _verifier.Verify(peReader, methodHandle, false);
                     foreach (var result in results)
                     {
                         if (ShouldIgnoreVerificationResult(result))
@@ -372,7 +392,7 @@ namespace ILVerify
                 }
                 if (verifying)
                 {
-                    var results = _verifier.Verify(peReader, typeHandle);
+                    var results = _verifier.Verify(peReader, typeHandle, false, false);
                     foreach (VerificationResult result in results)
                     {
                         if (ShouldIgnoreVerificationResult(result))


### PR DESCRIPTION
Fixes #96458 

Adds metadata reference validation to ILVerify.

ILVerify now validates supported metadata references before verifying types and methods, resolving each reference independently so that invalid references are reported even when they are otherwise unused. P/Invoke `ModuleRef`s are skipped, since they name native libraries rather than managed netmodules.


The `--metadata-references-only` option can be used to perform only metadata reference validation without verifying types or methods.


Duplicate metadata resolution diagnostics for the same underlying resolution failure are de-duplicated, including errors that would otherwise be reported again during type or method verification.


Diagnostics use the most specific available error identifier and include metadata tokens when `--tokens` is specified.
For example, running with `--tokens` can produce output like this:


```text
[MD]: Error [FileLoadErrorGeneric]: [X.dll][token 0x23000002] Unable to resolve metadata reference (AssemblyReference): Failed to load assembly 'ILVerifyAssemblyThatDoesNotExist'
[MD]: Error [TokenResolve]: [X.dll][token 0x1A000001] Unable to resolve metadata reference (ModuleReference): Assembly or module not found: ILVerifyManagedModuleThatDoesNotExist.netmodule
```


Tests cover all supported reference kinds, including unused invalid references and valid assembly, type, and managed netmodule references.
