### PR TITLE
Fix CompareInfo.IsPrefix/IsSuffix with CompareOptions.IgnoreSymbols not ignoring leading/trailing symbols

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -87,8 +87,7 @@ namespace System.Globalization.Tests
             else
             {
                 yield return new object[] { s_hungarianCompare, "dzsdzsfoobar", "ddzsf", CompareOptions.None, false, 0 };
-                // Bug in ICU (non-Apple) implementation, correct result should be true (https://github.com/dotnet/runtime/issues/118521)
-                yield return new object[] { s_invariantCompare, "''Tests", "Tests", CompareOptions.IgnoreSymbols, PlatformDetection.IsHybridGlobalizationOnApplePlatform ? true : false, 0 };
+                yield return new object[] { s_invariantCompare, "''Tests", "Tests", CompareOptions.IgnoreSymbols, true, 7 };
                 yield return new object[] { s_frenchCompare, "\u0153", "oe", CompareOptions.None, false, 0 };
                 if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
                 {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -81,6 +81,7 @@ namespace System.Globalization.Tests
 
             // Ignore symbols
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", CompareOptions.IgnoreSymbols, true, 6 };
+            yield return new object[] { s_invariantCompare, "Tests''", "Tests", CompareOptions.IgnoreSymbols, true, 7 };
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", CompareOptions.None, false, 0 };
 
             // NULL character

--- a/src/native/libs/System.Globalization.Native/pal_collation.c
+++ b/src/native/libs/System.Globalization.Native/pal_collation.c
@@ -407,29 +407,14 @@ static UCollator* CloneCollatorWithOptions(const UCollator* pCollator, int32_t o
     return pClonedCollator;
 }
 
-// Returns TRUE if all the collation elements in str are completely ignorable
+// Returns TRUE if str is completely ignorable by the collator.
 static int CanIgnoreAllCollationElements(const UCollator* pColl, const UChar* lpStr, int32_t length)
 {
-    int result = true;
-    UErrorCode err = U_ZERO_ERROR;
-    UCollationElements* pCollElem = ucol_openElements(pColl, lpStr, length, &err);
-
-    if (U_SUCCESS(err))
-    {
-        int32_t curCollElem = UCOL_NULLORDER;
-        while ((curCollElem = ucol_next(pCollElem, &err)) != UCOL_NULLORDER)
-        {
-            if (curCollElem != UCOL_IGNORABLE)
-            {
-                result = false;
-                break;
-            }
-        }
-
-        ucol_closeElements(pCollElem);
-    }
-
-    return U_SUCCESS(err) ? result : false;
+    // Collation element iterators expose raw elements and do not apply shifted
+    // alternate handling. Compare against an empty string so all collator
+    // options, including IgnoreSymbols, are honored.
+    UChar emptyString = 0;
+    return ucol_strcoll(pColl, lpStr, length, &emptyString, 0) == UCOL_EQUAL;
 }
 
 static void CreateSortHandle(SortHandle** ppSortHandle)


### PR DESCRIPTION
Fixes #118521

## Root cause

`ComplexStartsWith`/`ComplexEndsWith` in `pal_collation.c` use ICU string search to locate the requested affix, then call `CanIgnoreAllCollationElements` to check whether any skipped text before/after the match is entirely ignorable under the active `CompareOptions`.

`CanIgnoreAllCollationElements` walked the *raw* collation elements returned by `ucol_next` (via `ucol_openElements`) and required each one to equal `UCOL_IGNORABLE` (0). Raw collation-element iteration does not apply the collator's `UCOL_ALTERNATE_HANDLING` setting — so when `CompareOptions.IgnoreSymbols` sets `UCOL_ALTERNATE_HANDLING = UCOL_SHIFTED` on the collator, a symbol character that should now be ignorable (e.g. `'`) still produces a non-zero raw collation element. This made `CanIgnoreAllCollationElements` incorrectly report the skipped text as "not ignorable," so:

```csharp
CultureInfo.InvariantCulture.CompareInfo.IsPrefix("''Tests", "Tests", CompareOptions.IgnoreSymbols)
```

returned `false` instead of `true` on ICU (non-Windows NLS, non-Apple-hybrid) platforms — those other implementations already used a different code path that isn't affected by this quirk, which is why the existing test file already had a platform-conditional branch documenting this exact case as a known ICU-backend bug pointing at this issue.

I verified this against a live ICU instance: raw `ucol_next` elements for symbol characters made ignorable via `IgnoreSymbols` remain non-zero, while `ucol_strcoll` against those same characters correctly honors the collator's strength/alternate-handling and reports equality with an empty string.

## Fix

`CanIgnoreAllCollationElements` now compares the skipped substring against an empty string using `ucol_strcoll` (the same high-level comparison entry point already used elsewhere in this file, e.g. `GlobalizationNative_CompareString`), instead of manually iterating and masking raw collation elements. This honors the collator's configured strength, alternate handling (`IgnoreSymbols`), and locale tailoring uniformly, rather than re-implementing that logic against the low-level iterator API. A non-null empty `UChar` buffer is passed (rather than `NULL`) to avoid a documented old-ICU null-input issue that this file already works around elsewhere (`ICU-9396`).

This helper is shared by both `ComplexStartsWith` and `ComplexEndsWith`, so the fix resolves the symmetric `IsSuffix` case as well (e.g. `"Tests''".EndsWith("Tests", CompareOptions.IgnoreSymbols)`), for which I added a regression test.

## Changes

- `src/native/libs/System.Globalization.Native/pal_collation.c`: replaced the raw collation-element loop in `CanIgnoreAllCollationElements` with an `ucol_strcoll`-against-empty-string check.
- `src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsPrefix.cs`: removed the platform-conditional "known ICU bug" branch for `''Tests`/`Tests` and set the expected result to `true` (matched length 7) unconditionally.
- `src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.IsSuffix.cs`: added the symmetric `Tests''`/`Tests` regression case.

## Validation

I don't have a full native ICU build/toolchain available in this environment, so I wasn't able to run the managed test suite against a compiled `libSystem.Globalization.Native`. I did directly probe ICU's C collation API (`usearch_first`/`usearch_last`, raw `ucol_next` vs `ucol_strcoll`) to confirm the root cause and the fix's behavior character-by-character for the affected cases. The change is narrowly scoped to the single shared helper function and mirrors an existing, already-used API call pattern in the same file.