### PR TITLE
Avoid allocations propagating Activity baggage

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -428,12 +428,18 @@ namespace System.Diagnostics
         public Enumerator<ActivityLink> EnumerateLinks() => new Enumerator<ActivityLink>(_links?.First);
 
         /// <summary>
+        /// Enumerate the baggage attached to this Activity object and its ancestors without allocating.
+        /// </summary>
+        /// <returns><see cref="BaggageEnumerator"/>.</returns>
+        internal BaggageEnumerator EnumerateBaggage() => new BaggageEnumerator(this);
+
+        /// <summary>
         /// Returns the value of the key-value pair added to the activity with <see cref="AddBaggage(string, string)"/>.
         /// Returns null if that key does not exist.
         /// </summary>
         public string? GetBaggageItem(string key)
         {
-            foreach (KeyValuePair<string, string?> keyValue in Baggage)
+            foreach (KeyValuePair<string, string?> keyValue in EnumerateBaggage())
                 if (key == keyValue.Key)
                     return keyValue.Value;
             return null;
@@ -1596,6 +1602,54 @@ namespace System.Diagnostics
 
                 _currentNode = _nextNode;
                 _nextNode = _nextNode.Next;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Enumerates the baggage stored on this Activity and its ancestors without allocating.
+        /// Mirrors the semantics of the <see cref="Baggage"/> property, which uses an iterator
+        /// (allocating a state machine on every call) to walk the same data.
+        /// </summary>
+        internal struct BaggageEnumerator
+        {
+            // The next Activity (if any) to search for a non-empty baggage list. Always points at an
+            // Activity whose own baggage list has not yet been consumed by this enumerator.
+            private Activity? _activity;
+
+            // The remaining nodes of the baggage list currently being drained.
+            private DiagNode<KeyValuePair<string, string?>>? _next;
+
+            internal BaggageEnumerator(Activity? activity)
+            {
+                _activity = activity;
+                _next = null;
+                Current = default;
+            }
+
+            public KeyValuePair<string, string?> Current { get; private set; }
+
+            public readonly BaggageEnumerator GetEnumerator() => this;
+
+            public bool MoveNext()
+            {
+                while (_next is null)
+                {
+                    if (_activity is null)
+                    {
+                        return false;
+                    }
+
+                    BaggageLinkedList? baggage = _activity._baggage;
+                    _activity = _activity.Parent;
+                    if (baggage != null)
+                    {
+                        _next = baggage.First;
+                    }
+                }
+
+                Current = _next.Value;
+                _next = _next.Next;
                 return true;
             }
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DistributedContextPropagator.cs
@@ -122,22 +122,25 @@ namespace System.Diagnostics
 
         // internal stuff
 
-        internal static void InjectBaggage(object? carrier, IEnumerable<KeyValuePair<string, string?>> baggage, PropagatorSetterCallback setter)
+        internal static void InjectBaggage(object? carrier, Activity? activity, PropagatorSetterCallback setter)
         {
-            using (IEnumerator<KeyValuePair<string, string?>> e = baggage.GetEnumerator())
+            if (activity is null)
             {
-                if (e.MoveNext())
+                return;
+            }
+
+            Activity.BaggageEnumerator e = activity.EnumerateBaggage();
+            if (e.MoveNext())
+            {
+                StringBuilder baggageList = new StringBuilder();
+
+                do
                 {
-                    StringBuilder baggageList = new StringBuilder();
+                    KeyValuePair<string, string?> item = e.Current;
+                    baggageList.Append(WebUtility.UrlEncode(item.Key)).Append('=').Append(WebUtility.UrlEncode(item.Value)).Append(CommaWithSpace);
+                } while (e.MoveNext());
 
-                    do
-                    {
-                        KeyValuePair<string, string?> item = e.Current;
-                        baggageList.Append(WebUtility.UrlEncode(item.Key)).Append('=').Append(WebUtility.UrlEncode(item.Value)).Append(CommaWithSpace);
-                    } while (e.MoveNext());
-
-                    setter(carrier, CorrelationContext, baggageList.ToString(0, baggageList.Length - 2));
-                }
+                setter(carrier, CorrelationContext, baggageList.ToString(0, baggageList.Length - 2));
             }
         }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/LegacyPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/LegacyPropagator.cs
@@ -39,7 +39,7 @@ namespace System.Diagnostics
                 setter(carrier, RequestId, id);
             }
 
-            InjectBaggage(carrier, activity.Baggage, setter);
+            InjectBaggage(carrier, activity, setter);
         }
 
         public override void ExtractTraceIdAndState(object? carrier, PropagatorGetterCallback? getter, out string? traceId, out string? traceState)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/PassThroughPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/PassThroughPropagator.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics
                 return;
             }
 
-            GetRootId(out string? parentId, out string? traceState, out bool isW3c, out IEnumerable<KeyValuePair<string, string?>>? baggage);
+            GetRootId(out string? parentId, out string? traceState, out bool isW3c, out Activity? rootActivity);
             if (parentId is null)
             {
                 return;
@@ -31,17 +31,14 @@ namespace System.Diagnostics
                 setter(carrier, TraceState, traceState);
             }
 
-            if (baggage is not null)
-            {
-                InjectBaggage(carrier, baggage, setter);
-            }
+            InjectBaggage(carrier, rootActivity, setter);
         }
 
         public override void ExtractTraceIdAndState(object? carrier, PropagatorGetterCallback? getter, out string? traceId, out string? traceState) => LegacyPropagator.Instance.ExtractTraceIdAndState(carrier, getter, out traceId, out traceState);
 
         public override IEnumerable<KeyValuePair<string, string?>>? ExtractBaggage(object? carrier, PropagatorGetterCallback? getter) => LegacyPropagator.Instance.ExtractBaggage(carrier, getter);
 
-        private static void GetRootId(out string? parentId, out string? traceState, out bool isW3c, out IEnumerable<KeyValuePair<string, string?>>? baggage)
+        private static void GetRootId(out string? parentId, out string? traceState, out bool isW3c, out Activity? rootActivity)
         {
             Activity? activity = Activity.Current;
 
@@ -53,7 +50,7 @@ namespace System.Diagnostics
             traceState = activity?.TraceStateString;
             parentId = activity?.ParentId ?? activity?.Id;
             isW3c = parentId is not null ? Activity.TryConvertIdToContext(parentId, traceState, isRemote: false, out _) : false;
-            baggage = activity?.Baggage;
+            rootActivity = activity;
         }
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/W3CPropagator.cs
@@ -49,7 +49,7 @@ namespace System.Diagnostics
                 InjectTraceState(traceState, carrier, setter);
             }
 
-            InjectW3CBaggage(carrier, activity.Baggage, setter);
+            InjectW3CBaggage(carrier, activity, setter);
         }
 
         public override void ExtractTraceIdAndState(object? carrier, PropagatorGetterCallback? getter, out string? traceId, out string? traceState)
@@ -234,48 +234,46 @@ namespace System.Diagnostics
             }
         }
 
-        internal static void InjectW3CBaggage(object? carrier, IEnumerable<KeyValuePair<string, string?>> baggage, PropagatorSetterCallback setter)
+        internal static void InjectW3CBaggage(object? carrier, Activity activity, PropagatorSetterCallback setter)
         {
-            using (IEnumerator<KeyValuePair<string, string?>> e = baggage.GetEnumerator())
+            Activity.BaggageEnumerator e = activity.EnumerateBaggage();
+            if (e.MoveNext())
             {
-                if (e.MoveNext())
+                ValueStringBuilder encodedBaggage = new ValueStringBuilder(stackalloc char[256]);
+
+                int entriesCount = 0;
+                int lastGoodLength = 0;
+
+                do
                 {
-                    ValueStringBuilder encodedBaggage = new ValueStringBuilder(stackalloc char[256]);
+                    KeyValuePair<string, string?> item = e.Current;
 
-                    int entriesCount = 0;
-                    int lastGoodLength = 0;
-
-                    do
+                    if (EncodeBaggageKey(item.Key, ref encodedBaggage))
                     {
-                        KeyValuePair<string, string?> item = e.Current;
-
-                        if (EncodeBaggageKey(item.Key, ref encodedBaggage))
+                        encodedBaggage.Append(Space);
+                        encodedBaggage.Append(Equal);
+                        encodedBaggage.Append(Space);
+                        if (!string.IsNullOrEmpty(item.Value))
                         {
-                            encodedBaggage.Append(Space);
-                            encodedBaggage.Append(Equal);
-                            encodedBaggage.Append(Space);
-                            if (!string.IsNullOrEmpty(item.Value))
-                            {
-                                EncodeBaggageValue(item.Value, ref encodedBaggage);
-                            }
-                            encodedBaggage.Append(CommaWithSpace);
-
-                            entriesCount++;
-
-                            if (encodedBaggage.Length < MaxBaggageEncodedLength)
-                            {
-                                lastGoodLength = encodedBaggage.Length;
-                            }
+                            EncodeBaggageValue(item.Value, ref encodedBaggage);
                         }
-                    } while (e.MoveNext() && entriesCount < MaxBaggageEntriesToEmit && encodedBaggage.Length < MaxBaggageEncodedLength);
+                        encodedBaggage.Append(CommaWithSpace);
 
-                    if (lastGoodLength - 2 > 0)
-                    {
-                        setter(carrier, Baggage, encodedBaggage.AsSpan(0, lastGoodLength - 2).ToString());
+                        entriesCount++;
+
+                        if (encodedBaggage.Length < MaxBaggageEncodedLength)
+                        {
+                            lastGoodLength = encodedBaggage.Length;
+                        }
                     }
+                } while (e.MoveNext() && entriesCount < MaxBaggageEntriesToEmit && encodedBaggage.Length < MaxBaggageEncodedLength);
 
-                    encodedBaggage.Dispose();
+                if (lastGoodLength - 2 > 0)
+                {
+                    setter(carrier, Baggage, encodedBaggage.AsSpan(0, lastGoodLength - 2).ToString());
                 }
+
+                encodedBaggage.Dispose();
             }
         }
 


### PR DESCRIPTION
Avoid allocations when enumerating baggage in internal code paths by using a struct-based enumerator.

Public API surface is unchanged.

| Method                      | Baseline (main) Mean | Fixed Mean | Ratio | Baseline Allocated | Fixed Allocated | Alloc Ratio |
|---------------------------- |---------------------:|-----------:|------:|-------------------:|----------------:|------------:|
| GetBaggageItem              |             17.10 ns |    3.37 ns | 5.07x |               64 B |             0 B |       0.00x |
| EnumerateBaggageViaProperty |             30.88 ns |   30.24 ns | 1.02x |               64 B |            64 B |       1.00x |


<details>

<summary>Benchmarks</summary>

### Before

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.26200.9168)
13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK 11.0.100-preview.7.26381.103
  [Host] : .NET 10.0.10 (10.0.1026.32716), X64 RyuJIT AVX2

Toolchain=InProcessEmitToolchain
```

| Method                      | Mean     | Error    | StdDev   | Gen0   | Allocated |
|---------------------------- |---------:|---------:|---------:|-------:|----------:|
| GetBaggageItem              | 17.10 ns | 0.367 ns | 0.477 ns | 0.0051 |      64 B |
| EnumerateBaggageViaProperty | 30.88 ns | 0.643 ns | 1.343 ns | 0.0051 |      64 B |

### After

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.26200.9168)
13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
.NET SDK 11.0.100-preview.7.26381.103
  [Host] : .NET 10.0.10 (10.0.1026.32716), X64 RyuJIT AVX2

Toolchain=InProcessEmitToolchain
```

| Method                      | Mean      | Error     | StdDev    | Gen0   | Allocated |
|---------------------------- |----------:|----------:|----------:|-------:|----------:|
| GetBaggageItem              |  3.370 ns | 0.1249 ns | 0.1227 ns |      - |         - |
| EnumerateBaggageViaProperty | 30.241 ns | 0.6105 ns | 0.6532 ns | 0.0051 |      64 B |

```csharp
using System.Diagnostics;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Jobs;
using BenchmarkDotNet.Running;
using BenchmarkDotNet.Toolchains.InProcess.Emit;

BenchmarkSwitcher.FromAssembly(typeof(Bench).Assembly).Run(args);

public class InProcessConfig : ManualConfig
{
    public InProcessConfig()
    {
        AddJob(Job.Default.WithToolchain(InProcessEmitToolchain.Instance));
        AddDiagnoser(BenchmarkDotNet.Diagnosers.MemoryDiagnoser.Default);
    }
}

[Config(typeof(InProcessConfig))]
public class Bench
{
    private ActivitySource _source = default!;
    private Activity _leaf = default!;

    [GlobalSetup]
    public void Setup()
    {
        _source = new ActivitySource("bench");
        ActivityListener listener = new ActivityListener
        {
            ShouldListenTo = _ => true,
            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
        };
        ActivitySource.AddActivityListener(listener);

        // Build a chain of 5 activities, baggage set on the root only,
        // so GetBaggageItem/Baggage must walk up the parent chain.
        Activity? root = _source.StartActivity("root");
        root!.SetBaggage("key1", "value1");
        root.SetBaggage("key2", "value2");
        root.SetBaggage("key3", "value3");

        Activity current = root;
        for (int i = 0; i < 4; i++)
        {
            current = _source.StartActivity("child" + i)!;
        }

        _leaf = current;
    }

    [Benchmark]
    public string? GetBaggageItem()
    {
        return _leaf.GetBaggageItem("key3");
    }

    [Benchmark]
    public int EnumerateBaggageViaProperty()
    {
        int count = 0;
        foreach (KeyValuePair<string, string?> kvp in _leaf.Baggage)
        {
            count++;
        }
        return count;
    }
}
```

</details>