### PR TITLE
Avoid unnecessary allocations in single-file app bundle launch

### DIFF
--- a/src/native/corehost/bundle/file_entry.h
+++ b/src/native/corehost/bundle/file_entry.h
@@ -63,7 +63,7 @@ namespace bundle
             m_type = fixed_data->type;
         }
 
-        const pal::string_t relative_path() const { return m_relative_path; }
+        const pal::string_t& relative_path() const { return m_relative_path; }
         int64_t offset() const { return m_offset; }
         int64_t size() const { return m_size; }
         int64_t compressedSize() const { return m_compressedSize; }

--- a/src/native/corehost/bundle/runner.cpp
+++ b/src/native/corehost/bundle/runner.cpp
@@ -95,9 +95,11 @@ bool runner_t::locate(const pal::string_t& relative_path, pal::string_t& full_pa
     assert(!entry->is_disabled());
 
     extracted_to_disk = entry->needs_extraction();
-    full_path.assign(extracted_to_disk ? extraction_path() : base_path());
-
-    append_path(&full_path, relative_path.c_str());
+    if (extracted_to_disk)
+    {
+        full_path.assign(extraction_path());
+        append_path(&full_path, relative_path.c_str());
+    }
 
     return true;
 }

--- a/src/native/corehost/bundle/runner.cpp
+++ b/src/native/corehost/bundle/runner.cpp
@@ -85,10 +85,10 @@ bool runner_t::probe(const pal::string_t& relative_path, int64_t* offset, int64_
 bool runner_t::locate(const pal::string_t& relative_path, pal::string_t& full_path, bool& extracted_to_disk) const
 {
     const bundle::file_entry_t* entry = probe(relative_path);
-
+    
     if (entry == nullptr)
     {
-        full_path.clear();
+        extracted_to_disk = false;
         return false;
     }
 

--- a/src/native/corehost/bundle/runner.h
+++ b/src/native/corehost/bundle/runner.h
@@ -31,8 +31,8 @@ namespace bundle
         const file_entry_t* probe(const pal::string_t& relative_path) const;
 
         // Locates a file within the bundle.
-        // If the file was extracted to disk, sets full_path to the extracted path
-        bool locate(const pal::string_t& relative_path, pal::string_t& full_path, bool& extracted_to_disk) const;
+        // If the file was extracted to disk, sets full_path to the extracted path and sets extracted_to_disk to true.
+        // Otherwise sets extracted_to_disk to false and leaves full_path unchanged.
         bool locate(const pal::string_t& relative_path, pal::string_t& full_path) const
         {
             bool extracted_to_disk;

--- a/src/native/corehost/bundle/runner.h
+++ b/src/native/corehost/bundle/runner.h
@@ -33,6 +33,7 @@ namespace bundle
         // Locates a file within the bundle.
         // If the file was extracted to disk, sets full_path to the extracted path and sets extracted_to_disk to true.
         // Otherwise sets extracted_to_disk to false and leaves full_path unchanged.
+        bool locate(const pal::string_t& relative_path, pal::string_t& full_path, bool& extracted_to_disk) const;
         bool locate(const pal::string_t& relative_path, pal::string_t& full_path) const
         {
             bool extracted_to_disk;

--- a/src/native/corehost/bundle/runner.h
+++ b/src/native/corehost/bundle/runner.h
@@ -31,7 +31,8 @@ namespace bundle
         const file_entry_t* probe(const pal::string_t& relative_path) const;
 
         // Locates a file within the bundle.
-        // If the file was extracted to disk, sets full_path to the extracted path and sets extracted_to_disk to true.
+        // Returns true if the file was found in the bundle (in memory or extracted), false otherwise.
+        // If the file was found and extracted to disk, sets extracted_to_disk to true and full_path to the extracted path.
         // Otherwise sets extracted_to_disk to false and leaves full_path unchanged.
         bool locate(const pal::string_t& relative_path, pal::string_t& full_path, bool& extracted_to_disk) const;
         bool locate(const pal::string_t& relative_path, pal::string_t& full_path) const

--- a/src/native/corehost/bundle/runner.h
+++ b/src/native/corehost/bundle/runner.h
@@ -29,6 +29,9 @@ namespace bundle
 
         bool probe(const pal::string_t& relative_path, int64_t* offset, int64_t* size, int64_t* compressedSize) const;
         const file_entry_t* probe(const pal::string_t& relative_path) const;
+
+        // Locates a file within the bundle.
+        // If the file was extracted to disk, sets full_path to the extracted path
         bool locate(const pal::string_t& relative_path, pal::string_t& full_path, bool& extracted_to_disk) const;
         bool locate(const pal::string_t& relative_path, pal::string_t& full_path) const
         {

--- a/src/native/corehost/hostpolicy/args.cpp
+++ b/src/native/corehost/hostpolicy/args.cpp
@@ -86,7 +86,7 @@ bool set_root_from_app(const pal::string_t& managed_application_path,
         args.app_root = app->base_path();
 
         // Check for the main app within the bundle.
-        // locate() sets args.managed_application to the full path of the app extracted to disk.
+        // If extracted, locate() sets args.managed_application to the full path of the app extracted to disk.
         pal::string_t managed_application_name = get_filename(managed_application_path);
         if (app->locate(managed_application_name, args.managed_application))
         {
@@ -94,10 +94,6 @@ bool set_root_from_app(const pal::string_t& managed_application_path,
         }
 
         trace::info(_X("Managed application [%s] not found in single-file bundle"), managed_application_name.c_str());
-
-        // The locate call above will clear the string when it returns false so reinitialize to the specified
-        // path before continuing.
-        args.managed_application = managed_application_path;
 
         // If the main assembly is not found in the bundle, continue checking on disk
         // for very unlikely case where the main app.dll was itself excluded from the app bundle.

--- a/src/native/corehost/hostpolicy/deps_entry.cpp
+++ b/src/native/corehost/hostpolicy/deps_entry.cpp
@@ -39,9 +39,6 @@ static bool to_path(const pal::string_t& base, const pal::string_t& relative_pat
         return false;
     }
 
-    // Reserve space for the path below
-    candidate.reserve(base.length() + relative_path.length() + 2); // +2 for directory separator and null terminator
-
     bool look_in_bundle = search_options & deps_entry_t::search_options::look_in_bundle;
     bool is_servicing = search_options & deps_entry_t::search_options::is_servicing;
 
@@ -53,13 +50,13 @@ static bool to_path(const pal::string_t& base, const pal::string_t& relative_pat
 
         if (app->has_base(base))
         {
-            // If relative_path is found in the single-file bundle,
-            // app::locate() will set candidate to the full-path to the assembly extracted out to disk.
+            // candidate is only set if the file was extracted to disk. Files used directly from the
+            // bundle have no path - the runtime resolves those by probing the bundle manifest.
             bool extracted_to_disk = false;
             if (app->locate(relative_path, candidate, extracted_to_disk))
             {
                 found_in_bundle = !extracted_to_disk;
-                trace::verbose(_X("    %s found in bundle [%s] %s"), relative_path.c_str(), candidate.c_str(), extracted_to_disk ? _X("(extracted)") : _X(""));
+                trace::verbose(_X("    %s found in bundle %s"), relative_path.c_str(), extracted_to_disk ? candidate.c_str() : _X("(no extraction)"));
                 return true;
             }
             else
@@ -74,6 +71,7 @@ static bool to_path(const pal::string_t& base, const pal::string_t& relative_pat
         }
     }
 
+    candidate.reserve(base.length() + relative_path.length() + 2); // +2 for directory separator and null terminator
     candidate.assign(base);
     append_path(&candidate, relative_path.c_str());
 

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -329,8 +329,14 @@ probe_result_t deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, cons
                 {
                     // Bundles are expected to be RID-specific themselves, so RID-specific assets are not expected to be found in the bundle.
                     assert(!entry.is_rid_specific || !found_in_bundle);
+                    if (found_in_bundle)
+                    {
+                        trace::verbose(_X("    Probed deps dir and matched in bundle"));
+                        return probe_result_t::bundled;
+                    }
+
                     trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
-                    return found_in_bundle ? probe_result_t::bundled : probe_result_t::found;
+                    return probe_result_t::found;
                 }
             }
 


### PR DESCRIPTION
Remove a bunch of unnecessary transient allocations during single-file launch. The amount scales with the number of bundled assets.

For single-file, self-contained, empty console app, Windows x64:
| | Before | After | Delta |
|---|---:|---:|---:|
| Startup time | 81.033 ms | 79.007 ms | **-2.026 ms (-2.50%)** |
| Native heap allocation count | 36,318 | 15,585 | **-20,733 (-57.09%)** |
| Native heap allocated bytes | 11,022.17 KB | 9,589.94 KB | **-1,432.23 KB (-12.99%)** |

Startup was using the dotnet/performance repo's `TimeToMain` scenario - average over 10 runs of 20 launches per run, with every run showing an improvement between 1.3-4.8%. Native heap allocation count and bytes were measured with xperf heap tracing.

cc @dotnet/appmodel @AaronRobinsonMSFT 