### PR TITLE
NativeAOT: remove BOM from generated source/response files

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -462,7 +462,7 @@ int main(int argc, char** argv)
     </ItemGroup>
 
     <MakeDir Directories="$(NativeIntermediateOutputPath);$(NativeOutputPath)" />
-    <WriteLinesToFile File="%(_AggregateExecutableReferencePath.ShimSource)" Lines="$([MSBuild]::Escape('%(_AggregateExecutableReferencePath.ShimSourceCode)'))" Overwrite="true" Encoding="utf-8" WriteOnlyWhenDifferent="true" />
-    <WriteLinesToFile File="%(_AggregateExecutableReferencePath.ShimCompileLinkRspFile)" Lines="@(_AggregateExecutableShimCompilerAndLinkerArg);&quot;%(_AggregateExecutableReferencePath.ShimSource)&quot;;@(_AggregateExecutableShimNativeLibraryArg);-o;&quot;%(_AggregateExecutableReferencePath.ShimBinary)&quot;" Overwrite="true" Encoding="utf-8" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="%(_AggregateExecutableReferencePath.ShimSource)" Lines="$([MSBuild]::Escape('%(_AggregateExecutableReferencePath.ShimSourceCode)'))" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="%(_AggregateExecutableReferencePath.ShimCompileLinkRspFile)" Lines="@(_AggregateExecutableShimCompilerAndLinkerArg);&quot;%(_AggregateExecutableReferencePath.ShimSource)&quot;;@(_AggregateExecutableShimNativeLibraryArg);-o;&quot;%(_AggregateExecutableReferencePath.ShimBinary)&quot;" Overwrite="true" WriteOnlyWhenDifferent="true" />
   </Target>
 </Project>


### PR DESCRIPTION
When the repsonse file starts with a BOM followed by a flag, it will be interpreted as a filename:

  clang : error : no such file or directory: '<feff>-fuse-ld=bfd'

WriteLinesToFile uses utf-8 without BOM when the encoding attribute is removed.

Out of caution I decided to remove the attribute for both response and source files.

Fixes: #132378
Fixes: 4832002fd28748322015287b8fb3b8126334865f