### PR TITLE
Make LegacyPropagator list sort linear

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/LegacyPropagator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/LegacyPropagator.cs
@@ -167,8 +167,7 @@ namespace System.Diagnostics
                 {
                     baggageList ??= new List<KeyValuePair<string, string?>>();
 
-                    // Insert in reverse order for asp.net compatibility.
-                    baggageList.Insert(0, new KeyValuePair<string, string?>(
+                    baggageList.Add(new KeyValuePair<string, string?>(
                                                 WebUtility.UrlDecode(baggageString.Substring(keyStart, keyEnd - keyStart)).Trim(s_trimmingSpaceCharacters),
                                                 WebUtility.UrlDecode(baggageString.Substring(valueStart, currentIndex - valueStart)).Trim(s_trimmingSpaceCharacters)));
                 }
@@ -181,6 +180,9 @@ namespace System.Diagnostics
 
                 currentIndex++; // Move to next key-value entry
             } while (currentIndex < baggageString.Length);
+
+            // Reverse order for asp.net compatibility.
+            baggageList?.Reverse();
 
             baggage = baggageList;
             return baggageList != null;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/PropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/PropagatorTests.cs
@@ -41,12 +41,18 @@ namespace System.Diagnostics.Tests
                 TestLegacyPropagatorUsingW3CActivity(
                                 DistributedContextPropagator.Current,
                                 "Legacy1=true",
-                                new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>("     LegacyKey1     ", "    LegacyValue1    ") });
+                                new List<KeyValuePair<string, string>>() {
+                                    new KeyValuePair<string, string>("     LegacyKey1     ", "    LegacyValue1    "),
+                                    new KeyValuePair<string, string>("LegacyKey1b", "LegacyValue1b"),
+                                    new KeyValuePair<string, string>("LegacyKey1c", "LegacyValue1c") });
 
                 TestLegacyPropagatorUsingHierarchicalActivity(
                                 DistributedContextPropagator.Current,
                                 "Legacy2=true",
-                                new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>("LegacyKey2", "LegacyValue2") });
+                                new List<KeyValuePair<string, string>>() {
+                                    new KeyValuePair<string, string>("LegacyKey2", "LegacyValue2"),
+                                    new KeyValuePair<string, string>("LegacyKey2b", "LegacyValue2b"),
+                                    new KeyValuePair<string, string>("LegacyKey2c", "LegacyValue2c") });
 
                 TestFields(DistributedContextPropagator.Current);
 


### PR DESCRIPTION
Replace O(n^2) behaviour with O(n) to reverse the list of keys parsed from the baggage header by `LegacyPropagator`, matching the implementation in `W3CPropagator`.

Also adds a test to verify the ordering.

Impact in the default case is minimised by Kestrel and IIS' HTTP request header limits (8KB and 16KB) and the legacy propagator being opt-in in .NET 10+.

| N (entries) | Header size | Old (Insert) | New (Add+Reverse) | Ratio | Allocated (both) |
|---|---|---|---|---|---|
| 3 | ~11 B | 135.6 ns | 134.6 ns | 1.0x | 528 B |
| 10 | ~39 B | 499.0 ns | 518.7 ns | 1.0x | 1,912 B |
| 50 | ~199 B | 2,832.3 ns | 2,481.9 ns | 1.1x | 8,936 B |
| 500 | ~2 KB | 56.4 µs | 25.3 µs | 2.2x | 87,744 B |
| 2,000 | ~7.8 KB | 556.9 µs | 113.2 µs | 4.9x | 360,948 B |
| 2,048 (8 KB) | 8 KB | 519.9 µs | 65.0 µs | 8.0x | 288.25 KB |
| 4,096 (16 KB) | 16 KB | 1,992.0 µs | 229.4 µs | 8.7x | 576.28 KB |
| 8,192 (32 KB) | 32 KB | 8,298.8 µs | 916.7 µs | 9.1x | 1,152.45 KB |
| 16,384 (64 KB) | 64 KB | 32,119.9 µs | 2,696.4 µs | 11.9x | 2,304.73 KB |