### PR TITLE
Fix codegen of NotMask on x64

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1011,6 +1011,7 @@ protected:
     void genBaseIntrinsic(GenTreeHWIntrinsic* node, insOpts instOptions);
     void genX86BaseIntrinsic(GenTreeHWIntrinsic* node, insOpts instOptions);
     void genAvxFamilyIntrinsic(GenTreeHWIntrinsic* node, insOpts instOptions);
+    void ClearUnusedMaskBits(regNumber maskReg, uint32_t count);
     void genFmaIntrinsic(GenTreeHWIntrinsic* node, insOpts instOptions);
     void genPermuteVar2x(GenTreeHWIntrinsic* node, insOpts instOptions);
     void genXCNTIntrinsic(GenTreeHWIntrinsic* node, instruction ins);

--- a/src/coreclr/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenxarch.cpp
@@ -3424,6 +3424,16 @@ void CodeGen::genAvxFamilyIntrinsic(GenTreeHWIntrinsic* node, insOpts instOption
             assert(emitter::isMaskReg(op1Reg));
 
             emit->emitIns_R_R(ins, EA_8BYTE, targetReg, op1Reg);
+
+            if (count < 8)
+            {
+                // Emit shifts to clear bits N to 7 for 2-bit or 4-bit NotMask.
+                // There is no 2 or 4-bit knot*.  Normally not an issue, but would cause wrong codegen
+                // if k is used in a kmovb+POPCNT for example.
+
+                emit->emitIns_R_R_I(INS_kshiftlb, EA_8BYTE, targetReg, targetReg, (int8_t)(8 - count));
+                emit->emitIns_R_R_I(INS_kshiftrb, EA_8BYTE, targetReg, targetReg, (int8_t)(8 - count));
+            }
             break;
         }
 
@@ -3626,6 +3636,14 @@ void CodeGen::genAvxFamilyIntrinsic(GenTreeHWIntrinsic* node, insOpts instOption
 
             // Use EA_32BYTE to ensure the VEX.L bit gets set
             emit->emitIns_R_R_R(ins, EA_32BYTE, targetReg, op1Reg, op2Reg);
+
+            if (count < 8)
+            {
+                // Same issue here as with knotb/NI_AVX512_NotMask above.
+
+                emit->emitIns_R_R_I(INS_kshiftlb, EA_8BYTE, targetReg, targetReg, (int8_t)(8 - count));
+                emit->emitIns_R_R_I(INS_kshiftrb, EA_8BYTE, targetReg, targetReg, (int8_t)(8 - count));
+            }
             break;
         }
 

--- a/src/coreclr/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenxarch.cpp
@@ -2884,6 +2884,24 @@ void CodeGen::genX86BaseIntrinsic(GenTreeHWIntrinsic* node, insOpts instOptions)
 }
 
 //------------------------------------------------------------------------
+// ClearUnusedMaskBits: Zeroes up to 8 bits of the mask register, for small lane counts
+//
+// Arguments:
+//    maskReg - The mask register to clear the unused bits of
+//    count   - The number of live lanes in the mask, which must be less than 8
+//
+void CodeGen::ClearUnusedMaskBits(regNumber maskReg, uint32_t count)
+{
+    assert((count == 2) || (count == 4));
+    assert(emitter::isMaskReg(maskReg));
+
+    emitter* emit = GetEmitter();
+
+    emit->emitIns_R_R_I(INS_kshiftlb, EA_8BYTE, maskReg, maskReg, (int8_t)(8 - count));
+    emit->emitIns_R_R_I(INS_kshiftrb, EA_8BYTE, maskReg, maskReg, (int8_t)(8 - count));
+}
+
+//------------------------------------------------------------------------
 // genAvxFamilyIntrinsic: Generates the code for an AVX/AVX2/AVX512 hardware intrinsic node
 //
 // Arguments:
@@ -3431,8 +3449,7 @@ void CodeGen::genAvxFamilyIntrinsic(GenTreeHWIntrinsic* node, insOpts instOption
                 // There is no 2 or 4-bit knot*.  Normally not an issue, but would cause wrong codegen
                 // if k is used in a kmovb+POPCNT for example.
 
-                emit->emitIns_R_R_I(INS_kshiftlb, EA_8BYTE, targetReg, targetReg, (int8_t)(8 - count));
-                emit->emitIns_R_R_I(INS_kshiftrb, EA_8BYTE, targetReg, targetReg, (int8_t)(8 - count));
+                ClearUnusedMaskBits(targetReg, count);
             }
             break;
         }
@@ -3641,8 +3658,7 @@ void CodeGen::genAvxFamilyIntrinsic(GenTreeHWIntrinsic* node, insOpts instOption
             {
                 // Same issue here as with knotb/NI_AVX512_NotMask above.
 
-                emit->emitIns_R_R_I(INS_kshiftlb, EA_8BYTE, targetReg, targetReg, (int8_t)(8 - count));
-                emit->emitIns_R_R_I(INS_kshiftrb, EA_8BYTE, targetReg, targetReg, (int8_t)(8 - count));
+                ClearUnusedMaskBits(targetReg, count);
             }
             break;
         }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3063,36 +3063,12 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
 
                     if (!TryInvertMask(maskNode, simdSize, maskBaseType))
                     {
-                        // We weren't able to invert the mask, so we need to do it here, keeping the upper
-                        // n-bits clear. If we have 1 element, then the upper 7-bits need to be cleared. If we have
-                        // 2, then the upper 6-bits, and if we have 4, then the upper 4-bits.
-                        //
-                        // There isn't necessarily a trivial way to do this outside not, shift-left by n,
-                        // shift-right by n. This preserves count bits, while clearing the upper n-bits
-
-                        GenTree* cnsNode;
+                        // We weren't able to invert the mask, so we need to do it here.
+                        // The upper 8 - N bits area cleared during codegen
 
                         maskNode = m_compiler->gtNewSimdHWIntrinsicNode(TYP_MASK, maskNode, NI_AVX512_NotMask,
                                                                         maskBaseType, simdSize);
                         BlockRange().InsertBefore(node, maskNode);
-
-                        cnsNode = m_compiler->gtNewIconNode(8 - count);
-                        BlockRange().InsertAfter(maskNode, cnsNode);
-
-                        maskNode =
-                            m_compiler->gtNewSimdHWIntrinsicNode(TYP_MASK, maskNode, cnsNode, NI_AVX512_ShiftLeftMask,
-                                                                 maskBaseType, simdSize);
-                        BlockRange().InsertAfter(cnsNode, maskNode);
-                        LowerNode(maskNode);
-
-                        cnsNode = m_compiler->gtNewIconNode(8 - count);
-                        BlockRange().InsertAfter(maskNode, cnsNode);
-
-                        maskNode =
-                            m_compiler->gtNewSimdHWIntrinsicNode(TYP_MASK, maskNode, cnsNode, NI_AVX512_ShiftRightMask,
-                                                                 maskBaseType, simdSize);
-                        BlockRange().InsertAfter(cnsNode, maskNode);
-                        LowerNode(maskNode);
                     }
                 }
                 else if (cmpOp == GT_EQ)
@@ -6349,11 +6325,8 @@ bool Lowering::TryInvertMask(GenTree* node, unsigned simdSize, var_types simdBas
 
         if (mskIntrin->GetHWIntrinsicId() == NI_AVX512_OrMask)
         {
-            // `~(a | ~b)` is `~a & b`, which is a single `AndNotMask`. Folding it here means we
-            // never materialize the outer `NotMask`, which is both smaller and avoids `knotb`
-            // needing its unused upper bits cleared afterwards.
-            //
-            // `AndNotMask(op1, op2)` computes `~op1 & op2`, so `b` has to end up as op2.
+            // Transform ~(a | ~b) into ~a & b, to enable AndNotMask.
+            // Also has the nice effect of not having to fixup knotb during emit.
 
             unsigned simdBaseTypeSize = genTypeSize(mskIntrin->GetSimdBaseType());
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3064,7 +3064,7 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
                     if (!TryInvertMask(maskNode, simdSize, maskBaseType))
                     {
                         // We weren't able to invert the mask, so we need to do it here.
-                        // The upper 8 - N bits area cleared during codegen
+                        // The upper 8 - N bits are zeroed during codegen
 
                         maskNode = m_compiler->gtNewSimdHWIntrinsicNode(TYP_MASK, maskNode, NI_AVX512_NotMask,
                                                                         maskBaseType, simdSize);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6347,6 +6347,55 @@ bool Lowering::TryInvertMask(GenTree* node, unsigned simdSize, var_types simdBas
     {
         GenTreeHWIntrinsic* mskIntrin = node->AsHWIntrinsic();
 
+        if (mskIntrin->GetHWIntrinsicId() == NI_AVX512_OrMask)
+        {
+            // `~(a | ~b)` is `~a & b`, which is a single `AndNotMask`. Folding it here means we
+            // never materialize the outer `NotMask`, which is both smaller and avoids `knotb`
+            // needing its unused upper bits cleared afterwards.
+            //
+            // `AndNotMask(op1, op2)` computes `~op1 & op2`, so `b` has to end up as op2.
+
+            unsigned simdBaseTypeSize = genTypeSize(mskIntrin->GetSimdBaseType());
+
+            GenTree* op1 = mskIntrin->Op(1);
+            GenTree* op2 = mskIntrin->Op(2);
+
+            bool transform = false;
+
+            if (op2->OperIsHWIntrinsic(NI_AVX512_NotMask))
+            {
+                GenTreeHWIntrinsic* opIntrin = op2->AsHWIntrinsic();
+
+                if (genTypeSize(opIntrin->GetSimdBaseType()) == simdBaseTypeSize)
+                {
+                    transform = true;
+
+                    op2 = opIntrin->Op(1);
+                    BlockRange().Remove(opIntrin);
+                }
+            }
+            else if (op1->OperIsHWIntrinsic(NI_AVX512_NotMask))
+            {
+                GenTreeHWIntrinsic* opIntrin = op1->AsHWIntrinsic();
+
+                if (genTypeSize(opIntrin->GetSimdBaseType()) == simdBaseTypeSize)
+                {
+                    transform = true;
+
+                    op1 = opIntrin->Op(1);
+                    BlockRange().Remove(opIntrin);
+
+                    std::swap(op1, op2);
+                }
+            }
+
+            if (transform)
+            {
+                mskIntrin->ChangeHWIntrinsicId(NI_AVX512_AndNotMask, op1, op2);
+                return true;
+            }
+        }
+
         bool       mskIsScalar = false;
         genTreeOps mskOper     = mskIntrin->GetOperForHWIntrinsicId(&mskIsScalar, /* getEffectiveOp */ true);
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.cs
@@ -12,10 +12,6 @@ using Xunit;
 // register, leaving the bits above the lane count set, and nothing cleared
 // them. A following MoveMask handed those stale bits to PopCount, which then
 // over-counted by (8 - laneCount).
-//
-// This is latent in normal codegen because NotMask(CompareEqualMask(a, b)) is
-// folded into CompareNotEqualMask. The stress modes set in the .csproj keep
-// that fold from firing so a bare NotMask reaches codegen.
 
 public class Runtime_124154
 {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+// Codegen for NI_AVX512_NotMask selected `knotb` for any mask with 8 or fewer
+// lanes. For a 2- or 4-lane mask `knotb` inverts all 8 bits of the mask
+// register, leaving the bits above the lane count set, and nothing cleared
+// them. A following MoveMask handed those stale bits to PopCount, which then
+// over-counted by (8 - laneCount).
+//
+// This is latent in normal codegen because NotMask(CompareEqualMask(a, b)) is
+// folded into CompareNotEqualMask. The stress modes set in the .csproj keep
+// that fold from firing so a bare NotMask reaches codegen.
+
+public class Runtime_124154
+{
+    [ConditionalFact(typeof(Avx512F), nameof(Avx512F.IsSupported))]
+    public static void TestEntryPoint()
+    {
+        // Vector128<int>: 4 lanes, `knotb` left 4 stale bits set.
+        for (int n = 0; n <= 4; n++)
+        {
+            Assert.Equal(n, Count128Int32(Vector128<int>.Zero, Differing128Int32(n)));
+        }
+
+        // Vector128<long>: 2 lanes, the worst case at 6 stale bits.
+        for (int n = 0; n <= 2; n++)
+        {
+            Assert.Equal(n, Count128Int64(Vector128<long>.Zero, Differing128Int64(n)));
+        }
+
+        // Vector256<long>: 4 lanes.
+        for (int n = 0; n <= 4; n++)
+        {
+            Assert.Equal(n, Count256Int64(Vector256<long>.Zero, Differing256Int64(n)));
+        }
+
+        // Vector128<short>: 8 lanes, unaffected. Guards against a fix that
+        // over-corrects the full-width case.
+        for (int n = 0; n <= 8; n++)
+        {
+            Assert.Equal(n, Count128Int16(Vector128<short>.Zero, Differing128Int16(n)));
+        }
+    }
+
+    private static Vector128<int> Differing128Int32(int n)
+    {
+        int[] values = new int[4];
+        for (int i = 0; i < n; i++)
+        {
+            values[i] = 1;
+        }
+
+        return Vector128.Create(values);
+    }
+
+    private static Vector128<long> Differing128Int64(int n)
+    {
+        long[] values = new long[2];
+        for (int i = 0; i < n; i++)
+        {
+            values[i] = 1;
+        }
+
+        return Vector128.Create(values);
+    }
+
+    private static Vector256<long> Differing256Int64(int n)
+    {
+        long[] values = new long[4];
+        for (int i = 0; i < n; i++)
+        {
+            values[i] = 1;
+        }
+
+        return Vector256.Create(values);
+    }
+
+    private static Vector128<short> Differing128Int16(int n)
+    {
+        short[] values = new short[8];
+        for (int i = 0; i < n; i++)
+        {
+            values[i] = 1;
+        }
+
+        return Vector128.Create(values);
+    }
+
+    // ~Vector.Equals(a, b) imports as NotMask(CompareEqualMask(a, b)) and
+    // ExtractMostSignificantBits as MoveMask, which is the miscompiled chain.
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Count128Int32(Vector128<int> a, Vector128<int> b) =>
+        BitOperations.PopCount((~Vector128.Equals(a, b)).ExtractMostSignificantBits());
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Count128Int64(Vector128<long> a, Vector128<long> b) =>
+        BitOperations.PopCount((~Vector128.Equals(a, b)).ExtractMostSignificantBits());
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Count256Int64(Vector256<long> a, Vector256<long> b) =>
+        BitOperations.PopCount((~Vector256.Equals(a, b)).ExtractMostSignificantBits());
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Count128Int16(Vector128<short> a, Vector128<short> b) =>
+        BitOperations.PopCount((~Vector128.Equals(a, b)).ExtractMostSignificantBits());
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 using Xunit;
 
 // Codegen for NI_AVX512_NotMask selected `knotb` for any mask with 8 or fewer
@@ -15,95 +13,27 @@ using Xunit;
 
 public class Runtime_124154
 {
-    [ConditionalFact(typeof(Avx512F), nameof(Avx512F.IsSupported))]
+    [Fact]
     public static void TestEntryPoint()
     {
-        // Vector128<int>: 4 lanes, `knotb` left 4 stale bits set.
-        for (int n = 0; n <= 4; n++)
-        {
-            Assert.Equal(n, Count128Int32(Vector128<int>.Zero, Differing128Int32(n)));
-        }
+        // Vector128<uint> is 4 lanes, so only bits 0-3 may ever be set.
+        Vector128<uint> zero32 = Vector128<uint>.Zero;
+        Assert.Equal(0xFu, NotAnd128UInt32(zero32, zero32, zero32, zero32));
+        Assert.Equal(0x0u, NotAnd128UInt32(zero32, Vector128.Create(1u), zero32, Vector128.Create(1u)));
+        Assert.Equal(0x5u, NotAnd128UInt32(zero32, Vector128.Create(0u, 1u, 0u, 1u), zero32, Vector128.Create(0u, 1u, 0u, 1u)));
 
-        // Vector128<long>: 2 lanes, the worst case at 6 stale bits.
-        for (int n = 0; n <= 2; n++)
-        {
-            Assert.Equal(n, Count128Int64(Vector128<long>.Zero, Differing128Int64(n)));
-        }
-
-        // Vector256<long>: 4 lanes.
-        for (int n = 0; n <= 4; n++)
-        {
-            Assert.Equal(n, Count256Int64(Vector256<long>.Zero, Differing256Int64(n)));
-        }
-
-        // Vector128<short>: 8 lanes, unaffected. Guards against a fix that
-        // over-corrects the full-width case.
-        for (int n = 0; n <= 8; n++)
-        {
-            Assert.Equal(n, Count128Int16(Vector128<short>.Zero, Differing128Int16(n)));
-        }
+        // Vector128<ulong> is 2 lanes, the worst case at 6 stale bits.
+        Vector128<ulong> zero64 = Vector128<ulong>.Zero;
+        Assert.Equal(0x3u, NotAnd128UInt64(zero64, zero64, zero64, zero64));
+        Assert.Equal(0x0u, NotAnd128UInt64(zero64, Vector128.Create(1ul), zero64, Vector128.Create(1ul)));
+        Assert.Equal(0x1u, NotAnd128UInt64(zero64, Vector128.Create(0ul, 1ul), zero64, Vector128.Create(0ul, 1ul)));
     }
-
-    private static Vector128<int> Differing128Int32(int n)
-    {
-        int[] values = new int[4];
-        for (int i = 0; i < n; i++)
-        {
-            values[i] = 1;
-        }
-
-        return Vector128.Create(values);
-    }
-
-    private static Vector128<long> Differing128Int64(int n)
-    {
-        long[] values = new long[2];
-        for (int i = 0; i < n; i++)
-        {
-            values[i] = 1;
-        }
-
-        return Vector128.Create(values);
-    }
-
-    private static Vector256<long> Differing256Int64(int n)
-    {
-        long[] values = new long[4];
-        for (int i = 0; i < n; i++)
-        {
-            values[i] = 1;
-        }
-
-        return Vector256.Create(values);
-    }
-
-    private static Vector128<short> Differing128Int16(int n)
-    {
-        short[] values = new short[8];
-        for (int i = 0; i < n; i++)
-        {
-            values[i] = 1;
-        }
-
-        return Vector128.Create(values);
-    }
-
-    // ~Vector.Equals(a, b) imports as NotMask(CompareEqualMask(a, b)) and
-    // ExtractMostSignificantBits as MoveMask, which is the miscompiled chain.
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static int Count128Int32(Vector128<int> a, Vector128<int> b) =>
-        BitOperations.PopCount((~Vector128.Equals(a, b)).ExtractMostSignificantBits());
+    private static uint NotAnd128UInt32(Vector128<uint> a, Vector128<uint> b, Vector128<uint> c, Vector128<uint> d) =>
+        (~(Vector128.LessThan(a, b) & Vector128.LessThan(c, d))).ExtractMostSignificantBits();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static int Count128Int64(Vector128<long> a, Vector128<long> b) =>
-        BitOperations.PopCount((~Vector128.Equals(a, b)).ExtractMostSignificantBits());
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static int Count256Int64(Vector256<long> a, Vector256<long> b) =>
-        BitOperations.PopCount((~Vector256.Equals(a, b)).ExtractMostSignificantBits());
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static int Count128Int16(Vector128<short> a, Vector128<short> b) =>
-        BitOperations.PopCount((~Vector128.Equals(a, b)).ExtractMostSignificantBits());
+    private static uint NotAnd128UInt64(Vector128<ulong> a, Vector128<ulong> b, Vector128<ulong> c, Vector128<ulong> d) =>
+        (~(Vector128.LessThan(a, b) & Vector128.LessThan(c, d))).ExtractMostSignificantBits();
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <!-- Needed to prevent morph from folding away NotMask -->
     <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_MIN_OPTS STRESS_SPLIT_TREES_RANDOMLY" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.csproj
@@ -7,7 +7,5 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
-    <!-- Needed to prevent morph from folding away NotMask -->
-    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_MIN_OPTS STRESS_SPLIT_TREES_RANDOMLY" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124154/Runtime_124154.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_MIN_OPTS STRESS_SPLIT_TREES_RANDOMLY" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Jitstress-random failure in `System.Numerics.Tensors.Tests.UInt32GenericTensorPrimitives.HammingDistance_AllLengths`.

Incorrect codegen for NotMask on x64.  There's knotb+kmovb+popcnt for `count < 8`, but knotb will still set up to 8 bits (above) count, causing the wrong result from popcnt.

Normally global morph transforms `CompareEqualMask+NotMask`-->`CompareNotEqualMask`, but statement splitting stress prevented this transform.

Fix is to introduce left+right shifts during codegen to clear the rest of the bottom 8 bits of k.  There was a similar fixup in lower that did this for LowerHWIntrinsicCmpOp - removing that and generalizing in the emit path instead.

This caused a diff regression in `Vector128<T>.Equals`, so I also added a `~(a | ~b)`-->`~a & b` transform in TryInvertMask to recover the diff (ends up better overall).  The alternative here was to apply the fixup in lower instead of codegen, but tracking all the places that used a potentially-wrong NotMask got too hairy.

fixes #124154