### PR TITLE
Fix Serialize_ManagementException by referencing functional BinaryFormatter

### DIFF
--- a/src/libraries/System.Management/tests/System.Management.Tests.csproj
+++ b/src/libraries/System.Management/tests/System.Management.Tests.csproj
@@ -29,4 +29,12 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Management" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!-- The shared framework's BinaryFormatter always throws, so reference the `NetCoreAppMinimum` build which
+         still has a functional implementation. Private="true" is required because eng/references.targets defaults
+         shared framework project references to Private="false", which would keep it out of the output directory. -->
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
+                      Private="true"
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Management/tests/System/Management/ManagementObjectTests.cs
+++ b/src/libraries/System.Management/tests/System/Management/ManagementObjectTests.cs
@@ -13,6 +13,8 @@ namespace System.Management.Tests
 {
     public class ManagementObjectTests
     {
+        private static bool IsWmiAndBinaryFormatterSupported => WmiTestHelper.IsWmiSupported && PlatformDetection.IsBinaryFormatterSupported;
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindowsNanoServer))]
         public void PlatformNotSupportedException_On_Nano()
         {
@@ -103,7 +105,7 @@ namespace System.Management.Tests
             }, maxAttempts: 10, retryWhen: e => e is XunitException);
         }
 
-        [ConditionalFact(typeof(WmiTestHelper), nameof(WmiTestHelper.IsWmiSupported))]
+        [ConditionalFact(typeof(ManagementObjectTests), nameof(IsWmiAndBinaryFormatterSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34689", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [OuterLoop]
 #if NET


### PR DESCRIPTION
The in-box BinaryFormatter has thrown `PlatformNotSupportedException` since .NET 9, so this OuterLoop, WMI-gated test has been failing whenever it actually runs.

Follow the established pattern used by nine other libraries test projects (for example `Microsoft.Extensions.Hosting.Unit.Tests` and `System.Runtime.Tests`): take a private `ProjectReference` on the `NetCoreAppMinimum` build of `System.Runtime.Serialization.Formatters`, which has a functional implementation, and gate the test on `PlatformDetection.IsBinaryFormatterSupported` so it skips where the feature is unavailable (source-build, NativeAOT, mobile, browser).

`ManagementException` remains `[Serializable]` with a `GetObjectData` override that deliberately omits `ErrorInformation`, so this keeps real coverage of shipping product behavior on both net11.0 and net481 instead of deleting it.

Fixes #119631

## Validation

Ran locally on Windows 11 ARM64 (`WmiTestHelper.IsWmiSupported` gates on Arm32, not ARM64, so these tests really do execute here):

- Baseline `build.cmd clr+libs -rc release` — exit 0
- Both TFMs build with 0 warnings, 0 errors
- Target test, net11.0-windows, OuterLoop — Total 1, **Failed 0**
- Control with the csproj change reverted — **Failed 1**, with the exact `PlatformNotSupportedException` from the issue
- Target test, net481, OuterLoop — Total 1, **Failed 0**
- Full suite, net11.0-windows — 36 total, **0 failed**, 10 skipped
- Full suite, net481 — 35 total, **0 failed**, 10 skipped

Verified the functional 157,184 B assembly is copied to the test output and that the generated runtimeconfig carries `"System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": true`.

## Why each attribute is required

Each was confirmed empirically by removing it and observing the failure:

| Missing | Lands in output | Failure |
| --- | --- | --- |
| `Private="true"` | nothing | `FileNotFoundException` for `Version=11.0.0.0` |
| `SetTargetFramework` | 70,144 B stub | `PlatformNotSupportedException` |
| the `IsBinaryFormatterSupported` gate | n/a | breaks source-build, where `NetCoreAppMinimum` collapses onto `NetCoreAppCurrent` and the reference resolves back to the throwing build |
| nothing (this PR) | 157,184 B functional | passes |

`Private="true"` is needed because `eng/references.targets` defaults `Private` to `false` for any `ProjectReference` whose filename appears in `@(NetCoreAppLibrary)`, which includes `System.Runtime.Serialization.Formatters`. That default is normally right, but here we deliberately want a different build than the one in the shared framework.

> [!NOTE]
> This pull request was authored by GitHub Copilot.