### PR TITLE
JIT: Remove redundant integral cast round trips

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -641,11 +641,12 @@ static void optAssertionProp_HWIntrinsic(Compiler* comp, GenTreeHWIntrinsic* tre
 // Arguments:
 //   cast     - the cast node for which the range will be computed
 //   compiler - Compiler object
+//   operandRange - if provided, the precomputed range of the cast operand
 //
 // Return Value:
 //   The range this cast produces - see description.
 //
-/* static */ IntegralRange IntegralRange::ForCastOutput(GenTreeCast* cast, Compiler* compiler)
+static IntegralRange ForCastOutputCore(GenTreeCast* cast, Compiler* compiler, const IntegralRange* operandRange)
 {
     var_types fromType     = genActualType(cast->CastOp());
     var_types toType       = cast->CastToType();
@@ -675,14 +676,15 @@ static void optAssertionProp_HWIntrinsic(Compiler* comp, GenTreeHWIntrinsic* tre
 
     if (varTypeIsSmall(toType) || (genActualType(toType) == fromType))
     {
-        return ForCastInput(cast);
+        return IntegralRange::ForCastInput(cast);
     }
 
     // if we're upcasting and the cast op is a known non-negative - consider
     // this cast unsigned
     if (!fromUnsigned && (genTypeSize(toType) >= genTypeSize(fromType)))
     {
-        fromUnsigned = cast->CastOp()->IsNeverNegative(compiler);
+        fromUnsigned =
+            (operandRange != nullptr) ? operandRange->IsNonNegative() : cast->CastOp()->IsNeverNegative(compiler);
     }
 
     // CAST(uint/int <- ulong/long) - [INT_MIN..INT_MAX]
@@ -690,12 +692,17 @@ static void optAssertionProp_HWIntrinsic(Compiler* comp, GenTreeHWIntrinsic* tre
     // CAST(ulong/long <- int)      - [INT_MIN..INT_MAX]
     if (!cast->gtOverflow())
     {
-        if ((fromType == TYP_INT) && fromUnsigned)
-        {
-            return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::UIntMax};
-        }
+        IntegralRange result = ((fromType == TYP_INT) && fromUnsigned)
+                                   ? IntegralRange{SymbolicIntegerValue::Zero, SymbolicIntegerValue::UIntMax}
+                                   : IntegralRange{SymbolicIntegerValue::IntMin, SymbolicIntegerValue::IntMax};
 
-        return {SymbolicIntegerValue::IntMin, SymbolicIntegerValue::IntMax};
+        // Only preserve the source range when the cast is guaranteed
+        // to preserve every possible value in that range.
+        if ((operandRange != nullptr) && result.Contains(*operandRange))
+        {
+            return *operandRange;
+        }
+        return result;
     }
 
     SymbolicIntegerValue lowerBound;
@@ -735,6 +742,16 @@ static void optAssertionProp_HWIntrinsic(Compiler* comp, GenTreeHWIntrinsic* tre
     }
 
     return {lowerBound, upperBound};
+}
+
+/* static */ IntegralRange IntegralRange::ForCastOutput(GenTreeCast* cast, Compiler* compiler)
+{
+    return ForCastOutputCore(cast, compiler, nullptr);
+}
+
+/* static */ IntegralRange IntegralRange::ForCastOutput(GenTreeCast* cast, const IntegralRange& operandRange)
+{
+    return ForCastOutputCore(cast, nullptr, &operandRange);
 }
 
 /* static */ IntegralRange IntegralRange::Union(IntegralRange range1, IntegralRange range2)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1365,6 +1365,7 @@ public:
     static IntegralRange ForNode(GenTree* node, Compiler* compiler);
     static IntegralRange ForCastInput(GenTreeCast* cast);
     static IntegralRange ForCastOutput(GenTreeCast* cast, Compiler* compiler);
+    static IntegralRange ForCastOutput(GenTreeCast* cast, const IntegralRange& operandRange);
     static IntegralRange Union(IntegralRange range1, IntegralRange range2);
 
 #ifdef DEBUG

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8660,14 +8660,31 @@ GenTree* Compiler::fgOptimizeCast(GenTreeCast* cast)
         // Check for two consecutive casts, we may be able to discard the intermediate one.
         if (opts.OptimizationEnabled() && src->OperIs(GT_CAST) && !src->gtOverflow())
         {
+            GenTreeCast* srcCast   = src->AsCast();
+            GenTree*     srcCastOp = srcCast->CastOp();
+
+            // CAST(T <- CAST(U <- X)) can be replaced by X if both casts
+            // preserve X's range and the final type is the same as X's type.
+            if (cast->TypeIs(srcCastOp->TypeGet()))
+            {
+                IntegralRange operandRange = IntegralRange::ForNode(srcCastOp, this);
+                IntegralRange srcCastRange = IntegralRange::ForCastOutput(srcCast, operandRange);
+                IntegralRange dstRange     = IntegralRange::ForCastOutput(cast, srcCastRange);
+
+                if (srcCastRange.Equals(operandRange) && dstRange.Equals(operandRange))
+                {
+                    return srcCastOp;
+                }
+            }
+
             var_types dstCastToType = castToType;
-            var_types srcCastToType = src->AsCast()->CastToType();
+            var_types srcCastToType = srcCast->CastToType();
 
             // CAST(ubyte <- CAST(short <- X)): CAST(ubyte <- X).
             // CAST(ushort <- CAST(short <- X)): CAST(ushort <- X).
             if (varTypeIsSmall(srcCastToType) && (genTypeSize(dstCastToType) <= genTypeSize(srcCastToType)))
             {
-                cast->CastOp() = src->AsCast()->CastOp();
+                cast->CastOp() = srcCastOp;
                 DEBUG_DESTROY_NODE(src);
             }
         }

--- a/src/tests/JIT/opt/Casts/IntCast.cs
+++ b/src/tests/JIT/opt/Casts/IntCast.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -27,6 +28,48 @@ namespace CodeGenTests
             return (long)value1 + (long)value2;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static nint Cast_LeadingZeroCount_To_NInt(ulong value)
+        {
+            // X64-NOT: cdqe
+            // X64-NOT: movsxd
+            return BitOperations.LeadingZeroCount(value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static nint Cast_TrailingZeroCount_To_NInt(ulong value)
+        {
+            // X64-NOT: cdqe
+            // X64-NOT: movsxd
+            return BitOperations.TrailingZeroCount(value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static nint Cast_PopCount_To_NInt(ulong value)
+        {
+            // X64-NOT: cdqe
+            // X64-NOT: movsxd
+            return BitOperations.PopCount(value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool TruncatedValueCanBeNegative(long value)
+        {
+            return unchecked((int)value) < 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static long TruncatingRoundTripMustRemain(long value)
+        {
+            return (long)(int)value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static long ZeroExtendingRoundTripMustRemain(long value)
+        {
+            return unchecked((long)(uint)value);
+        }
+
         [Fact]
         public static int TestEntryPoint()
         {
@@ -34,6 +77,33 @@ namespace CodeGenTests
                 return 0;
 
             if (Cast_Short_To_Long_Add(Int16.MaxValue, Int16.MaxValue) != 65534)
+                return 0;
+
+            if (Cast_LeadingZeroCount_To_NInt(0) != 64)
+                return 0;
+
+            if (Cast_LeadingZeroCount_To_NInt(ulong.MaxValue) != 0)
+                return 0;
+
+            if (Cast_TrailingZeroCount_To_NInt(0) != 64)
+                return 0;
+
+            if (Cast_TrailingZeroCount_To_NInt(1) != 0)
+                return 0;
+
+            if (Cast_PopCount_To_NInt(0) != 0)
+                return 0;
+
+            if (Cast_PopCount_To_NInt(ulong.MaxValue) != 64)
+                return 0;
+
+            if (!TruncatedValueCanBeNegative(0xFFFF_FFFFL))
+                return 0;
+
+            if (TruncatingRoundTripMustRemain(0xFFFF_FFFFL) != -1)
+                return 0;
+
+            if (ZeroExtendingRoundTripMustRemain(-1) != uint.MaxValue)
                 return 0;
 
             return 100;


### PR DESCRIPTION
Fixes #119699

`LeadingZeroCount`, `TrailingZeroCount`, and `PopCount` can end up with an extra sign extension when their `int` result is returned as `nint`.

The result range is already known for these intrinsics, but it gets widened after the first non-truncating cast. Morph then cannot tell that the outer cast is redundant.

This change keeps the operand's range when the destination type can represent all of its values. `fgOptimizeCast` can then remove the round trip when both casts preserve the value and the final type matches the original type.

This follows the range-based approach suggested in the discussion on #119699, where the optimization is allowed when the intermediate cast is proven to preserve the value.

For example, on x64:

```diff
        xor      eax, eax
        lzcnt    rax, rdi
-       cdqe
        ret
```

The same applies to `TrailingZeroCount` and `PopCount`.

## Testing

* Extended `JIT/opt/Casts/IntCast` with runtime and x64 disassembly checks.
* Added negative coverage for round trips where the intermediate cast truncates the value.
* Replayed 4 SuperPMI collections covering 1,800,601 contexts; all replays completed successfully.
* Found 311 asm diffs, with a total code-size change of -653 bytes. 
* PerfScore reported 32 improvements and no regressions. Most diffs remove redundant zero/sign extensions, including 129 `mov r32, r32` and 6 `cdqe` instructions.