### PR TITLE
Validate null before mutating CodeNamespaceImportCollection

### DIFF
--- a/src/libraries/System.CodeDom/src/System/CodeDom/CodeNamespaceImportCollection.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/CodeNamespaceImportCollection.cs
@@ -16,7 +16,7 @@ namespace System.CodeDom
             get => (CodeNamespaceImport)_data[index];
             set
             {
-                _data[index] = value;
+                _data[index] = Validated(value);
                 SyncKeys();
             }
         }
@@ -52,6 +52,17 @@ namespace System.CodeDom
             _keys.Clear();
         }
 
+        // Add(CodeNamespaceImport) reads value.Namespace before touching _data, so a null
+        // throws before the collection is modified. The IList members and the indexer setter
+        // store first, which leaves an element behind that SyncKeys() cannot enumerate.
+        // Reading Namespace here reproduces that same NullReferenceException at the same
+        // point, before the store.
+        private static CodeNamespaceImport Validated(CodeNamespaceImport value)
+        {
+            _ = value.Namespace;
+            return value;
+        }
+
         private void SyncKeys()
         {
             _keys.Clear();
@@ -83,7 +94,7 @@ namespace System.CodeDom
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        int IList.Add(object value) => _data.Add((CodeNamespaceImport)value);
+        int IList.Add(object value) => _data.Add(Validated((CodeNamespaceImport)value));
 
         void IList.Clear() => Clear();
 
@@ -93,7 +104,7 @@ namespace System.CodeDom
 
         void IList.Insert(int index, object value)
         {
-            _data.Insert(index, (CodeNamespaceImport)value);
+            _data.Insert(index, Validated((CodeNamespaceImport)value));
             SyncKeys();
         }
 

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/CodeNamespaceImportCollectionTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/CodeNamespaceImportCollectionTests.cs
@@ -55,6 +55,40 @@ namespace System.CodeDom.Tests
             Assert.Throws<NullReferenceException>(() => collection.Add(null));
         }
 
+        [Fact]
+        public void IListAdd_Null_ThrowsNullReferenceExceptionAndLeavesCollectionUsable()
+        {
+            IList collection = new CodeNamespaceImportCollection();
+            Assert.Throws<NullReferenceException>(() => collection.Add(null));
+
+            // The failed add must not leave an element behind, otherwise the next
+            // operation throws while rebuilding the namespace keys.
+            collection.Insert(0, new CodeNamespaceImport("Namespace"));
+            Assert.Equal(1, collection.Count);
+        }
+
+        [Fact]
+        public void IListInsert_Null_ThrowsNullReferenceExceptionAndLeavesCollectionUsable()
+        {
+            IList collection = new CodeNamespaceImportCollection();
+            Assert.Throws<NullReferenceException>(() => collection.Insert(0, null));
+
+            collection.Insert(0, new CodeNamespaceImport("Namespace"));
+            Assert.Equal(1, collection.Count);
+        }
+
+        [Fact]
+        public void ItemSet_Null_ThrowsNullReferenceExceptionAndLeavesCollectionUsable()
+        {
+            var collection = new CodeNamespaceImportCollection();
+            collection.Add(new CodeNamespaceImport("Namespace"));
+
+            Assert.Throws<NullReferenceException>(() => collection[0] = null);
+
+            Assert.Equal(1, collection.Count);
+            Assert.Equal("Namespace", collection[0].Namespace);
+        }
+
         public static IEnumerable<object[]> AddRange_TestData()
         {
             yield return new object[] { new CodeNamespaceImport[0] };


### PR DESCRIPTION
Fixes #131870.

`Add(CodeNamespaceImport)` reads `value.Namespace` before it touches `_data`, so a null argument throws `NullReferenceException` and the collection is left untouched. That is the behaviour `Add_Null_ThrowsNullReferenceException` pins.

Three other paths store first and validate afterwards, if at all:

- `IList.Add` is `_data.Add((CodeNamespaceImport)value)`. The cast succeeds for null, `ArrayList.Add` accepts it, and the method never calls `SyncKeys()`, so it does not throw at all. The null stays in `_data`, and the next operation that calls `SyncKeys()` throws while enumerating it.
- `IList.Insert` inserts and then calls `SyncKeys()`, which throws on `c.Namespace` after the element is already in the list.
- The indexer setter does the same via `_data[index] = value`.

So the collection ends up in a state where every later mutation throws, which is what the issue reports.

This routes the three paths through a small helper that reads `Namespace` before the store, so they throw the same `NullReferenceException` at the same point as `Add(CodeNamespaceImport)` and leave the collection unchanged.

I checked the behaviour against the shipped `System.CodeDom` 8.0.0 first, then against the patched class compiled standalone:

```
                                   before        after
IList.Add(null) throws             no            yes
  collection usable afterwards     no            yes
IList.Insert(0, null) throws       yes           yes
  collection usable afterwards     no            yes
collection[0] = null throws        yes           yes
  collection usable afterwards     no            yes
```

Added three tests next to `Add_Null_ThrowsNullReferenceException`, each asserting both halves: that the null throws, and that a normal insert still works afterwards. The second half is the part that fails on current main.

I kept `NullReferenceException` rather than switching to `ArgumentNullException`, since the existing tests assert it for `Add` and `AddRange` and changing it would be a separate, observable break. Happy to switch if you would rather these paths threw `ArgumentNullException`.

One thing I noticed but did not change: `IList.Add` also never updates `_keys`, so a non-null value added through it is invisible to the duplicate check in `Add(CodeNamespaceImport)` and can be added twice. Routing `IList.Add` through the public `Add` would fix that too, but it changes the returned index and applies the dedup, so it seemed better left out of a null-handling fix. Let me know if you want it here.
