### PR TITLE
Rename WasmObjectWriter to WebCilObjectWriter

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WebcilSection.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WebcilSection.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.ObjectWriter
             : base(stream, name, sectionIndex)
         {
             Header = header;
-            _paddingHelper = new PaddingHelper(WasmObjectWriter.WebcilSectionAlignment);
+            _paddingHelper = new PaddingHelper(WebCilObjectWriter.WebcilSectionAlignment);
         }
 
         public override int EncodeSize()

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmGlobalImports.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmGlobalImports.cs
@@ -7,7 +7,7 @@ namespace ILCompiler.ObjectWriter
     /// Indices of the Wasm globals imported from the <c>webcil</c> host module into every R2R Wasm module.
     /// </summary>
     /// <remarks>
-    /// Must stay in sync with <c>WasmObjectWriter.CreateDefaultGlobalImports()</c>, <c>_globalSymbolNameToGlobalIndex</c>,
+    /// Must stay in sync with <c>WebCilObjectWriter.CreateDefaultGlobalImports()</c>, <c>_globalSymbolNameToGlobalIndex</c>,
     /// and the host loader (<c>libCorerun.js</c>). The JIT references these via relocatable well-known-global
     /// handles (<c>CORINFO_WASM_WELLKNOWN_GLOBALS</c>), not the indices below.
     /// </remarks>

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
@@ -52,10 +52,18 @@ namespace ILCompiler.ObjectWriter
         public static readonly ObjectNodeSection GlobalSection = new ObjectNodeSection("wasm.global", SectionType.ReadOnly, needsAlign: false);
     }
 
+    internal abstract partial class WasmObjectWriter : ObjectWriter
+    {
+        protected WasmObjectWriter(NodeFactory factory, ObjectWritingOptions options, OutputInfoBuilder outputInfoBuilder)
+            : base(factory, options, outputInfoBuilder)
+        {
+        }
+    }
+
     /// <summary>
-    /// Wasm object file format writer.
+    /// WebCIL object file format writer.
     /// </summary>
-    internal sealed class WasmObjectWriter : ObjectWriter
+    internal sealed class WebCilObjectWriter : WasmObjectWriter
     {
         protected override CodeDataLayout LayoutMode => CodeDataLayout.Separate;
 
@@ -63,7 +71,7 @@ namespace ILCompiler.ObjectWriter
         // 1 for the payload size, and the second for the payload itself.
         const int NumDataSegments = 2;
 
-        public WasmObjectWriter(NodeFactory factory, ObjectWritingOptions options, OutputInfoBuilder outputInfoBuilder)
+        public WebCilObjectWriter(NodeFactory factory, ObjectWritingOptions options, OutputInfoBuilder outputInfoBuilder)
             : base(factory, options, outputInfoBuilder)
         {
         }
@@ -333,7 +341,7 @@ namespace ILCompiler.ObjectWriter
         WasmFunctionBody FillWebcilTable(int tableSize) => new WasmFunctionBody(
             new WasmFuncType(new([]), new([])), // (func)
                 [
-                    Global.Get(WasmObjectWriter.TableBaseGlobalIndex),
+                    Global.Get(WebCilObjectWriter.TableBaseGlobalIndex),
                     I32.Const(0),
                     I32.Const(tableSize),
                     Table.Init(0, 0)
@@ -352,7 +360,7 @@ namespace ILCompiler.ObjectWriter
                     I32.Ge_s,
                     Block.If(WasmBlockType.Empty),
                     Local.Get(0), // (local.get $d)
-                    Global.Get(WasmObjectWriter.TableBaseGlobalIndex), // (global.get $tableBase)
+                    Global.Get(WebCilObjectWriter.TableBaseGlobalIndex), // (global.get $tableBase)
                     I32.Store((ulong)WebcilEncoder.TableBaseOffset), // i32.store offset=TableBaseOffset
                     Block.End
                 ]

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -309,7 +309,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private WasmObjectWriter CreateWasmObjectWriter()
         {
-            return new WasmObjectWriter(_nodeFactory, ObjectWritingOptions.None,  _outputInfoBuilder);
+            return new WebCilObjectWriter(_nodeFactory, ObjectWritingOptions.None, _outputInfoBuilder);
         }
 
         public static void EmitObject(

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -330,7 +330,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             expressions.Add(Local.Get(0)); // The address of the args is passed as the first argument
             expressions.Add(Local.Get(portableEntrypointLocalIndex)); // The address of the portable entrypoint is passed as the second
-            expressions.Add(Global.Get(WasmObjectWriter.ImageBaseGlobalIndex)); // The module base address is passed as the third argument
+            expressions.Add(Global.Get(WebCilObjectWriter.ImageBaseGlobalIndex)); // The module base address is passed as the third argument
 
             // Pass the RVA of the Module fixup as the fourth argument
             // i32.const (RVA of Module fixup)
@@ -338,7 +338,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // Load the helper function address and dispatch
             // global.get {module base}
-            expressions.Add(Global.Get(WasmObjectWriter.ImageBaseGlobalIndex)); // Module base used to load the helper function address
+            expressions.Add(Global.Get(WebCilObjectWriter.ImageBaseGlobalIndex)); // Module base used to load the helper function address
             expressions.Add(I32.LoadWithRVAOffset(_helperCell)); // Load the helper call function pointer from the helper cell, using a load with an RVA offset so that the helper cell can be left as a zero in the R2R image and fixed up at runtime. This avoids the need to emit a runtime relocation for the helper cell.
             // call_indirect (i32, i32, i32, i32) -> (i32)
             expressions.Add(ControlFlow.CallIndirect(helperTypeIndex, 0));

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmInterpreterToR2RThunkNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmInterpreterToR2RThunkNode.cs
@@ -157,17 +157,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             List<WasmExpr> expressions = new List<WasmExpr>();
 
             // Save the current stack pointer global
-            expressions.Add(Global.Get(WasmObjectWriter.StackPointerGlobalIndex));
+            expressions.Add(Global.Get(WebCilObjectWriter.StackPointerGlobalIndex));
             expressions.Add(Local.Set(localSavedSp));
 
             // Allocate frame space: sp -= FrameSize
             expressions.Add(Local.Get(localSavedSp));
             expressions.Add(I32.Const(FrameSize));
             expressions.Add(I32.Sub);
-            expressions.Add(Global.Set(WasmObjectWriter.StackPointerGlobalIndex));
+            expressions.Add(Global.Set(WebCilObjectWriter.StackPointerGlobalIndex));
 
             // Write TERMINATE_R2R_STACK_WALK (1) into the framePointer at new SP
-            expressions.Add(Global.Get(WasmObjectWriter.StackPointerGlobalIndex));
+            expressions.Add(Global.Get(WebCilObjectWriter.StackPointerGlobalIndex));
             expressions.Add(I32.Const(TerminateR2RStackWalk));
             expressions.Add(I32.Store(0));
 
@@ -185,7 +185,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             // Param 0: $sp — pointer to the framePointer on the shadow stack
-            expressions.Add(Global.Get(WasmObjectWriter.StackPointerGlobalIndex));
+            expressions.Add(Global.Get(WebCilObjectWriter.StackPointerGlobalIndex));
             targetParamIndex++;
 
             // If the method has a 'this' pointer, load it from pArgs at offset 0
@@ -318,7 +318,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // Restore the stack pointer global
             expressions.Add(Local.Get(localSavedSp));
-            expressions.Add(Global.Set(WasmObjectWriter.StackPointerGlobalIndex));
+            expressions.Add(Global.Set(WebCilObjectWriter.StackPointerGlobalIndex));
 
             instructionEncoder.FunctionBody = new WasmFunctionBody(
                 sigForInterpToR2RThunks.FuncType,

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmR2RToInterpreterThunkNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmR2RToInterpreterThunkNode.cs
@@ -364,13 +364,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // Save the current stack pointer global into a local, then set it to local 0
             // (16-byte aligned, <= all buffers allocated in this thunk).
-            expressions.Add(Global.Get(WasmObjectWriter.StackPointerGlobalIndex));
+            expressions.Add(Global.Get(WebCilObjectWriter.StackPointerGlobalIndex));
             expressions.Add(Local.Set(savedSpLocalIndex));
             expressions.Add(Local.Get(0));
-            expressions.Add(Global.Set(WasmObjectWriter.StackPointerGlobalIndex));
+            expressions.Add(Global.Set(WebCilObjectWriter.StackPointerGlobalIndex));
 
             // Load the helper function address and call
-            expressions.Add(Global.Get(WasmObjectWriter.ImageBaseGlobalIndex));
+            expressions.Add(Global.Get(WebCilObjectWriter.ImageBaseGlobalIndex));
             expressions.Add(I32.LoadWithRVAOffset(_helperCell));
             expressions.Add(ControlFlow.CallIndirect(helperTypeIndex, 0));
 
@@ -379,7 +379,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             // Restore the old stack pointer global
             expressions.Add(Local.Get(savedSpLocalIndex));
-            expressions.Add(Global.Set(WasmObjectWriter.StackPointerGlobalIndex));
+            expressions.Add(Global.Set(WebCilObjectWriter.StackPointerGlobalIndex));
 
             // If the function has a wasm return value, load it from the local return buffer
             if (hasWasmReturn)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -201,7 +201,7 @@
     <Compile Include="..\..\Common\Compiler\ObjectWriter\Wasm\WasmSection.cs" Link="Compiler\ObjectWriter\Wasm\WasmSection.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\Wasm\WasmSections.cs" Link="Compiler\ObjectWriter\Wasm\WasmSections.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\Wasm\WebcilSection.cs" Link="Compiler\ObjectWriter\Wasm\WebcilSection.cs" />
-    <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmObjectWriter.cs" Link="Compiler\ObjectWriter\WasmObjectWriter.cs" />
+    <Compile Include="..\..\Common\Compiler\ObjectWriter\WebCilObjectWriter.cs" Link="Compiler\ObjectWriter\WebCilObjectWriter.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmSymbolManager.cs" Link="Compiler\ObjectWriter\WasmSymbolManager.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmGlobalImports.cs" Link="Compiler\ObjectWriter\WasmGlobalImports.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\WasmNative.cs" Link="Compiler\ObjectWriter\WasmNative.cs" />


### PR DESCRIPTION
Follow-up work has `WasmObjectWriter` as the base class for the WebCil module and NativeAOT's module format. It's easier for git to recognize `WebCilObjectWriter.cs` as a move of `WasmObjectWriter.cs` if the rename is separate from the extraction and `WasmObjectWriter.cs` is deleted.

This PR renames `WasmObjectWriter` to `WebCilObjectWriter`, creates an empty base `WasmObjectWriter` and updates references to use the new name.