### PR TITLE
Select latest installed Xcode 26 in macOS CI

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -178,6 +178,9 @@ jobs:
 
     - template: /eng/common/${{ parameters.templatePath }}/steps/enable-internal-sources.yml
 
+    - ${{ if or(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), eq(parameters.hostedOs, 'osx')) }}:
+      - template: /eng/pipelines/common/select-xcode.yml
+
     - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
       - script: $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh ${{ parameters.osGroup }}
         displayName: Install Build Dependencies

--- a/eng/pipelines/common/select-xcode.yml
+++ b/eng/pipelines/common/select-xcode.yml
@@ -1,0 +1,15 @@
+steps:
+- script: |
+    set -euo pipefail
+
+    xcode_path="$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1 || true)"
+    if [[ -z "$xcode_path" ]]; then
+      echo "##vso[task.logissue type=error]Xcode 26 is not installed on this machine."
+      exit 1
+    fi
+
+    developer_dir="$xcode_path/Contents/Developer"
+    echo "Selecting Xcode at $developer_dir"
+    echo "##vso[task.setvariable variable=DEVELOPER_DIR]$developer_dir"
+    DEVELOPER_DIR="$developer_dir" xcodebuild -version
+  displayName: Select Xcode 26

--- a/eng/pipelines/common/templates/runtimes/xplat-job.yml
+++ b/eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -103,7 +103,7 @@ jobs:
       - ${{insert}}: ${{ variable }}
 
     steps:
-    - ${{ if or(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), eq(parameters.hostedOs, 'osx')) }}:
+    - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
       - template: /eng/pipelines/common/select-xcode.yml
 
     - ${{ if eq(parameters.osGroup, 'windows') }}:

--- a/eng/pipelines/common/templates/runtimes/xplat-job.yml
+++ b/eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -103,6 +103,9 @@ jobs:
       - ${{insert}}: ${{ variable }}
 
     steps:
+    - ${{ if or(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), eq(parameters.hostedOs, 'osx')) }}:
+      - template: /eng/pipelines/common/select-xcode.yml
+
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - template: /eng/pipelines/common/templates/disable-vsupdate-or-failfast.yml
 

--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -169,6 +169,9 @@ jobs:
 
     - template: /eng/common/${{ parameters.templatePath }}/steps/enable-internal-sources.yml
 
+    - ${{ if or(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), eq(parameters.hostedOs, 'osx')) }}:
+      - template: /eng/pipelines/common/select-xcode.yml
+
     - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
       - script: $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh ${{ parameters.osGroup }}
         displayName: Install Build Dependencies

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -93,6 +93,8 @@ jobs:
       - template: /eng/common/${{ parameters.templatePath }}/steps/enable-internal-sources.yml
 
       - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
+        - template: /eng/pipelines/common/select-xcode.yml
+
         - script: $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh ${{ parameters.osGroup }}
           displayName: Install Build Dependencies
 


### PR DESCRIPTION
## Summary

- Select the newest installed Xcode 26 on macOS build agents.
- Publish the detected developer directory through `DEVELOPER_DIR` for subsequent tasks.
- Apply the selection consistently to runtime, diagnostics, and libraries jobs.

## Motivation

The `macOS-15` hosted image includes Xcode 26 but defaults to Xcode 16.4. Discovering the installed Xcode 26 path at runtime avoids hard-coding its minor or patch version while opting builds into Xcode 26.

## Validation

- Parsed the modified YAML files.
- Checked the selector script syntax with `bash -n`.
- Ran `git diff --check`.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.