### PR TITLE
[wasm][coreCLR] workaround: Reject R2R methods whose TypeHandle fixup cannot be tokenized

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -2919,6 +2919,18 @@ namespace Internal.JitInterface
             return null;
         }
 
+        private bool CanEncodeTypeHandleFixup(TypeDesc type)
+        {
+            if (type.IsPrimitive || type.IsString || type.IsObject || type.IsWellKnownType(WellKnownType.TypedReference))
+                return true;
+
+            if (type.GetTypeDefinition() is not EcmaType ecmaType)
+                return true;
+
+            return !_compilation.NodeFactory.Resolver.GetModuleTokenForType(
+                ecmaType, allowDynamicallyCreatedReference: true, throwIfNotFound: false).IsNull;
+        }
+
         private void embedGenericHandle(ref CORINFO_RESOLVED_TOKEN pResolvedToken, bool fEmbedParent, CORINFO_METHOD_STRUCT_* callerHandle, ref CORINFO_GENERICHANDLE_RESULT pResult)
         {
             ceeInfoEmbedGenericHandle(ref pResolvedToken, fEmbedParent, callerHandle, ref pResult);
@@ -2941,9 +2953,20 @@ namespace Internal.JitInterface
                 switch (pResult.handleType)
                 {
                     case CorInfoGenericHandleType.CORINFO_HANDLETYPE_CLASS:
-                        symbolNode = _compilation.SymbolNodeFactory.CreateReadyToRunHelper(
-                            ReadyToRunHelperId.TypeHandle,
-                            HandleToObject(pResolvedToken.hClass));
+                        {
+                            TypeDesc classHandleType = HandleToObject(pResolvedToken.hClass);
+
+                            // A TypeHandle fixup has to be encodable as a module token. See dotnet/runtime#130585.
+                            if (_compilation.NodeFactory.Target.Architecture == TargetArchitecture.Wasm32 &&
+                                !CanEncodeTypeHandleFixup(classHandleType))
+                            {
+                                throw new RequiresRuntimeJitException(classHandleType.ToString());
+                            }
+
+                            symbolNode = _compilation.SymbolNodeFactory.CreateReadyToRunHelper(
+                                ReadyToRunHelperId.TypeHandle,
+                                classHandleType);
+                        }
                         break;
 
                     case CorInfoGenericHandleType.CORINFO_HANDLETYPE_METHOD:


### PR DESCRIPTION
Fixes the crossgen2 crash in #130585.

## Problem

`embedGenericHandle` emitted a `TypeHandle` fixup for the `CORINFO_HANDLETYPE_CLASS` case without checking that the type can be encoded as a module token:

```csharp
case CorInfoGenericHandleType.CORINFO_HANDLETYPE_CLASS:
    symbolNode = _compilation.SymbolNodeFactory.CreateReadyToRunHelper(
        ReadyToRunHelperId.TypeHandle,
        HandleToObject(pResolvedToken.hClass));
    break;
```

When the type is outside the version bubble and nothing can produce a token for it, `TypeFixupSignature.GetData` → `SignatureContext.GetTargetModule` → `ModuleTokenResolver.GetModuleTokenForType` throws `NotImplementedException`. That happens while `ObjectWriter.EmitObject` materializes import signatures, with no `try`/`catch` anywhere on the path, so crossgen2 dies with an unhandled exception and the whole compilation fails:

```
Unhandled exception. System.NotImplementedException: [S.P.CoreLib]System.Reflection.MemberInfo
   at ILCompiler.DependencyAnalysis.ReadyToRun.ModuleTokenResolver.GetModuleTokenForType(...)
   at ILCompiler.DependencyAnalysis.ReadyToRun.SignatureContext.GetTargetModule(TypeDesc type)
   at ILCompiler.DependencyAnalysis.ReadyToRun.TypeFixupSignature.GetData(...)
   at ILCompiler.DependencyAnalysis.ReadyToRun.ImportSectionNode.MaterializeSignature(...)
   ...
   at ILCompiler.ObjectWriter.ObjectWriter.EmitObject(...)
```

The canonical case is `System.Reflection.MemberInfo`, which an assembly can reference only transitively through a `MemberRef` on `System.Type`, so no `TypeRef` row exists for it.

The sibling callback `embedClassHandle` immediately above already guards this class of problem with `VersionsWithType`; this branch had no guard at all.

## Fix

Check encodability up front and throw `RequiresRuntimeJitException`, so the method falls back to the runtime JIT instead of taking down the compilation.

Placement matters: this runs **before** `CreateReadyToRunHelper`, so the rejected method never reaches `SetCode`, its `Import` node is never marked, `ImportSectionNode.AddImport` never runs, and the un-encodable signature never enters the import section. A `catch` around `EmitObject` would not work — by then the fixup is already committed.

The check mirrors `SignatureContext.GetTargetModule` exactly, because that is the code that would throw:

```csharp
if (type.IsPrimitive || type.IsString || type.IsObject || type.IsWellKnownType(WellKnownType.TypedReference))
    return true;
if (type.GetTypeDefinition() is not EcmaType ecmaType)
    return true;
return !Resolver.GetModuleTokenForType(ecmaType, allowDynamicallyCreatedReference: true, throwIfNotFound: false).IsNull;
```

Mirroring it matters for R2R coverage. Two simpler forms both over-reject:

- copying `embedClassHandle`'s `!VersionsWithType(type)` verbatim would reject out-of-bubble types that *do* have a `TypeRef` in an input module and resolve fine today;
- probing the resolver with the *instantiated* type and without the primitive/array early-outs rejects things `GetTargetModule` never even asks about.

I measured the second one: on `xunit.runner.utility.netcoreapp10.dll` it rejected **250** methods, the top reasons being `object[]` (40), `string[]` (16) and `char[]` (5) — all trivially encodable. Mirroring `GetTargetModule` brings that to **72**, of which **68** are pre-existing `embedClassHandle` rejections (`MessageHandler<T>` over out-of-bubble interfaces). The incremental cost of this PR on that assembly is a single method — the one that was crashing.

## No impact on other targets

The guard is gated on `TargetArchitecture.Wasm32`, so nothing changes for x64/arm64/x86.

That is deliberate, for two reasons:

1. Every other target takes the method-keyed `CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR` path in `impImportLdvirtftn`; only wasm is carved out of it (`#if defined(FEATURE_READYTORUN) && !defined(TARGET_WASM)`), and only the generic `CORINFO_HELP_VIRTUAL_FUNC_PTR` helper needs the declaring type handle. So the un-encodable case is a wasm problem in practice — consistent with x64 R2R-compiling the framework today without hitting it.
2. More importantly, the check runs at **method compile time** whereas the encoding happens during **object writing**, after all methods are compiled. `ModuleTokenResolver._typeToRefTokens` is a `ConcurrentDictionary` populated lazily by `AddModuleTokenForType` *during* compilation, so a type that is not yet resolvable when the check runs can become resolvable later. Ungated, that could reject a method that would otherwise have compiled — losing R2R coverage, and in a parallel compilation potentially non-deterministically. Restricting to wasm keeps that window off every other target.

Note the path itself *is* reachable on other targets (`impParentClassTokenToHandle` has four non-wasm call sites plus `getVirtMethodPointerTree` in `morph.cpp`), so this is a deliberate scoping decision rather than dead code. If the crash is ever observed off-wasm, the gate is one condition to relax.

## Verification

Built locally for browser-wasm Release with `PublishReadyToRun=true`. All three projects that crossgen2 previously killed now build:

| | before | after |
|---|---|---|
| `src/libraries/Common/tests/Common.Tests.csproj` (`net11.0-browser`) | `NotImplementedException` | builds; 125 R2R images incl. `System.Private.CoreLib.dll` |
| `WebAssembly.Browser.RuntimeConfig.Test.csproj` | `NotImplementedException` | builds |
| `WebAssembly.Browser.HotReload.Test.csproj` | `NotImplementedException` | builds |

And the single-method repro from #130585 now reports a clean rejection instead of crashing:

```
Info: Method `[xunit.runner.utility.netcoreapp10]Xunit.RunnerReporterUtility.GetAvailableRunnerReporters(string,List`1<string>&)`
      was not compiled because `[S.P.CoreLib]System.Reflection.MemberInfo` requires runtime JIT
```

Re-run after adding the wasm gate: identical result, and the total rejection count for that assembly is unchanged at 72.

> [!IMPORTANT]
> **CI on this PR cannot exercise the fix.** Nothing on `main` enables `PublishReadyToRun` for browser-wasm yet — that is #132339. The verification above is from local builds against that branch. CI here should confirm no regression on other targets; the wasm coverage arrives with #132339.

## Scope

This is a workaround, not the real fix. Affected methods silently lose ReadyToRun. #132412 tracks the proper fix (take the method-keyed `CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR` fast path on wasm, which needs `DelayLoad_Helper_Obj`/`_ObjObj` implemented there), and the code comment points at it.

> [!NOTE]
> This PR description was generated by GitHub Copilot and reviewed before posting.
