### PR TITLE
Reject malformed UTF-8 number separators

### DIFF
--- a/src/libraries/Common/src/System/Number.Parsing.Common.cs
+++ b/src/libraries/Common/src/System/Number.Parsing.Common.cs
@@ -382,8 +382,8 @@ namespace System
                     // This fix is for cultures that use NBSP (U+00A0) or narrow NBSP (U+202F) as group/decimal separators
                     // (e.g., French, Kazakh, Ukrainian). Since a user cannot easily type these characters,
                     // we accept regular space (U+0020) as equivalent.
-                    // We also need to handle the reverse case where the input has NBSP and the format string has space.
-                    if (cp != val && NormalizeSpaceReplacingChar(cp) != NormalizeSpaceReplacingChar(val))
+                    // For UTF-16, we also handle the reverse case where the input has NBSP and the format string has space.
+                    if (cp != val && (sizeof(TChar) == sizeof(byte) || NormalizeSpaceReplacingChar(cp) != NormalizeSpaceReplacingChar(val)))
                     {
                         return null;
                     }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
@@ -1356,6 +1356,14 @@ namespace System.Numerics.Tests
             result = BigInteger.Parse("1\u202F234\u202F567", NumberStyles.AllowThousands, spaceCulture);
             Assert.Equal((BigInteger)1234567, result);
         }
+
+        [Fact]
+        public static void ParseUtf8WithInvalidGroupSeparator()
+        {
+            NumberFormatInfo format = new() { NumberGroupSeparator = " " };
+
+            Assert.False(BigInteger.TryParse([(byte)'1', 0xA0, (byte)'2'], NumberStyles.AllowThousands, format, out _));
+        }
     }
 
     [Collection(nameof(DisableParallelization))]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int32Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int32Tests.cs
@@ -925,6 +925,14 @@ namespace System.Tests
             Assert.DoesNotContain("\uFFFD", fe.Message, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public static void Parse_Utf8Span_InvalidUtf8GroupSeparator()
+        {
+            NumberFormatInfo format = new() { NumberGroupSeparator = " " };
+
+            Assert.False(int.TryParse([(byte)'1', 0xA0, (byte)'2'], NumberStyles.AllowThousands, format, out _));
+        }
+
         [Theory]
         [InlineData("N")]
         [InlineData("F")]


### PR DESCRIPTION
`MatchChars<TChar>` currently applies UTF-16 NBSP normalization directly to UTF-8 bytes. This allows a standalone `0xA0` continuation byte to match an ASCII space in a configured number separator, so malformed UTF-8 can parse successfully.

Restrict the compatibility normalization to UTF-16 while preserving exact UTF-8 matching. Regression tests cover both the CoreLib numeric parser and the separate `BigInteger` shared-source instantiation.

This regressed in #123783.

> [!NOTE]
> This pull request description was drafted by GitHub Copilot.