### PR TITLE
Add Composite ML-KEM base APIs

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKem.cs
@@ -305,13 +305,13 @@ namespace System.Security.Cryptography
         protected abstract void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret);
 
         /// <summary>
-        ///   Imports a Composite ML-KEM encapsulation key.
+        ///   Imports a Composite ML-KEM key from an encapsulation key.
         /// </summary>
         /// <param name="algorithm">
         ///   The specific Composite ML-KEM algorithm for this key.
         /// </param>
         /// <param name="source">
-        ///   The bytes of the encapsulation key.
+        ///   The encapsulation key.
         /// </param>
         /// <returns>
         ///   The imported key.
@@ -332,9 +332,6 @@ namespace System.Security.Cryptography
         ///   The platform does not support the specified Composite ML-KEM algorithm. Callers can use <see cref="IsAlgorithmSupported" />
         ///   to determine if the algorithm is supported.
         /// </exception>
-        /// <remarks>
-        ///   This overload accepts the encapsulation key as a byte array.
-        /// </remarks>
         public static CompositeMLKem ImportEncapsulationKey(CompositeMLKemAlgorithm algorithm, byte[] source)
         {
             ArgumentNullException.ThrowIfNull(algorithm);
@@ -344,13 +341,13 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Imports a Composite ML-KEM encapsulation key.
+        ///   Imports a Composite ML-KEM key from an encapsulation key.
         /// </summary>
         /// <param name="algorithm">
         ///   The specific Composite ML-KEM algorithm for this key.
         /// </param>
         /// <param name="source">
-        ///   The bytes of the encapsulation key.
+        ///   The encapsulation key.
         /// </param>
         /// <returns>
         ///   The imported key.
@@ -386,13 +383,13 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Imports a Composite ML-KEM decapsulation key.
+        ///   Imports a Composite ML-KEM key from a decapsulation key.
         /// </summary>
         /// <param name="algorithm">
         ///   The specific Composite ML-KEM algorithm for this key.
         /// </param>
         /// <param name="source">
-        ///   The bytes of the decapsulation key.
+        ///   The decapsulation key.
         /// </param>
         /// <returns>
         ///   The imported key.
@@ -413,9 +410,6 @@ namespace System.Security.Cryptography
         ///   The platform does not support the specified Composite ML-KEM algorithm. Callers can use <see cref="IsAlgorithmSupported" />
         ///   to determine if the algorithm is supported.
         /// </exception>
-        /// <remarks>
-        ///   This overload accepts the decapsulation key as a byte array.
-        /// </remarks>
         public static CompositeMLKem ImportDecapsulationKey(CompositeMLKemAlgorithm algorithm, byte[] source)
         {
             ArgumentNullException.ThrowIfNull(algorithm);
@@ -425,13 +419,13 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Imports a Composite ML-KEM decapsulation key.
+        ///   Imports a Composite ML-KEM key from a decapsulation key.
         /// </summary>
         /// <param name="algorithm">
         ///   The specific Composite ML-KEM algorithm for this key.
         /// </param>
         /// <param name="source">
-        ///   The bytes of the decapsulation key.
+        ///   The decapsulation key.
         /// </param>
         /// <returns>
         ///   The imported key.
@@ -499,9 +493,6 @@ namespace System.Security.Cryptography
         ///     The specified Composite ML-KEM algorithm is not supported.
         ///   </para>
         /// </exception>
-        /// <remarks>
-        ///   This overload accepts the SubjectPublicKeyInfo structure as a byte array.
-        /// </remarks>
         public static CompositeMLKem ImportSubjectPublicKeyInfo(byte[] source)
         {
             ArgumentNullException.ThrowIfNull(source);
@@ -598,9 +589,6 @@ namespace System.Security.Cryptography
         ///     The specified Composite ML-KEM algorithm is not supported.
         ///   </para>
         /// </exception>
-        /// <remarks>
-        ///   This overload accepts the PrivateKeyInfo structure as a byte array.
-        /// </remarks>
         public static CompositeMLKem ImportPkcs8PrivateKey(byte[] source)
         {
             ArgumentNullException.ThrowIfNull(source);
@@ -707,9 +695,6 @@ namespace System.Security.Cryptography
         ///     The specified Composite ML-KEM algorithm is not supported.
         ///   </para>
         /// </exception>
-        /// <remarks>
-        ///   This overload accepts the password as a string and the EncryptedPrivateKeyInfo structure as a byte array.
-        /// </remarks>
         public static CompositeMLKem ImportEncryptedPkcs8PrivateKey(string password, byte[] source)
         {
             ArgumentNullException.ThrowIfNull(password);
@@ -820,25 +805,23 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Imports either the public or private key from a PEM-encoded key.
+        ///   Imports a Composite ML-KEM key from an RFC 7468 PEM-encoded string.
         /// </summary>
         /// <param name="source">
-        ///   The PEM text of the key to import.
+        ///   The text of the PEM key to import.
         /// </param>
         /// <returns>
-        ///   The imported key.
+        ///   The imported Composite ML-KEM key.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="source" /> is <see langword="null" />.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///   <para>
-        ///     <paramref name="source"/> does not contain a PEM-encoded key with a recognized label.
-        ///   </para>
+        ///   <para><paramref name="source" /> contains an encrypted PEM-encoded key.</para>
         ///   <para>-or-</para>
-        ///   <para>
-        ///     <paramref name="source"/> contains multiple PEM-encoded keys with a recognized label.
-        ///   </para>
+        ///   <para><paramref name="source" /> contains multiple PEM-encoded Composite ML-KEM keys.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="source" /> contains no PEM-encoded Composite ML-KEM keys.</para>
         /// </exception>
         /// <exception cref="CryptographicException">
         ///   <para>
@@ -860,23 +843,16 @@ namespace System.Security.Cryptography
         /// </exception>
         /// <remarks>
         ///   <para>
-        ///     When the base-64 decoded contents of <paramref name="source"/> indicate an algorithm that uses PBKDF1
-        ///     (Password-Based Key Derivation Function 1) or PBKDF2 (Password-Based Key Derivation Function 2),
-        ///     the password is converted to bytes via the UTF-8 encoding.
+        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels
+        ///     are found, an exception is raised to prevent importing a key when the key is ambiguous.
         ///   </para>
         ///   <para>
-        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels are found,
-        ///     an exception is raised to prevent importing a key when the key is ambiguous.
+        ///     This method supports the following PEM labels:
+        ///     <list type="bullet">
+        ///       <item><description>PUBLIC KEY</description></item>
+        ///       <item><description>PRIVATE KEY</description></item>
+        ///     </list>
         ///   </para>
-        ///   <para>This method supports the following PEM labels:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>PUBLIC KEY</description>
-        ///     </item>
-        ///     <item>
-        ///       <description>PRIVATE KEY</description>
-        ///     </item>
-        ///   </list>
         /// </remarks>
         public static CompositeMLKem ImportFromPem(string source)
         {
@@ -902,9 +878,22 @@ namespace System.Security.Cryptography
         ///   <para><paramref name="source" /> contains no PEM-encoded Composite ML-KEM keys.</para>
         /// </exception>
         /// <exception cref="CryptographicException">
-        ///   <para>An error occurred while importing the key.</para>
+        ///   <para>
+        ///     The contents of the PEM-encoded key do not represent an ASN.1-BER encoded PKCS#8 PrivateKeyInfo structure,
+        ///     or an ASN.1-DER encoded X.509 SubjectPublicKeyInfo structure.
+        ///   </para>
         ///   <para>-or-</para>
-        ///   <para>The specified Composite ML-KEM algorithm is not supported.</para>
+        ///   <para>
+        ///     The key is not a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific key import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
         /// </exception>
         /// <remarks>
         ///   <para>
@@ -931,16 +920,16 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Imports the private key from a PEM-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   Imports a Composite ML-KEM key from an encrypted RFC 7468 PEM-encoded string.
         /// </summary>
         /// <param name="source">
-        ///   The PEM text of the key to import.
+        ///   The PEM text of the encrypted key to import.
         /// </param>
         /// <param name="password">
-        ///   The password to use when decrypting the key material.
+        ///   The password to use for decrypting the key material.
         /// </param>
         /// <returns>
-        ///   The imported key.
+        ///   The imported Composite ML-KEM key.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="source" /> or <paramref name="password" /> is <see langword="null" />.
@@ -960,15 +949,17 @@ namespace System.Security.Cryptography
         ///   </para>
         ///   <para>-or-</para>
         ///   <para>
-        ///     The contents of the PEM-encoded key do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///     The base-64 decoded contents of the PEM text from <paramref name="source" />
+        ///     do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
         ///   </para>
         ///   <para>-or-</para>
         ///   <para>
-        ///     The key is not a Composite ML-KEM key.
+        ///     The base-64 decoded contents of the PEM text from <paramref name="source" />
+        ///     represent the key in a format that is not supported.
         ///   </para>
         ///   <para>-or-</para>
         ///   <para>
-        ///     The algorithm-specific key import failed.
+        ///     An error occurred while importing the key.
         ///   </para>
         ///   <para>-or-</para>
         ///   <para>
@@ -977,20 +968,16 @@ namespace System.Security.Cryptography
         /// </exception>
         /// <remarks>
         ///   <para>
-        ///     When the base-64 decoded contents of <paramref name="source"/> indicate an algorithm that uses PBKDF1
+        ///     When the base-64 decoded contents of <paramref name="source" /> indicate an algorithm that uses PBKDF1
         ///     (Password-Based Key Derivation Function 1) or PBKDF2 (Password-Based Key Derivation Function 2),
         ///     the password is converted to bytes via the UTF-8 encoding.
         ///   </para>
         ///   <para>
-        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels are found,
-        ///     an exception is raised to prevent importing a key when the key is ambiguous.
+        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels
+        ///     are found, an exception is thrown to prevent importing a key when
+        ///     the key is ambiguous.
         ///   </para>
-        ///   <para>This method supports the following PEM labels:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>ENCRYPTED PRIVATE KEY</description>
-        ///     </item>
-        ///   </list>
+        ///   <para>This method supports the <c>ENCRYPTED PRIVATE KEY</c> PEM label.</para>
         /// </remarks>
         public static CompositeMLKem ImportFromEncryptedPem(string source, string password)
         {
@@ -1066,16 +1053,16 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Imports the private key from a PEM-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   Imports a Composite ML-KEM key from an encrypted RFC 7468 PEM-encoded string.
         /// </summary>
         /// <param name="source">
-        ///   The PEM text of the key to import.
+        ///   The PEM text of the encrypted key to import.
         /// </param>
         /// <param name="passwordBytes">
         ///   The bytes to use as a password when decrypting the key material.
         /// </param>
         /// <returns>
-        ///   The imported key.
+        ///   The imported Composite ML-KEM key.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="source" /> or <paramref name="passwordBytes" /> is <see langword="null" />.
@@ -1095,15 +1082,17 @@ namespace System.Security.Cryptography
         ///   </para>
         ///   <para>-or-</para>
         ///   <para>
-        ///     The contents of the PEM-encoded key do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///     The base-64 decoded contents of the PEM text from <paramref name="source" />
+        ///     do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
         ///   </para>
         ///   <para>-or-</para>
         ///   <para>
-        ///     The key is not a Composite ML-KEM key.
+        ///     The base-64 decoded contents of the PEM text from <paramref name="source" />
+        ///     represent the key in a format that is not supported.
         ///   </para>
         ///   <para>-or-</para>
         ///   <para>
-        ///     The algorithm-specific key import failed.
+        ///     An error occurred while importing the key.
         ///   </para>
         ///   <para>-or-</para>
         ///   <para>
@@ -1112,21 +1101,11 @@ namespace System.Security.Cryptography
         /// </exception>
         /// <remarks>
         ///   <para>
-        ///     The password bytes are passed directly into the Key Derivation Function (KDF)
-        ///     used by the algorithm indicated by <c>pbeParameters</c>. This enables compatibility
-        ///     with other systems which use a text encoding other than UTF-8 when processing
-        ///     passwords with PBKDF2 (Password-Based Key Derivation Function 2).
+        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels
+        ///     are found, an exception is thrown to prevent importing a key when
+        ///     the key is ambiguous.
         ///   </para>
-        ///   <para>
-        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels are found,
-        ///     an exception is raised to prevent importing a key when the key is ambiguous.
-        ///   </para>
-        ///   <para>This method supports the following PEM labels:</para>
-        ///   <list type="bullet">
-        ///     <item>
-        ///       <description>ENCRYPTED PRIVATE KEY</description>
-        ///     </item>
-        ///   </list>
+        ///   <para>This method supports the <c>ENCRYPTED PRIVATE KEY</c> PEM label.</para>
         /// </remarks>
         public static CompositeMLKem ImportFromEncryptedPem(string source, byte[] passwordBytes)
         {
@@ -1197,8 +1176,8 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password,
-        ///   PEM encoded.
+        ///   Exports the current key in a PEM-encoded representation of the PKCS#8 EncryptedPrivateKeyInfo
+        ///   representation of this key, using a string password.
         /// </summary>
         /// <param name="password">
         ///   The password to use when encrypting the key material.
@@ -1224,9 +1203,6 @@ namespace System.Security.Cryptography
         ///   <para>-or-</para>
         ///   <para>An error occurred while exporting the key.</para>
         /// </exception>
-        /// <remarks>
-        ///   This overload accepts the password as a string.
-        /// </remarks>
         public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters)
         {
             ArgumentNullException.ThrowIfNull(password);
@@ -1326,7 +1302,7 @@ namespace System.Security.Cryptography
         ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
         /// </param>
         /// <returns>
-        ///   A byte array containing the PKCS#8 EncryptedPrivateKeyInfo.
+        ///   A byte array containing the PKCS#8 EncryptedPrivateKeyInfo representation of this key.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="password"/> or <paramref name="pbeParameters"/> is <see langword="null"/>.
@@ -1343,9 +1319,6 @@ namespace System.Security.Cryptography
         ///   <para>-or-</para>
         ///   <para>An error occurred while exporting the key.</para>
         /// </exception>
-        /// <remarks>
-        ///   This overload accepts the password as a string.
-        /// </remarks>
         public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters)
         {
             ArgumentNullException.ThrowIfNull(password);
@@ -1481,9 +1454,6 @@ namespace System.Security.Cryptography
         ///   <para>-or-</para>
         ///   <para>An error occurred while exporting the key.</para>
         /// </exception>
-        /// <remarks>
-        ///   This overload accepts the password as a string.
-        /// </remarks>
         public bool TryExportEncryptedPkcs8PrivateKey(
             string password,
             PbeParameters pbeParameters,
@@ -1617,8 +1587,7 @@ namespace System.Security.Cryptography
         ///   Exports the current key in a PEM-encoded representation of the PKCS#8 PrivateKeyInfo format.
         /// </summary>
         /// <returns>
-        ///   A string containing the PEM-encoded representation of the PKCS#8 PrivateKeyInfo
-        ///   representation of this key.
+        ///   A string containing the PEM-encoded representation of the PKCS#8 PrivateKeyInfo.
         /// </returns>
         /// <exception cref="ObjectDisposedException">
         ///   This instance has been disposed.
@@ -1795,10 +1764,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Exports the encapsulation key portion of the current key.
+        ///   Exports the encapsulation key.
         /// </summary>
         /// <returns>
-        ///   The Composite ML-KEM encapsulation key.
+        ///   The encapsulation key.
         /// </returns>
         /// <exception cref="ObjectDisposedException">
         ///   This instance has been disposed.
@@ -1827,10 +1796,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Exports the encapsulation key portion of the current key into the provided buffer.
+        ///   Exports the encapsulation key into the provided buffer.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the Composite ML-KEM encapsulation key value.
+        ///   The buffer to receive the encapsulation key.
         /// </param>
         /// <returns>
         ///   The number of bytes written to the <paramref name="destination"/> buffer.
@@ -1861,10 +1830,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Attempts to export the encapsulation key portion of the current key into the provided buffer.
+        ///   Attempts to export the encapsulation key into the provided buffer.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the encapsulation key value.
+        ///   The buffer to receive the encapsulation key.
         /// </param>
         /// <param name="bytesWritten">
         ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
@@ -1917,10 +1886,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   When overridden in a derived class, exports the encapsulation key portion of the current key.
+        ///   When overridden in a derived class, exports the encapsulation key into the provided buffer.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the encapsulation key value.
+        ///   The buffer to receive the encapsulation key.
         /// </param>
         /// <returns>
         ///   The number of bytes written to the <paramref name="destination"/> buffer.
@@ -1931,10 +1900,10 @@ namespace System.Security.Cryptography
         protected abstract int ExportEncapsulationKeyCore(Span<byte> destination);
 
         /// <summary>
-        ///   Exports the decapsulation key portion of the current key.
+        ///   Exports the decapsulation key.
         /// </summary>
         /// <returns>
-        ///   The Composite ML-KEM decapsulation key.
+        ///   The decapsulation key.
         /// </returns>
         /// <exception cref="ObjectDisposedException">
         ///   This instance has been disposed.
@@ -1968,10 +1937,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Exports the decapsulation key portion of the current key into the provided buffer.
+        ///   Exports the decapsulation key into the provided buffer.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the Composite ML-KEM decapsulation key value.
+        ///   The buffer to receive the decapsulation key.
         /// </param>
         /// <returns>
         ///   The number of bytes written to the <paramref name="destination"/> buffer.
@@ -2004,10 +1973,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   Attempts to export the decapsulation key portion of the current key into the provided buffer.
+        ///   Attempts to export the decapsulation key into the provided buffer.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the decapsulation key value.
+        ///   The buffer to receive the decapsulation key.
         /// </param>
         /// <param name="bytesWritten">
         ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
@@ -2067,10 +2036,10 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        ///   When overridden in a derived class, exports the decapsulation key portion of the current key.
+        ///   When overridden in a derived class, exports the decapsulation key into the provided buffer.
         /// </summary>
         /// <param name="destination">
-        ///   The buffer to receive the decapsulation key value.
+        ///   The buffer to receive the decapsulation key.
         /// </param>
         /// <returns>
         ///   The number of bytes written to the <paramref name="destination"/> buffer.
@@ -2232,32 +2201,35 @@ namespace System.Security.Cryptography
 
         private TResult ExportPkcs8PrivateKeyCallback<TResult>(ExportPkcs8PrivateKeyFunc<TResult> func)
         {
-            int size = Algorithm.MaxDecapsulationKeySizeInBytes;
-            byte[] buffer = CryptoPool.Rent(size);
-            int written;
-
-            while (!TryExportPkcs8PrivateKeyCore(buffer, out written))
-            {
-                size = buffer.Length;
-                CryptoPool.Return(buffer);
-                size = checked(size * 2);
-                buffer = CryptoPool.Rent(size);
-            }
-
-            if ((uint)written > (uint)buffer.Length)
-            {
-                // We got a nonsense value written back. Clear the buffer, but don't put it back in the pool.
-                CryptographicOperations.ZeroMemory(buffer);
-                throw new CryptographicException();
-            }
+            // A Composite ML-KEM PKCS#8 private key has at most 23 bytes of ASN.1 overhead, assuming no attributes.
+            // Make it an even 32 to provide a good starting point for the buffer size.
+            int size = checked(Algorithm.MaxDecapsulationKeySizeInBytes + 32);
+            CryptoPoolLease lease = CryptoPoolLease.Rent(size);
 
             try
             {
-                return func(buffer.AsSpan(0, written));
+                int written;
+
+                while (!TryExportPkcs8PrivateKeyCore(lease.Span, out written))
+                {
+                    size = checked(size * 2);
+                    lease.Dispose();
+
+                    // Dispose is idempotent, so even if this Rent fails,
+                    // we won't corrupt the pool during cleanup.
+                    lease = CryptoPoolLease.Rent(size);
+                }
+
+                if ((uint)written > (uint)lease.Span.Length)
+                {
+                    throw new CryptographicException();
+                }
+
+                return func(lease.Span.Slice(0, written));
             }
             finally
             {
-                CryptoPool.Return(buffer, written);
+                lease.Dispose();
             }
         }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKem.cs
@@ -1,0 +1,2287 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Formats.Asn1;
+using System.Security.Cryptography.Asn1;
+using Internal.Cryptography;
+
+namespace System.Security.Cryptography
+{
+    /// <summary>
+    ///   Represents a Composite ML-KEM key.
+    /// </summary>
+    /// <remarks>
+    ///   Developers are encouraged to program against the <see cref="CompositeMLKem"/> base class,
+    ///   rather than any specific derived class. The derived classes are intended for interop with the underlying system
+    ///   cryptographic libraries.
+    /// </remarks>
+    [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+    public abstract class CompositeMLKem : IDisposable
+#if DESIGNTIMEINTERFACES
+#pragma warning disable SA1001
+        , IImportExportShape<CompositeMLKem>
+#pragma warning restore SA1001
+#endif
+    {
+        private protected static readonly string[] KnownOids =
+        [
+            Oids.MLKem768WithRsaOaep2048Sha3_256,
+            Oids.MLKem768WithRsaOaep3072Sha3_256,
+            Oids.MLKem768WithRsaOaep4096Sha3_256,
+            Oids.MLKem768WithX25519Sha3_256,
+            Oids.MLKem768WithECDiffieHellmanP256Sha3_256,
+            Oids.MLKem768WithECDiffieHellmanP384Sha3_256,
+            Oids.MLKem768WithECDiffieHellmanBrainpoolP256r1Sha3_256,
+            Oids.MLKem1024WithRsaOaep3072Sha3_256,
+            Oids.MLKem1024WithECDiffieHellmanP384Sha3_256,
+            Oids.MLKem1024WithECDiffieHellmanBrainpoolP384r1Sha3_256,
+            Oids.MLKem1024WithX448Sha3_256,
+            Oids.MLKem1024WithECDiffieHellmanP521Sha3_256,
+        ];
+
+        private bool _disposed;
+
+        /// <summary>
+        ///   Gets the specific Composite ML-KEM algorithm for this key.
+        /// </summary>
+        /// <value>
+        ///   The specific Composite ML-KEM algorithm for this key.
+        /// </value>
+        public CompositeMLKemAlgorithm Algorithm { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="CompositeMLKem" /> class.
+        /// </summary>
+        /// <param name="algorithm">
+        ///   The specific Composite ML-KEM algorithm for this key.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="algorithm"/> is <see langword="null"/>.
+        /// </exception>
+        protected CompositeMLKem(CompositeMLKemAlgorithm algorithm)
+        {
+            ArgumentNullException.ThrowIfNull(algorithm);
+
+            Algorithm = algorithm;
+        }
+
+        /// <summary>
+        ///   Determines whether the specified algorithm is supported by the current platform.
+        /// </summary>
+        /// <param name="algorithm">
+        ///   The <see cref="CompositeMLKemAlgorithm"/> to check for support.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the algorithm is supported; otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="algorithm"/> is <see langword="null"/>.
+        /// </exception>
+        public static bool IsAlgorithmSupported(CompositeMLKemAlgorithm algorithm)
+        {
+            ArgumentNullException.ThrowIfNull(algorithm);
+
+            return CompositeMLKemImplementation.IsAlgorithmSupportedImpl(algorithm);
+        }
+
+        /// <summary>
+        ///   Generates a new Composite ML-KEM key.
+        /// </summary>
+        /// <param name="algorithm">
+        ///   An algorithm identifying what kind of Composite ML-KEM key to generate.
+        /// </param>
+        /// <returns>
+        ///   The generated key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="algorithm" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred generating the Composite ML-KEM key.
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The platform does not support the specified Composite ML-KEM algorithm. Callers can use <see cref="IsAlgorithmSupported" />
+        ///   to determine if the algorithm is supported.
+        /// </exception>
+        public static CompositeMLKem GenerateKey(CompositeMLKemAlgorithm algorithm)
+        {
+            ArgumentNullException.ThrowIfNull(algorithm);
+            ThrowIfNotSupported(algorithm);
+
+            return CompositeMLKemImplementation.GenerateKeyImpl(algorithm);
+        }
+
+        /// <summary>
+        ///   Creates an encapsulation ciphertext and shared secret.
+        /// </summary>
+        /// <param name="ciphertext">
+        ///   When this method returns, the ciphertext.
+        /// </param>
+        /// <param name="sharedSecret">
+        ///   When this method returns, the shared secret.
+        /// </param>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred during encapsulation.
+        /// </exception>
+        public void Encapsulate(out byte[] ciphertext, out byte[] sharedSecret)
+        {
+            ThrowIfDisposed();
+
+            byte[] localCiphertext = new byte[Algorithm.CiphertextSizeInBytes];
+            byte[] localSharedSecret = new byte[Algorithm.SharedSecretSizeInBytes];
+
+            EncapsulateCore(localCiphertext, localSharedSecret);
+
+            sharedSecret = localSharedSecret;
+            ciphertext = localCiphertext;
+        }
+
+        /// <summary>
+        ///   Creates an encapsulation ciphertext and shared secret, writing them into the provided buffers.
+        /// </summary>
+        /// <param name="ciphertext">
+        ///   The buffer to receive the ciphertext. Its length must be exactly
+        ///   <see cref="CompositeMLKemAlgorithm.CiphertextSizeInBytes"/>.
+        /// </param>
+        /// <param name="sharedSecret">
+        ///   The buffer to receive the shared secret. Its length must be exactly
+        ///   <see cref="CompositeMLKemAlgorithm.SharedSecretSizeInBytes"/>.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   <para><paramref name="ciphertext" /> is not the correct size.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="sharedSecret" /> is not the correct size.</para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>An error occurred during encapsulation.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="ciphertext"/> overlaps with <paramref name="sharedSecret"/>.</para>
+        /// </exception>
+        public void Encapsulate(Span<byte> ciphertext, Span<byte> sharedSecret)
+        {
+            if (ciphertext.Length != Algorithm.CiphertextSizeInBytes)
+            {
+                throw new ArgumentException(
+                    SR.Format(SR.Argument_DestinationImprecise, Algorithm.CiphertextSizeInBytes),
+                    nameof(ciphertext));
+            }
+
+            if (sharedSecret.Length != Algorithm.SharedSecretSizeInBytes)
+            {
+                throw new ArgumentException(
+                    SR.Format(SR.Argument_DestinationImprecise, Algorithm.SharedSecretSizeInBytes),
+                    nameof(sharedSecret));
+            }
+
+            if (ciphertext.Overlaps(sharedSecret))
+            {
+                throw new CryptographicException(SR.Cryptography_OverlappingBuffers);
+            }
+
+            ThrowIfDisposed();
+
+            EncapsulateCore(ciphertext, sharedSecret);
+        }
+
+        /// <summary>
+        ///   When overridden in a derived class, creates an encapsulation ciphertext and shared secret, writing them
+        ///   into the provided buffers.
+        /// </summary>
+        /// <param name="ciphertext">
+        ///   The buffer to receive the ciphertext, whose length will be exactly
+        ///   <see cref="CompositeMLKemAlgorithm.CiphertextSizeInBytes"/>.
+        /// </param>
+        /// <param name="sharedSecret">
+        ///   The buffer to receive the shared secret, whose length will be exactly
+        ///   <see cref="CompositeMLKemAlgorithm.SharedSecretSizeInBytes"/>.
+        /// </param>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred during encapsulation.
+        /// </exception>
+        protected abstract void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret);
+
+        /// <summary>
+        ///   Decapsulates a shared secret from a provided ciphertext.
+        /// </summary>
+        /// <param name="ciphertext">
+        ///   The ciphertext.
+        /// </param>
+        /// <returns>
+        ///   The shared secret.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="ciphertext" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="ciphertext" /> is not the correct size.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>The instance represents only an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred during decapsulation.</para>
+        /// </exception>
+        public byte[] Decapsulate(byte[] ciphertext)
+        {
+            ArgumentNullException.ThrowIfNull(ciphertext);
+
+            if (ciphertext.Length != Algorithm.CiphertextSizeInBytes)
+            {
+                throw new ArgumentException(SR.Argument_KemInvalidCiphertextLength, nameof(ciphertext));
+            }
+
+            ThrowIfDisposed();
+
+            byte[] sharedSecret = new byte[Algorithm.SharedSecretSizeInBytes];
+            DecapsulateCore(ciphertext, sharedSecret);
+            return sharedSecret;
+        }
+
+        /// <summary>
+        ///   Decapsulates a shared secret from a provided ciphertext, writing it into the provided buffer.
+        /// </summary>
+        /// <param name="ciphertext">
+        ///   The ciphertext.
+        /// </param>
+        /// <param name="sharedSecret">
+        ///   The buffer to receive the shared secret. Its length must be exactly
+        ///   <see cref="CompositeMLKemAlgorithm.SharedSecretSizeInBytes"/>.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   <para><paramref name="ciphertext" /> is not the correct size.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="sharedSecret" /> is not the correct size.</para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>The instance represents only an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred during decapsulation.</para>
+        /// </exception>
+        public void Decapsulate(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret)
+        {
+            if (ciphertext.Length != Algorithm.CiphertextSizeInBytes)
+            {
+                throw new ArgumentException(SR.Argument_KemInvalidCiphertextLength, nameof(ciphertext));
+            }
+
+            if (sharedSecret.Length != Algorithm.SharedSecretSizeInBytes)
+            {
+                throw new ArgumentException(
+                    SR.Format(SR.Argument_DestinationImprecise, Algorithm.SharedSecretSizeInBytes),
+                    nameof(sharedSecret));
+            }
+
+            ThrowIfDisposed();
+
+            DecapsulateCore(ciphertext, sharedSecret);
+        }
+
+        /// <summary>
+        ///   When overridden in a derived class, decapsulates a shared secret from a provided ciphertext.
+        /// </summary>
+        /// <param name="ciphertext">
+        ///   The ciphertext, whose length will be exactly <see cref="CompositeMLKemAlgorithm.CiphertextSizeInBytes"/>.
+        /// </param>
+        /// <param name="sharedSecret">
+        ///   The buffer to receive the shared secret, whose length will be exactly
+        ///   <see cref="CompositeMLKemAlgorithm.SharedSecretSizeInBytes"/>.
+        /// </param>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred during decapsulation.
+        /// </exception>
+        protected abstract void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret);
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM encapsulation key.
+        /// </summary>
+        /// <param name="algorithm">
+        ///   The specific Composite ML-KEM algorithm for this key.
+        /// </param>
+        /// <param name="source">
+        ///   The bytes of the encapsulation key.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="algorithm"/> or <paramref name="source" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     <paramref name="source"/> length is the wrong size for the specified algorithm.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     An error occurred while importing the key.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The platform does not support the specified Composite ML-KEM algorithm. Callers can use <see cref="IsAlgorithmSupported" />
+        ///   to determine if the algorithm is supported.
+        /// </exception>
+        /// <remarks>
+        ///   This overload accepts the encapsulation key as a byte array.
+        /// </remarks>
+        public static CompositeMLKem ImportEncapsulationKey(CompositeMLKemAlgorithm algorithm, byte[] source)
+        {
+            ArgumentNullException.ThrowIfNull(algorithm);
+            ArgumentNullException.ThrowIfNull(source);
+
+            return ImportEncapsulationKey(algorithm, new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM encapsulation key.
+        /// </summary>
+        /// <param name="algorithm">
+        ///   The specific Composite ML-KEM algorithm for this key.
+        /// </param>
+        /// <param name="source">
+        ///   The bytes of the encapsulation key.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="algorithm" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     <paramref name="source"/> length is the wrong size for the specified algorithm.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     An error occurred while importing the key.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The platform does not support the specified Composite ML-KEM algorithm. Callers can use <see cref="IsAlgorithmSupported" />
+        ///   to determine if the algorithm is supported.
+        /// </exception>
+        public static CompositeMLKem ImportEncapsulationKey(CompositeMLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
+        {
+            ArgumentNullException.ThrowIfNull(algorithm);
+
+            if (!algorithm.IsValidEncapsulationKeySize(source.Length))
+            {
+                throw new CryptographicException(SR.Argument_PublicKeyWrongSizeForAlgorithm);
+            }
+
+            ThrowIfNotSupported(algorithm);
+
+            return CompositeMLKemImplementation.ImportEncapsulationKeyImpl(algorithm, source);
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM decapsulation key.
+        /// </summary>
+        /// <param name="algorithm">
+        ///   The specific Composite ML-KEM algorithm for this key.
+        /// </param>
+        /// <param name="source">
+        ///   The bytes of the decapsulation key.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="algorithm"/> or <paramref name="source" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     <paramref name="source"/> length is the wrong size for the specified algorithm.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     An error occurred while importing the key.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The platform does not support the specified Composite ML-KEM algorithm. Callers can use <see cref="IsAlgorithmSupported" />
+        ///   to determine if the algorithm is supported.
+        /// </exception>
+        /// <remarks>
+        ///   This overload accepts the decapsulation key as a byte array.
+        /// </remarks>
+        public static CompositeMLKem ImportDecapsulationKey(CompositeMLKemAlgorithm algorithm, byte[] source)
+        {
+            ArgumentNullException.ThrowIfNull(algorithm);
+            ArgumentNullException.ThrowIfNull(source);
+
+            return ImportDecapsulationKey(algorithm, new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM decapsulation key.
+        /// </summary>
+        /// <param name="algorithm">
+        ///   The specific Composite ML-KEM algorithm for this key.
+        /// </param>
+        /// <param name="source">
+        ///   The bytes of the decapsulation key.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="algorithm" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     <paramref name="source"/> length is the wrong size for the specified algorithm.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     An error occurred while importing the key.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="PlatformNotSupportedException">
+        ///   The platform does not support the specified Composite ML-KEM algorithm. Callers can use <see cref="IsAlgorithmSupported" />
+        ///   to determine if the algorithm is supported.
+        /// </exception>
+        public static CompositeMLKem ImportDecapsulationKey(CompositeMLKemAlgorithm algorithm, ReadOnlySpan<byte> source)
+        {
+            ArgumentNullException.ThrowIfNull(algorithm);
+
+            if (!algorithm.IsValidDecapsulationKeySize(source.Length))
+            {
+                throw new CryptographicException(SR.Argument_PrivateKeyWrongSizeForAlgorithm);
+            }
+
+            ThrowIfNotSupported(algorithm);
+
+            return CompositeMLKemImplementation.ImportDecapsulationKeyImpl(algorithm, source);
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM encapsulation key from an X.509 SubjectPublicKeyInfo structure.
+        /// </summary>
+        /// <param name="source">
+        ///   The bytes of an X.509 SubjectPublicKeyInfo structure in the ASN.1-DER encoding.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The contents of <paramref name="source"/> do not represent an ASN.1-DER-encoded X.509 SubjectPublicKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The SubjectPublicKeyInfo value does not represent a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source" /> contains trailing data after the ASN.1 structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        /// <remarks>
+        ///   This overload accepts the SubjectPublicKeyInfo structure as a byte array.
+        /// </remarks>
+        public static CompositeMLKem ImportSubjectPublicKeyInfo(byte[] source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return ImportSubjectPublicKeyInfo(new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM encapsulation key from an X.509 SubjectPublicKeyInfo structure.
+        /// </summary>
+        /// <param name="source">
+        ///   The bytes of an X.509 SubjectPublicKeyInfo structure in the ASN.1-DER encoding.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The contents of <paramref name="source"/> do not represent an ASN.1-DER-encoded X.509 SubjectPublicKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The SubjectPublicKeyInfo value does not represent a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source" /> contains trailing data after the ASN.1 structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        public static CompositeMLKem ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source)
+        {
+            Helpers.ThrowIfAsnInvalidLength(source);
+
+            KeyFormatHelper.ReadSubjectPublicKeyInfo(KnownOids, source, SubjectPublicKeyReader, out int read, out CompositeMLKem kem);
+            Debug.Assert(read == source.Length);
+            return kem;
+
+            static void SubjectPublicKeyReader(ReadOnlySpan<byte> key, in ValueAlgorithmIdentifierAsn identifier, out CompositeMLKem kem)
+            {
+                CompositeMLKemAlgorithm algorithm = GetAlgorithmIdentifier(in identifier);
+
+                if (!IsAlgorithmSupported(algorithm))
+                {
+                    throw new CryptographicException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(CompositeMLKem)));
+                }
+
+                if (!algorithm.IsValidEncapsulationKeySize(key.Length))
+                {
+                    throw new CryptographicException(SR.Argument_PublicKeyWrongSizeForAlgorithm);
+                }
+
+                kem = CompositeMLKemImplementation.ImportEncapsulationKeyImpl(algorithm, key);
+            }
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM decapsulation key from a PKCS#8 PrivateKeyInfo structure.
+        /// </summary>
+        /// <param name="source">
+        ///   The bytes of a PKCS#8 PrivateKeyInfo structure in the ASN.1-BER encoding.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The contents of <paramref name="source"/> do not represent an ASN.1-BER-encoded PKCS#8 PrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The PrivateKeyInfo value does not represent a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source" /> contains trailing data after the ASN.1 structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        /// <remarks>
+        ///   This overload accepts the PrivateKeyInfo structure as a byte array.
+        /// </remarks>
+        public static CompositeMLKem ImportPkcs8PrivateKey(byte[] source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return ImportPkcs8PrivateKey(new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM decapsulation key from a PKCS#8 PrivateKeyInfo structure.
+        /// </summary>
+        /// <param name="source">
+        ///   The bytes of a PKCS#8 PrivateKeyInfo structure in the ASN.1-BER encoding.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The contents of <paramref name="source"/> do not represent an ASN.1-BER-encoded PKCS#8 PrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The PrivateKeyInfo value does not represent a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source" /> contains trailing data after the ASN.1 structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        public static CompositeMLKem ImportPkcs8PrivateKey(ReadOnlySpan<byte> source)
+        {
+            Helpers.ThrowIfAsnInvalidLength(source);
+
+            KeyFormatHelper.ReadPkcs8(KnownOids, source, PrivateKeyReader, out int read, out CompositeMLKem kem);
+            Debug.Assert(read == source.Length);
+            return kem;
+
+            static void PrivateKeyReader(
+                ReadOnlySpan<byte> privateKeyContents,
+                in ValueAlgorithmIdentifierAsn algorithmIdentifier,
+                out CompositeMLKem kem)
+            {
+                CompositeMLKemAlgorithm algorithm = GetAlgorithmIdentifier(in algorithmIdentifier);
+
+                if (!IsAlgorithmSupported(algorithm))
+                {
+                    throw new CryptographicException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(CompositeMLKem)));
+                }
+
+                if (!algorithm.IsValidDecapsulationKeySize(privateKeyContents.Length))
+                {
+                    throw new CryptographicException(SR.Argument_PrivateKeyWrongSizeForAlgorithm);
+                }
+
+                kem = CompositeMLKemImplementation.ImportDecapsulationKeyImpl(algorithm, privateKeyContents);
+            }
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM decapsulation key from a PKCS#8 EncryptedPrivateKeyInfo structure.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when decrypting the key material.
+        /// </param>
+        /// <param name="source">
+        ///   The bytes of a PKCS#8 EncryptedPrivateKeyInfo structure in the ASN.1-BER encoding.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="password" /> or <paramref name="source" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The contents of <paramref name="source"/> do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified password is incorrect.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The value does not represent a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source" /> contains trailing data after the ASN.1 structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        /// <remarks>
+        ///   This overload accepts the password as a string and the EncryptedPrivateKeyInfo structure as a byte array.
+        /// </remarks>
+        public static CompositeMLKem ImportEncryptedPkcs8PrivateKey(string password, byte[] source)
+        {
+            ArgumentNullException.ThrowIfNull(password);
+            ArgumentNullException.ThrowIfNull(source);
+
+            return ImportEncryptedPkcs8PrivateKey(password.AsSpan(), new ReadOnlySpan<byte>(source));
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM decapsulation key from a PKCS#8 EncryptedPrivateKeyInfo structure.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when decrypting the key material.
+        /// </param>
+        /// <param name="source">
+        ///   The bytes of a PKCS#8 EncryptedPrivateKeyInfo structure in the ASN.1-BER encoding.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The contents of <paramref name="source"/> do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified password is incorrect.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The value does not represent a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source" /> contains trailing data after the ASN.1 structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        public static CompositeMLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source)
+        {
+            Helpers.ThrowIfAsnInvalidLength(source);
+
+            return KeyFormatHelper.DecryptPkcs8(
+                password,
+                source,
+                ImportPkcs8PrivateKey,
+                out _);
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM decapsulation key from a PKCS#8 EncryptedPrivateKeyInfo structure.
+        /// </summary>
+        /// <param name="passwordBytes">
+        ///   The bytes to use as a password when decrypting the key material.
+        /// </param>
+        /// <param name="source">
+        ///   The bytes of a PKCS#8 EncryptedPrivateKeyInfo structure in the ASN.1-BER encoding.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The contents of <paramref name="source"/> do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified password is incorrect.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The EncryptedPrivateKeyInfo indicates the Key Derivation Function (KDF) to apply is the legacy PKCS#12 KDF,
+        ///     which requires <see cref="char"/>-based passwords.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The value does not represent a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source" /> contains trailing data after the ASN.1 structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        public static CompositeMLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source)
+        {
+            Helpers.ThrowIfAsnInvalidLength(source);
+
+            return KeyFormatHelper.DecryptPkcs8(
+                passwordBytes,
+                source,
+                ImportPkcs8PrivateKey,
+                out _);
+        }
+
+        /// <summary>
+        ///   Imports either the public or private key from a PEM-encoded key.
+        /// </summary>
+        /// <param name="source">
+        ///   The PEM text of the key to import.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <para>
+        ///     <paramref name="source"/> does not contain a PEM-encoded key with a recognized label.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source"/> contains multiple PEM-encoded keys with a recognized label.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The contents of the PEM-encoded key do not represent an ASN.1-BER encoded PKCS#8 PrivateKeyInfo structure,
+        ///     or an ASN.1-DER encoded X.509 SubjectPublicKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The key is not a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific key import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        /// <remarks>
+        ///   <para>
+        ///     When the base-64 decoded contents of <paramref name="source"/> indicate an algorithm that uses PBKDF1
+        ///     (Password-Based Key Derivation Function 1) or PBKDF2 (Password-Based Key Derivation Function 2),
+        ///     the password is converted to bytes via the UTF-8 encoding.
+        ///   </para>
+        ///   <para>
+        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels are found,
+        ///     an exception is raised to prevent importing a key when the key is ambiguous.
+        ///   </para>
+        ///   <para>This method supports the following PEM labels:</para>
+        ///   <list type="bullet">
+        ///     <item>
+        ///       <description>PUBLIC KEY</description>
+        ///     </item>
+        ///     <item>
+        ///       <description>PRIVATE KEY</description>
+        ///     </item>
+        ///   </list>
+        /// </remarks>
+        public static CompositeMLKem ImportFromPem(string source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return ImportFromPem(source.AsSpan());
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM key from an RFC 7468 PEM-encoded string.
+        /// </summary>
+        /// <param name="source">
+        ///   The text of the PEM key to import.
+        /// </param>
+        /// <returns>
+        ///   The imported Composite ML-KEM key.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   <para><paramref name="source" /> contains an encrypted PEM-encoded key.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="source" /> contains multiple PEM-encoded Composite ML-KEM keys.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="source" /> contains no PEM-encoded Composite ML-KEM keys.</para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>An error occurred while importing the key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The specified Composite ML-KEM algorithm is not supported.</para>
+        /// </exception>
+        /// <remarks>
+        ///   <para>
+        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels
+        ///     are found, an exception is raised to prevent importing a key when the key is ambiguous.
+        ///   </para>
+        ///   <para>
+        ///     This method supports the following PEM labels:
+        ///     <list type="bullet">
+        ///       <item><description>PUBLIC KEY</description></item>
+        ///       <item><description>PRIVATE KEY</description></item>
+        ///     </list>
+        ///   </para>
+        /// </remarks>
+        public static CompositeMLKem ImportFromPem(ReadOnlySpan<char> source)
+        {
+            return PemKeyHelpers.ImportFactoryPem<CompositeMLKem>(source, label =>
+                label switch
+                {
+                    PemLabels.Pkcs8PrivateKey => ImportPkcs8PrivateKey,
+                    PemLabels.SpkiPublicKey => ImportSubjectPublicKeyInfo,
+                    _ => null,
+                });
+        }
+
+        /// <summary>
+        ///   Imports the private key from a PEM-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        /// </summary>
+        /// <param name="source">
+        ///   The PEM text of the key to import.
+        /// </param>
+        /// <param name="password">
+        ///   The password to use when decrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source" /> or <paramref name="password" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <para>
+        ///     <paramref name="source"/> does not contain a PEM-encoded key with a recognized label.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source"/> contains multiple PEM-encoded keys with a recognized label.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The password is incorrect.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The contents of the PEM-encoded key do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The key is not a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific key import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        /// <remarks>
+        ///   <para>
+        ///     When the base-64 decoded contents of <paramref name="source"/> indicate an algorithm that uses PBKDF1
+        ///     (Password-Based Key Derivation Function 1) or PBKDF2 (Password-Based Key Derivation Function 2),
+        ///     the password is converted to bytes via the UTF-8 encoding.
+        ///   </para>
+        ///   <para>
+        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels are found,
+        ///     an exception is raised to prevent importing a key when the key is ambiguous.
+        ///   </para>
+        ///   <para>This method supports the following PEM labels:</para>
+        ///   <list type="bullet">
+        ///     <item>
+        ///       <description>ENCRYPTED PRIVATE KEY</description>
+        ///     </item>
+        ///   </list>
+        /// </remarks>
+        public static CompositeMLKem ImportFromEncryptedPem(string source, string password)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(password);
+
+            return ImportFromEncryptedPem(source.AsSpan(), password.AsSpan());
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM key from an encrypted RFC 7468 PEM-encoded string.
+        /// </summary>
+        /// <param name="source">
+        ///   The PEM text of the encrypted key to import.
+        /// </param>
+        /// <param name="password">
+        ///   The password to use for decrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   The imported Composite ML-KEM key.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   <para>
+        ///     <paramref name="source"/> does not contain a PEM-encoded key with a recognized label.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source"/> contains multiple PEM-encoded keys with a recognized label.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The password is incorrect.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The base-64 decoded contents of the PEM text from <paramref name="source" />
+        ///     do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The base-64 decoded contents of the PEM text from <paramref name="source" />
+        ///     represent the key in a format that is not supported.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     An error occurred while importing the key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        /// <remarks>
+        ///   <para>
+        ///     When the base-64 decoded contents of <paramref name="source" /> indicate an algorithm that uses PBKDF1
+        ///     (Password-Based Key Derivation Function 1) or PBKDF2 (Password-Based Key Derivation Function 2),
+        ///     the password is converted to bytes via the UTF-8 encoding.
+        ///   </para>
+        ///   <para>
+        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels
+        ///     are found, an exception is thrown to prevent importing a key when
+        ///     the key is ambiguous.
+        ///   </para>
+        ///   <para>This method supports the <c>ENCRYPTED PRIVATE KEY</c> PEM label.</para>
+        /// </remarks>
+        public static CompositeMLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password)
+        {
+            return PemKeyHelpers.ImportEncryptedFactoryPem<CompositeMLKem, char>(
+                source,
+                password,
+                ImportEncryptedPkcs8PrivateKey);
+        }
+
+        /// <summary>
+        ///   Imports the private key from a PEM-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        /// </summary>
+        /// <param name="source">
+        ///   The PEM text of the key to import.
+        /// </param>
+        /// <param name="passwordBytes">
+        ///   The bytes to use as a password when decrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   The imported key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="source" /> or <paramref name="passwordBytes" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <para>
+        ///     <paramref name="source"/> does not contain a PEM-encoded key with a recognized label.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source"/> contains multiple PEM-encoded keys with a recognized label.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The password is incorrect.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The contents of the PEM-encoded key do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The key is not a Composite ML-KEM key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The algorithm-specific key import failed.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        /// <remarks>
+        ///   <para>
+        ///     The password bytes are passed directly into the Key Derivation Function (KDF)
+        ///     used by the algorithm indicated by <c>pbeParameters</c>. This enables compatibility
+        ///     with other systems which use a text encoding other than UTF-8 when processing
+        ///     passwords with PBKDF2 (Password-Based Key Derivation Function 2).
+        ///   </para>
+        ///   <para>
+        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels are found,
+        ///     an exception is raised to prevent importing a key when the key is ambiguous.
+        ///   </para>
+        ///   <para>This method supports the following PEM labels:</para>
+        ///   <list type="bullet">
+        ///     <item>
+        ///       <description>ENCRYPTED PRIVATE KEY</description>
+        ///     </item>
+        ///   </list>
+        /// </remarks>
+        public static CompositeMLKem ImportFromEncryptedPem(string source, byte[] passwordBytes)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(passwordBytes);
+
+            return ImportFromEncryptedPem(source.AsSpan(), new ReadOnlySpan<byte>(passwordBytes));
+        }
+
+        /// <summary>
+        ///   Imports a Composite ML-KEM key from an encrypted RFC 7468 PEM-encoded string.
+        /// </summary>
+        /// <param name="source">
+        ///   The PEM text of the encrypted key to import.
+        /// </param>
+        /// <param name="passwordBytes">
+        ///   The bytes to use as a password when decrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   The imported Composite ML-KEM key.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   <para>
+        ///     <paramref name="source"/> does not contain a PEM-encoded key with a recognized label.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     <paramref name="source"/> contains multiple PEM-encoded keys with a recognized label.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///     The password is incorrect.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The base-64 decoded contents of the PEM text from <paramref name="source" />
+        ///     do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The base-64 decoded contents of the PEM text from <paramref name="source" />
+        ///     represent the key in a format that is not supported.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     An error occurred while importing the key.
+        ///   </para>
+        ///   <para>-or-</para>
+        ///   <para>
+        ///     The specified Composite ML-KEM algorithm is not supported.
+        ///   </para>
+        /// </exception>
+        /// <remarks>
+        ///   <para>
+        ///     Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels
+        ///     are found, an exception is thrown to prevent importing a key when
+        ///     the key is ambiguous.
+        ///   </para>
+        ///   <para>This method supports the <c>ENCRYPTED PRIVATE KEY</c> PEM label.</para>
+        /// </remarks>
+        public static CompositeMLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes)
+        {
+            return PemKeyHelpers.ImportEncryptedFactoryPem<CompositeMLKem, byte>(
+                source,
+                passwordBytes,
+                ImportEncryptedPkcs8PrivateKey);
+        }
+
+        /// <summary>
+        ///   Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password,
+        ///   PEM encoded.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   A string containing the PEM-encoded PKCS#8 EncryptedPrivateKeyInfo.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="password"/> or <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        ///   <para>-or-</para>
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        /// <remarks>
+        ///   This overload accepts the password as a string.
+        /// </remarks>
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters)
+        {
+            ArgumentNullException.ThrowIfNull(password);
+
+            return ExportEncryptedPkcs8PrivateKeyPem(password.AsSpan(), pbeParameters);
+        }
+
+        /// <summary>
+        ///   Exports the current key in a PEM-encoded representation of the PKCS#8 EncryptedPrivateKeyInfo
+        ///   representation of this key, using a char-based password.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   A string containing the PEM-encoded PKCS#8 EncryptedPrivateKeyInfo.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        ///   <para>-or-</para>
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters)
+        {
+            ArgumentNullException.ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, password, ReadOnlySpan<byte>.Empty);
+            ThrowIfDisposed();
+
+            AsnWriter writer = WriteEncryptedPkcs8PrivateKeyToAsnWriter(password, pbeParameters);
+
+            // Skip clear since the data is already encrypted.
+            return Helpers.EncodeAsnWriterToPem(PemLabels.EncryptedPkcs8PrivateKey, writer, clear: false);
+        }
+
+        /// <summary>
+        ///   Exports the current key in a PEM-encoded representation of the PKCS#8 EncryptedPrivateKeyInfo
+        ///   representation of this key, using a byte-based password.
+        /// </summary>
+        /// <param name="passwordBytes">
+        ///   The bytes to use as a password when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   A string containing the PEM-encoded PKCS#8 EncryptedPrivateKeyInfo.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="pbeParameters"/> specifies a KDF that requires a char-based password.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        ///   <para>-or-</para>
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters)
+        {
+            ArgumentNullException.ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, ReadOnlySpan<char>.Empty, passwordBytes);
+            ThrowIfDisposed();
+
+            AsnWriter writer = WriteEncryptedPkcs8PrivateKeyToAsnWriter(passwordBytes, pbeParameters);
+
+            // Skip clear since the data is already encrypted.
+            return Helpers.EncodeAsnWriterToPem(PemLabels.EncryptedPkcs8PrivateKey, writer, clear: false);
+        }
+
+        /// <summary>
+        ///   Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   A byte array containing the PKCS#8 EncryptedPrivateKeyInfo.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="password"/> or <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        ///   <para>-or-</para>
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        /// <remarks>
+        ///   This overload accepts the password as a string.
+        /// </remarks>
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters)
+        {
+            ArgumentNullException.ThrowIfNull(password);
+
+            return ExportEncryptedPkcs8PrivateKey(password.AsSpan(), pbeParameters);
+        }
+
+        /// <summary>
+        ///   Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a char-based password.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   A byte array containing the PKCS#8 EncryptedPrivateKeyInfo representation of this key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        ///   <para>-or-</para>
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters)
+        {
+            ArgumentNullException.ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, password, ReadOnlySpan<byte>.Empty);
+            ThrowIfDisposed();
+
+            AsnWriter writer = WriteEncryptedPkcs8PrivateKeyToAsnWriter(password, pbeParameters);
+
+            try
+            {
+                return writer.Encode();
+            }
+            finally
+            {
+                writer.Reset();
+            }
+        }
+
+        /// <summary>
+        ///   Exports the current key in the PKCS#8 EncryptedPrivateKeyInfo format with a byte-based password.
+        /// </summary>
+        /// <param name="passwordBytes">
+        ///   The bytes to use as a password when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <returns>
+        ///   A byte array containing the PKCS#8 EncryptedPrivateKeyInfo representation of this key.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="pbeParameters"/> specifies a KDF that requires a char-based password.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        ///   <para>-or-</para>
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters)
+        {
+            ArgumentNullException.ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, ReadOnlySpan<char>.Empty, passwordBytes);
+            ThrowIfDisposed();
+
+            AsnWriter writer = WriteEncryptedPkcs8PrivateKeyToAsnWriter(passwordBytes, pbeParameters);
+
+            try
+            {
+                return writer.Encode();
+            }
+            finally
+            {
+                writer.Reset();
+            }
+        }
+
+        /// <summary>
+        ///   Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
+        ///   using a char-based password.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 EncryptedPrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="password"/> or <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        ///   <para>-or-</para>
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        /// <remarks>
+        ///   This overload accepts the password as a string.
+        /// </remarks>
+        public bool TryExportEncryptedPkcs8PrivateKey(
+            string password,
+            PbeParameters pbeParameters,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            ArgumentNullException.ThrowIfNull(password);
+
+            return TryExportEncryptedPkcs8PrivateKey(password.AsSpan(), pbeParameters, destination, out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
+        ///   using a char-based password.
+        /// </summary>
+        /// <param name="password">
+        ///   The password to use when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 EncryptedPrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        ///   <para>-or-</para>
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public bool TryExportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<char> password,
+            PbeParameters pbeParameters,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            ArgumentNullException.ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, password, ReadOnlySpan<byte>.Empty);
+            ThrowIfDisposed();
+
+            AsnWriter writer = WriteEncryptedPkcs8PrivateKeyToAsnWriter(password, pbeParameters);
+
+            try
+            {
+                return writer.TryEncode(destination, out bytesWritten);
+            }
+            finally
+            {
+                writer.Reset();
+            }
+        }
+
+        /// <summary>
+        ///   Attempts to export the current key in the PKCS#8 EncryptedPrivateKeyInfo format into a provided buffer,
+        ///   using a byte-based password.
+        /// </summary>
+        /// <param name="passwordBytes">
+        ///   The bytes to use as a password when encrypting the key material.
+        /// </param>
+        /// <param name="pbeParameters">
+        ///   The password-based encryption (PBE) parameters to use when encrypting the key material.
+        /// </param>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 EncryptedPrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pbeParameters"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="pbeParameters"/> specifies a KDF that requires a char-based password.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="pbeParameters"/> does not represent a valid password-based encryption algorithm.</para>
+        ///   <para>-or-</para>
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public bool TryExportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<byte> passwordBytes,
+            PbeParameters pbeParameters,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            ArgumentNullException.ThrowIfNull(pbeParameters);
+            PasswordBasedEncryption.ValidatePbeParameters(pbeParameters, ReadOnlySpan<char>.Empty, passwordBytes);
+            ThrowIfDisposed();
+
+            AsnWriter writer = WriteEncryptedPkcs8PrivateKeyToAsnWriter(passwordBytes, pbeParameters);
+
+            try
+            {
+                return writer.TryEncode(destination, out bytesWritten);
+            }
+            finally
+            {
+                writer.Reset();
+            }
+        }
+
+        /// <summary>
+        ///   Exports the current key in a PEM-encoded representation of the PKCS#8 PrivateKeyInfo format.
+        /// </summary>
+        /// <returns>
+        ///   A string containing the PEM-encoded representation of the PKCS#8 PrivateKeyInfo
+        ///   representation of this key.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public string ExportPkcs8PrivateKeyPem()
+        {
+            ThrowIfDisposed();
+
+            return ExportPkcs8PrivateKeyCallback(static pkcs8 => PemEncoding.WriteString(PemLabels.Pkcs8PrivateKey, pkcs8));
+        }
+
+        /// <summary>
+        ///   Exports the current key in the PKCS#8 PrivateKeyInfo format.
+        /// </summary>
+        /// <returns>
+        ///   A byte array containing the PKCS#8 PrivateKeyInfo representation of this key.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public byte[] ExportPkcs8PrivateKey()
+        {
+            ThrowIfDisposed();
+
+            return ExportPkcs8PrivateKeyCallback(static pkcs8 => pkcs8.ToArray());
+        }
+
+        /// <summary>
+        ///   Attempts to export the current key in the PKCS#8 PrivateKeyInfo format
+        ///   into the provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 PrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>This instance only represents an encapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>The decapsulation key is not exportable.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten)
+        {
+            ThrowIfDisposed();
+
+            // The bound can be tightened but decapsulation key length of some traditional algorithms
+            // can vary and aren't worth the complex calculation.
+            int minimumPossiblePkcs8Key = Algorithm.MinDecapsulationKeySizeInBytes;
+
+            if (destination.Length < minimumPossiblePkcs8Key)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            return TryExportPkcs8PrivateKeyCore(destination, out bytesWritten);
+        }
+
+        /// <summary>
+        ///   When overridden in a derived class, attempts to export the current key in the PKCS#8 PrivateKeyInfo format
+        ///   into the provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the PKCS#8 PrivateKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+
+        /// <summary>
+        ///   Exports the encapsulation key portion of the current key in a PEM-encoded representation of
+        ///   the X.509 SubjectPublicKeyInfo format.
+        /// </summary>
+        /// <returns>
+        ///   A string containing the PEM-encoded representation of the X.509 SubjectPublicKeyInfo
+        ///   representation of the encapsulation key portion of this key.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
+        public string ExportSubjectPublicKeyInfoPem()
+        {
+            ThrowIfDisposed();
+
+            AsnWriter writer = WriteSubjectPublicKeyToAsnWriter();
+
+            // SPKI does not contain sensitive data.
+            return Helpers.EncodeAsnWriterToPem(PemLabels.SpkiPublicKey, writer, clear: false);
+        }
+
+        /// <summary>
+        ///   Exports the encapsulation key portion of the current key in the X.509 SubjectPublicKeyInfo format.
+        /// </summary>
+        /// <returns>
+        ///   A byte array containing the X.509 SubjectPublicKeyInfo representation of the encapsulation key portion
+        ///   of this key.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
+        public byte[] ExportSubjectPublicKeyInfo()
+        {
+            ThrowIfDisposed();
+
+            return WriteSubjectPublicKeyToAsnWriter().Encode();
+        }
+
+        /// <summary>
+        ///   Attempts to export the encapsulation key portion of the current key in the X.509 SubjectPublicKeyInfo format
+        ///   into the provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the X.509 SubjectPublicKeyInfo value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten)
+        {
+            ThrowIfDisposed();
+
+            AsnWriter writer = WriteSubjectPublicKeyToAsnWriter();
+            return writer.TryEncode(destination, out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Exports the encapsulation key portion of the current key.
+        /// </summary>
+        /// <returns>
+        ///   The Composite ML-KEM encapsulation key.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
+        public byte[] ExportEncapsulationKey()
+        {
+            ThrowIfDisposed();
+
+            byte[] encapsulationKey = new byte[Algorithm.MaxEncapsulationKeySizeInBytes];
+
+            if (!TryExportEncapsulationKey(encapsulationKey, out int bytesWritten))
+            {
+                Debug.Fail("Max sized buffer was not large enough.");
+                throw new CryptographicException();
+            }
+
+            if (bytesWritten < encapsulationKey.Length)
+            {
+                Array.Resize(ref encapsulationKey, bytesWritten);
+            }
+
+            return encapsulationKey;
+        }
+
+        /// <summary>
+        ///   Exports the encapsulation key portion of the current key into the provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the Composite ML-KEM encapsulation key value.
+        /// </param>
+        /// <returns>
+        ///   The number of bytes written to the <paramref name="destination"/> buffer.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="destination"/> was not large enough to hold the result.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public int ExportEncapsulationKey(Span<byte> destination)
+        {
+            ThrowIfDisposed();
+
+            if (destination.Length < Algorithm.MinEncapsulationKeySizeInBytes)
+            {
+                throw new CryptographicException(SR.Argument_DestinationTooShort);
+            }
+
+            if (!TryExportEncapsulationKey(destination, out int bytesWritten))
+            {
+                throw new CryptographicException(SR.Argument_DestinationTooShort);
+            }
+
+            return bytesWritten;
+        }
+
+        /// <summary>
+        ///   Attempts to export the encapsulation key portion of the current key into the provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the encapsulation key value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
+        public bool TryExportEncapsulationKey(Span<byte> destination, out int bytesWritten)
+        {
+            ThrowIfDisposed();
+
+            if (destination.Length < Algorithm.MinEncapsulationKeySizeInBytes)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            using (CryptoPoolLease lease = CryptoPoolLease.RentConditionally(Algorithm.MaxEncapsulationKeySizeInBytes, destination, skipClear: true))
+            {
+                int localBytesWritten = ExportEncapsulationKeyCore(lease.Span);
+
+                if (!Algorithm.IsValidEncapsulationKeySize(localBytesWritten))
+                {
+                    bytesWritten = 0;
+                    throw new CryptographicException();
+                }
+
+                if (lease.IsRented)
+                {
+                    if (localBytesWritten > destination.Length)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
+                    lease.Span.Slice(0, localBytesWritten).CopyTo(destination);
+                }
+
+                bytesWritten = localBytesWritten;
+                return true;
+            }
+        }
+
+        /// <summary>
+        ///   When overridden in a derived class, exports the encapsulation key portion of the current key.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the encapsulation key value.
+        /// </param>
+        /// <returns>
+        ///   The number of bytes written to the <paramref name="destination"/> buffer.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred while exporting the key.
+        /// </exception>
+        protected abstract int ExportEncapsulationKeyCore(Span<byte> destination);
+
+        /// <summary>
+        ///   Exports the decapsulation key portion of the current key.
+        /// </summary>
+        /// <returns>
+        ///   The Composite ML-KEM decapsulation key.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>The current instance cannot export a decapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public byte[] ExportDecapsulationKey()
+        {
+            ThrowIfDisposed();
+
+            byte[] decapsulationKey = new byte[Algorithm.MaxDecapsulationKeySizeInBytes];
+
+            if (!TryExportDecapsulationKey(decapsulationKey, out int bytesWritten))
+            {
+                Debug.Fail("Max sized buffer was not large enough.");
+                throw new CryptographicException();
+            }
+
+            if (bytesWritten < decapsulationKey.Length)
+            {
+                byte[] temp = new byte[bytesWritten];
+                Array.Copy(decapsulationKey, temp, bytesWritten);
+                CryptographicOperations.ZeroMemory(decapsulationKey);
+                decapsulationKey = temp;
+            }
+
+            return decapsulationKey;
+        }
+
+        /// <summary>
+        ///   Exports the decapsulation key portion of the current key into the provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the Composite ML-KEM decapsulation key value.
+        /// </param>
+        /// <returns>
+        ///   The number of bytes written to the <paramref name="destination"/> buffer.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para><paramref name="destination"/> was not large enough to hold the result.</para>
+        ///   <para>-or-</para>
+        ///   <para>The current instance cannot export a decapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public int ExportDecapsulationKey(Span<byte> destination)
+        {
+            ThrowIfDisposed();
+
+            if (destination.Length < Algorithm.MinDecapsulationKeySizeInBytes)
+            {
+                throw new CryptographicException(SR.Argument_DestinationTooShort);
+            }
+
+            if (!TryExportDecapsulationKey(destination, out int bytesWritten))
+            {
+                throw new CryptographicException(SR.Argument_DestinationTooShort);
+            }
+
+            return bytesWritten;
+        }
+
+        /// <summary>
+        ///   Attempts to export the decapsulation key portion of the current key into the provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the decapsulation key value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, contains the number of bytes written to the <paramref name="destination"/> buffer.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination"/> was large enough to hold the result;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">
+        ///   This instance has been disposed.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>The current instance cannot export a decapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        public bool TryExportDecapsulationKey(Span<byte> destination, out int bytesWritten)
+        {
+            ThrowIfDisposed();
+
+            if (destination.Length < Algorithm.MinDecapsulationKeySizeInBytes)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            using (CryptoPoolLease lease = CryptoPoolLease.RentConditionally(Algorithm.MaxDecapsulationKeySizeInBytes, destination, skipClearIfNotRented: true))
+            {
+                int localBytesWritten = ExportDecapsulationKeyCore(lease.Span);
+
+                if (!Algorithm.IsValidDecapsulationKeySize(localBytesWritten))
+                {
+                    if (!lease.IsRented)
+                    {
+                        CryptographicOperations.ZeroMemory(destination);
+                    }
+
+                    bytesWritten = 0;
+                    throw new CryptographicException();
+                }
+
+                if (lease.IsRented)
+                {
+                    if (localBytesWritten > destination.Length)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
+                    lease.Span.Slice(0, localBytesWritten).CopyTo(destination);
+                }
+
+                bytesWritten = localBytesWritten;
+                return true;
+            }
+        }
+
+        /// <summary>
+        ///   When overridden in a derived class, exports the decapsulation key portion of the current key.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the decapsulation key value.
+        /// </param>
+        /// <returns>
+        ///   The number of bytes written to the <paramref name="destination"/> buffer.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   <para>The current instance cannot export a decapsulation key.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while exporting the key.</para>
+        /// </exception>
+        protected abstract int ExportDecapsulationKeyCore(Span<byte> destination);
+
+        /// <summary>
+        ///   Releases all resources used by the <see cref="CompositeMLKem"/> class.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        /// <summary>
+        ///   Called by the <see cref="Dispose()" /> method to release the managed and unmanaged
+        ///   resources used by the current instance of the <see cref="CompositeMLKem"/> class.
+        /// </summary>
+        /// <param name="disposing">
+        ///   <see langword="true" /> to release managed and unmanaged resources;
+        ///   <see langword="false" /> to release only unmanaged resources.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+
+        private protected bool TryExportPkcs8FromExportedDecapsulationKey(Span<byte> destination, out int bytesWritten)
+        {
+            AsnWriter? writer = null;
+
+            try
+            {
+                using (CryptoPoolLease lease = CryptoPoolLease.Rent(Algorithm.MaxDecapsulationKeySizeInBytes))
+                {
+                    int decapsulationKeySize = ExportDecapsulationKeyCore(lease.Span);
+
+                    if (!Algorithm.IsValidDecapsulationKeySize(decapsulationKeySize))
+                    {
+                        bytesWritten = 0;
+                        throw new CryptographicException(SR.Argument_PrivateKeyWrongSizeForAlgorithm);
+                    }
+
+                    int initialCapacity = checked(32 + decapsulationKeySize);
+                    writer = new AsnWriter(AsnEncodingRules.DER, initialCapacity);
+
+                    using (writer.PushSequence())
+                    {
+                        writer.WriteInteger(0);
+
+                        using (writer.PushSequence())
+                        {
+                            writer.WriteObjectIdentifier(Algorithm.Oid);
+                        }
+
+                        writer.WriteOctetString(lease.Span.Slice(0, decapsulationKeySize));
+                    }
+
+                    Debug.Assert(writer.GetEncodedLength() <= initialCapacity);
+                    return writer.TryEncode(destination, out bytesWritten);
+                }
+            }
+            finally
+            {
+                writer?.Reset();
+            }
+        }
+
+        private AsnWriter WriteEncryptedPkcs8PrivateKeyToAsnWriter(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters)
+        {
+            AsnWriter? tmp = null;
+
+            try
+            {
+                tmp = WritePkcs8ToAsnWriter();
+                return KeyFormatHelper.WriteEncryptedPkcs8(passwordBytes, tmp, pbeParameters);
+            }
+            finally
+            {
+                tmp?.Reset();
+            }
+        }
+
+        private AsnWriter WriteEncryptedPkcs8PrivateKeyToAsnWriter(ReadOnlySpan<char> password, PbeParameters pbeParameters)
+        {
+            AsnWriter? tmp = null;
+
+            try
+            {
+                tmp = WritePkcs8ToAsnWriter();
+                return KeyFormatHelper.WriteEncryptedPkcs8(password, tmp, pbeParameters);
+            }
+            finally
+            {
+                tmp?.Reset();
+            }
+        }
+
+        private AsnWriter WritePkcs8ToAsnWriter()
+        {
+            return ExportPkcs8PrivateKeyCallback(static pkcs8 =>
+            {
+                AsnWriter writer = new(AsnEncodingRules.BER, initialCapacity: pkcs8.Length);
+
+                try
+                {
+                    writer.WriteEncodedValueForCrypto(pkcs8);
+                }
+                catch
+                {
+                    writer.Reset();
+                    throw;
+                }
+
+                return writer;
+            });
+        }
+
+        private AsnWriter WriteSubjectPublicKeyToAsnWriter()
+        {
+            byte[] buffer = new byte[Algorithm.MaxEncapsulationKeySizeInBytes];
+            int written = ExportEncapsulationKeyCore(buffer);
+
+            if (!Algorithm.IsValidEncapsulationKeySize(written))
+            {
+                throw new CryptographicException();
+            }
+
+            ReadOnlySpan<byte> encapsulationKey = buffer.AsSpan(0, written);
+
+            // The ASN.1 overhead of a SubjectPublicKeyInfo encoding an encapsulation key is around 24 bytes.
+            // Round it off to 32. This checked operation should never throw because the inputs are not
+            // user provided.
+            int capacity = checked(32 + encapsulationKey.Length);
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER, capacity);
+
+            using (writer.PushSequence())
+            {
+                using (writer.PushSequence())
+                {
+                    writer.WriteObjectIdentifier(Algorithm.Oid);
+                }
+
+                writer.WriteBitString(encapsulationKey);
+            }
+
+            Debug.Assert(writer.GetEncodedLength() <= capacity);
+            return writer;
+        }
+
+        private TResult ExportPkcs8PrivateKeyCallback<TResult>(ExportPkcs8PrivateKeyFunc<TResult> func)
+        {
+            int size = Algorithm.MaxDecapsulationKeySizeInBytes;
+            byte[] buffer = CryptoPool.Rent(size);
+            int written;
+
+            while (!TryExportPkcs8PrivateKeyCore(buffer, out written))
+            {
+                size = buffer.Length;
+                CryptoPool.Return(buffer);
+                size = checked(size * 2);
+                buffer = CryptoPool.Rent(size);
+            }
+
+            if ((uint)written > (uint)buffer.Length)
+            {
+                // We got a nonsense value written back. Clear the buffer, but don't put it back in the pool.
+                CryptographicOperations.ZeroMemory(buffer);
+                throw new CryptographicException();
+            }
+
+            try
+            {
+                return func(buffer.AsSpan(0, written));
+            }
+            finally
+            {
+                CryptoPool.Return(buffer, written);
+            }
+        }
+
+        private static CompositeMLKemAlgorithm GetAlgorithmIdentifier(ref readonly ValueAlgorithmIdentifierAsn identifier)
+        {
+            CompositeMLKemAlgorithm? algorithm = CompositeMLKemAlgorithm.GetAlgorithmFromOid(identifier.Algorithm);
+            Debug.Assert(algorithm is not null, "Algorithm identifier should have been pre-validated by KeyFormatHelper.");
+
+            if (identifier.HasParameters)
+            {
+                throw Helpers.CreateAlgorithmUnknownException(in identifier);
+            }
+
+            return algorithm;
+        }
+
+        private static void ThrowIfNotSupported(CompositeMLKemAlgorithm algorithm)
+        {
+            if (!IsAlgorithmSupported(algorithm))
+            {
+                throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(CompositeMLKem)));
+            }
+        }
+
+        private protected void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, typeof(CompositeMLKem));
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKemAlgorithm.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKemAlgorithm.cs
@@ -23,18 +23,18 @@ namespace System.Security.Cryptography
         public string Name { get; }
 
         /// <summary>
-        ///   Gets the size of the ciphertext for the composite algorithm, in bytes.
+        ///   Gets the size of the ciphertext for the algorithm, in bytes.
         /// </summary>
         /// <value>
-        ///   The size of the ciphertext for the composite algorithm, in bytes.
+        ///   The size of the ciphertext for the algorithm, in bytes.
         /// </value>
         public int CiphertextSizeInBytes { get; }
 
         /// <summary>
-        ///   Gets the size of the shared secret for the composite algorithm, in bytes.
+        ///   Gets the size of the shared secret for the algorithm, in bytes.
         /// </summary>
         /// <value>
-        ///   The size of the shared secret for the composite algorithm, in bytes.
+        ///   The size of the shared secret for the algorithm, in bytes.
         /// </value>
         public int SharedSecretSizeInBytes { get; }
 
@@ -315,15 +315,51 @@ namespace System.Security.Cryptography
             Debug.Assert(keySizeInBits % 8 == 0);
             int keySizeInBytes = keySizeInBits / 8;
 
-            const int MaxUniversalTagLength = 1;
+            int maxRsaPublicKeySizeInBytes =
+                keySizeInBits switch
+                {
+                    2048 => 300,
+                    3072 => 428,
+                    4096 => 556,
+                    _ => AssertAndThrow(keySizeInBits),
+                };
 
-            // long form prefix and 4 bytes for length. CLR arrays and spans only support length up to int.MaxValue.
-            // Padding with leading zero bytes is allowed, but we still limit the length to 4 bytes since the only
-            // plausible scenario would be encoding a 4-byte numeric data type without trimming.
-            // Note this bound also covers indefinite length encodings which require only 1 + 2 bytes of overhead.
-            const int MaxLengthLength = 1 + 4;
+            int maxRsaPrivateKeySizeInBytes =
+                keySizeInBits switch
+                {
+                    2048 => 1224,
+                    3072 => 1800,
+                    4096 => 2381,
+                    _ => AssertAndThrow(keySizeInBits),
+                };
 
-            const int MaxPrefixLength = MaxUniversalTagLength + MaxLengthLength;
+            DebugVerifyRsaKeySizes(keySizeInBits, maxRsaPublicKeySizeInBytes, maxRsaPrivateKeySizeInBytes);
+
+            return new CompositeMLKemAlgorithm(
+                name,
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + keySizeInBytes, // Encapsulation key contains at least n
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + maxRsaPublicKeySizeInBytes,
+                mlkemAlgorithm.PrivateSeedSizeInBytes + keySizeInBytes, // Decapsulation key contains at least n
+                mlkemAlgorithm.PrivateSeedSizeInBytes + maxRsaPrivateKeySizeInBytes,
+                mlkemAlgorithm.CiphertextSizeInBytes + keySizeInBytes, // RSA-OAEP ciphertext is the size of the modulus
+                mlkemAlgorithm.SharedSecretSizeInBytes,
+                oid);
+
+            static int AssertAndThrow(int keySizeInBits)
+            {
+                Debug.Fail($"Unsupported RSA key size: {keySizeInBits}.");
+                throw new CryptographicException();
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void DebugVerifyRsaKeySizes(
+            int keySizeInBits,
+            int maxRsaPublicKeySizeInBytes,
+            int maxRsaPrivateKeySizeInBytes)
+        {
+            Debug.Assert(keySizeInBits % 8 == 0);
+            int keySizeInBytes = keySizeInBits / 8;
 
             const int PossibleLeadingZeroByte = 1; // ASN.1 INTEGER can have a leading zero byte.
             int maxKeyEncodingLength = keySizeInBytes + PossibleLeadingZeroByte;
@@ -336,12 +372,13 @@ namespace System.Security.Cryptography
             //     publicExponent INTEGER   --e
             // }
 
-            int maxRsaPublicKeySizeInBytes =
-                MaxPrefixLength +
-                (
-                    MaxPrefixLength + maxKeyEncodingLength +
-                    MaxPrefixLength + maxExponentEncodingLength
+            int calculatedMaxRsaPublicKeySizeInBytes =
+                GetDerTlvLengthWithSingleByteTag(
+                    GetDerTlvLengthWithSingleByteTag(maxKeyEncodingLength) +
+                    GetDerTlvLengthWithSingleByteTag(maxExponentEncodingLength)
                 );
+
+            Debug.Assert(calculatedMaxRsaPublicKeySizeInBytes == maxRsaPublicKeySizeInBytes);
 
             // RFC 8017, A.1.2
             // RSAPrivateKey::= SEQUENCE {
@@ -357,30 +394,21 @@ namespace System.Security.Cryptography
             //     otherPrimeInfos OtherPrimeInfos OPTIONAL
             // }
 
-            int maxRsaPrivateKeySizeInBytes =
-                MaxPrefixLength +
-                (
-                    MaxPrefixLength + 1 + // Version should always be 0 or 1
-                    MaxPrefixLength + maxKeyEncodingLength +
-                    MaxPrefixLength + maxExponentEncodingLength +
-                    MaxPrefixLength + maxKeyEncodingLength +
-                    MaxPrefixLength + maxHalfKeyEncodingLength +
-                    MaxPrefixLength + maxHalfKeyEncodingLength +
-                    MaxPrefixLength + maxHalfKeyEncodingLength +
-                    MaxPrefixLength + maxHalfKeyEncodingLength +
-                    MaxPrefixLength + maxHalfKeyEncodingLength
+            int calculatedMaxRsaPrivateKeySizeInBytes =
+                GetDerTlvLengthWithSingleByteTag(
+                    GetDerTlvLengthWithSingleByteTag(1) + // Version is always 0
+                    GetDerTlvLengthWithSingleByteTag(maxKeyEncodingLength) +
+                    GetDerTlvLengthWithSingleByteTag(maxExponentEncodingLength) +
+                    GetDerTlvLengthWithSingleByteTag(maxKeyEncodingLength) +
+                    GetDerTlvLengthWithSingleByteTag(maxHalfKeyEncodingLength) +
+                    GetDerTlvLengthWithSingleByteTag(maxHalfKeyEncodingLength) +
+                    GetDerTlvLengthWithSingleByteTag(maxHalfKeyEncodingLength) +
+                    GetDerTlvLengthWithSingleByteTag(maxHalfKeyEncodingLength) +
+                    GetDerTlvLengthWithSingleByteTag(maxHalfKeyEncodingLength)
                     // OtherPrimeInfos omitted since multi-prime is not supported
                 );
 
-            return new CompositeMLKemAlgorithm(
-                name,
-                mlkemAlgorithm.EncapsulationKeySizeInBytes + keySizeInBytes, // Encapsulation key contains at least n
-                mlkemAlgorithm.EncapsulationKeySizeInBytes + maxRsaPublicKeySizeInBytes,
-                mlkemAlgorithm.PrivateSeedSizeInBytes + keySizeInBytes, // Decapsulation key contains at least n
-                mlkemAlgorithm.PrivateSeedSizeInBytes + maxRsaPrivateKeySizeInBytes,
-                mlkemAlgorithm.CiphertextSizeInBytes + keySizeInBytes, // RSA-OAEP ciphertext is the size of the modulus
-                mlkemAlgorithm.SharedSecretSizeInBytes,
-                oid);
+            Debug.Assert(calculatedMaxRsaPrivateKeySizeInBytes == maxRsaPrivateKeySizeInBytes);
         }
 
         private static CompositeMLKemAlgorithm CreateECDiffieHellman(
@@ -389,7 +417,69 @@ namespace System.Security.Cryptography
             int keySizeInBits,
             string oid)
         {
+            int uncompressedPointSizeInBytes =
+                keySizeInBits switch
+                {
+                    256 => 65,
+                    384 => 97,
+                    521 => 133,
+                    _ => AssertAndThrow($"Unsupported EC key size: {keySizeInBits}."),
+                };
+
+            int ecPrivateKeySizeInBytes =
+                oid switch
+                {
+                    Oids.MLKem768WithECDiffieHellmanP256Sha3_256 =>
+                        51,
+                    Oids.MLKem768WithECDiffieHellmanP384Sha3_256 or
+                    Oids.MLKem1024WithECDiffieHellmanP384Sha3_256 =>
+                        64,
+                    Oids.MLKem1024WithECDiffieHellmanP521Sha3_256 =>
+                        82,
+                    Oids.MLKem768WithECDiffieHellmanBrainpoolP256r1Sha3_256 =>
+                        52,
+                    Oids.MLKem1024WithECDiffieHellmanBrainpoolP384r1Sha3_256 =>
+                        68,
+                    _ => AssertAndThrow($"Unsupported OID: {oid}."),
+                };
+
+            DebugVerifyECDiffieHellmanKeySizes(
+                keySizeInBits,
+                oid,
+                uncompressedPointSizeInBytes,
+                ecPrivateKeySizeInBytes);
+
+            return new CompositeMLKemAlgorithm(
+                name,
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + uncompressedPointSizeInBytes,
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + uncompressedPointSizeInBytes,
+                mlkemAlgorithm.PrivateSeedSizeInBytes + ecPrivateKeySizeInBytes,
+                mlkemAlgorithm.PrivateSeedSizeInBytes + ecPrivateKeySizeInBytes,
+                mlkemAlgorithm.CiphertextSizeInBytes + uncompressedPointSizeInBytes,
+                mlkemAlgorithm.SharedSecretSizeInBytes,
+                oid);
+
+            static int AssertAndThrow(string message)
+            {
+                Debug.Fail(message);
+                throw new CryptographicException();
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void DebugVerifyECDiffieHellmanKeySizes(
+            int keySizeInBits,
+            string oid,
+            int uncompressedPointSizeInBytes,
+            int ecPrivateKeySizeInBytes)
+        {
             int keySizeInBytes = (keySizeInBits + 7) / 8;
+
+            // The traditional component of the encapsulation key and the ciphertext are both uncompressed
+            // elliptic curve points, i.e. 0x04 followed by the X and Y coordinates.
+            int calculatedUncompressedPointSizeInBytes = 1 + 2 * keySizeInBytes;
+
+            Debug.Assert(calculatedUncompressedPointSizeInBytes == uncompressedPointSizeInBytes);
 
             // RFC 5915, Section 3
             // ECPrivateKey ::= SEQUENCE {
@@ -401,17 +491,28 @@ namespace System.Security.Cryptography
 
             // version
 
-            int versionSizeInBytes =
-                1 + // Tag for INTEGER
-                1 + // Length field
-                1;  // Value (always 1)
+            int versionSizeInBytes = GetDerTlvLengthWithSingleByteTag(1); // Version is always 1
 
             // privateKey
 
-            int privateKeySizeInBytes =
-                1 +                                     // Tag for OCTET STRING
-                GetDerLengthLength(keySizeInBytes) +    // Length field
-                keySizeInBytes;                         // Value
+            // The curve order and field size often, but do not always, have the same bit length.
+            int orderSizeInBits =
+                oid switch
+                {
+                    Oids.MLKem768WithECDiffieHellmanP256Sha3_256 or
+                    Oids.MLKem768WithECDiffieHellmanBrainpoolP256r1Sha3_256 =>
+                        256,
+                    Oids.MLKem768WithECDiffieHellmanP384Sha3_256 or
+                    Oids.MLKem1024WithECDiffieHellmanP384Sha3_256 or
+                    Oids.MLKem1024WithECDiffieHellmanBrainpoolP384r1Sha3_256 =>
+                        384,
+                    Oids.MLKem1024WithECDiffieHellmanP521Sha3_256 =>
+                        521,
+                    _ => AssertAndThrow(oid),
+                };
+
+            int privateScalarSizeInBytes = (orderSizeInBits + 7) / 8;
+            int privateKeySizeInBytes = GetDerTlvLengthWithSingleByteTag(privateScalarSizeInBytes);
 
             // parameters
 
@@ -442,37 +543,20 @@ namespace System.Security.Cryptography
                     _ => AssertAndThrow(oid),
                 };
 
+            int parametersSizeInBytes = GetDerTlvLengthWithSingleByteTag(namedCurveSizeInBytes);
+
+            // publicKey must be omitted for Composite ML-KEM
+
+            int calculatedEcPrivateKeySizeInBytes =
+                GetDerTlvLengthWithSingleByteTag(versionSizeInBytes + privateKeySizeInBytes + parametersSizeInBytes);
+
+            Debug.Assert(calculatedEcPrivateKeySizeInBytes == ecPrivateKeySizeInBytes);
+
             static int AssertAndThrow(string oid)
             {
                 Debug.Fail($"Unsupported OID: {oid}.");
                 throw new CryptographicException();
             }
-
-            int parametersSizeInBytes =
-                1 +                                         // Context-specific tag for [0]
-                GetDerLengthLength(namedCurveSizeInBytes) + // Length field
-                namedCurveSizeInBytes;                      // Value
-
-            // publicKey must be omitted for Composite ML-KEM
-
-            int ecPrivateKeySizeInBytes =
-                1 +                                                                                         // Tag for SEQUENCE
-                GetDerLengthLength(versionSizeInBytes + privateKeySizeInBytes + parametersSizeInBytes) +    // Length field
-                versionSizeInBytes + privateKeySizeInBytes + parametersSizeInBytes;                         // Value
-
-            // The traditional component of the encapsulation key and the ciphertext are both uncompressed
-            // elliptic curve points, i.e. 0x04 followed by the X and Y coordinates.
-            int uncompressedPointSizeInBytes = 1 + 2 * keySizeInBytes;
-
-            return new CompositeMLKemAlgorithm(
-                name,
-                mlkemAlgorithm.EncapsulationKeySizeInBytes + uncompressedPointSizeInBytes,
-                mlkemAlgorithm.EncapsulationKeySizeInBytes + uncompressedPointSizeInBytes,
-                mlkemAlgorithm.PrivateSeedSizeInBytes + ecPrivateKeySizeInBytes,
-                mlkemAlgorithm.PrivateSeedSizeInBytes + ecPrivateKeySizeInBytes,
-                mlkemAlgorithm.CiphertextSizeInBytes + uncompressedPointSizeInBytes,
-                mlkemAlgorithm.SharedSecretSizeInBytes,
-                oid);
         }
 
         private static CompositeMLKemAlgorithm CreateXDiffieHellman(
@@ -494,6 +578,9 @@ namespace System.Security.Cryptography
                 mlkemAlgorithm.SharedSecretSizeInBytes,
                 oid);
         }
+
+        private static int GetDerTlvLengthWithSingleByteTag(int valueLength) =>
+            1 + GetDerLengthLength(valueLength) + valueLength;
 
         private static int GetDerLengthLength(int payloadLength)
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKemAlgorithm.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKemAlgorithm.cs
@@ -1,0 +1,517 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Security.Cryptography
+{
+    /// <summary>
+    ///   Represents a Composite ML-KEM algorithm identifier, combining ML-KEM with a traditional algorithm.
+    /// </summary>
+    /// <seealso cref="CompositeMLKem" />
+    [DebuggerDisplay("{Name,nq}")]
+    [Experimental(Experimentals.PostQuantumCryptographyDiagId, UrlFormat = Experimentals.SharedUrlFormat)]
+    public sealed class CompositeMLKemAlgorithm : IEquatable<CompositeMLKemAlgorithm>
+    {
+        /// <summary>
+        ///   Gets the name of the algorithm.
+        /// </summary>
+        /// <value>
+        ///   A string representing the algorithm name.
+        /// </value>
+        public string Name { get; }
+
+        /// <summary>
+        ///   Gets the size of the ciphertext for the composite algorithm, in bytes.
+        /// </summary>
+        /// <value>
+        ///   The size of the ciphertext for the composite algorithm, in bytes.
+        /// </value>
+        public int CiphertextSizeInBytes { get; }
+
+        /// <summary>
+        ///   Gets the size of the shared secret for the composite algorithm, in bytes.
+        /// </summary>
+        /// <value>
+        ///   The size of the shared secret for the composite algorithm, in bytes.
+        /// </value>
+        public int SharedSecretSizeInBytes { get; }
+
+        internal int MinEncapsulationKeySizeInBytes { get; }
+        internal int MaxEncapsulationKeySizeInBytes { get; }
+        internal int MinDecapsulationKeySizeInBytes { get; }
+        internal int MaxDecapsulationKeySizeInBytes { get; }
+
+        internal string Oid { get; }
+
+        private CompositeMLKemAlgorithm(
+            string name,
+            int minEncapsulationKeySizeInBytes,
+            int maxEncapsulationKeySizeInBytes,
+            int minDecapsulationKeySizeInBytes,
+            int maxDecapsulationKeySizeInBytes,
+            int ciphertextSizeInBytes,
+            int sharedSecretSizeInBytes,
+            string oid)
+        {
+            Debug.Assert(minEncapsulationKeySizeInBytes <= maxEncapsulationKeySizeInBytes);
+            Debug.Assert(minDecapsulationKeySizeInBytes <= maxDecapsulationKeySizeInBytes);
+
+            Name = name;
+            MinEncapsulationKeySizeInBytes = minEncapsulationKeySizeInBytes;
+            MaxEncapsulationKeySizeInBytes = maxEncapsulationKeySizeInBytes;
+            MinDecapsulationKeySizeInBytes = minDecapsulationKeySizeInBytes;
+            MaxDecapsulationKeySizeInBytes = maxDecapsulationKeySizeInBytes;
+            CiphertextSizeInBytes = ciphertextSizeInBytes;
+            SharedSecretSizeInBytes = sharedSecretSizeInBytes;
+            Oid = oid;
+        }
+
+        internal bool IsValidEncapsulationKeySize(int size) =>
+            MinEncapsulationKeySizeInBytes <= size && size <= MaxEncapsulationKeySizeInBytes;
+
+        internal bool IsValidDecapsulationKeySize(int size) =>
+            MinDecapsulationKeySizeInBytes <= size && size <= MaxDecapsulationKeySizeInBytes;
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-768 and 2048-bit RSA-OAEP algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-768 and 2048-bit RSA-OAEP algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem768WithRsaOaep2048 { get; } =
+            CreateRsaOaep(
+                "MLKEM768-RSA2048-SHA3-256",
+                MLKemAlgorithm.MLKem768,
+                2048,
+                Oids.MLKem768WithRsaOaep2048Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-768 and 3072-bit RSA-OAEP algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-768 and 3072-bit RSA-OAEP algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem768WithRsaOaep3072 { get; } =
+            CreateRsaOaep(
+                "MLKEM768-RSA3072-SHA3-256",
+                MLKemAlgorithm.MLKem768,
+                3072,
+                Oids.MLKem768WithRsaOaep3072Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-768 and 4096-bit RSA-OAEP algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-768 and 4096-bit RSA-OAEP algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem768WithRsaOaep4096 { get; } =
+            CreateRsaOaep(
+                "MLKEM768-RSA4096-SHA3-256",
+                MLKemAlgorithm.MLKem768,
+                4096,
+                Oids.MLKem768WithRsaOaep4096Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-768 and X25519 algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-768 and X25519 algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem768WithX25519 { get; } =
+            CreateXDiffieHellman(
+                "MLKEM768-X25519-SHA3-256",
+                MLKemAlgorithm.MLKem768,
+                32 * 8,
+                Oids.MLKem768WithX25519Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-768 and ECDH P-256 algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-768 and ECDH P-256 algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem768WithECDiffieHellmanP256 { get; } =
+            CreateECDiffieHellman(
+                "MLKEM768-ECDH-P256-SHA3-256",
+                MLKemAlgorithm.MLKem768,
+                256,
+                Oids.MLKem768WithECDiffieHellmanP256Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-768 and ECDH P-384 algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-768 and ECDH P-384 algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem768WithECDiffieHellmanP384 { get; } =
+            CreateECDiffieHellman(
+                "MLKEM768-ECDH-P384-SHA3-256",
+                MLKemAlgorithm.MLKem768,
+                384,
+                Oids.MLKem768WithECDiffieHellmanP384Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-768 and ECDH brainpoolP256r1 algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-768 and ECDH brainpoolP256r1 algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem768WithECDiffieHellmanBrainpoolP256r1 { get; } =
+            CreateECDiffieHellman(
+                "MLKEM768-ECDH-brainpoolP256r1-SHA3-256",
+                MLKemAlgorithm.MLKem768,
+                256,
+                Oids.MLKem768WithECDiffieHellmanBrainpoolP256r1Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-1024 and 3072-bit RSA-OAEP algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-1024 and 3072-bit RSA-OAEP algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem1024WithRsaOaep3072 { get; } =
+            CreateRsaOaep(
+                "MLKEM1024-RSA3072-SHA3-256",
+                MLKemAlgorithm.MLKem1024,
+                3072,
+                Oids.MLKem1024WithRsaOaep3072Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-1024 and ECDH P-384 algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-1024 and ECDH P-384 algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem1024WithECDiffieHellmanP384 { get; } =
+            CreateECDiffieHellman(
+                "MLKEM1024-ECDH-P384-SHA3-256",
+                MLKemAlgorithm.MLKem1024,
+                384,
+                Oids.MLKem1024WithECDiffieHellmanP384Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-1024 and ECDH brainpoolP384r1 algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-1024 and ECDH brainpoolP384r1 algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem1024WithECDiffieHellmanBrainpoolP384r1 { get; } =
+            CreateECDiffieHellman(
+                "MLKEM1024-ECDH-brainpoolP384r1-SHA3-256",
+                MLKemAlgorithm.MLKem1024,
+                384,
+                Oids.MLKem1024WithECDiffieHellmanBrainpoolP384r1Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-1024 and X448 algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-1024 and X448 algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem1024WithX448 { get; } =
+            CreateXDiffieHellman(
+                "MLKEM1024-X448-SHA3-256",
+                MLKemAlgorithm.MLKem1024,
+                56 * 8,
+                Oids.MLKem1024WithX448Sha3_256);
+
+        /// <summary>
+        ///   Gets a Composite ML-KEM algorithm identifier for the ML-KEM-1024 and ECDH P-521 algorithm.
+        /// </summary>
+        /// <value>
+        ///   A Composite ML-KEM algorithm identifier for the ML-KEM-1024 and ECDH P-521 algorithm.
+        /// </value>
+        public static CompositeMLKemAlgorithm MLKem1024WithECDiffieHellmanP521 { get; } =
+            CreateECDiffieHellman(
+                "MLKEM1024-ECDH-P521-SHA3-256",
+                MLKemAlgorithm.MLKem1024,
+                521,
+                Oids.MLKem1024WithECDiffieHellmanP521Sha3_256);
+
+        /// <summary>
+        ///   Compares two <see cref="CompositeMLKemAlgorithm" /> objects.
+        /// </summary>
+        /// <param name="other">
+        ///   An object to be compared to the current <see cref="CompositeMLKemAlgorithm"/> object.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if the objects are considered equal; otherwise, <see langword="false" />.
+        /// </returns>
+        // This is a closed type, so all we need to compare are the names.
+        public bool Equals([NotNullWhen(true)] CompositeMLKemAlgorithm? other) => other is not null && other.Name == Name;
+
+        /// <inheritdoc />
+        public override bool Equals([NotNullWhen(true)] object? obj) => obj is CompositeMLKemAlgorithm alg && alg.Name == Name;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => Name.GetHashCode();
+
+        /// <inheritdoc />
+        public override string ToString() => Name;
+
+        /// <summary>
+        ///   Determines whether two <see cref="CompositeMLKemAlgorithm" /> objects specify the same algorithm name.
+        /// </summary>
+        /// <param name="left">
+        ///   An object that specifies an algorithm name.
+        /// </param>
+        /// <param name="right">
+        ///   A second object, to be compared to the object that is identified by the <paramref name="left" /> parameter.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if the objects are considered equal; otherwise, <see langword="false" />.
+        /// </returns>
+        public static bool operator ==(CompositeMLKemAlgorithm? left, CompositeMLKemAlgorithm? right)
+        {
+            return left is null ? right is null : left.Equals(right);
+        }
+
+        /// <summary>
+        ///   Determines whether two <see cref="CompositeMLKemAlgorithm" /> objects do not specify the same algorithm name.
+        /// </summary>
+        /// <param name="left">
+        ///   An object that specifies an algorithm name.
+        /// </param>
+        /// <param name="right">
+        ///   A second object, to be compared to the object that is identified by the <paramref name="left" /> parameter.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if the objects are not considered equal; otherwise, <see langword="false" />.
+        /// </returns>
+        public static bool operator !=(CompositeMLKemAlgorithm? left, CompositeMLKemAlgorithm? right)
+        {
+            return !(left == right);
+        }
+
+        internal static CompositeMLKemAlgorithm? GetAlgorithmFromOid(string? oid)
+        {
+            return oid switch
+            {
+                Oids.MLKem768WithRsaOaep2048Sha3_256 =>                      MLKem768WithRsaOaep2048,
+                Oids.MLKem768WithRsaOaep3072Sha3_256 =>                      MLKem768WithRsaOaep3072,
+                Oids.MLKem768WithRsaOaep4096Sha3_256 =>                      MLKem768WithRsaOaep4096,
+                Oids.MLKem768WithX25519Sha3_256 =>                           MLKem768WithX25519,
+                Oids.MLKem768WithECDiffieHellmanP256Sha3_256 =>              MLKem768WithECDiffieHellmanP256,
+                Oids.MLKem768WithECDiffieHellmanP384Sha3_256 =>              MLKem768WithECDiffieHellmanP384,
+                Oids.MLKem768WithECDiffieHellmanBrainpoolP256r1Sha3_256 =>   MLKem768WithECDiffieHellmanBrainpoolP256r1,
+                Oids.MLKem1024WithRsaOaep3072Sha3_256 =>                     MLKem1024WithRsaOaep3072,
+                Oids.MLKem1024WithECDiffieHellmanP384Sha3_256 =>             MLKem1024WithECDiffieHellmanP384,
+                Oids.MLKem1024WithECDiffieHellmanBrainpoolP384r1Sha3_256 =>  MLKem1024WithECDiffieHellmanBrainpoolP384r1,
+                Oids.MLKem1024WithX448Sha3_256 =>                            MLKem1024WithX448,
+                Oids.MLKem1024WithECDiffieHellmanP521Sha3_256 =>             MLKem1024WithECDiffieHellmanP521,
+
+                _ => null,
+            };
+        }
+
+        private static CompositeMLKemAlgorithm CreateRsaOaep(
+            string name,
+            MLKemAlgorithm mlkemAlgorithm,
+            int keySizeInBits,
+            string oid)
+        {
+            Debug.Assert(keySizeInBits % 8 == 0);
+            int keySizeInBytes = keySizeInBits / 8;
+
+            const int MaxUniversalTagLength = 1;
+
+            // long form prefix and 4 bytes for length. CLR arrays and spans only support length up to int.MaxValue.
+            // Padding with leading zero bytes is allowed, but we still limit the length to 4 bytes since the only
+            // plausible scenario would be encoding a 4-byte numeric data type without trimming.
+            // Note this bound also covers indefinite length encodings which require only 1 + 2 bytes of overhead.
+            const int MaxLengthLength = 1 + 4;
+
+            const int MaxPrefixLength = MaxUniversalTagLength + MaxLengthLength;
+
+            const int PossibleLeadingZeroByte = 1; // ASN.1 INTEGER can have a leading zero byte.
+            int maxKeyEncodingLength = keySizeInBytes + PossibleLeadingZeroByte;
+            int maxHalfKeyEncodingLength = (keySizeInBytes + 1) / 2 + PossibleLeadingZeroByte;
+            int maxExponentEncodingLength = 256 / 8 + PossibleLeadingZeroByte; // FIPS 186-5, 5.4 (e): The exponent e shall be an odd, positive integer such that 2^16 < e < 2^256
+
+            // RFC 8017, A.1.1
+            // RSAPublicKey::= SEQUENCE {
+            //     modulus INTEGER,  --n
+            //     publicExponent INTEGER   --e
+            // }
+
+            int maxRsaPublicKeySizeInBytes =
+                MaxPrefixLength +
+                (
+                    MaxPrefixLength + maxKeyEncodingLength +
+                    MaxPrefixLength + maxExponentEncodingLength
+                );
+
+            // RFC 8017, A.1.2
+            // RSAPrivateKey::= SEQUENCE {
+            //     version Version,
+            //     modulus           INTEGER,  --n
+            //     publicExponent INTEGER,  --e
+            //     privateExponent INTEGER,  --d
+            //     prime1 INTEGER,  --p
+            //     prime2 INTEGER,  --q
+            //     exponent1 INTEGER,  --d mod(p - 1)
+            //     exponent2 INTEGER,  --d mod(q - 1)
+            //     coefficient INTEGER,  --(inverse of q) mod p
+            //     otherPrimeInfos OtherPrimeInfos OPTIONAL
+            // }
+
+            int maxRsaPrivateKeySizeInBytes =
+                MaxPrefixLength +
+                (
+                    MaxPrefixLength + 1 + // Version should always be 0 or 1
+                    MaxPrefixLength + maxKeyEncodingLength +
+                    MaxPrefixLength + maxExponentEncodingLength +
+                    MaxPrefixLength + maxKeyEncodingLength +
+                    MaxPrefixLength + maxHalfKeyEncodingLength +
+                    MaxPrefixLength + maxHalfKeyEncodingLength +
+                    MaxPrefixLength + maxHalfKeyEncodingLength +
+                    MaxPrefixLength + maxHalfKeyEncodingLength +
+                    MaxPrefixLength + maxHalfKeyEncodingLength
+                    // OtherPrimeInfos omitted since multi-prime is not supported
+                );
+
+            return new CompositeMLKemAlgorithm(
+                name,
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + keySizeInBytes, // Encapsulation key contains at least n
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + maxRsaPublicKeySizeInBytes,
+                mlkemAlgorithm.PrivateSeedSizeInBytes + keySizeInBytes, // Decapsulation key contains at least n
+                mlkemAlgorithm.PrivateSeedSizeInBytes + maxRsaPrivateKeySizeInBytes,
+                mlkemAlgorithm.CiphertextSizeInBytes + keySizeInBytes, // RSA-OAEP ciphertext is the size of the modulus
+                mlkemAlgorithm.SharedSecretSizeInBytes,
+                oid);
+        }
+
+        private static CompositeMLKemAlgorithm CreateECDiffieHellman(
+            string name,
+            MLKemAlgorithm mlkemAlgorithm,
+            int keySizeInBits,
+            string oid)
+        {
+            int keySizeInBytes = (keySizeInBits + 7) / 8;
+
+            // RFC 5915, Section 3
+            // ECPrivateKey ::= SEQUENCE {
+            //   version        INTEGER { ecPrivkeyVer1(1) } (ecPrivkeyVer1),
+            //   privateKey     OCTET STRING,
+            //   parameters [0] ECParameters {{ NamedCurve }} OPTIONAL,
+            //   publicKey  [1] BIT STRING OPTIONAL
+            // }
+
+            // version
+
+            int versionSizeInBytes =
+                1 + // Tag for INTEGER
+                1 + // Length field
+                1;  // Value (always 1)
+
+            // privateKey
+
+            int privateKeySizeInBytes =
+                1 +                                     // Tag for OCTET STRING
+                GetDerLengthLength(keySizeInBytes) +    // Length field
+                keySizeInBytes;                         // Value
+
+            // parameters
+
+            int namedCurveSizeInBytes =
+                oid switch
+                {
+                    Oids.MLKem768WithECDiffieHellmanP256Sha3_256 =>
+                        // 1.2.840.10045.3.1.7
+                        // 06 08 2A 86 48 CE 3D 03 01 07
+                        10,
+                    Oids.MLKem768WithECDiffieHellmanP384Sha3_256 or
+                    Oids.MLKem1024WithECDiffieHellmanP384Sha3_256 =>
+                        // 1.3.132.0.34
+                        // 06 05 2B 81 04 00 22
+                        7,
+                    Oids.MLKem1024WithECDiffieHellmanP521Sha3_256 =>
+                        // 1.3.132.0.35
+                        // 06 05 2B 81 04 00 23
+                        7,
+                    Oids.MLKem768WithECDiffieHellmanBrainpoolP256r1Sha3_256 =>
+                        // 1.3.36.3.3.2.8.1.1.7
+                        // 06 09 2B 24 03 03 02 08 01 01 07
+                        11,
+                    Oids.MLKem1024WithECDiffieHellmanBrainpoolP384r1Sha3_256 =>
+                        // 1.3.36.3.3.2.8.1.1.11
+                        // 06 09 2B 24 03 03 02 08 01 01 0B
+                        11,
+                    _ => AssertAndThrow(oid),
+                };
+
+            static int AssertAndThrow(string oid)
+            {
+                Debug.Fail($"Unsupported OID: {oid}.");
+                throw new CryptographicException();
+            }
+
+            int parametersSizeInBytes =
+                1 +                                         // Context-specific tag for [0]
+                GetDerLengthLength(namedCurveSizeInBytes) + // Length field
+                namedCurveSizeInBytes;                      // Value
+
+            // publicKey must be omitted for Composite ML-KEM
+
+            int ecPrivateKeySizeInBytes =
+                1 +                                                                                         // Tag for SEQUENCE
+                GetDerLengthLength(versionSizeInBytes + privateKeySizeInBytes + parametersSizeInBytes) +    // Length field
+                versionSizeInBytes + privateKeySizeInBytes + parametersSizeInBytes;                         // Value
+
+            // The traditional component of the encapsulation key and the ciphertext are both uncompressed
+            // elliptic curve points, i.e. 0x04 followed by the X and Y coordinates.
+            int uncompressedPointSizeInBytes = 1 + 2 * keySizeInBytes;
+
+            return new CompositeMLKemAlgorithm(
+                name,
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + uncompressedPointSizeInBytes,
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + uncompressedPointSizeInBytes,
+                mlkemAlgorithm.PrivateSeedSizeInBytes + ecPrivateKeySizeInBytes,
+                mlkemAlgorithm.PrivateSeedSizeInBytes + ecPrivateKeySizeInBytes,
+                mlkemAlgorithm.CiphertextSizeInBytes + uncompressedPointSizeInBytes,
+                mlkemAlgorithm.SharedSecretSizeInBytes,
+                oid);
+        }
+
+        private static CompositeMLKemAlgorithm CreateXDiffieHellman(
+            string name,
+            MLKemAlgorithm mlkemAlgorithm,
+            int keySizeInBits,
+            string oid)
+        {
+            Debug.Assert(keySizeInBits % 8 == 0);
+            int keySizeInBytes = keySizeInBits / 8;
+
+            return new CompositeMLKemAlgorithm(
+                name,
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + keySizeInBytes,
+                mlkemAlgorithm.EncapsulationKeySizeInBytes + keySizeInBytes,
+                mlkemAlgorithm.PrivateSeedSizeInBytes + keySizeInBytes,
+                mlkemAlgorithm.PrivateSeedSizeInBytes + keySizeInBytes,
+                mlkemAlgorithm.CiphertextSizeInBytes + keySizeInBytes,
+                mlkemAlgorithm.SharedSecretSizeInBytes,
+                oid);
+        }
+
+        private static int GetDerLengthLength(int payloadLength)
+        {
+            Debug.Assert(payloadLength >= 0);
+
+            if (payloadLength <= 0x7F)
+                return 1;
+
+            if (payloadLength <= 0xFF)
+                return 2;
+
+            if (payloadLength <= 0xFFFF)
+                return 3;
+
+            if (payloadLength <= 0xFFFFFF)
+                return 4;
+
+            return 5;
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKemImplementation.NotSupported.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKemImplementation.NotSupported.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable IDE0060 // Remove unused parameter
+
+namespace System.Security.Cryptography
+{
+    internal sealed partial class CompositeMLKemImplementation : CompositeMLKem
+    {
+        public CompositeMLKemImplementation(CompositeMLKemAlgorithm algorithm)
+            : base(algorithm)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        internal static partial bool IsAlgorithmSupportedImpl(CompositeMLKemAlgorithm algorithm) => false;
+
+        internal static partial CompositeMLKem GenerateKeyImpl(CompositeMLKemAlgorithm algorithm) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial CompositeMLKem ImportEncapsulationKeyImpl(CompositeMLKemAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+
+        internal static partial CompositeMLKem ImportDecapsulationKeyImpl(CompositeMLKemAlgorithm algorithm, ReadOnlySpan<byte> source) =>
+            throw new PlatformNotSupportedException();
+
+        protected override void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret) =>
+            throw new PlatformNotSupportedException();
+
+        protected override void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) =>
+            throw new PlatformNotSupportedException();
+
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) =>
+            throw new PlatformNotSupportedException();
+
+        protected override int ExportEncapsulationKeyCore(Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+
+        protected override int ExportDecapsulationKeyCore(Span<byte> destination) =>
+            throw new PlatformNotSupportedException();
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKemImplementation.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CompositeMLKemImplementation.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Security.Cryptography
+{
+    internal sealed partial class CompositeMLKemImplementation : CompositeMLKem
+    {
+        internal static partial bool IsAlgorithmSupportedImpl(CompositeMLKemAlgorithm algorithm);
+
+        internal static partial CompositeMLKem GenerateKeyImpl(CompositeMLKemAlgorithm algorithm);
+
+        internal static partial CompositeMLKem ImportEncapsulationKeyImpl(CompositeMLKemAlgorithm algorithm, ReadOnlySpan<byte> source);
+
+        internal static partial CompositeMLKem ImportDecapsulationKeyImpl(CompositeMLKemAlgorithm algorithm, ReadOnlySpan<byte> source);
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Oids.cs
@@ -154,6 +154,19 @@ namespace System.Security.Cryptography
         internal const string MLDsa87WithRSA4096PssPreHashSha512 = "1.3.6.1.5.5.7.6.53";
         internal const string MLDsa87WithECDsaP521PreHashSha512 = "1.3.6.1.5.5.7.6.54";
 
+        internal const string MLKem768WithRsaOaep2048Sha3_256 = "1.3.6.1.5.5.7.6.55";
+        internal const string MLKem768WithRsaOaep3072Sha3_256 = "1.3.6.1.5.5.7.6.56";
+        internal const string MLKem768WithRsaOaep4096Sha3_256 = "1.3.6.1.5.5.7.6.57";
+        internal const string MLKem768WithX25519Sha3_256 = "1.3.6.1.5.5.7.6.58";
+        internal const string MLKem768WithECDiffieHellmanP256Sha3_256 = "1.3.6.1.5.5.7.6.59";
+        internal const string MLKem768WithECDiffieHellmanP384Sha3_256 = "1.3.6.1.5.5.7.6.60";
+        internal const string MLKem768WithECDiffieHellmanBrainpoolP256r1Sha3_256 = "1.3.6.1.5.5.7.6.61";
+        internal const string MLKem1024WithRsaOaep3072Sha3_256 = "1.3.6.1.5.5.7.6.62";
+        internal const string MLKem1024WithECDiffieHellmanP384Sha3_256 = "1.3.6.1.5.5.7.6.63";
+        internal const string MLKem1024WithECDiffieHellmanBrainpoolP384r1Sha3_256 = "1.3.6.1.5.5.7.6.64";
+        internal const string MLKem1024WithX448Sha3_256 = "1.3.6.1.5.5.7.6.65";
+        internal const string MLKem1024WithECDiffieHellmanP521Sha3_256 = "1.3.6.1.5.5.7.6.66";
+
         // PKCS#7
         internal const string NoSignature = "1.3.6.1.5.5.7.6.2";
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemContractTests.cs
@@ -1,0 +1,995 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Formats.Asn1;
+using System.Security.Cryptography.Asn1;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    public static class CompositeMLKemContractTests
+    {
+        private static readonly PbeParameters s_aes256Sha256Pbe =
+            new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 42);
+
+        [Fact]
+        public static void ArgumentValidation_Ctor_NullAlgorithm()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => new CompositeMLKemMockImplementation(null));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Algorithm_MatchesConstructorArgument(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKem kem = CompositeMLKemMockImplementation.Create(algorithm);
+            Assert.Same(algorithm, kem.Algorithm);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsAndDisposalTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void NullArgumentValidation(CompositeMLKemAlgorithm algorithm, bool shouldDispose)
+        {
+            using CompositeMLKem kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            if (shouldDispose)
+            {
+                // Test that argument validation exceptions take precedence over ObjectDisposedException
+                kem.Dispose();
+            }
+
+            AssertExtensions.Throws<ArgumentNullException>("ciphertext", () => kem.Decapsulate(null));
+
+            AssertExtensions.Throws<ArgumentNullException>("password", () => kem.ExportEncryptedPkcs8PrivateKey((string)null, null));
+            AssertExtensions.Throws<ArgumentNullException>("password", () => kem.ExportEncryptedPkcs8PrivateKeyPem((string)null, null));
+            AssertExtensions.Throws<ArgumentNullException>("password", () => kem.TryExportEncryptedPkcs8PrivateKey((string)null, null, Span<byte>.Empty, out _));
+
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte>.Empty, null));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char>.Empty, null));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.ExportEncryptedPkcs8PrivateKey(string.Empty, null));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte>.Empty, null));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char>.Empty, null));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.ExportEncryptedPkcs8PrivateKeyPem(string.Empty, null));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte>.Empty, null, Span<byte>.Empty, out _));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char>.Empty, null, Span<byte>.Empty, out _));
+            AssertExtensions.Throws<ArgumentNullException>("pbeParameters", () => kem.TryExportEncryptedPkcs8PrivateKey(string.Empty, null, Span<byte>.Empty, out _));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsAndDisposalTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ArgumentValidation_BufferSizes(CompositeMLKemAlgorithm algorithm, bool shouldDispose)
+        {
+            using CompositeMLKem kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int ciphertextSize = algorithm.CiphertextSizeInBytes;
+            int sharedSecretSize = algorithm.SharedSecretSizeInBytes;
+
+            if (shouldDispose)
+            {
+                // Test that argument validation exceptions take precedence over ObjectDisposedException
+                kem.Dispose();
+            }
+
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Encapsulate(new byte[ciphertextSize - 1], new byte[sharedSecretSize]));
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Encapsulate(new byte[ciphertextSize + 1], new byte[sharedSecretSize]));
+            AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Encapsulate(new byte[ciphertextSize], new byte[sharedSecretSize - 1]));
+            AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Encapsulate(new byte[ciphertextSize], new byte[sharedSecretSize + 1]));
+
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(new byte[ciphertextSize - 1]));
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(new byte[ciphertextSize + 1]));
+
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(new byte[ciphertextSize - 1].AsSpan(), new byte[sharedSecretSize]));
+            AssertExtensions.Throws<ArgumentException>("ciphertext", () => kem.Decapsulate(new byte[ciphertextSize + 1].AsSpan(), new byte[sharedSecretSize]));
+            AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Decapsulate(new byte[ciphertextSize].AsSpan(), new byte[sharedSecretSize - 1]));
+            AssertExtensions.Throws<ArgumentException>("sharedSecret", () => kem.Decapsulate(new byte[ciphertextSize].AsSpan(), new byte[sharedSecretSize + 1]));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsAndDisposalTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ArgumentValidation_OverlappingEncapsulateBuffers(CompositeMLKemAlgorithm algorithm, bool shouldDispose)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            byte[] buffer = new byte[algorithm.CiphertextSizeInBytes];
+
+            if (shouldDispose)
+            {
+                // Test that overlap validation takes precedence over ObjectDisposedException
+                kem.Dispose();
+            }
+
+            Assert.Throws<CryptographicException>(() =>
+                kem.Encapsulate(buffer.AsSpan(0, algorithm.CiphertextSizeInBytes), buffer.AsSpan(0, algorithm.SharedSecretSizeInBytes)));
+
+            Assert.Equal(0, kem.EncapsulateCoreCallCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncryptedPkcs8PrivateKey_PbeAlgorithmUnknown(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKem kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            CompositeMLKemTestHelpers.AssertEncryptedExportPkcs8PrivateKey(export =>
+                Assert.Throws<CryptographicException>(() =>
+                    export(kem, "PLACEHOLDER", new PbeParameters(PbeEncryptionAlgorithm.Unknown, HashAlgorithmName.SHA1, 42))));
+        }
+
+        [Theory]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires TripleDES, which is not supported on Browser.")]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncryptedPkcs8PrivateKey_Pkcs12HashInvalid(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKem kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            CompositeMLKemTestHelpers.AssertEncryptedExportPkcs8PrivateKey(export =>
+                Assert.Throws<CryptographicException>(() =>
+                    export(kem, "PLACEHOLDER", new PbeParameters(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA512, 42))));
+        }
+
+        [Theory]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires TripleDES, which is not supported on Browser.")]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncryptedPkcs8PrivateKey_BytePasswordRejectsPkcs12Kdf(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKem kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            CompositeMLKemTestHelpers.AssertEncryptedExportPkcs8PrivateKey(export =>
+                Assert.Throws<CryptographicException>(() =>
+                    export(kem, "PLACEHOLDER", new PbeParameters(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 42))),
+                CompositeMLKemTestHelpers.EncryptionPasswordType.Byte);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Encapsulate_Array_CallsCore(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            kem.EncapsulateCoreHook = (_, _) => { };
+            kem.AddLengthAssertion();
+            kem.AddFillDestination(42);
+
+            kem.Encapsulate(out byte[] ciphertext, out byte[] sharedSecret);
+
+            Assert.Equal(1, kem.EncapsulateCoreCallCount);
+            Assert.Equal(algorithm.CiphertextSizeInBytes, ciphertext.Length);
+            Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecret.Length);
+            AssertExtensions.FilledWith<byte>(42, ciphertext);
+            AssertExtensions.FilledWith<byte>(42, sharedSecret);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Encapsulate_Span_CallsCore(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            byte[] ciphertext = new byte[algorithm.CiphertextSizeInBytes];
+            byte[] sharedSecret = new byte[algorithm.SharedSecretSizeInBytes];
+
+            kem.EncapsulateCoreHook = (_, _) => { };
+            kem.AddLengthAssertion();
+            kem.AddCiphertextBufferIsSameAssertion(ciphertext);
+            kem.AddSharedSecretBufferIsSameAssertion(sharedSecret);
+            kem.AddFillDestination(7);
+
+            kem.Encapsulate(ciphertext, sharedSecret);
+
+            Assert.Equal(1, kem.EncapsulateCoreCallCount);
+            AssertExtensions.FilledWith<byte>(7, ciphertext);
+            AssertExtensions.FilledWith<byte>(7, sharedSecret);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Encapsulate_CoreCryptographicException_Propagates(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            CryptographicException expected = new();
+
+            kem.EncapsulateCoreHook = (_, _) => throw expected;
+
+            Assert.Same(expected, Assert.Throws<CryptographicException>(() => kem.Encapsulate(out _, out _)));
+            Assert.Same(
+                expected,
+                Assert.Throws<CryptographicException>(() =>
+                    kem.Encapsulate(new byte[algorithm.CiphertextSizeInBytes], new byte[algorithm.SharedSecretSizeInBytes])));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Decapsulate_Array_CallsCore(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            byte[] ciphertext = new byte[algorithm.CiphertextSizeInBytes];
+            ciphertext.AsSpan().Fill(1);
+
+            kem.DecapsulateCoreHook = (_, _) => { };
+            kem.AddLengthAssertion();
+            kem.AddCiphertextBufferIsSameAssertion(ciphertext);
+            kem.AddFillDestination(3);
+
+            byte[] sharedSecret = kem.Decapsulate(ciphertext);
+
+            Assert.Equal(1, kem.DecapsulateCoreCallCount);
+            Assert.Equal(algorithm.SharedSecretSizeInBytes, sharedSecret.Length);
+            AssertExtensions.FilledWith<byte>(3, sharedSecret);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Decapsulate_Span_CallsCore(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            byte[] ciphertext = new byte[algorithm.CiphertextSizeInBytes];
+            byte[] sharedSecret = new byte[algorithm.SharedSecretSizeInBytes];
+
+            kem.DecapsulateCoreHook = (_, _) => { };
+            kem.AddLengthAssertion();
+            kem.AddCiphertextBufferIsSameAssertion(ciphertext);
+            kem.AddSharedSecretBufferIsSameAssertion(sharedSecret);
+            kem.AddFillDestination(9);
+
+            kem.Decapsulate(new ReadOnlySpan<byte>(ciphertext), sharedSecret);
+
+            Assert.Equal(1, kem.DecapsulateCoreCallCount);
+            AssertExtensions.FilledWith<byte>(9, sharedSecret);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Decapsulate_CoreCryptographicException_Propagates(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            CryptographicException expected = new();
+            byte[] ciphertext = new byte[algorithm.CiphertextSizeInBytes];
+
+            kem.DecapsulateCoreHook = (_, _) => throw expected;
+
+            Assert.Same(expected, Assert.Throws<CryptographicException>(() => kem.Decapsulate(ciphertext)));
+            Assert.Same(
+                expected,
+                Assert.Throws<CryptographicException>(() =>
+                    kem.Decapsulate(ciphertext, new byte[algorithm.SharedSecretSizeInBytes])));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Decapsulate_OverlappingBuffersAreAllowed(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            byte[] buffer = new byte[algorithm.CiphertextSizeInBytes];
+
+            kem.DecapsulateCoreHook = (_, _) => { };
+            kem.AddLengthAssertion();
+            kem.AddFillDestination(5);
+
+            // Unlike encapsulation, decapsulation does not reject overlapping buffers.
+            kem.Decapsulate(buffer.AsSpan(), buffer.AsSpan(0, algorithm.SharedSecretSizeInBytes));
+
+            Assert.Equal(1, kem.DecapsulateCoreCallCount);
+            AssertExtensions.FilledWith<byte>(5, buffer.AsSpan(0, algorithm.SharedSecretSizeInBytes));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncapsulationKey_AllOverloads(CompositeMLKemAlgorithm algorithm)
+        {
+            byte[] expected = new byte[CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm)];
+            expected.AsSpan().Fill(0x5A);
+
+            CompositeMLKemTestHelpers.AssertExportEncapsulationKey(export =>
+            {
+                using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+                kem.SetNoOpHooks();
+                kem.AddFillDestination(expected);
+
+                AssertExtensions.SequenceEqual(expected, export(kem));
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncapsulationKey_CoreCryptographicException_Propagates(CompositeMLKemAlgorithm algorithm)
+        {
+            CompositeMLKemTestHelpers.AssertExportEncapsulationKey(export =>
+            {
+                using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+                CryptographicException expected = new();
+
+                kem.ExportEncapsulationKeyCoreHook = _ => throw expected;
+
+                Assert.Same(expected, Assert.Throws<CryptographicException>(() => export(kem)));
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportDecapsulationKey_AllOverloads(CompositeMLKemAlgorithm algorithm)
+        {
+            byte[] expected = new byte[CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm)];
+            expected.AsSpan().Fill(0x3C);
+
+            CompositeMLKemTestHelpers.AssertExportDecapsulationKey(
+                export =>
+                {
+                    using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+                    kem.SetNoOpHooks();
+                    kem.AddFillDestination(expected);
+
+                    AssertExtensions.SequenceEqual(expected, export(kem));
+                },
+                export =>
+                {
+                    // The PKCS#8 route needs a well-formed PrivateKeyInfo which embeds the raw key.
+                    using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+                    kem.SetNoOpHooks();
+                    kem.AddFillDestination(CreatePkcs8PrivateKey(algorithm, expected));
+
+                    AssertExtensions.SequenceEqual(expected, export(kem));
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportDecapsulationKey_CoreCryptographicException_Propagates(CompositeMLKemAlgorithm algorithm)
+        {
+            CompositeMLKemTestHelpers.AssertExportDecapsulationKey(
+                export =>
+                {
+                    using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+                    CryptographicException expected = new();
+
+                    kem.ExportDecapsulationKeyCoreHook = _ => throw expected;
+
+                    Assert.Same(expected, Assert.Throws<CryptographicException>(() => export(kem)));
+                },
+                export =>
+                {
+                    using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+                    CryptographicException expected = new();
+
+                    kem.TryExportPkcs8PrivateKeyCoreHook =
+                        (Span<byte> _, out int bytesWritten) =>
+                        {
+                            bytesWritten = 0;
+                            throw expected;
+                        };
+
+                    Assert.Same(expected, Assert.Throws<CryptographicException>(() => export(kem)));
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void TryExportEncapsulationKey_LowerBound(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+
+            // Buffer is too small
+            byte[] bytes = new byte[lowerBound - 1];
+            AssertExtensions.FalseExpression(kem.TryExportEncapsulationKey(bytes, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(0, kem.ExportEncapsulationKeyCoreCallCount);
+
+            // Buffer meets the lower bound
+            bytes = new byte[lowerBound];
+
+            kem.ExportEncapsulationKeyCoreHook = destination =>
+            {
+                AssertExtensions.GreaterThanOrEqualTo(destination.Length, lowerBound);
+                destination.Fill(1);
+                return lowerBound;
+            };
+
+            AssertExtensions.TrueExpression(kem.TryExportEncapsulationKey(bytes, out bytesWritten));
+            Assert.Equal(lowerBound, bytesWritten);
+            AssertExtensions.FilledWith<byte>(1, bytes);
+
+            // Buffer meets the lower bound, but returned value is too small
+            kem.ExportEncapsulationKeyCoreHook = destination =>
+            {
+                AssertExtensions.GreaterThanOrEqualTo(destination.Length, lowerBound);
+                destination.Fill(1);
+
+                // Writing less than lower bound isn't allowed.
+                return lowerBound - 1;
+            };
+
+            Assert.Throws<CryptographicException>(() => kem.TryExportEncapsulationKey(bytes, out bytesWritten));
+            Assert.Equal(2, kem.ExportEncapsulationKeyCoreCallCount);
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void TryExportEncapsulationKey_UpperBound(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeUpperBound(algorithm);
+
+            byte[] bytes = new byte[upperBound];
+
+            kem.ExportEncapsulationKeyCoreHook = destination =>
+            {
+                Assert.Equal(upperBound, destination.Length);
+                destination.Fill(2);
+                return upperBound;
+            };
+
+            AssertExtensions.TrueExpression(kem.TryExportEncapsulationKey(bytes, out int bytesWritten));
+            Assert.Equal(upperBound, bytesWritten);
+            AssertExtensions.FilledWith<byte>(2, bytes);
+
+            // Writing more than the upper bound isn't allowed.
+            kem.ExportEncapsulationKeyCoreHook = destination => upperBound + 1;
+
+            Assert.Throws<CryptographicException>(() => kem.TryExportEncapsulationKey(bytes, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void TryExportEncapsulationKey_KeyLargerThanDestination(CompositeMLKemAlgorithm algorithm)
+        {
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeUpperBound(algorithm);
+
+            if (lowerBound == upperBound)
+            {
+                // Only variable sized keys can write more than the destination can hold.
+                return;
+            }
+
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            kem.ExportEncapsulationKeyCoreHook = destination =>
+            {
+                Assert.Equal(upperBound, destination.Length);
+                destination.Fill(4);
+                return upperBound;
+            };
+
+            byte[] bytes = new byte[lowerBound];
+            AssertExtensions.FalseExpression(kem.TryExportEncapsulationKey(bytes, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(1, kem.ExportEncapsulationKeyCoreCallCount);
+            AssertExtensions.FilledWith<byte>(0, bytes);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncapsulationKey_KeyLargerThanDestination(CompositeMLKemAlgorithm algorithm)
+        {
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeUpperBound(algorithm);
+
+            if (lowerBound == upperBound)
+            {
+                return;
+            }
+
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            kem.ExportEncapsulationKeyCoreHook = _ => upperBound;
+
+            byte[] bytes = new byte[lowerBound];
+            Assert.Throws<CryptographicException>(() => kem.ExportEncapsulationKey(bytes));
+            Assert.Equal(1, kem.ExportEncapsulationKeyCoreCallCount);
+            AssertExtensions.FilledWith<byte>(0, bytes);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void TryExportDecapsulationKey_KeyLargerThanDestination(CompositeMLKemAlgorithm algorithm)
+        {
+            int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeUpperBound(algorithm);
+
+            if (lowerBound == upperBound)
+            {
+                // Only variable sized keys can write more than the destination can hold.
+                return;
+            }
+
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            kem.ExportDecapsulationKeyCoreHook = destination =>
+            {
+                Assert.Equal(upperBound, destination.Length);
+                destination.Fill(4);
+                return upperBound;
+            };
+
+            byte[] bytes = new byte[lowerBound];
+            AssertExtensions.FalseExpression(kem.TryExportDecapsulationKey(bytes, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(1, kem.ExportDecapsulationKeyCoreCallCount);
+            AssertExtensions.FilledWith<byte>(0, bytes);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportDecapsulationKey_KeyLargerThanDestination(CompositeMLKemAlgorithm algorithm)
+        {
+            int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeUpperBound(algorithm);
+
+            if (lowerBound == upperBound)
+            {
+                return;
+            }
+
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            kem.ExportDecapsulationKeyCoreHook = _ => upperBound;
+
+            byte[] bytes = new byte[lowerBound];
+            Assert.Throws<CryptographicException>(() => kem.ExportDecapsulationKey(bytes));
+            Assert.Equal(1, kem.ExportDecapsulationKeyCoreCallCount);
+            AssertExtensions.FilledWith<byte>(0, bytes);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncapsulationKey_Span(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+
+            byte[] bytes = new byte[lowerBound];
+
+            // Buffer is too small
+            Assert.Throws<CryptographicException>(() => kem.ExportEncapsulationKey(bytes.AsSpan(0, lowerBound - 1)));
+            Assert.Equal(0, kem.ExportEncapsulationKeyCoreCallCount);
+            AssertExtensions.FilledWith<byte>(0, bytes);
+
+            kem.ExportEncapsulationKeyCoreHook = destination =>
+            {
+                AssertExtensions.GreaterThanOrEqualTo(destination.Length, lowerBound);
+                destination.Fill(1);
+                return lowerBound;
+            };
+
+            int bytesWritten = kem.ExportEncapsulationKey(bytes.AsSpan(0, lowerBound));
+            Assert.Equal(1, kem.ExportEncapsulationKeyCoreCallCount);
+            Assert.Equal(lowerBound, bytesWritten);
+            AssertExtensions.FilledWith<byte>(1, bytes);
+
+            // Buffer meets the lower bound, but returned value is too small
+            kem.ExportEncapsulationKeyCoreHook = destination =>
+            {
+                destination.Fill(1);
+
+                // Writing less than lower bound isn't allowed.
+                return lowerBound - 1;
+            };
+
+            Assert.Throws<CryptographicException>(() => kem.ExportEncapsulationKey(bytes.AsSpan(0, lowerBound)));
+            Assert.Equal(2, kem.ExportEncapsulationKeyCoreCallCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncapsulationKey_Array(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeUpperBound(algorithm);
+
+            kem.ExportEncapsulationKeyCoreHook = destination =>
+            {
+                Assert.Equal(upperBound, destination.Length);
+                destination.Fill(6);
+                return lowerBound;
+            };
+
+            byte[] encapsulationKey = kem.ExportEncapsulationKey();
+            Assert.Equal(1, kem.ExportEncapsulationKeyCoreCallCount);
+            Assert.Equal(lowerBound, encapsulationKey.Length);
+            AssertExtensions.FilledWith<byte>(6, encapsulationKey);
+
+            // Writing less than the lower bound isn't allowed.
+            kem.ExportEncapsulationKeyCoreHook = destination => lowerBound - 1;
+
+            Assert.Throws<CryptographicException>(() => kem.ExportEncapsulationKey());
+            Assert.Equal(2, kem.ExportEncapsulationKeyCoreCallCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void TryExportDecapsulationKey_LowerBound(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
+
+            // Buffer is too small
+            byte[] bytes = new byte[lowerBound - 1];
+            AssertExtensions.FalseExpression(kem.TryExportDecapsulationKey(bytes, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(0, kem.ExportDecapsulationKeyCoreCallCount);
+
+            // Buffer meets the lower bound
+            bytes = new byte[lowerBound];
+
+            kem.ExportDecapsulationKeyCoreHook = destination =>
+            {
+                AssertExtensions.GreaterThanOrEqualTo(destination.Length, lowerBound);
+                destination.Fill(1);
+                return lowerBound;
+            };
+
+            AssertExtensions.TrueExpression(kem.TryExportDecapsulationKey(bytes, out bytesWritten));
+            Assert.Equal(lowerBound, bytesWritten);
+            AssertExtensions.FilledWith<byte>(1, bytes);
+
+            // Buffer meets the lower bound, but returned value is too small
+            kem.ExportDecapsulationKeyCoreHook = destination =>
+            {
+                destination.Fill(1);
+
+                // Writing less than lower bound isn't allowed.
+                return lowerBound - 1;
+            };
+
+            Assert.Throws<CryptographicException>(() => kem.TryExportDecapsulationKey(bytes, out bytesWritten));
+            Assert.Equal(2, kem.ExportDecapsulationKeyCoreCallCount);
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void TryExportDecapsulationKey_UpperBound(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeUpperBound(algorithm);
+
+            byte[] bytes = new byte[upperBound];
+
+            kem.ExportDecapsulationKeyCoreHook = destination =>
+            {
+                Assert.Equal(upperBound, destination.Length);
+                destination.Fill(2);
+                return upperBound;
+            };
+
+            AssertExtensions.TrueExpression(kem.TryExportDecapsulationKey(bytes, out int bytesWritten));
+            Assert.Equal(upperBound, bytesWritten);
+            AssertExtensions.FilledWith<byte>(2, bytes);
+
+            // Writing more than the upper bound isn't allowed.
+            kem.ExportDecapsulationKeyCoreHook = destination => upperBound + 1;
+
+            Assert.Throws<CryptographicException>(() => kem.TryExportDecapsulationKey(bytes, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+
+            // The destination is cleared when the core implementation misbehaves.
+            AssertExtensions.FilledWith<byte>(0, bytes);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportDecapsulationKey_Span(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
+
+            byte[] bytes = new byte[lowerBound];
+
+            // Buffer is too small
+            Assert.Throws<CryptographicException>(() => kem.ExportDecapsulationKey(bytes.AsSpan(0, lowerBound - 1)));
+            Assert.Equal(0, kem.ExportDecapsulationKeyCoreCallCount);
+            AssertExtensions.FilledWith<byte>(0, bytes);
+
+            kem.ExportDecapsulationKeyCoreHook = destination =>
+            {
+                AssertExtensions.GreaterThanOrEqualTo(destination.Length, lowerBound);
+                destination.Fill(1);
+                return lowerBound;
+            };
+
+            int bytesWritten = kem.ExportDecapsulationKey(bytes.AsSpan(0, lowerBound));
+            Assert.Equal(1, kem.ExportDecapsulationKeyCoreCallCount);
+            Assert.Equal(lowerBound, bytesWritten);
+            AssertExtensions.FilledWith<byte>(1, bytes);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportDecapsulationKey_Array(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeUpperBound(algorithm);
+
+            kem.ExportDecapsulationKeyCoreHook = destination =>
+            {
+                Assert.Equal(upperBound, destination.Length);
+                destination.Fill(6);
+                return lowerBound;
+            };
+
+            byte[] decapsulationKey = kem.ExportDecapsulationKey();
+            Assert.Equal(1, kem.ExportDecapsulationKeyCoreCallCount);
+            Assert.Equal(lowerBound, decapsulationKey.Length);
+            AssertExtensions.FilledWith<byte>(6, decapsulationKey);
+
+            // Writing less than the lower bound isn't allowed.
+            kem.ExportDecapsulationKeyCoreHook = destination => lowerBound - 1;
+
+            Assert.Throws<CryptographicException>(() => kem.ExportDecapsulationKey());
+            Assert.Equal(2, kem.ExportDecapsulationKeyCoreCallCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void TryExportPkcs8PrivateKey_LowerBound(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
+
+            // A PKCS#8 blob is always larger than the raw key, so anything smaller than the
+            // smallest possible key can be rejected without calling the core implementation.
+            byte[] bytes = new byte[lowerBound - 1];
+            AssertExtensions.FalseExpression(kem.TryExportPkcs8PrivateKey(bytes, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.Equal(0, kem.TryExportPkcs8PrivateKeyCoreCallCount);
+
+            bytes = new byte[lowerBound];
+            kem.TryExportPkcs8PrivateKeyCoreHook = (Span<byte> destination, out int written) =>
+            {
+                AssertExtensions.GreaterThanOrEqualTo(destination.Length, lowerBound);
+                destination.Fill(1);
+                written = destination.Length;
+                return true;
+            };
+
+            AssertExtensions.TrueExpression(kem.TryExportPkcs8PrivateKey(bytes, out bytesWritten));
+            Assert.Equal(1, kem.TryExportPkcs8PrivateKeyCoreCallCount);
+            Assert.Equal(lowerBound, bytesWritten);
+            AssertExtensions.FilledWith<byte>(1, bytes);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportPkcs8PrivateKey_UsesCore(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            byte[] pkcs8 = CreatePkcs8PrivateKey(algorithm);
+
+            kem.SetNoOpHooks();
+            kem.AddFillDestination(pkcs8);
+
+            CompositeMLKemTestHelpers.AssertExportPkcs8PrivateKey(kem, exported =>
+                AssertExtensions.SequenceEqual(pkcs8, exported));
+
+            AssertExtensions.GreaterThanOrEqualTo(kem.TryExportPkcs8PrivateKeyCoreCallCount, 3);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportPkcs8PrivateKey_GrowsBuffer(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int requiredSize = CompositeMLKemTestData.ExpectedDecapsulationKeySizeUpperBound(algorithm) * 4;
+
+            kem.TryExportPkcs8PrivateKeyCoreHook = (Span<byte> destination, out int written) =>
+            {
+                if (destination.Length < requiredSize)
+                {
+                    written = 0;
+                    return false;
+                }
+
+                destination.Slice(0, requiredSize).Fill(8);
+                written = requiredSize;
+                return true;
+            };
+
+            byte[] exported = kem.ExportPkcs8PrivateKey();
+
+            AssertExtensions.GreaterThanOrEqualTo(kem.TryExportPkcs8PrivateKeyCoreCallCount, 2);
+            Assert.Equal(requiredSize, exported.Length);
+            AssertExtensions.FilledWith<byte>(8, exported);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportPkcs8PrivateKey_CoreReturnsNonsense(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+
+            kem.TryExportPkcs8PrivateKeyCoreHook = (Span<byte> destination, out int written) =>
+            {
+                written = destination.Length + 1;
+                return true;
+            };
+
+            Assert.Throws<CryptographicException>(() => kem.ExportPkcs8PrivateKey());
+
+            kem.TryExportPkcs8PrivateKeyCoreHook = (Span<byte> destination, out int written) =>
+            {
+                written = -1;
+                return true;
+            };
+
+            Assert.Throws<CryptographicException>(() => kem.ExportPkcs8PrivateKey());
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportSubjectPublicKeyInfo_Shape(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+            byte[] encapsulationKey = new byte[lowerBound];
+            encapsulationKey.AsSpan().Fill(0xAA);
+
+            kem.SetNoOpHooks();
+            kem.AddFillDestination(encapsulationKey);
+
+            CompositeMLKemTestHelpers.AssertExportSubjectPublicKeyInfo(kem, spki =>
+            {
+                SubjectPublicKeyInfoAsn decoded = SubjectPublicKeyInfoAsn.Decode(spki, AsnEncodingRules.DER);
+
+                Assert.Equal(CompositeMLKemTestHelpers.AlgorithmToOid(algorithm), decoded.Algorithm.Algorithm);
+                AssertExtensions.FalseExpression(decoded.Algorithm.Parameters.HasValue);
+                AssertExtensions.SequenceEqual(encapsulationKey, decoded.SubjectPublicKey.ToArray());
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportSubjectPublicKeyInfo_CoreReturnsInvalidSize(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+
+            kem.ExportEncapsulationKeyCoreHook = destination => lowerBound - 1;
+
+            Assert.Throws<CryptographicException>(() => kem.ExportSubjectPublicKeyInfo());
+            Assert.Throws<CryptographicException>(() => kem.ExportSubjectPublicKeyInfoPem());
+            Assert.Throws<CryptographicException>(() => kem.TryExportSubjectPublicKeyInfo(new byte[4096], out _));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void TryExportSubjectPublicKeyInfo_DestinationTooSmall(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+            byte[] encapsulationKey = new byte[lowerBound];
+
+            kem.SetNoOpHooks();
+            kem.AddFillDestination(encapsulationKey);
+
+            AssertExtensions.FalseExpression(kem.TryExportSubjectPublicKeyInfo(new byte[lowerBound], out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Theory]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires AES, which is not supported on Browser.")]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncryptedPkcs8PrivateKey_ProducesEncryptedPrivateKeyInfo(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            byte[] pkcs8 = CreatePkcs8PrivateKey(algorithm);
+
+            kem.SetNoOpHooks();
+            kem.AddFillDestination(pkcs8);
+
+            CompositeMLKemTestHelpers.AssertEncryptedExportPkcs8PrivateKey(export =>
+            {
+                byte[] encrypted = export(kem, "PLACEHOLDER", s_aes256Sha256Pbe);
+
+                // EncryptedPrivateKeyInfo ::= SEQUENCE { encryptionAlgorithm AlgorithmIdentifier, encryptedData OCTET STRING }
+                AsnReader reader = new AsnReader(encrypted, AsnEncodingRules.BER);
+                AsnReader encryptedPrivateKeyInfo = reader.ReadSequence();
+                AssertExtensions.FalseExpression(reader.HasData);
+
+                encryptedPrivateKeyInfo.ReadSequence(); // encryptionAlgorithm
+                AssertExtensions.GreaterThanOrEqualTo(encryptedPrivateKeyInfo.ReadOctetString().Length, pkcs8.Length);
+                AssertExtensions.FalseExpression(encryptedPrivateKeyInfo.HasData);
+            });
+        }
+
+        [Theory]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires AES, which is not supported on Browser.")]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ExportEncryptedPkcs8PrivateKey_CoreCryptographicException_Propagates(CompositeMLKemAlgorithm algorithm)
+        {
+            CompositeMLKemTestHelpers.AssertEncryptedExportPkcs8PrivateKey(export =>
+            {
+                using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+                CryptographicException expected = new();
+
+                kem.TryExportPkcs8PrivateKeyCoreHook =
+                    (Span<byte> _, out int bytesWritten) =>
+                    {
+                        bytesWritten = 0;
+                        throw expected;
+                    };
+
+                Assert.Same(expected, Assert.Throws<CryptographicException>(() => export(kem, "PLACEHOLDER", s_aes256Sha256Pbe)));
+            });
+        }
+
+        [Theory]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires AES, which is not supported on Browser.")]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void TryExportEncryptedPkcs8PrivateKey_DestinationTooSmall(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            byte[] pkcs8 = CreatePkcs8PrivateKey(algorithm);
+
+            kem.SetNoOpHooks();
+            kem.AddFillDestination(pkcs8);
+
+            AssertExtensions.FalseExpression(
+                kem.TryExportEncryptedPkcs8PrivateKey("PLACEHOLDER", s_aes256Sha256Pbe, Span<byte>.Empty, out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+
+            AssertExtensions.FalseExpression(
+                kem.TryExportEncryptedPkcs8PrivateKey("PLACEHOLDER".AsSpan(), s_aes256Sha256Pbe, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+
+            AssertExtensions.FalseExpression(
+                kem.TryExportEncryptedPkcs8PrivateKey("PLACEHOLDER"u8, s_aes256Sha256Pbe, Span<byte>.Empty, out bytesWritten));
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Dispose_IsIdempotentAndCallsCore(CompositeMLKemAlgorithm algorithm)
+        {
+            CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            kem.DisposeHook = disposing => AssertExtensions.TrueExpression(disposing);
+
+            Assert.Equal(0, kem.DisposeCallCount);
+
+            kem.Dispose();
+            Assert.Equal(1, kem.DisposeCallCount);
+
+            kem.Dispose();
+            kem.Dispose();
+            Assert.Equal(1, kem.DisposeCallCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void Dispose_ThrowsObjectDisposed(CompositeMLKemAlgorithm algorithm)
+        {
+            CompositeMLKemMockImplementation kem = CompositeMLKemMockImplementation.Create(algorithm);
+            kem.Dispose();
+
+            CompositeMLKemTestHelpers.VerifyDisposed(kem);
+
+            // No core method should have been called.
+            Assert.Equal(0, kem.EncapsulateCoreCallCount);
+            Assert.Equal(0, kem.DecapsulateCoreCallCount);
+            Assert.Equal(0, kem.ExportEncapsulationKeyCoreCallCount);
+            Assert.Equal(0, kem.ExportDecapsulationKeyCoreCallCount);
+            Assert.Equal(0, kem.TryExportPkcs8PrivateKeyCoreCallCount);
+        }
+
+        private static byte[] CreatePkcs8PrivateKey(CompositeMLKemAlgorithm algorithm) =>
+            CreatePkcs8PrivateKey(algorithm, new byte[CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm)]);
+
+        private static byte[] CreatePkcs8PrivateKey(CompositeMLKemAlgorithm algorithm, byte[] decapsulationKey)
+        {
+            PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
+            {
+                PrivateKeyAlgorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
+                    Parameters = default(ReadOnlyMemory<byte>?),
+                },
+                PrivateKey = decapsulationKey,
+            };
+
+            return pkcs8.Encode();
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemContractTests.cs
@@ -355,7 +355,6 @@ namespace System.Security.Cryptography.Tests
                     kem.TryExportPkcs8PrivateKeyCoreHook =
                         (Span<byte> _, out int bytesWritten) =>
                         {
-                            bytesWritten = 0;
                             throw expected;
                         };
 
@@ -908,7 +907,6 @@ namespace System.Security.Cryptography.Tests
                 kem.TryExportPkcs8PrivateKeyCoreHook =
                     (Span<byte> _, out int bytesWritten) =>
                     {
-                        bytesWritten = 0;
                         throw expected;
                     };
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemFactoryTests.cs
@@ -44,31 +44,11 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Theory]
-        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
-        public static void GenerateKey_NotSupported(CompositeMLKemAlgorithm algorithm)
-        {
-            AssertNotSupported(algorithm, () => CompositeMLKem.GenerateKey(algorithm));
-        }
-
-        [Theory]
         [MemberData(nameof(CompositeMLKemTestData.SupportedAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
         public static void AlgorithmMatches_GenerateKey(CompositeMLKemAlgorithm algorithm)
         {
             using CompositeMLKem kem = CompositeMLKem.GenerateKey(algorithm);
             Assert.Equal(algorithm, kem.Algorithm);
-        }
-
-        [Theory]
-        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
-        public static void ImportEncapsulationKey_ValidSizes_NotSupported(CompositeMLKemAlgorithm algorithm)
-        {
-            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
-            int upperBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeUpperBound(algorithm);
-
-            AssertNotSupported(algorithm, () => CompositeMLKem.ImportEncapsulationKey(algorithm, new byte[lowerBound]));
-            AssertNotSupported(algorithm, () => CompositeMLKem.ImportEncapsulationKey(algorithm, new byte[upperBound]));
-            AssertNotSupported(algorithm, () => CompositeMLKem.ImportEncapsulationKey(algorithm, new byte[lowerBound].AsSpan()));
-            AssertNotSupported(algorithm, () => CompositeMLKem.ImportEncapsulationKey(algorithm, new byte[upperBound].AsSpan()));
         }
 
         [Theory]
@@ -90,19 +70,6 @@ namespace System.Security.Cryptography.Tests
 
         [Theory]
         [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
-        public static void ImportDecapsulationKey_ValidSizes_NotSupported(CompositeMLKemAlgorithm algorithm)
-        {
-            int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
-            int upperBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeUpperBound(algorithm);
-
-            AssertNotSupported(algorithm, () => CompositeMLKem.ImportDecapsulationKey(algorithm, new byte[lowerBound]));
-            AssertNotSupported(algorithm, () => CompositeMLKem.ImportDecapsulationKey(algorithm, new byte[upperBound]));
-            AssertNotSupported(algorithm, () => CompositeMLKem.ImportDecapsulationKey(algorithm, new byte[lowerBound].AsSpan()));
-            AssertNotSupported(algorithm, () => CompositeMLKem.ImportDecapsulationKey(algorithm, new byte[upperBound].AsSpan()));
-        }
-
-        [Theory]
-        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
         public static void ImportDecapsulationKey_InvalidSizes(CompositeMLKemAlgorithm algorithm)
         {
             int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
@@ -118,61 +85,6 @@ namespace System.Security.Cryptography.Tests
                 new byte[CompositeMLKemTestData.GetMLKemAlgorithm(algorithm).PrivateSeedSizeInBytes]);
         }
 
-        [Theory]
-        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
-        public static void ImportSubjectPublicKeyInfo_KnownAlgorithm(CompositeMLKemAlgorithm algorithm)
-        {
-            SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn
-            {
-                Algorithm = new AlgorithmIdentifierAsn
-                {
-                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
-                    Parameters = null,
-                },
-                SubjectPublicKey = new byte[CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm)],
-            };
-
-            byte[] encoded = spki.Encode();
-
-            // The OID is recognized, so the failure is that the algorithm has no implementation.
-            CompositeMLKemTestHelpers.AssertImportSubjectPublicKeyInfo(
-                import => AssertAlgorithmNotSupported(() => import(encoded)));
-        }
-
-        [Theory]
-        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
-        public static void ImportPkcs8PrivateKey_KnownAlgorithmNotSupported(CompositeMLKemAlgorithm algorithm)
-        {
-            byte[] privateKey = new byte[CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm)];
-            PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
-            {
-                PrivateKeyAlgorithm = new AlgorithmIdentifierAsn
-                {
-                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
-                    Parameters = null,
-                },
-                PrivateKey = privateKey,
-            };
-
-            byte[] encoded = pkcs8.Encode();
-
-            // The OID is recognized, so the failure is that the algorithm has no implementation.
-            CompositeMLKemTestHelpers.AssertImportPkcs8PrivateKey(
-                import => AssertAlgorithmNotSupported(() => import(encoded)));
-
-            // PBE AES is unavailable on Browser.
-            if (!PlatformDetection.IsBrowser)
-            {
-                byte[] encrypted = CompositeMLKemTestHelpers.CreateEncryptedPkcs8PrivateKey(
-                    CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
-                    privateKey,
-                    new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 42));
-
-                CompositeMLKemTestHelpers.AssertImportEncryptedPkcs8PrivateKey(
-                    import => AssertAlgorithmNotSupported(() => import("PLACEHOLDER", encrypted)));
-            }
-        }
-
         [Fact]
         public static void ImportSubjectPublicKeyInfo_UnknownAlgorithm()
         {
@@ -180,8 +92,8 @@ namespace System.Security.Cryptography.Tests
             {
                 Algorithm = new AlgorithmIdentifierAsn
                 {
-                    // One past the last Composite ML-KEM OID.
-                    Algorithm = "1.3.6.1.5.5.7.6.67",
+                    // ML-KEM is not Composite ML-KEM.
+                    Algorithm = MLKemTestData.MlKem768Oid,
                     Parameters = null,
                 },
                 SubjectPublicKey = new byte[1216],
@@ -203,8 +115,8 @@ namespace System.Security.Cryptography.Tests
             {
                 PrivateKeyAlgorithm = new AlgorithmIdentifierAsn
                 {
-                    // The last Composite ML-DSA OID, which is not a Composite ML-KEM OID.
-                    Algorithm = "1.3.6.1.5.5.7.6.54",
+                    // ML-KEM is not Composite ML-KEM.
+                    Algorithm = MLKemTestData.MlKem768Oid,
                     Parameters = null,
                 },
                 PrivateKey = new byte[96],
@@ -272,15 +184,15 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public static void Import_EncodedKeyTrailingData()
         {
-            AssertSubjectPublicKeyInfoImportThrows(AppendTrailingByte(CreateSubjectPublicKeyInfo()));
-            AssertPkcs8PrivateKeyImportThrows(AppendTrailingByte(CreatePkcs8PrivateKey()));
+            AssertSubjectPublicKeyInfoImportThrows(AppendTrailingByte(CreateEmptySubjectPublicKeyInfo()));
+            AssertPkcs8PrivateKeyImportThrows(AppendTrailingByte(CreateEmptyPkcs8PrivateKey()));
         }
 
         [Fact]
         public static void Import_EncodedKeyTruncated()
         {
-            AssertSubjectPublicKeyInfoImportThrows(TruncateLastByte(CreateSubjectPublicKeyInfo()));
-            AssertPkcs8PrivateKeyImportThrows(TruncateLastByte(CreatePkcs8PrivateKey()));
+            AssertSubjectPublicKeyInfoImportThrows(TruncateLastByte(CreateEmptySubjectPublicKeyInfo()));
+            AssertPkcs8PrivateKeyImportThrows(TruncateLastByte(CreateEmptyPkcs8PrivateKey()));
         }
 
         [Fact]
@@ -447,24 +359,7 @@ namespace System.Security.Cryptography.Tests
                 decapsulationKey);
         }
 
-        // Asserts that the operation throws PlatformNotSupportedException because the algorithm has no implementation
-        // on this platform. When an implementation is added, the positive case needs to be asserted instead.
-        private static void AssertNotSupported(CompositeMLKemAlgorithm algorithm, Action test)
-        {
-            AssertExtensions.FalseExpression(CompositeMLKem.IsAlgorithmSupported(algorithm));
-
-            PlatformNotSupportedException pnse = Assert.Throws<PlatformNotSupportedException>(test);
-            Assert.Contains(nameof(CompositeMLKem), pnse.Message);
-        }
-
-        // Encoded key imports surface an unsupported algorithm as a CryptographicException.
-        private static void AssertAlgorithmNotSupported(Action test)
-        {
-            CryptographicException ex = Assert.Throws<CryptographicException>(test);
-            Assert.Contains(nameof(CompositeMLKem), ex.Message);
-        }
-
-        private static byte[] CreateSubjectPublicKeyInfo()
+        private static byte[] CreateEmptySubjectPublicKeyInfo()
         {
             SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn
             {
@@ -479,7 +374,7 @@ namespace System.Security.Cryptography.Tests
             return spki.Encode();
         }
 
-        private static byte[] CreatePkcs8PrivateKey()
+        private static byte[] CreateEmptyPkcs8PrivateKey()
         {
             PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
             {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemFactoryTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemFactoryTests.cs
@@ -1,0 +1,538 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Formats.Asn1;
+using System.Security.Cryptography.Asn1;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    public static class CompositeMLKemFactoryTests
+    {
+        [Fact]
+        public static void NullArgumentValidation()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => CompositeMLKem.GenerateKey(null));
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => CompositeMLKem.IsAlgorithmSupported(null));
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => CompositeMLKem.ImportEncapsulationKey(null, null));
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => CompositeMLKem.ImportEncapsulationKey(null, ReadOnlySpan<byte>.Empty));
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => CompositeMLKem.ImportDecapsulationKey(null, null));
+            AssertExtensions.Throws<ArgumentNullException>("algorithm", static () => CompositeMLKem.ImportDecapsulationKey(null, ReadOnlySpan<byte>.Empty));
+
+            AssertExtensions.Throws<ArgumentNullException>("source", static () => CompositeMLKem.ImportEncapsulationKey(CompositeMLKemAlgorithm.MLKem768WithX25519, null));
+            AssertExtensions.Throws<ArgumentNullException>("source", static () => CompositeMLKem.ImportDecapsulationKey(CompositeMLKemAlgorithm.MLKem768WithX25519, null));
+            AssertExtensions.Throws<ArgumentNullException>("source", static () => CompositeMLKem.ImportPkcs8PrivateKey(null));
+            AssertExtensions.Throws<ArgumentNullException>("source", static () => CompositeMLKem.ImportSubjectPublicKeyInfo(null));
+            AssertExtensions.Throws<ArgumentNullException>("source", static () => CompositeMLKem.ImportFromPem(null));
+            AssertExtensions.Throws<ArgumentNullException>("source", static () => CompositeMLKem.ImportEncryptedPkcs8PrivateKey("PLACEHOLDER", null));
+            AssertExtensions.Throws<ArgumentNullException>("source", static () => CompositeMLKem.ImportFromEncryptedPem(null, (string)null));
+            AssertExtensions.Throws<ArgumentNullException>("source", static () => CompositeMLKem.ImportFromEncryptedPem(null, (byte[])null));
+
+            AssertExtensions.Throws<ArgumentNullException>("password", static () => CompositeMLKem.ImportEncryptedPkcs8PrivateKey((string)null, null));
+            AssertExtensions.Throws<ArgumentNullException>("password", static () => CompositeMLKem.ImportFromEncryptedPem(string.Empty, (string)null));
+
+            AssertExtensions.Throws<ArgumentNullException>("passwordBytes", static () => CompositeMLKem.ImportFromEncryptedPem(string.Empty, (byte[])null));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void IsAlgorithmSupported_AgreesWithPlatform(CompositeMLKemAlgorithm algorithm)
+        {
+            // No platform implements Composite ML-KEM yet.
+            AssertExtensions.FalseExpression(CompositeMLKem.IsAlgorithmSupported(algorithm));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void GenerateKey_NotSupported(CompositeMLKemAlgorithm algorithm)
+        {
+            AssertNotSupported(algorithm, () => CompositeMLKem.GenerateKey(algorithm));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.SupportedAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void AlgorithmMatches_GenerateKey(CompositeMLKemAlgorithm algorithm)
+        {
+            using CompositeMLKem kem = CompositeMLKem.GenerateKey(algorithm);
+            Assert.Equal(algorithm, kem.Algorithm);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ImportEncapsulationKey_ValidSizes_NotSupported(CompositeMLKemAlgorithm algorithm)
+        {
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeUpperBound(algorithm);
+
+            AssertNotSupported(algorithm, () => CompositeMLKem.ImportEncapsulationKey(algorithm, new byte[lowerBound]));
+            AssertNotSupported(algorithm, () => CompositeMLKem.ImportEncapsulationKey(algorithm, new byte[upperBound]));
+            AssertNotSupported(algorithm, () => CompositeMLKem.ImportEncapsulationKey(algorithm, new byte[lowerBound].AsSpan()));
+            AssertNotSupported(algorithm, () => CompositeMLKem.ImportEncapsulationKey(algorithm, new byte[upperBound].AsSpan()));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ImportEncapsulationKey_InvalidSizes(CompositeMLKemAlgorithm algorithm)
+        {
+            int lowerBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedEncapsulationKeySizeUpperBound(algorithm);
+
+            AssertImportBadEncapsulationKey(algorithm, Array.Empty<byte>());
+            AssertImportBadEncapsulationKey(algorithm, new byte[lowerBound - 1]);
+            AssertImportBadEncapsulationKey(algorithm, new byte[upperBound + 1]);
+
+            // The ML-KEM component alone is not a valid Composite ML-KEM encapsulation key.
+            AssertImportBadEncapsulationKey(
+                algorithm,
+                new byte[CompositeMLKemTestData.GetMLKemAlgorithm(algorithm).EncapsulationKeySizeInBytes]);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ImportDecapsulationKey_ValidSizes_NotSupported(CompositeMLKemAlgorithm algorithm)
+        {
+            int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeUpperBound(algorithm);
+
+            AssertNotSupported(algorithm, () => CompositeMLKem.ImportDecapsulationKey(algorithm, new byte[lowerBound]));
+            AssertNotSupported(algorithm, () => CompositeMLKem.ImportDecapsulationKey(algorithm, new byte[upperBound]));
+            AssertNotSupported(algorithm, () => CompositeMLKem.ImportDecapsulationKey(algorithm, new byte[lowerBound].AsSpan()));
+            AssertNotSupported(algorithm, () => CompositeMLKem.ImportDecapsulationKey(algorithm, new byte[upperBound].AsSpan()));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ImportDecapsulationKey_InvalidSizes(CompositeMLKemAlgorithm algorithm)
+        {
+            int lowerBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm);
+            int upperBound = CompositeMLKemTestData.ExpectedDecapsulationKeySizeUpperBound(algorithm);
+
+            AssertImportBadDecapsulationKey(algorithm, Array.Empty<byte>());
+            AssertImportBadDecapsulationKey(algorithm, new byte[lowerBound - 1]);
+            AssertImportBadDecapsulationKey(algorithm, new byte[upperBound + 1]);
+
+            // The ML-KEM private seed alone is not a valid Composite ML-KEM decapsulation key.
+            AssertImportBadDecapsulationKey(
+                algorithm,
+                new byte[CompositeMLKemTestData.GetMLKemAlgorithm(algorithm).PrivateSeedSizeInBytes]);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ImportSubjectPublicKeyInfo_KnownAlgorithm(CompositeMLKemAlgorithm algorithm)
+        {
+            SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn
+            {
+                Algorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
+                    Parameters = null,
+                },
+                SubjectPublicKey = new byte[CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm)],
+            };
+
+            byte[] encoded = spki.Encode();
+
+            // The OID is recognized, so the failure is that the algorithm has no implementation.
+            CompositeMLKemTestHelpers.AssertImportSubjectPublicKeyInfo(
+                import => AssertAlgorithmNotSupported(() => import(encoded)));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemTestData.AllAlgorithmsTestData), MemberType = typeof(CompositeMLKemTestData))]
+        public static void ImportPkcs8PrivateKey_KnownAlgorithmNotSupported(CompositeMLKemAlgorithm algorithm)
+        {
+            byte[] privateKey = new byte[CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm)];
+            PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
+            {
+                PrivateKeyAlgorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
+                    Parameters = null,
+                },
+                PrivateKey = privateKey,
+            };
+
+            byte[] encoded = pkcs8.Encode();
+
+            // The OID is recognized, so the failure is that the algorithm has no implementation.
+            CompositeMLKemTestHelpers.AssertImportPkcs8PrivateKey(
+                import => AssertAlgorithmNotSupported(() => import(encoded)));
+
+            // PBE AES is unavailable on Browser.
+            if (!PlatformDetection.IsBrowser)
+            {
+                byte[] encrypted = CompositeMLKemTestHelpers.CreateEncryptedPkcs8PrivateKey(
+                    CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
+                    privateKey,
+                    new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 42));
+
+                CompositeMLKemTestHelpers.AssertImportEncryptedPkcs8PrivateKey(
+                    import => AssertAlgorithmNotSupported(() => import("PLACEHOLDER", encrypted)));
+            }
+        }
+
+        [Fact]
+        public static void ImportSubjectPublicKeyInfo_UnknownAlgorithm()
+        {
+            SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn
+            {
+                Algorithm = new AlgorithmIdentifierAsn
+                {
+                    // One past the last Composite ML-KEM OID.
+                    Algorithm = "1.3.6.1.5.5.7.6.67",
+                    Parameters = null,
+                },
+                SubjectPublicKey = new byte[1216],
+            };
+
+            byte[] encoded = spki.Encode();
+
+            CompositeMLKemTestHelpers.AssertImportSubjectPublicKeyInfo(import =>
+            {
+                CryptographicException ex = Assert.Throws<CryptographicException>(() => import(encoded));
+                Assert.DoesNotContain(nameof(CompositeMLKem), ex.Message);
+            });
+        }
+
+        [Fact]
+        public static void ImportPkcs8PrivateKey_UnknownAlgorithm()
+        {
+            PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
+            {
+                PrivateKeyAlgorithm = new AlgorithmIdentifierAsn
+                {
+                    // The last Composite ML-DSA OID, which is not a Composite ML-KEM OID.
+                    Algorithm = "1.3.6.1.5.5.7.6.54",
+                    Parameters = null,
+                },
+                PrivateKey = new byte[96],
+            };
+
+            byte[] encoded = pkcs8.Encode();
+
+            CompositeMLKemTestHelpers.AssertImportPkcs8PrivateKey(import =>
+            {
+                CryptographicException ex = Assert.Throws<CryptographicException>(() => import(encoded));
+                Assert.DoesNotContain(nameof(CompositeMLKem), ex.Message);
+            });
+        }
+
+        [Fact]
+        public static void ImportSubjectPublicKeyInfo_AlgorithmErrorsInAsn()
+        {
+            CompositeMLKemAlgorithm algorithm = CompositeMLKemAlgorithm.MLKem768WithX25519;
+
+            // Create an invalid Composite ML-KEM SPKI with parameters
+            SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn
+            {
+                Algorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
+                    Parameters = CompositeMLKemTestHelpers.s_derBitStringFoo, // <-- Invalid
+                },
+                SubjectPublicKey = new byte[CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm)],
+            };
+
+            CompositeMLKemTestHelpers.AssertImportSubjectPublicKeyInfo(
+                import => Assert.Throws<CryptographicException>(() => import(spki.Encode())));
+
+            spki.Algorithm.Parameters = AsnUtils.DerNull;
+
+            CompositeMLKemTestHelpers.AssertImportSubjectPublicKeyInfo(
+                import => Assert.Throws<CryptographicException>(() => import(spki.Encode())));
+        }
+
+        [Fact]
+        public static void ImportPkcs8PrivateKey_AlgorithmErrorsInAsn()
+        {
+            CompositeMLKemAlgorithm algorithm = CompositeMLKemAlgorithm.MLKem768WithX25519;
+
+            // Create an invalid Composite ML-KEM PKCS#8 with parameters
+            PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
+            {
+                PrivateKeyAlgorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
+                    Parameters = CompositeMLKemTestHelpers.s_derBitStringFoo, // <-- Invalid
+                },
+                PrivateKey = new byte[CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(algorithm)],
+            };
+
+            CompositeMLKemTestHelpers.AssertImportPkcs8PrivateKey(
+                import => Assert.Throws<CryptographicException>(() => import(pkcs8.Encode())));
+
+            pkcs8.PrivateKeyAlgorithm.Parameters = AsnUtils.DerNull;
+
+            CompositeMLKemTestHelpers.AssertImportPkcs8PrivateKey(
+                import => Assert.Throws<CryptographicException>(() => import(pkcs8.Encode())));
+        }
+
+        [Fact]
+        public static void Import_EncodedKeyTrailingData()
+        {
+            AssertSubjectPublicKeyInfoImportThrows(AppendTrailingByte(CreateSubjectPublicKeyInfo()));
+            AssertPkcs8PrivateKeyImportThrows(AppendTrailingByte(CreatePkcs8PrivateKey()));
+        }
+
+        [Fact]
+        public static void Import_EncodedKeyTruncated()
+        {
+            AssertSubjectPublicKeyInfoImportThrows(TruncateLastByte(CreateSubjectPublicKeyInfo()));
+            AssertPkcs8PrivateKeyImportThrows(TruncateLastByte(CreatePkcs8PrivateKey()));
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires AES, which is not supported on Browser.")]
+        public static void ImportEncryptedPkcs8PrivateKey_TrailingData()
+        {
+            byte[] encryptedPkcs8 = CompositeMLKemTestHelpers.CreateEncryptedPkcs8PrivateKey(
+                CompositeMLKemTestHelpers.AlgorithmToOid(CompositeMLKemAlgorithm.MLKem768WithX25519),
+                [],
+                new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 42));
+
+            AssertEncryptedPkcs8PrivateKeyImportThrows(AppendTrailingByte(encryptedPkcs8));
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires AES, which is not supported on Browser.")]
+        public static void ImportEncryptedPkcs8PrivateKey_Truncated()
+        {
+            byte[] encryptedPkcs8 = CompositeMLKemTestHelpers.CreateEncryptedPkcs8PrivateKey(
+                CompositeMLKemTestHelpers.AlgorithmToOid(CompositeMLKemAlgorithm.MLKem768WithX25519),
+                [],
+                new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 42));
+
+            AssertEncryptedPkcs8PrivateKeyImportThrows(TruncateLastByte(encryptedPkcs8));
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires AES, which is not supported on Browser.")]
+        public static void ImportEncryptedPkcs8PrivateKey_WrongPassword()
+        {
+            byte[] encryptedPkcs8 = CompositeMLKemTestHelpers.CreateEncryptedPkcs8PrivateKey(
+                CompositeMLKemTestHelpers.AlgorithmToOid(CompositeMLKemAlgorithm.MLKem768WithX25519),
+                [],
+                new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 42));
+
+            CompositeMLKemTestHelpers.AssertImportEncryptedPkcs8PrivateKey(
+                import => Assert.Throws<CryptographicException>(() => import("WRONG PASSWORD", encryptedPkcs8)));
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires AES, which is not supported on Browser.")]
+        public static void ImportEncryptedPkcs8PrivateKey_NotCompositeMLKemKey()
+        {
+            byte[] encryptedPkcs8 = CompositeMLKemTestHelpers.CreateEncryptedPkcs8PrivateKey(
+                "1.3.6.1.5.5.7.6.54",
+                [],
+                new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 42),
+                CompositeMLKemTestHelpers.EncryptionPasswordType.Byte);
+
+            CompositeMLKemTestHelpers.AssertImportEncryptedPkcs8PrivateKey(import =>
+            {
+                CryptographicException exception =
+                    Assert.Throws<CryptographicException>(() => import("PLACEHOLDER", encryptedPkcs8));
+                Assert.DoesNotContain(nameof(CompositeMLKem), exception.Message);
+            });
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Password-based encryption requires TripleDES, which is not supported on Browser.")]
+        public static void ImportEncryptedPkcs8PrivateKey_BytePassword_RejectsPkcs12Kdf()
+        {
+            byte[] encryptedPkcs8 = CompositeMLKemTestHelpers.CreateEncryptedPkcs8PrivateKey(
+                CompositeMLKemTestHelpers.AlgorithmToOid(CompositeMLKemAlgorithm.MLKem768WithX25519),
+                [],
+                new PbeParameters(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 42));
+
+            CompositeMLKemTestHelpers.AssertImportEncryptedPkcs8PrivateKey(
+                import => Assert.Throws<CryptographicException>(() => import("PLACEHOLDER", encryptedPkcs8)),
+                CompositeMLKemTestHelpers.EncryptionPasswordType.Byte);
+        }
+
+        [Fact]
+        public static void Import_WrongAsnType()
+        {
+            // Create an incorrect ASN.1 structure to pass into the import methods.
+            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
+            AlgorithmIdentifierAsn algorithmIdentifier = new AlgorithmIdentifierAsn
+            {
+                Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(CompositeMLKemAlgorithm.MLKem768WithX25519),
+            };
+            algorithmIdentifier.Encode(writer);
+            byte[] wrongAsnType = writer.Encode();
+
+            CompositeMLKemTestHelpers.AssertImportSubjectPublicKeyInfo(
+                import => Assert.Throws<CryptographicException>(() => import(wrongAsnType)));
+
+            CompositeMLKemTestHelpers.AssertImportPkcs8PrivateKey(
+                import => Assert.Throws<CryptographicException>(() => import(wrongAsnType)));
+
+            CompositeMLKemTestHelpers.AssertImportEncryptedPkcs8PrivateKey(
+                import => Assert.Throws<CryptographicException>(() => import("PLACEHOLDER", wrongAsnType)));
+        }
+
+        [Fact]
+        public static void ImportSpki_BerEncoding()
+        {
+            CompositeMLKemAlgorithm algorithm = CompositeMLKemAlgorithm.MLKem768WithX25519;
+
+            SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn
+            {
+                Algorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(algorithm),
+                    Parameters = null,
+                },
+                SubjectPublicKey = new byte[CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(algorithm)],
+            };
+
+            byte[] berSpki = AsnUtils.ConvertDerToNonDerBer(spki.Encode());
+
+            // SubjectPublicKeyInfo must be DER encoded.
+            CompositeMLKemTestHelpers.AssertImportSubjectPublicKeyInfo(
+                import => Assert.Throws<CryptographicException>(() => import(berSpki)));
+        }
+
+        [Fact]
+        public static void ImportFromPem_MissingRecognizedLabel()
+        {
+            AssertImportFromPemArgumentException(WritePemRaw("UNKNOWN LABEL", []));
+            AssertImportFromPemArgumentException(string.Empty);
+            AssertImportFromPemArgumentException(WritePemRaw("ENCRYPTED PRIVATE KEY", []));
+            AssertImportFromPemArgumentException(WritePemRaw("PRIVATE KEY", "%"));
+            AssertImportFromPemArgumentException(WritePemRaw("PUBLIC KEY", "%"));
+        }
+
+        [Fact]
+        public static void ImportFromPem_MultipleRecognizedLabels()
+        {
+            AssertImportFromPemArgumentException(WritePemRaw("PUBLIC KEY", []) + '\n' + WritePemRaw("PUBLIC KEY", []));
+            AssertImportFromPemArgumentException(WritePemRaw("PRIVATE KEY", []) + '\n' + WritePemRaw("PUBLIC KEY", []));
+            AssertImportFromPemArgumentException(WritePemRaw("PUBLIC KEY", []) + '\n' + WritePemRaw("PRIVATE KEY", []));
+            AssertImportFromPemArgumentException(WritePemRaw("PRIVATE KEY", []) + '\n' + WritePemRaw("PRIVATE KEY", []));
+        }
+
+        [Fact]
+        public static void ImportFromEncryptedPem_MissingRecognizedLabel()
+        {
+            AssertImportFromEncryptedPemArgumentException(WritePemRaw("UNKNOWN LABEL", []));
+            AssertImportFromEncryptedPemArgumentException(WritePemRaw("CERTIFICATE", []));
+            AssertImportFromEncryptedPemArgumentException(string.Empty);
+            AssertImportFromEncryptedPemArgumentException(WritePemRaw("ENCRYPTED PRIVATE KEY", "%"));
+        }
+
+        [Fact]
+        public static void ImportFromEncryptedPem_MultipleRecognizedLabels()
+        {
+            AssertImportFromEncryptedPemArgumentException(
+                WritePemRaw("ENCRYPTED PRIVATE KEY", []) + '\n' + WritePemRaw("ENCRYPTED PRIVATE KEY", []));
+        }
+
+        private static void AssertImportBadEncapsulationKey(CompositeMLKemAlgorithm algorithm, byte[] encapsulationKey)
+        {
+            CompositeMLKemTestHelpers.AssertImportEncapsulationKey(
+                import => Assert.Throws<CryptographicException>(() => import()),
+                algorithm,
+                encapsulationKey);
+        }
+
+        private static void AssertImportBadDecapsulationKey(CompositeMLKemAlgorithm algorithm, byte[] decapsulationKey)
+        {
+            CompositeMLKemTestHelpers.AssertImportDecapsulationKey(
+                import => Assert.Throws<CryptographicException>(() => import()),
+                algorithm,
+                decapsulationKey);
+        }
+
+        // Asserts that the operation throws PlatformNotSupportedException because the algorithm has no implementation
+        // on this platform. When an implementation is added, the positive case needs to be asserted instead.
+        private static void AssertNotSupported(CompositeMLKemAlgorithm algorithm, Action test)
+        {
+            AssertExtensions.FalseExpression(CompositeMLKem.IsAlgorithmSupported(algorithm));
+
+            PlatformNotSupportedException pnse = Assert.Throws<PlatformNotSupportedException>(test);
+            Assert.Contains(nameof(CompositeMLKem), pnse.Message);
+        }
+
+        // Encoded key imports surface an unsupported algorithm as a CryptographicException.
+        private static void AssertAlgorithmNotSupported(Action test)
+        {
+            CryptographicException ex = Assert.Throws<CryptographicException>(test);
+            Assert.Contains(nameof(CompositeMLKem), ex.Message);
+        }
+
+        private static byte[] CreateSubjectPublicKeyInfo()
+        {
+            SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn
+            {
+                Algorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(CompositeMLKemAlgorithm.MLKem768WithX25519),
+                    Parameters = null,
+                },
+                SubjectPublicKey = ReadOnlyMemory<byte>.Empty,
+            };
+
+            return spki.Encode();
+        }
+
+        private static byte[] CreatePkcs8PrivateKey()
+        {
+            PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
+            {
+                PrivateKeyAlgorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = CompositeMLKemTestHelpers.AlgorithmToOid(CompositeMLKemAlgorithm.MLKem768WithX25519),
+                    Parameters = null,
+                },
+                PrivateKey = ReadOnlyMemory<byte>.Empty,
+            };
+
+            return pkcs8.Encode();
+        }
+
+        private static byte[] AppendTrailingByte(byte[] encoded)
+        {
+            Array.Resize(ref encoded, encoded.Length + 1);
+            return encoded;
+        }
+
+        private static byte[] TruncateLastByte(byte[] encoded)
+        {
+            Array.Resize(ref encoded, encoded.Length - 1);
+            return encoded;
+        }
+
+        private static void AssertSubjectPublicKeyInfoImportThrows(byte[] encoded) =>
+            CompositeMLKemTestHelpers.AssertImportSubjectPublicKeyInfo(
+                import => Assert.Throws<CryptographicException>(() => import(encoded)));
+
+        private static void AssertPkcs8PrivateKeyImportThrows(byte[] encoded) =>
+            CompositeMLKemTestHelpers.AssertImportPkcs8PrivateKey(
+                import => Assert.Throws<CryptographicException>(() => import(encoded)));
+
+        private static void AssertEncryptedPkcs8PrivateKeyImportThrows(byte[] encoded) =>
+            CompositeMLKemTestHelpers.AssertImportEncryptedPkcs8PrivateKey(
+                import => Assert.Throws<CryptographicException>(() => import("PLACEHOLDER", encoded)));
+
+        private static void AssertImportFromPemArgumentException(string pem)
+        {
+            AssertExtensions.Throws<ArgumentException>("source", () => CompositeMLKem.ImportFromPem(pem));
+            AssertExtensions.Throws<ArgumentException>("source", () => CompositeMLKem.ImportFromPem(pem.AsSpan()));
+        }
+
+        private static void AssertImportFromEncryptedPemArgumentException(string encryptedPem)
+        {
+            AssertExtensions.Throws<ArgumentException>("source", () => CompositeMLKem.ImportFromEncryptedPem(encryptedPem, "PLACEHOLDER"));
+            AssertExtensions.Throws<ArgumentException>("source", () => CompositeMLKem.ImportFromEncryptedPem(encryptedPem, "PLACEHOLDER"u8));
+            AssertExtensions.Throws<ArgumentException>("source", () => CompositeMLKem.ImportFromEncryptedPem(encryptedPem.AsSpan(), "PLACEHOLDER"));
+            AssertExtensions.Throws<ArgumentException>("source", () => CompositeMLKem.ImportFromEncryptedPem(encryptedPem, "PLACEHOLDER"u8.ToArray()));
+        }
+
+        private static string WritePemRaw(string label, ReadOnlySpan<char> data) =>
+            $"-----BEGIN {label}-----\n{data.ToString()}\n-----END {label}-----";
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemMockImplementation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemMockImplementation.cs
@@ -1,0 +1,275 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    internal sealed class CompositeMLKemMockImplementation : CompositeMLKem
+    {
+        internal static CompositeMLKemMockImplementation Create(CompositeMLKemAlgorithm algorithm) =>
+            new CompositeMLKemMockImplementation(algorithm);
+
+        public CompositeMLKemMockImplementation(CompositeMLKemAlgorithm algorithm)
+            : base(algorithm)
+        {
+        }
+
+        internal delegate void EncapsulateAction(Span<byte> ciphertext, Span<byte> sharedSecret);
+        internal delegate void DecapsulateAction(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret);
+        internal delegate int ExportFunc(Span<byte> destination);
+        internal delegate bool TryExportFunc(Span<byte> destination, out int written);
+        internal delegate void DisposeAction(bool disposing);
+
+        public int EncapsulateCoreCallCount;
+        public int DecapsulateCoreCallCount;
+        public int ExportEncapsulationKeyCoreCallCount;
+        public int ExportDecapsulationKeyCoreCallCount;
+        public int TryExportPkcs8PrivateKeyCoreCallCount;
+        public int DisposeCallCount;
+
+        public EncapsulateAction EncapsulateCoreHook { get; set; } = (_, _) => Assert.Fail();
+        public DecapsulateAction DecapsulateCoreHook { get; set; } = (_, _) => Assert.Fail();
+        public ExportFunc ExportEncapsulationKeyCoreHook { get; set; } = _ => { Assert.Fail(); return 0; };
+        public ExportFunc ExportDecapsulationKeyCoreHook { get; set; } = _ => { Assert.Fail(); return 0; };
+        public TryExportFunc TryExportPkcs8PrivateKeyCoreHook { get; set; } = (Span<byte> destination, out int bytesWritten) => { Assert.Fail(); bytesWritten = 0; return false; };
+        public DisposeAction DisposeHook { get; set; } = _ => { };
+
+        protected override void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret)
+        {
+            EncapsulateCoreCallCount++;
+            EncapsulateCoreHook(ciphertext, sharedSecret);
+        }
+
+        protected override void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret)
+        {
+            DecapsulateCoreCallCount++;
+            DecapsulateCoreHook(ciphertext, sharedSecret);
+        }
+
+        protected override int ExportEncapsulationKeyCore(Span<byte> destination)
+        {
+            ExportEncapsulationKeyCoreCallCount++;
+            return ExportEncapsulationKeyCoreHook(destination);
+        }
+
+        protected override int ExportDecapsulationKeyCore(Span<byte> destination)
+        {
+            ExportDecapsulationKeyCoreCallCount++;
+            return ExportDecapsulationKeyCoreHook(destination);
+        }
+
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            TryExportPkcs8PrivateKeyCoreCallCount++;
+            return TryExportPkcs8PrivateKeyCoreHook(destination, out bytesWritten);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCallCount++;
+            DisposeHook(disposing);
+        }
+
+        public void AddLengthAssertion()
+        {
+            EncapsulateAction oldEncapsulateCoreHook = EncapsulateCoreHook;
+            EncapsulateCoreHook = (Span<byte> ciphertext, Span<byte> sharedSecret) =>
+            {
+                oldEncapsulateCoreHook(ciphertext, sharedSecret);
+                Assert.Equal(Algorithm.CiphertextSizeInBytes, ciphertext.Length);
+                Assert.Equal(Algorithm.SharedSecretSizeInBytes, sharedSecret.Length);
+            };
+
+            DecapsulateAction oldDecapsulateCoreHook = DecapsulateCoreHook;
+            DecapsulateCoreHook = (ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) =>
+            {
+                oldDecapsulateCoreHook(ciphertext, sharedSecret);
+                Assert.Equal(Algorithm.CiphertextSizeInBytes, ciphertext.Length);
+                Assert.Equal(Algorithm.SharedSecretSizeInBytes, sharedSecret.Length);
+            };
+
+            ExportFunc oldExportEncapsulationKeyCoreHook = ExportEncapsulationKeyCoreHook;
+            ExportEncapsulationKeyCoreHook = (Span<byte> destination) =>
+            {
+                int ret = oldExportEncapsulationKeyCoreHook(destination);
+                AssertExtensions.GreaterThanOrEqualTo(
+                    destination.Length,
+                    CompositeMLKemTestData.ExpectedEncapsulationKeySizeLowerBound(Algorithm));
+                return ret;
+            };
+
+            ExportFunc oldExportDecapsulationKeyCoreHook = ExportDecapsulationKeyCoreHook;
+            ExportDecapsulationKeyCoreHook = (Span<byte> destination) =>
+            {
+                int ret = oldExportDecapsulationKeyCoreHook(destination);
+                AssertExtensions.GreaterThanOrEqualTo(
+                    destination.Length,
+                    CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(Algorithm));
+                return ret;
+            };
+
+            TryExportFunc oldTryExportPkcs8PrivateKeyCoreHook = TryExportPkcs8PrivateKeyCoreHook;
+            TryExportPkcs8PrivateKeyCoreHook = (Span<byte> destination, out int bytesWritten) =>
+            {
+                bool ret = oldTryExportPkcs8PrivateKeyCoreHook(destination, out bytesWritten);
+                AssertExtensions.GreaterThanOrEqualTo(
+                    destination.Length,
+                    CompositeMLKemTestData.ExpectedDecapsulationKeySizeLowerBound(Algorithm));
+                return ret;
+            };
+        }
+
+        public void AddDestinationBufferIsSameAssertion(ReadOnlyMemory<byte> buffer)
+        {
+            ExportFunc oldExportEncapsulationKeyCoreHook = ExportEncapsulationKeyCoreHook;
+            ExportEncapsulationKeyCoreHook = (Span<byte> destination) =>
+            {
+                int ret = oldExportEncapsulationKeyCoreHook(destination);
+                AssertExtensions.Same(buffer.Span, destination);
+                return ret;
+            };
+
+            ExportFunc oldExportDecapsulationKeyCoreHook = ExportDecapsulationKeyCoreHook;
+            ExportDecapsulationKeyCoreHook = (Span<byte> destination) =>
+            {
+                int ret = oldExportDecapsulationKeyCoreHook(destination);
+                AssertExtensions.Same(buffer.Span, destination);
+                return ret;
+            };
+        }
+
+        public void AddCiphertextBufferIsSameAssertion(ReadOnlyMemory<byte> buffer)
+        {
+            EncapsulateAction oldEncapsulateCoreHook = EncapsulateCoreHook;
+            EncapsulateCoreHook = (Span<byte> ciphertext, Span<byte> sharedSecret) =>
+            {
+                oldEncapsulateCoreHook(ciphertext, sharedSecret);
+                AssertExtensions.Same(buffer.Span, ciphertext);
+            };
+
+            DecapsulateAction oldDecapsulateCoreHook = DecapsulateCoreHook;
+            DecapsulateCoreHook = (ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) =>
+            {
+                oldDecapsulateCoreHook(ciphertext, sharedSecret);
+                AssertExtensions.Same(buffer.Span, ciphertext);
+            };
+        }
+
+        public void AddSharedSecretBufferIsSameAssertion(ReadOnlyMemory<byte> buffer)
+        {
+            EncapsulateAction oldEncapsulateCoreHook = EncapsulateCoreHook;
+            EncapsulateCoreHook = (Span<byte> ciphertext, Span<byte> sharedSecret) =>
+            {
+                oldEncapsulateCoreHook(ciphertext, sharedSecret);
+                AssertExtensions.Same(buffer.Span, sharedSecret);
+            };
+
+            DecapsulateAction oldDecapsulateCoreHook = DecapsulateCoreHook;
+            DecapsulateCoreHook = (ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) =>
+            {
+                oldDecapsulateCoreHook(ciphertext, sharedSecret);
+                AssertExtensions.Same(buffer.Span, sharedSecret);
+            };
+        }
+
+        public void AddFillDestination(byte b)
+        {
+            EncapsulateAction oldEncapsulateCoreHook = EncapsulateCoreHook;
+            EncapsulateCoreHook = (Span<byte> ciphertext, Span<byte> sharedSecret) =>
+            {
+                oldEncapsulateCoreHook(ciphertext, sharedSecret);
+                ciphertext.Fill(b);
+                sharedSecret.Fill(b);
+            };
+
+            DecapsulateAction oldDecapsulateCoreHook = DecapsulateCoreHook;
+            DecapsulateCoreHook = (ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) =>
+            {
+                oldDecapsulateCoreHook(ciphertext, sharedSecret);
+                sharedSecret.Fill(b);
+            };
+
+            ExportFunc oldExportEncapsulationKeyCoreHook = ExportEncapsulationKeyCoreHook;
+            ExportEncapsulationKeyCoreHook = (Span<byte> destination) =>
+            {
+                _ = oldExportEncapsulationKeyCoreHook(destination);
+                destination.Fill(b);
+                return destination.Length;
+            };
+
+            ExportFunc oldExportDecapsulationKeyCoreHook = ExportDecapsulationKeyCoreHook;
+            ExportDecapsulationKeyCoreHook = (Span<byte> destination) =>
+            {
+                _ = oldExportDecapsulationKeyCoreHook(destination);
+                destination.Fill(b);
+                return destination.Length;
+            };
+
+            TryExportFunc oldTryExportPkcs8PrivateKeyCoreHook = TryExportPkcs8PrivateKeyCoreHook;
+            TryExportPkcs8PrivateKeyCoreHook = (Span<byte> destination, out int bytesWritten) =>
+            {
+                bool ret = oldTryExportPkcs8PrivateKeyCoreHook(destination, out bytesWritten);
+                destination.Fill(b);
+                return ret;
+            };
+        }
+
+        public void SetNoOpHooks()
+        {
+            EncapsulateCoreHook = (_, _) => { };
+            DecapsulateCoreHook = (_, _) => { };
+            ExportEncapsulationKeyCoreHook = destination => destination.Length;
+            ExportDecapsulationKeyCoreHook = destination => destination.Length;
+            TryExportPkcs8PrivateKeyCoreHook = (Span<byte> destination, out int bytesWritten) =>
+            {
+                bytesWritten = destination.Length;
+                return true;
+            };
+        }
+
+        public void AddFillDestination(byte[] fillContents)
+        {
+            ExportFunc oldExportEncapsulationKeyCoreHook = ExportEncapsulationKeyCoreHook;
+            ExportEncapsulationKeyCoreHook = (Span<byte> destination) =>
+            {
+                _ = oldExportEncapsulationKeyCoreHook(destination);
+
+                if (fillContents.AsSpan().TryCopyTo(destination))
+                {
+                    return fillContents.Length;
+                }
+
+                return 0;
+            };
+
+            ExportFunc oldExportDecapsulationKeyCoreHook = ExportDecapsulationKeyCoreHook;
+            ExportDecapsulationKeyCoreHook = (Span<byte> destination) =>
+            {
+                _ = oldExportDecapsulationKeyCoreHook(destination);
+
+                if (fillContents.AsSpan().TryCopyTo(destination))
+                {
+                    return fillContents.Length;
+                }
+
+                return 0;
+            };
+
+            TryExportFunc oldTryExportPkcs8PrivateKeyCoreHook = TryExportPkcs8PrivateKeyCoreHook;
+            TryExportPkcs8PrivateKeyCoreHook = (Span<byte> destination, out int bytesWritten) =>
+            {
+                _ = oldTryExportPkcs8PrivateKeyCoreHook(destination, out _);
+
+                if (fillContents.AsSpan().TryCopyTo(destination))
+                {
+                    bytesWritten = fillContents.Length;
+                    return true;
+                }
+
+                bytesWritten = 0;
+                return false;
+            };
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemTestData.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemTestData.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Sdk;
+
+namespace System.Security.Cryptography.Tests
+{
+    public static class CompositeMLKemTestData
+    {
+        internal static CompositeMLKemAlgorithm[] AllAlgorithms { get; } =
+        [
+            CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048,
+            CompositeMLKemAlgorithm.MLKem768WithRsaOaep3072,
+            CompositeMLKemAlgorithm.MLKem768WithRsaOaep4096,
+            CompositeMLKemAlgorithm.MLKem768WithX25519,
+            CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP256,
+            CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP384,
+            CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanBrainpoolP256r1,
+            CompositeMLKemAlgorithm.MLKem1024WithRsaOaep3072,
+            CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP384,
+            CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanBrainpoolP384r1,
+            CompositeMLKemAlgorithm.MLKem1024WithX448,
+            CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP521,
+        ];
+
+        public static IEnumerable<object[]> AllAlgorithmsTestData =>
+            AllAlgorithms.Select(algorithm => new object[] { algorithm });
+
+        public static IEnumerable<object[]> SupportedAlgorithmsTestData =>
+            AllAlgorithms.Where(CompositeMLKem.IsAlgorithmSupported).Select(algorithm => new object[] { algorithm });
+
+        public static IEnumerable<object[]> AllAlgorithmsAndDisposalTestData =>
+            from algorithm in AllAlgorithms
+            from shouldDispose in new[] { true, false }
+            select new object[] { algorithm, shouldDispose };
+
+        internal sealed class RsaAlgorithm(int keySizeInBits)
+        {
+            internal int KeySizeInBits { get; } = keySizeInBits;
+        }
+
+        internal sealed class ECDiffieHellmanAlgorithm(int keySizeInBits, int privateKeySizeInBytes)
+        {
+            internal int KeySizeInBits { get; } = keySizeInBits;
+
+            // ECPrivateKey size with parameters and without public key.
+            internal int PrivateKeySizeInBytes { get; } = privateKeySizeInBytes;
+        }
+
+        internal sealed class XDiffieHellmanAlgorithm(int keySizeInBits)
+        {
+            internal int KeySizeInBits { get; } = keySizeInBits;
+        }
+
+        internal static MLKemAlgorithm GetMLKemAlgorithm(CompositeMLKemAlgorithm algorithm) =>
+            algorithm.Name.StartsWith("MLKEM768-", StringComparison.Ordinal) ? MLKemAlgorithm.MLKem768 :
+            algorithm.Name.StartsWith("MLKEM1024-", StringComparison.Ordinal) ? MLKemAlgorithm.MLKem1024 :
+            throw new XunitException($"Algorithm '{algorithm.Name}' doesn't have an ML-KEM component.");
+
+        internal static T ExecuteComponentFunc<T>(
+            CompositeMLKemAlgorithm algorithm,
+            Func<RsaAlgorithm, T> rsaFunc,
+            Func<ECDiffieHellmanAlgorithm, T> ecdhFunc,
+            Func<XDiffieHellmanAlgorithm, T> xdhFunc)
+        {
+            // Traditional component sizes are derived from the size table in the Composite ML-KEM specification.
+            return algorithm.Name switch
+            {
+                "MLKEM768-RSA2048-SHA3-256" => rsaFunc(new RsaAlgorithm(2048)),
+                "MLKEM768-RSA3072-SHA3-256" or
+                "MLKEM1024-RSA3072-SHA3-256" => rsaFunc(new RsaAlgorithm(3072)),
+                "MLKEM768-RSA4096-SHA3-256" => rsaFunc(new RsaAlgorithm(4096)),
+                "MLKEM768-ECDH-P256-SHA3-256" => ecdhFunc(new ECDiffieHellmanAlgorithm(256, 51)),
+                "MLKEM768-ECDH-P384-SHA3-256" or
+                "MLKEM1024-ECDH-P384-SHA3-256" => ecdhFunc(new ECDiffieHellmanAlgorithm(384, 64)),
+                "MLKEM1024-ECDH-P521-SHA3-256" => ecdhFunc(new ECDiffieHellmanAlgorithm(521, 82)),
+                "MLKEM768-ECDH-brainpoolP256r1-SHA3-256" => ecdhFunc(new ECDiffieHellmanAlgorithm(256, 52)),
+                "MLKEM1024-ECDH-brainpoolP384r1-SHA3-256" => ecdhFunc(new ECDiffieHellmanAlgorithm(384, 68)),
+                "MLKEM768-X25519-SHA3-256" => xdhFunc(new XDiffieHellmanAlgorithm(32 * 8)),
+                "MLKEM1024-X448-SHA3-256" => xdhFunc(new XDiffieHellmanAlgorithm(56 * 8)),
+                _ => throw new XunitException($"Unsupported algorithm: {algorithm.Name}"),
+            };
+        }
+
+        internal static int ExpectedEncapsulationKeySizeLowerBound(CompositeMLKemAlgorithm algorithm)
+        {
+            return GetMLKemAlgorithm(algorithm).EncapsulationKeySizeInBytes +
+                ExecuteComponentFunc(
+                    algorithm,
+                    rsa => rsa.KeySizeInBits / 8, // RSAPublicKey contains at least the modulus
+                    ecdh => 1 + 2 * ((ecdh.KeySizeInBits + 7) / 8),
+                    xdh => xdh.KeySizeInBits / 8);
+        }
+
+        internal static int ExpectedEncapsulationKeySizeUpperBound(CompositeMLKemAlgorithm algorithm)
+        {
+            return GetMLKemAlgorithm(algorithm).EncapsulationKeySizeInBytes +
+                ExecuteComponentFunc(
+                    algorithm,
+                    rsa => (rsa.KeySizeInBits / 8) + 52, // Add max ASN.1 overhead
+                    ecdh => 1 + 2 * ((ecdh.KeySizeInBits + 7) / 8),
+                    xdh => xdh.KeySizeInBits / 8);
+        }
+
+        internal static int ExpectedDecapsulationKeySizeLowerBound(CompositeMLKemAlgorithm algorithm)
+        {
+            // The ML-KEM component of a Composite ML-KEM private key is the private seed.
+            return GetMLKemAlgorithm(algorithm).PrivateSeedSizeInBytes +
+                ExecuteComponentFunc(
+                    algorithm,
+                    rsa => rsa.KeySizeInBits / 8, // RSAPrivateKey contains at least the modulus
+                    ecdh => ecdh.PrivateKeySizeInBytes,
+                    xdh => xdh.KeySizeInBits / 8);
+        }
+
+        internal static int ExpectedDecapsulationKeySizeUpperBound(CompositeMLKemAlgorithm algorithm)
+        {
+            return GetMLKemAlgorithm(algorithm).PrivateSeedSizeInBytes +
+                ExecuteComponentFunc(
+                    algorithm,
+                    rsa => (rsa.KeySizeInBits / 8) * 9 / 2 + 101, // Add max ASN.1 overhead
+                    ecdh => ecdh.PrivateKeySizeInBytes,
+                    xdh => xdh.KeySizeInBits / 8);
+        }
+
+        internal static int ExpectedCiphertextSize(CompositeMLKemAlgorithm algorithm)
+        {
+            return GetMLKemAlgorithm(algorithm).CiphertextSizeInBytes +
+                ExecuteComponentFunc(
+                    algorithm,
+                    rsa => rsa.KeySizeInBits / 8, // RSA-OAEP ciphertexts are the size of the modulus
+                    ecdh => 1 + 2 * ((ecdh.KeySizeInBits + 7) / 8),
+                    xdh => xdh.KeySizeInBits / 8);
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemTestData.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemTestData.cs
@@ -36,17 +36,20 @@ namespace System.Security.Cryptography.Tests
             from shouldDispose in new[] { true, false }
             select new object[] { algorithm, shouldDispose };
 
-        internal sealed class RsaAlgorithm(int keySizeInBits)
+        internal sealed class RsaAlgorithm(int keySizeInBits, int maxPublicKeySizeInBytes, int maxPrivateKeySizeInBytes)
         {
             internal int KeySizeInBits { get; } = keySizeInBits;
+
+            internal int MaxPublicKeySizeInBytes { get; } = maxPublicKeySizeInBytes;
+
+            internal int MaxPrivateKeySizeInBytes { get; } = maxPrivateKeySizeInBytes;
         }
 
-        internal sealed class ECDiffieHellmanAlgorithm(int keySizeInBits, int privateKeySizeInBytes)
+        internal sealed class ECDiffieHellmanAlgorithm(int keySizeInBits, int maxPrivateKeySizeInBytes)
         {
             internal int KeySizeInBits { get; } = keySizeInBits;
 
-            // ECPrivateKey size with parameters and without public key.
-            internal int PrivateKeySizeInBytes { get; } = privateKeySizeInBytes;
+            internal int MaxPrivateKeySizeInBytes { get; } = maxPrivateKeySizeInBytes;
         }
 
         internal sealed class XDiffieHellmanAlgorithm(int keySizeInBits)
@@ -68,10 +71,10 @@ namespace System.Security.Cryptography.Tests
             // Traditional component sizes are derived from the size table in the Composite ML-KEM specification.
             return algorithm.Name switch
             {
-                "MLKEM768-RSA2048-SHA3-256" => rsaFunc(new RsaAlgorithm(2048)),
+                "MLKEM768-RSA2048-SHA3-256" => rsaFunc(new RsaAlgorithm(2048, 300, 1224)),
                 "MLKEM768-RSA3072-SHA3-256" or
-                "MLKEM1024-RSA3072-SHA3-256" => rsaFunc(new RsaAlgorithm(3072)),
-                "MLKEM768-RSA4096-SHA3-256" => rsaFunc(new RsaAlgorithm(4096)),
+                "MLKEM1024-RSA3072-SHA3-256" => rsaFunc(new RsaAlgorithm(3072, 428, 1800)),
+                "MLKEM768-RSA4096-SHA3-256" => rsaFunc(new RsaAlgorithm(4096, 556, 2381)),
                 "MLKEM768-ECDH-P256-SHA3-256" => ecdhFunc(new ECDiffieHellmanAlgorithm(256, 51)),
                 "MLKEM768-ECDH-P384-SHA3-256" or
                 "MLKEM1024-ECDH-P384-SHA3-256" => ecdhFunc(new ECDiffieHellmanAlgorithm(384, 64)),
@@ -99,7 +102,7 @@ namespace System.Security.Cryptography.Tests
             return GetMLKemAlgorithm(algorithm).EncapsulationKeySizeInBytes +
                 ExecuteComponentFunc(
                     algorithm,
-                    rsa => (rsa.KeySizeInBits / 8) + 52, // Add max ASN.1 overhead
+                    rsa => rsa.MaxPublicKeySizeInBytes,
                     ecdh => 1 + 2 * ((ecdh.KeySizeInBits + 7) / 8),
                     xdh => xdh.KeySizeInBits / 8);
         }
@@ -111,7 +114,7 @@ namespace System.Security.Cryptography.Tests
                 ExecuteComponentFunc(
                     algorithm,
                     rsa => rsa.KeySizeInBits / 8, // RSAPrivateKey contains at least the modulus
-                    ecdh => ecdh.PrivateKeySizeInBytes,
+                    ecdh => ecdh.MaxPrivateKeySizeInBytes,
                     xdh => xdh.KeySizeInBits / 8);
         }
 
@@ -120,8 +123,8 @@ namespace System.Security.Cryptography.Tests
             return GetMLKemAlgorithm(algorithm).PrivateSeedSizeInBytes +
                 ExecuteComponentFunc(
                     algorithm,
-                    rsa => (rsa.KeySizeInBits / 8) * 9 / 2 + 101, // Add max ASN.1 overhead
-                    ecdh => ecdh.PrivateKeySizeInBytes,
+                    rsa => rsa.MaxPrivateKeySizeInBytes,
+                    ecdh => ecdh.MaxPrivateKeySizeInBytes,
                     xdh => xdh.KeySizeInBits / 8);
         }
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemTestHelpers.cs
@@ -1,0 +1,448 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Formats.Asn1;
+using System.Reflection;
+using System.Security.Cryptography.Asn1;
+using System.Text;
+using Test.Cryptography;
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Security.Cryptography.Tests
+{
+    internal static class CompositeMLKemTestHelpers
+    {
+        private delegate AsnWriter WriteEncryptedPkcs8<T>(ReadOnlySpan<T> password, AsnWriter writer, PbeParameters pbeParameters);
+
+        // DER encoding of ASN.1 BitString "foo"
+        internal static readonly ReadOnlyMemory<byte> s_derBitStringFoo = new byte[] { 0x03, 0x04, 0x00, 0x66, 0x6f, 0x6f };
+        private static readonly WriteEncryptedPkcs8<char> s_writeEncryptedPkcs8Char = GetWriteEncryptedPkcs8<char>();
+        private static readonly WriteEncryptedPkcs8<byte> s_writeEncryptedPkcs8Byte = GetWriteEncryptedPkcs8<byte>();
+
+        internal static void AssertImportEncapsulationKey(
+            Action<Func<CompositeMLKem>> test,
+            CompositeMLKemAlgorithm algorithm,
+            byte[] encapsulationKey) =>
+            AssertImportEncapsulationKey(test, test, algorithm, encapsulationKey);
+
+        internal static void AssertImportEncapsulationKey(
+            Action<Func<CompositeMLKem>> testDirectCall,
+            Action<Func<CompositeMLKem>> testEmbeddedCall,
+            CompositeMLKemAlgorithm algorithm,
+            byte[] encapsulationKey)
+        {
+            testDirectCall(() => CompositeMLKem.ImportEncapsulationKey(algorithm, encapsulationKey));
+
+            if (encapsulationKey?.Length == 0)
+            {
+                testDirectCall(() => CompositeMLKem.ImportEncapsulationKey(algorithm, Array.Empty<byte>().AsSpan()));
+                testDirectCall(() => CompositeMLKem.ImportEncapsulationKey(algorithm, ReadOnlySpan<byte>.Empty));
+            }
+            else
+            {
+                testDirectCall(() => CompositeMLKem.ImportEncapsulationKey(algorithm, encapsulationKey.AsSpan()));
+            }
+
+            SubjectPublicKeyInfoAsn spki = new SubjectPublicKeyInfoAsn
+            {
+                Algorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = AlgorithmToOid(algorithm),
+                    Parameters = default(ReadOnlyMemory<byte>?),
+                },
+                SubjectPublicKey = encapsulationKey,
+            };
+
+            AssertImportSubjectPublicKeyInfo(import => testEmbeddedCall(() => import(spki.Encode())));
+        }
+
+        internal delegate CompositeMLKem ImportSubjectPublicKeyInfoCallback(byte[] spki);
+
+        internal static void AssertImportSubjectPublicKeyInfo(Action<ImportSubjectPublicKeyInfoCallback> test) =>
+            AssertImportSubjectPublicKeyInfo(test, test);
+
+        internal static void AssertImportSubjectPublicKeyInfo(
+            Action<ImportSubjectPublicKeyInfoCallback> testDirectCall,
+            Action<ImportSubjectPublicKeyInfoCallback> testEmbeddedCall)
+        {
+            testDirectCall(spki => CompositeMLKem.ImportSubjectPublicKeyInfo(spki));
+            testDirectCall(spki => CompositeMLKem.ImportSubjectPublicKeyInfo(spki.AsSpan()));
+
+            testEmbeddedCall(spki => CompositeMLKem.ImportFromPem(PemEncoding.WriteString("PUBLIC KEY", spki)));
+            testEmbeddedCall(spki => CompositeMLKem.ImportFromPem(PemEncoding.WriteString("PUBLIC KEY", spki).AsSpan()));
+        }
+
+        internal static void AssertImportDecapsulationKey(
+            Action<Func<CompositeMLKem>> test,
+            CompositeMLKemAlgorithm algorithm,
+            byte[] decapsulationKey) =>
+            AssertImportDecapsulationKey(test, test, algorithm, decapsulationKey);
+
+        internal static void AssertImportDecapsulationKey(
+            Action<Func<CompositeMLKem>> testDirectCall,
+            Action<Func<CompositeMLKem>> testEmbeddedCall,
+            CompositeMLKemAlgorithm algorithm,
+            byte[] decapsulationKey)
+        {
+            testDirectCall(() => CompositeMLKem.ImportDecapsulationKey(algorithm, decapsulationKey));
+
+            if (decapsulationKey?.Length == 0)
+            {
+                testDirectCall(() => CompositeMLKem.ImportDecapsulationKey(algorithm, Array.Empty<byte>().AsSpan()));
+                testDirectCall(() => CompositeMLKem.ImportDecapsulationKey(algorithm, ReadOnlySpan<byte>.Empty));
+            }
+            else
+            {
+                testDirectCall(() => CompositeMLKem.ImportDecapsulationKey(algorithm, decapsulationKey.AsSpan()));
+            }
+
+            PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
+            {
+                PrivateKeyAlgorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = AlgorithmToOid(algorithm),
+                    Parameters = default(ReadOnlyMemory<byte>?),
+                },
+                PrivateKey = decapsulationKey,
+            };
+
+            AssertImportPkcs8PrivateKey(import => testEmbeddedCall(() => import(pkcs8.Encode())));
+        }
+
+        internal delegate CompositeMLKem ImportPkcs8PrivateKeyCallback(ReadOnlySpan<byte> pkcs8);
+
+        internal static void AssertImportPkcs8PrivateKey(Action<ImportPkcs8PrivateKeyCallback> callback) =>
+            AssertImportPkcs8PrivateKey(callback, callback);
+
+        internal static void AssertImportPkcs8PrivateKey(
+            Action<ImportPkcs8PrivateKeyCallback> testDirectCall,
+            Action<ImportPkcs8PrivateKeyCallback> testEmbeddedCall)
+        {
+            testDirectCall(pkcs8 => CompositeMLKem.ImportPkcs8PrivateKey(pkcs8));
+            testDirectCall(pkcs8 => CompositeMLKem.ImportPkcs8PrivateKey(pkcs8.ToArray()));
+
+            AssertImportFromPem(importPem =>
+            {
+                testEmbeddedCall(pkcs8 => importPem(PemEncoding.WriteString("PRIVATE KEY", pkcs8)));
+            });
+        }
+
+        internal static void AssertImportFromPem(Action<Func<string, CompositeMLKem>> callback)
+        {
+            callback(static (string pem) => CompositeMLKem.ImportFromPem(pem));
+            callback(static (string pem) => CompositeMLKem.ImportFromPem(pem.AsSpan()));
+        }
+
+        internal delegate CompositeMLKem ImportEncryptedPkcs8PrivateKeyCallback(string password, ReadOnlySpan<byte> pkcs8);
+
+        internal static void AssertImportEncryptedPkcs8PrivateKey(
+            Action<ImportEncryptedPkcs8PrivateKeyCallback> test,
+            EncryptionPasswordType passwordTypeToTest = EncryptionPasswordType.All) =>
+            AssertImportEncryptedPkcs8PrivateKey(test, test, passwordTypeToTest);
+
+        internal static void AssertImportEncryptedPkcs8PrivateKey(
+            Action<ImportEncryptedPkcs8PrivateKeyCallback> testDirectCall,
+            Action<ImportEncryptedPkcs8PrivateKeyCallback> testEmbeddedCall,
+            EncryptionPasswordType passwordTypeToTest = EncryptionPasswordType.All)
+        {
+            if ((passwordTypeToTest & EncryptionPasswordType.Char) != 0)
+            {
+                testDirectCall((password, pkcs8) => CompositeMLKem.ImportEncryptedPkcs8PrivateKey(password, pkcs8.ToArray()));
+                testDirectCall((password, pkcs8) => CompositeMLKem.ImportEncryptedPkcs8PrivateKey(password.AsSpan(), pkcs8));
+            }
+
+            if ((passwordTypeToTest & EncryptionPasswordType.Byte) != 0)
+            {
+                testDirectCall((password, pkcs8) =>
+                    CompositeMLKem.ImportEncryptedPkcs8PrivateKey(Encoding.UTF8.GetBytes(password), pkcs8.ToArray()));
+            }
+
+            AssertImportFromEncryptedPem(importPem =>
+            {
+                testEmbeddedCall((string password, ReadOnlySpan<byte> pkcs8) =>
+                {
+                    string pem = PemEncoding.WriteString("ENCRYPTED PRIVATE KEY", pkcs8);
+                    return importPem(pem, password);
+                });
+            }, passwordTypeToTest);
+        }
+
+        internal delegate CompositeMLKem ImportFromEncryptedPemCallback(string source, string password);
+
+        internal static void AssertImportFromEncryptedPem(
+            Action<ImportFromEncryptedPemCallback> callback,
+            EncryptionPasswordType passwordTypeToTest = EncryptionPasswordType.All)
+        {
+            if ((passwordTypeToTest & EncryptionPasswordType.Char) != 0)
+            {
+                callback(static (string pem, string password) => CompositeMLKem.ImportFromEncryptedPem(pem, password));
+                callback(static (string pem, string password) => CompositeMLKem.ImportFromEncryptedPem(pem.AsSpan(), password));
+            }
+
+            if ((passwordTypeToTest & EncryptionPasswordType.Byte) != 0)
+            {
+                callback(static (string pem, string password) =>
+                    CompositeMLKem.ImportFromEncryptedPem(pem, Encoding.UTF8.GetBytes(password)));
+                callback(static (string pem, string password) =>
+                    CompositeMLKem.ImportFromEncryptedPem(pem.AsSpan(), Encoding.UTF8.GetBytes(password)));
+            }
+        }
+
+        internal static void AssertExportEncapsulationKey(Action<Func<CompositeMLKem, byte[]>> callback)
+        {
+            callback(kem =>
+            {
+                // For simplicity, use a large enough size for all algorithms.
+                byte[] buffer = new byte[4096];
+
+                int size = kem.ExportEncapsulationKey(buffer.AsSpan());
+                Array.Resize(ref buffer, size);
+
+                return buffer;
+            });
+
+            callback(kem => kem.ExportEncapsulationKey());
+            callback(kem => DoTryUntilDone(kem.TryExportEncapsulationKey));
+
+            AssertExportSubjectPublicKeyInfo(exportSpki =>
+                callback(kem =>
+                    SubjectPublicKeyInfoAsn.Decode(exportSpki(kem), AsnEncodingRules.DER).SubjectPublicKey.ToArray()));
+        }
+
+        internal static void AssertExportDecapsulationKey(Action<Func<CompositeMLKem, byte[]>> callback) =>
+            AssertExportDecapsulationKey(callback, callback);
+
+        internal static void AssertExportDecapsulationKey(
+            Action<Func<CompositeMLKem, byte[]>> directCallback,
+            Action<Func<CompositeMLKem, byte[]>> indirectCallback)
+        {
+            directCallback(kem =>
+            {
+                // For simplicity, use a large enough size for all algorithms.
+                byte[] buffer = new byte[4096];
+
+                int size = kem.ExportDecapsulationKey(buffer.AsSpan());
+                Array.Resize(ref buffer, size);
+
+                return buffer;
+            });
+
+            directCallback(kem => kem.ExportDecapsulationKey());
+            directCallback(kem => DoTryUntilDone(kem.TryExportDecapsulationKey));
+
+            AssertExportPkcs8PrivateKey(exportPkcs8 =>
+                indirectCallback(kem =>
+                    PrivateKeyInfoAsn.Decode(exportPkcs8(kem), AsnEncodingRules.DER).PrivateKey.ToArray()));
+        }
+
+        internal static void AssertExportPkcs8PrivateKey(CompositeMLKem kem, Action<byte[]> callback) =>
+            AssertExportPkcs8PrivateKey(export => callback(export(kem)));
+
+        internal static void AssertExportPkcs8PrivateKey(Action<Func<CompositeMLKem, byte[]>> callback)
+        {
+            callback(kem => DoTryUntilDone(kem.TryExportPkcs8PrivateKey));
+            callback(kem => kem.ExportPkcs8PrivateKey());
+            callback(kem => DecodePem(kem.ExportPkcs8PrivateKeyPem(), "PRIVATE KEY"));
+        }
+
+        internal static void AssertExportSubjectPublicKeyInfo(CompositeMLKem kem, Action<byte[]> callback) =>
+            AssertExportSubjectPublicKeyInfo(export => callback(export(kem)));
+
+        internal static void AssertExportSubjectPublicKeyInfo(Action<Func<CompositeMLKem, byte[]>> callback)
+        {
+            callback(kem => DoTryUntilDone(kem.TryExportSubjectPublicKeyInfo));
+            callback(kem => kem.ExportSubjectPublicKeyInfo());
+            callback(kem => DecodePem(kem.ExportSubjectPublicKeyInfoPem(), "PUBLIC KEY"));
+        }
+
+        internal delegate byte[] ExportEncryptedPkcs8PrivateKeyCallback(CompositeMLKem kem, string password, PbeParameters pbeParameters);
+
+        internal static void AssertEncryptedExportPkcs8PrivateKey(
+            CompositeMLKem kem,
+            string password,
+            PbeParameters pbeParameters,
+            Action<byte[]> callback) =>
+            AssertEncryptedExportPkcs8PrivateKey(export => callback(export(kem, password, pbeParameters)));
+
+        internal static void AssertEncryptedExportPkcs8PrivateKey(
+            Action<ExportEncryptedPkcs8PrivateKeyCallback> callback,
+            EncryptionPasswordType passwordTypesToTest = EncryptionPasswordType.All)
+        {
+            if ((passwordTypesToTest & EncryptionPasswordType.Char) != 0)
+            {
+                callback((kem, password, pbeParameters) =>
+                    DoTryUntilDone((Span<byte> destination, out int bytesWritten) =>
+                        kem.TryExportEncryptedPkcs8PrivateKey(password.AsSpan(), pbeParameters, destination, out bytesWritten)));
+                callback((kem, password, pbeParameters) =>
+                    DoTryUntilDone((Span<byte> destination, out int bytesWritten) =>
+                        kem.TryExportEncryptedPkcs8PrivateKey(password, pbeParameters, destination, out bytesWritten)));
+
+                callback((kem, password, pbeParameters) => kem.ExportEncryptedPkcs8PrivateKey(password.AsSpan(), pbeParameters));
+                callback((kem, password, pbeParameters) => kem.ExportEncryptedPkcs8PrivateKey(password, pbeParameters));
+
+                callback((kem, password, pbeParameters) =>
+                    DecodePem(kem.ExportEncryptedPkcs8PrivateKeyPem(password.AsSpan(), pbeParameters), "ENCRYPTED PRIVATE KEY"));
+                callback((kem, password, pbeParameters) =>
+                    DecodePem(kem.ExportEncryptedPkcs8PrivateKeyPem(password, pbeParameters), "ENCRYPTED PRIVATE KEY"));
+            }
+
+            if ((passwordTypesToTest & EncryptionPasswordType.Byte) != 0)
+            {
+                callback((kem, password, pbeParameters) =>
+                    DoTryUntilDone((Span<byte> destination, out int bytesWritten) =>
+                        kem.TryExportEncryptedPkcs8PrivateKey(new ReadOnlySpan<byte>(Encoding.UTF8.GetBytes(password)), pbeParameters, destination, out bytesWritten)));
+
+                callback((kem, password, pbeParameters) =>
+                    kem.ExportEncryptedPkcs8PrivateKey(new ReadOnlySpan<byte>(Encoding.UTF8.GetBytes(password)), pbeParameters));
+
+                callback((kem, password, pbeParameters) =>
+                    DecodePem(kem.ExportEncryptedPkcs8PrivateKeyPem(new ReadOnlySpan<byte>(Encoding.UTF8.GetBytes(password)), pbeParameters), "ENCRYPTED PRIVATE KEY"));
+            }
+        }
+
+        internal static byte[] CreateEncryptedPkcs8PrivateKey(
+            string algorithmOid,
+            byte[] privateKey,
+            PbeParameters pbeParameters,
+            EncryptionPasswordType passwordType = EncryptionPasswordType.Char)
+        {
+            PrivateKeyInfoAsn pkcs8 = new PrivateKeyInfoAsn
+            {
+                Version = 0,
+                PrivateKeyAlgorithm = new AlgorithmIdentifierAsn
+                {
+                    Algorithm = algorithmOid,
+                    Parameters = null,
+                },
+                PrivateKey = privateKey,
+            };
+
+            AsnWriter pkcs8Writer = new(AsnEncodingRules.DER);
+            AsnWriter? encryptedWriter = null;
+
+            try
+            {
+                pkcs8.Encode(pkcs8Writer);
+
+                encryptedWriter = passwordType switch
+                {
+                    EncryptionPasswordType.Char => s_writeEncryptedPkcs8Char("PLACEHOLDER", pkcs8Writer, pbeParameters),
+                    EncryptionPasswordType.Byte => s_writeEncryptedPkcs8Byte("PLACEHOLDER"u8, pkcs8Writer, pbeParameters),
+                    _ => throw new XunitException("Exactly one password type is required."),
+                };
+
+                return encryptedWriter.Encode();
+            }
+            finally
+            {
+                encryptedWriter?.Reset();
+                pkcs8Writer.Reset();
+            }
+        }
+
+        private static WriteEncryptedPkcs8<T> GetWriteEncryptedPkcs8<T>()
+        {
+            Type keyFormatHelper = typeof(PbeParameters).Assembly.GetType(
+                "System.Security.Cryptography.KeyFormatHelper",
+                throwOnError: true)!;
+            MethodInfo method = keyFormatHelper.GetMethod(
+                "WriteEncryptedPkcs8",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                binder: null,
+                new[] { typeof(ReadOnlySpan<T>), typeof(AsnWriter), typeof(PbeParameters) },
+                modifiers: null)!;
+
+            return (WriteEncryptedPkcs8<T>)method.CreateDelegate(typeof(WriteEncryptedPkcs8<T>));
+        }
+
+        internal static void VerifyDisposed(CompositeMLKem kem)
+        {
+            CompositeMLKemAlgorithm algorithm = kem.Algorithm;
+            byte[] ciphertext = new byte[algorithm.CiphertextSizeInBytes];
+            byte[] sharedSecret = new byte[algorithm.SharedSecretSizeInBytes];
+            byte[] tempBuffer = new byte[4096];
+
+            Assert.Throws<ObjectDisposedException>(() => kem.Encapsulate(out _, out _));
+            Assert.Throws<ObjectDisposedException>(() => kem.Encapsulate(ciphertext, sharedSecret));
+            Assert.Throws<ObjectDisposedException>(() => kem.Decapsulate(ciphertext));
+            Assert.Throws<ObjectDisposedException>(() => kem.Decapsulate(new ReadOnlySpan<byte>(ciphertext), sharedSecret));
+
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportEncapsulationKey());
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportEncapsulationKey(tempBuffer));
+            Assert.Throws<ObjectDisposedException>(() => kem.TryExportEncapsulationKey(tempBuffer, out _));
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportDecapsulationKey());
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportDecapsulationKey(tempBuffer));
+            Assert.Throws<ObjectDisposedException>(() => kem.TryExportDecapsulationKey(tempBuffer, out _));
+
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportPkcs8PrivateKey());
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportPkcs8PrivateKeyPem());
+            Assert.Throws<ObjectDisposedException>(() => kem.TryExportPkcs8PrivateKey(tempBuffer, out _));
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportSubjectPublicKeyInfo());
+            Assert.Throws<ObjectDisposedException>(() => kem.ExportSubjectPublicKeyInfoPem());
+            Assert.Throws<ObjectDisposedException>(() => kem.TryExportSubjectPublicKeyInfo(tempBuffer, out _));
+
+            PbeParameters pbeParameters = new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 42);
+
+            AssertEncryptedExportPkcs8PrivateKey(export =>
+                Assert.Throws<ObjectDisposedException>(() => export(kem, "PLACEHOLDER", pbeParameters)));
+        }
+
+        internal static string AlgorithmToOid(CompositeMLKemAlgorithm algorithm)
+        {
+            return algorithm?.Name switch
+            {
+                "MLKEM768-RSA2048-SHA3-256"                 => "1.3.6.1.5.5.7.6.55",
+                "MLKEM768-RSA3072-SHA3-256"                 => "1.3.6.1.5.5.7.6.56",
+                "MLKEM768-RSA4096-SHA3-256"                 => "1.3.6.1.5.5.7.6.57",
+                "MLKEM768-X25519-SHA3-256"                  => "1.3.6.1.5.5.7.6.58",
+                "MLKEM768-ECDH-P256-SHA3-256"               => "1.3.6.1.5.5.7.6.59",
+                "MLKEM768-ECDH-P384-SHA3-256"               => "1.3.6.1.5.5.7.6.60",
+                "MLKEM768-ECDH-brainpoolP256r1-SHA3-256"    => "1.3.6.1.5.5.7.6.61",
+                "MLKEM1024-RSA3072-SHA3-256"                => "1.3.6.1.5.5.7.6.62",
+                "MLKEM1024-ECDH-P384-SHA3-256"              => "1.3.6.1.5.5.7.6.63",
+                "MLKEM1024-ECDH-brainpoolP384r1-SHA3-256"   => "1.3.6.1.5.5.7.6.64",
+                "MLKEM1024-X448-SHA3-256"                   => "1.3.6.1.5.5.7.6.65",
+                "MLKEM1024-ECDH-P521-SHA3-256"              => "1.3.6.1.5.5.7.6.66",
+
+                _ => throw new XunitException("Unknown algorithm."),
+            };
+        }
+
+        internal static byte[] DecodePem(string pem, string expectedLabel)
+        {
+            PemFields fields = PemEncoding.Find(pem.AsSpan());
+            Assert.Equal(Index.FromStart(0), fields.Location.Start);
+            Assert.Equal(Index.FromStart(pem.Length), fields.Location.End);
+            Assert.Equal(expectedLabel, pem.AsSpan()[fields.Label].ToString());
+            return Convert.FromBase64String(pem.AsSpan()[fields.Base64Data].ToString());
+        }
+
+        internal delegate bool TryExportFunc(Span<byte> destination, out int bytesWritten);
+
+        internal static byte[] DoTryUntilDone(TryExportFunc func)
+        {
+            byte[] buffer = new byte[512];
+            int written;
+
+            while (!func(buffer, out written))
+            {
+                Array.Resize(ref buffer, buffer.Length * 2);
+            }
+
+            return buffer.AsSpan(0, written).ToArray();
+        }
+
+        internal static EncryptionPasswordType GetValidPasswordTypes(PbeParameters pbeParameters)
+            => pbeParameters.EncryptionAlgorithm == PbeEncryptionAlgorithm.TripleDes3KeyPkcs12
+            ? EncryptionPasswordType.Char
+            : EncryptionPasswordType.All;
+
+        [Flags]        internal enum EncryptionPasswordType
+        {
+            Byte = 1,
+            Char = 2,
+            All = Char | Byte,
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemTestHelpers.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/CompositeMLKem/CompositeMLKemTestHelpers.cs
@@ -438,7 +438,8 @@ namespace System.Security.Cryptography.Tests
             ? EncryptionPasswordType.Char
             : EncryptionPasswordType.All;
 
-        [Flags]        internal enum EncryptionPasswordType
+        [Flags]
+        internal enum EncryptionPasswordType
         {
             Byte = 1,
             Char = 2,

--- a/src/libraries/Common/tests/System/Security/Cryptography/CompositeMLKemAlgorithmTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/CompositeMLKemAlgorithmTests.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    public static class CompositeMLKemAlgorithmTests
+    {
+        [Fact]
+        public static void AlgorithmsHaveExpectedParameters()
+        {
+            CompositeMLKemAlgorithm algorithm;
+
+            algorithm = CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048;
+            Assert.Equal("MLKEM768-RSA2048-SHA3-256", algorithm.Name);
+            Assert.Equal(1088 + 256, algorithm.CiphertextSizeInBytes); // ML-KEM + Traditional ciphertext
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem768WithRsaOaep3072;
+            Assert.Equal("MLKEM768-RSA3072-SHA3-256", algorithm.Name);
+            Assert.Equal(1088 + 384, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem768WithRsaOaep4096;
+            Assert.Equal("MLKEM768-RSA4096-SHA3-256", algorithm.Name);
+            Assert.Equal(1088 + 512, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem768WithX25519;
+            Assert.Equal("MLKEM768-X25519-SHA3-256", algorithm.Name);
+            Assert.Equal(1088 + 32, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP256;
+            Assert.Equal("MLKEM768-ECDH-P256-SHA3-256", algorithm.Name);
+            Assert.Equal(1088 + 65, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP384;
+            Assert.Equal("MLKEM768-ECDH-P384-SHA3-256", algorithm.Name);
+            Assert.Equal(1088 + 97, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanBrainpoolP256r1;
+            Assert.Equal("MLKEM768-ECDH-brainpoolP256r1-SHA3-256", algorithm.Name);
+            Assert.Equal(1088 + 65, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem1024WithRsaOaep3072;
+            Assert.Equal("MLKEM1024-RSA3072-SHA3-256", algorithm.Name);
+            Assert.Equal(1568 + 384, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP384;
+            Assert.Equal("MLKEM1024-ECDH-P384-SHA3-256", algorithm.Name);
+            Assert.Equal(1568 + 97, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanBrainpoolP384r1;
+            Assert.Equal("MLKEM1024-ECDH-brainpoolP384r1-SHA3-256", algorithm.Name);
+            Assert.Equal(1568 + 97, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem1024WithX448;
+            Assert.Equal("MLKEM1024-X448-SHA3-256", algorithm.Name);
+            Assert.Equal(1568 + 56, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+
+            algorithm = CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP521;
+            Assert.Equal("MLKEM1024-ECDH-P521-SHA3-256", algorithm.Name);
+            Assert.Equal(1568 + 133, algorithm.CiphertextSizeInBytes);
+            Assert.Equal(32, algorithm.SharedSecretSizeInBytes);
+        }
+
+        [Fact]
+        public static void Algorithms_AreSame()
+        {
+            Assert.Same(CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048, CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem768WithRsaOaep3072, CompositeMLKemAlgorithm.MLKem768WithRsaOaep3072);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem768WithRsaOaep4096, CompositeMLKemAlgorithm.MLKem768WithRsaOaep4096);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem768WithX25519, CompositeMLKemAlgorithm.MLKem768WithX25519);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP256, CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP256);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP384, CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP384);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanBrainpoolP256r1, CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanBrainpoolP256r1);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem1024WithRsaOaep3072, CompositeMLKemAlgorithm.MLKem1024WithRsaOaep3072);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP384, CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP384);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanBrainpoolP384r1, CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanBrainpoolP384r1);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem1024WithX448, CompositeMLKemAlgorithm.MLKem1024WithX448);
+            Assert.Same(CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP521, CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP521);
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemAlgorithms))]
+        public static void Algorithms_Equal(CompositeMLKemAlgorithm algorithm)
+        {
+            AssertExtensions.TrueExpression(algorithm.Equals(algorithm));
+            AssertExtensions.TrueExpression(algorithm.Equals((object)algorithm));
+            AssertExtensions.FalseExpression(algorithm.Equals(null));
+            AssertExtensions.FalseExpression(algorithm.Equals((object)algorithm.Name));
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemAlgorithms))]
+        public static void Algorithms_GetHashCode(CompositeMLKemAlgorithm algorithm)
+        {
+            Assert.Equal(algorithm.Name.GetHashCode(), algorithm.GetHashCode());
+        }
+
+        [Theory]
+        [MemberData(nameof(CompositeMLKemAlgorithms))]
+        public static void Algorithms_ToString(CompositeMLKemAlgorithm algorithm)
+        {
+            Assert.Equal(algorithm.Name, algorithm.ToString());
+        }
+
+        [Fact]
+        public static void Algorithms_Equality()
+        {
+            AssertExtensions.TrueExpression(CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048 == CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048);
+            AssertExtensions.TrueExpression(CompositeMLKemAlgorithm.MLKem768WithX25519 == CompositeMLKemAlgorithm.MLKem768WithX25519);
+            AssertExtensions.TrueExpression(CompositeMLKemAlgorithm.MLKem1024WithX448 == CompositeMLKemAlgorithm.MLKem1024WithX448);
+            AssertExtensions.TrueExpression(CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP521 == CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP521);
+
+            // Test some cross-combinations are false
+            AssertExtensions.FalseExpression(CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048 == CompositeMLKemAlgorithm.MLKem768WithRsaOaep3072);
+            AssertExtensions.FalseExpression(CompositeMLKemAlgorithm.MLKem768WithRsaOaep3072 == CompositeMLKemAlgorithm.MLKem1024WithRsaOaep3072);
+            AssertExtensions.FalseExpression(CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP384 == CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP384);
+            AssertExtensions.FalseExpression(CompositeMLKemAlgorithm.MLKem768WithX25519 == CompositeMLKemAlgorithm.MLKem1024WithX448);
+
+            AssertExtensions.FalseExpression(CompositeMLKemAlgorithm.MLKem768WithX25519 == null);
+            AssertExtensions.FalseExpression(null == CompositeMLKemAlgorithm.MLKem768WithX25519);
+            AssertExtensions.TrueExpression((CompositeMLKemAlgorithm)null == (CompositeMLKemAlgorithm)null);
+        }
+
+        [Fact]
+        public static void Algorithms_Inequality()
+        {
+            AssertExtensions.FalseExpression(CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048 != CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048);
+            AssertExtensions.FalseExpression(CompositeMLKemAlgorithm.MLKem768WithX25519 != CompositeMLKemAlgorithm.MLKem768WithX25519);
+
+            // Test some cross-combinations are true
+            AssertExtensions.TrueExpression(CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048 != CompositeMLKemAlgorithm.MLKem768WithRsaOaep3072);
+            AssertExtensions.TrueExpression(CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP384 != CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP384);
+            AssertExtensions.TrueExpression(CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanBrainpoolP256r1 != CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanBrainpoolP384r1);
+
+            AssertExtensions.TrueExpression(CompositeMLKemAlgorithm.MLKem768WithX25519 != null);
+            AssertExtensions.TrueExpression(null != CompositeMLKemAlgorithm.MLKem768WithX25519);
+            AssertExtensions.FalseExpression((CompositeMLKemAlgorithm)null != (CompositeMLKemAlgorithm)null);
+        }
+
+        public static IEnumerable<object[]> CompositeMLKemAlgorithms()
+        {
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem768WithRsaOaep2048 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem768WithRsaOaep3072 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem768WithRsaOaep4096 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem768WithX25519 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP256 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanP384 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem768WithECDiffieHellmanBrainpoolP256r1 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem1024WithRsaOaep3072 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP384 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanBrainpoolP384r1 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem1024WithX448 };
+            yield return new object[] { CompositeMLKemAlgorithm.MLKem1024WithECDiffieHellmanP521 };
+        }
+    }
+}

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.Forwards.cs
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.Forwards.cs
@@ -21,6 +21,8 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SlhDsaAlgorithm))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SlhDsaCng))]
 #if NET11_0_OR_GREATER
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.CompositeMLKem))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.CompositeMLKemAlgorithm))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.X25519DiffieHellman))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.X25519DiffieHellmanCng))]
 #endif

--- a/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/src/Microsoft.Bcl.Cryptography.csproj
@@ -19,7 +19,9 @@
     <BuildPqc Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</BuildPqc>
     <!-- X25519DiffieHellman is new in .NET 11. For this package, build it only for .NET Framework. -->
     <BuildX25519 Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">true</BuildX25519>
-    <OmitResources Condition="'$(BuildX509Loader)' != 'true' and '$(BuildPqc)' != 'true' and '$(BuildX25519)' != 'true'">true</OmitResources>
+    <!-- Composite ML-KEM is new in .NET 11. For this package, build it only for .NET Framework. -->
+    <BuildCompositeMLKem Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">true</BuildCompositeMLKem>
+    <OmitResources Condition="'$(BuildX509Loader)' != 'true' and '$(BuildPqc)' != 'true' and '$(BuildX25519)' != 'true' and '$(BuildCompositeMLKem)' != 'true'">true</OmitResources>
   </PropertyGroup>
 
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(BuildX509Loader)' == 'true' or '$(BuildX25519)' == 'true'" />
@@ -417,6 +419,17 @@
     <Compile Include="$(CommonPath)System\Security\Cryptography\PemLabels.cs"
              Link="Common\System\Security\Cryptography\PemLabels.cs" />
     <Compile Include="System\Security\Cryptography\PinAndClear.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildCompositeMLKem)' == 'true'">
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKem.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKem.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemAlgorithm.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemAlgorithm.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemImplementation.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemImplementation.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildX25519)' == 'true'">

--- a/src/libraries/Microsoft.Bcl.Cryptography/tests/Microsoft.Bcl.Cryptography.Tests.csproj
+++ b/src/libraries/Microsoft.Bcl.Cryptography/tests/Microsoft.Bcl.Cryptography.Tests.csproj
@@ -125,6 +125,8 @@
              Link="TestCommon\System\Security\Cryptography\CngKeyWrapper.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CompositeMLDsaAlgorithmTests.cs"
              Link="CommonTest\System\Security\Cryptography\CompositeMLDsaAlgorithmTests.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\CompositeMLKemAlgorithmTests.cs"
+             Link="CommonTest\System\Security\Cryptography\CompositeMLKemAlgorithmTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\MLDsaAlgorithmTests.cs"
              Link="CommonTest\System\Security\Cryptography\MLDsaAlgorithmTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\MLKemAlgorithmTests.cs"
@@ -226,6 +228,16 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLDsa\CompositeMLDsaTestsBase.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLDsa\CompositeMLDsaMockImplementation.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLDsa\CompositeMLDsaMockImplementation.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemContractTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemContractTests.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemFactoryTests.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemMockImplementation.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemMockImplementation.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemTestData.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemTestData.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemTestHelpers.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemTestHelpers.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\EccTestData.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\MLDsa\MLDsaCngTests.cs"

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -658,6 +658,89 @@ namespace System.Security.Cryptography
         protected override bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected override bool VerifyDataCore(System.ReadOnlySpan<byte> data, System.ReadOnlySpan<byte> context, System.ReadOnlySpan<byte> signature) { throw null; }
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+    public abstract partial class CompositeMLKem : System.IDisposable
+    {
+        protected CompositeMLKem(System.Security.Cryptography.CompositeMLKemAlgorithm algorithm) { }
+        public System.Security.Cryptography.CompositeMLKemAlgorithm Algorithm { get { throw null; } }
+        public byte[] Decapsulate(byte[] ciphertext) { throw null; }
+        public void Decapsulate(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret) { }
+        protected abstract void DecapsulateCore(System.ReadOnlySpan<byte> ciphertext, System.Span<byte> sharedSecret);
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Encapsulate(out byte[] ciphertext, out byte[] sharedSecret) { throw null; }
+        public void Encapsulate(System.Span<byte> ciphertext, System.Span<byte> sharedSecret) { }
+        protected abstract void EncapsulateCore(System.Span<byte> ciphertext, System.Span<byte> sharedSecret);
+        public byte[] ExportDecapsulationKey() { throw null; }
+        public int ExportDecapsulationKey(System.Span<byte> destination) { throw null; }
+        protected abstract int ExportDecapsulationKeyCore(System.Span<byte> destination);
+        public byte[] ExportEncapsulationKey() { throw null; }
+        public int ExportEncapsulationKey(System.Span<byte> destination) { throw null; }
+        protected abstract int ExportEncapsulationKeyCore(System.Span<byte> destination);
+        public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem GenerateKey(System.Security.Cryptography.CompositeMLKemAlgorithm algorithm) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportDecapsulationKey(System.Security.Cryptography.CompositeMLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportDecapsulationKey(System.Security.Cryptography.CompositeMLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportEncapsulationKey(System.Security.Cryptography.CompositeMLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportEncapsulationKey(System.Security.Cryptography.CompositeMLKemAlgorithm algorithm, System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportFromEncryptedPem(System.ReadOnlySpan<char> source, System.ReadOnlySpan<char> password) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportFromPem(System.ReadOnlySpan<char> source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportFromPem(string source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static System.Security.Cryptography.CompositeMLKem ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source) { throw null; }
+        public static bool IsAlgorithmSupported(System.Security.Cryptography.CompositeMLKemAlgorithm algorithm) { throw null; }
+        public bool TryExportDecapsulationKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncapsulationKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten);
+        public bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SYSLIB5006", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class CompositeMLKemAlgorithm : System.IEquatable<System.Security.Cryptography.CompositeMLKemAlgorithm>
+    {
+        internal CompositeMLKemAlgorithm() { }
+        public int CiphertextSizeInBytes { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem1024WithECDiffieHellmanBrainpoolP384r1 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem1024WithECDiffieHellmanP384 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem1024WithECDiffieHellmanP521 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem1024WithRsaOaep3072 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem1024WithX448 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem768WithECDiffieHellmanBrainpoolP256r1 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem768WithECDiffieHellmanP256 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem768WithECDiffieHellmanP384 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem768WithRsaOaep2048 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem768WithRsaOaep3072 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem768WithRsaOaep4096 { get { throw null; } }
+        public static System.Security.Cryptography.CompositeMLKemAlgorithm MLKem768WithX25519 { get { throw null; } }
+        public string Name { get { throw null; } }
+        public int SharedSecretSizeInBytes { get { throw null; } }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Security.Cryptography.CompositeMLKemAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.CompositeMLKemAlgorithm? left, System.Security.Cryptography.CompositeMLKemAlgorithm? right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.CompositeMLKemAlgorithm? left, System.Security.Cryptography.CompositeMLKemAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
     public partial class CryptoConfig
     {
         public CryptoConfig() { }

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -386,6 +386,12 @@
              Link="Common\System\Security\Cryptography\CompositeMLDsaCng.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLDsaImplementation.cs"
              Link="Common\System\Security\Cryptography\CompositeMLDsaImplementation.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKem.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKem.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemAlgorithm.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemAlgorithm.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemImplementation.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemImplementation.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptographicAttributeObject.cs"
              Link="Common\System\Security\Cryptography\CryptographicAttributeObject.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptographicAttributeObjectCollection.cs"
@@ -840,6 +846,8 @@
              Link="Common\System\Sha1ForNonSecretPurposes.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLDsaImplementation.NotSupported.cs"
              Link="Common\System\Security\Cryptography\CompositeMLDsaImplementation.NotSupported.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs"
              Link="Common\System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\MLDsaImplementation.NotSupported.cs"
@@ -1085,6 +1093,8 @@
     <Compile Include="System\Security\Cryptography\CapiHelper.Unix.cs" />
     <Compile Include="System\Security\Cryptography\ChaCha20Poly1305.OpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\CompositeMLDsaImplementation.OpenSsl.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\Cng.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\CspKeyContainerInfo.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\DESCryptoServiceProvider.Unix.cs" />
@@ -1228,6 +1238,8 @@
              Link="Common\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLDsaImplementation.NotSupported.cs"
              Link="Common\System\Security\Cryptography\CompositeMLDsaImplementation.NotSupported.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\DSAAndroid.cs"
              Link="Common\System\Security\Cryptography\DSAAndroid.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\ECAndroid.cs"
@@ -1384,6 +1396,8 @@
              Link="Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLDsaImplementation.NotSupported.cs"
              Link="Common\System\Security\Cryptography\CompositeMLDsaImplementation.NotSupported.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\EccAppleCrypto.cs"
              Link="Common\System\Security\Cryptography\EccAppleCrypto.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\ECDiffieHellmanDerivation.cs"
@@ -1895,6 +1909,8 @@
              Link="Common\System\Security\Cryptography\CompositeMLDsaCng.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLDsaImplementation.Windows.cs"
              Link="Common\System\Security\Cryptography\CompositeMLDsaImplementation.Windows.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs"
+             Link="Common\System\Security\Cryptography\CompositeMLKemImplementation.NotSupported.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoThrowHelper.Windows.cs"
              Link="Common\System\Security\Cryptography\CryptoThrowHelper.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\DSACng.cs"

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -228,6 +228,8 @@
              Link="ProductionCode\Common\System\Net\StreamBuffer.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CompositeMLDsaAlgorithmTests.cs"
              Link="CommonTest\System\Security\Cryptography\CompositeMLDsaAlgorithmTests.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\CompositeMLKemAlgorithmTests.cs"
+             Link="CommonTest\System\Security\Cryptography\CompositeMLKemAlgorithmTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\MLDsaAlgorithmTests.cs"
              Link="CommonTest\System\Security\Cryptography\MLDsaAlgorithmTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\MLKemAlgorithmTests.cs"
@@ -310,6 +312,16 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLDsa\CompositeMLDsaTestsBase.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLDsa\CompositeMLDsaMockImplementation.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLDsa\CompositeMLDsaMockImplementation.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemContractTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemContractTests.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemFactoryTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemFactoryTests.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemMockImplementation.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemMockImplementation.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemTestData.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemTestData.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemTestHelpers.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\CompositeMLKem\CompositeMLKemTestHelpers.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\DES\DESCipherOneShotTests.cs"


### PR DESCRIPTION
Adds the approved Composite ML-KEM base APIs, algorithm identifiers, import/export support, and contract tests. Platform implementations will follow.

> [!NOTE]
> GitHub Copilot helped create this PR.

Contributes to #129633