### PR TITLE
[System.Text.Json] Fix ARM64 Utf8JsonReader regression

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -1174,7 +1174,7 @@ namespace System.Text.Json
 
                 Debug.Assert(result == ConsumeNumberResult.OperationIncomplete);
                 nextByte = data[i];
-                if (nextByte is not ((byte)'.' or (byte)'E' or (byte)'e'))
+                if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
                 {
                     RollBackState(rollBackState, isError: true);
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, nextByte);
@@ -1200,7 +1200,7 @@ namespace System.Text.Json
 
                 Debug.Assert(result == ConsumeNumberResult.OperationIncomplete);
                 nextByte = data[i];
-                if (nextByte is not ((byte)'E' or (byte)'e'))
+                if (nextByte != 'E' && nextByte != 'e')
                 {
                     RollBackState(rollBackState, isError: true);
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedNextDigitEValueNotFound, nextByte);
@@ -1341,7 +1341,7 @@ namespace System.Text.Json
                 }
             }
             nextByte = data[i];
-            if (nextByte is not ((byte)'.' or (byte)'E' or (byte)'e'))
+            if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
             {
                 RollBackState(rollBackState, isError: true);
                 ThrowHelper.ThrowJsonReaderException(ref this,
@@ -1490,7 +1490,7 @@ namespace System.Text.Json
             }
 
             byte nextByte = data[i];
-            if (nextByte is (byte)'+' or (byte)'-')
+            if (nextByte == '+' || nextByte == '-')
             {
                 i++;
                 _bytePositionInLine++;
@@ -2264,7 +2264,7 @@ namespace System.Text.Json
             }
 
             byte marker = localBuffer[0];
-            if (marker is not (JsonConstants.Slash or JsonConstants.Asterisk))
+            if (marker != JsonConstants.Slash && marker != JsonConstants.Asterisk)
             {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidCharacterAtStartOfComment, marker);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -1529,7 +1529,7 @@ namespace System.Text.Json
 
                 Debug.Assert(result == ConsumeNumberResult.OperationIncomplete);
                 nextByte = data[i];
-                if (nextByte is not ((byte)'E' or (byte)'e'))
+                if (nextByte != 'E' && nextByte != 'e')
                 {
                     _bytePositionInLine += i;
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedNextDigitEValueNotFound, nextByte);
@@ -1624,7 +1624,7 @@ namespace System.Text.Json
                 }
             }
             nextByte = data[i];
-            if (nextByte is not ((byte)'.' or (byte)'E' or (byte)'e'))
+            if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
             {
                 _bytePositionInLine += i;
                 ThrowHelper.ThrowJsonReaderException(ref this,
@@ -1703,7 +1703,7 @@ namespace System.Text.Json
             }
 
             byte nextByte = data[i];
-            if (nextByte is (byte)'+' or (byte)'-')
+            if (nextByte == '+' || nextByte == '-')
             {
                 i++;
                 if (i >= data.Length)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -1505,7 +1505,7 @@ namespace System.Text.Json
 
                 Debug.Assert(result == ConsumeNumberResult.OperationIncomplete);
                 nextByte = data[i];
-                if (nextByte is not ((byte)'.' or (byte)'E' or (byte)'e'))
+                if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
                 {
                     _bytePositionInLine += i;
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, nextByte);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
@@ -212,7 +212,7 @@ namespace System.Text.Json
                 val = utf8FormattedNumber[i];
             }
 
-            if (val is (byte)'e' or (byte)'E')
+            if (val == 'e' || val == 'E')
             {
                 i++;
 
@@ -223,7 +223,7 @@ namespace System.Text.Json
 
                 val = utf8FormattedNumber[i];
 
-                if (val is (byte)'+' or (byte)'-')
+                if (val == '+' || val == '-')
                 {
                     i++;
                 }


### PR DESCRIPTION
Fixes #131600.

Restore the explicit comparison form for the number terminator check in `Utf8JsonReader.TryGetNumber`. The pattern-matching form is semantically equivalent, but introduced a large Linux ARM64 regression in `System.Text.Json.Tests.Perf_Get.GetUInt64`.

## Performance

EgorBot on an Azure Ampere ARM64 machine measured the regressed pattern form against the selectively restored reader code:

| State | Mean | Ratio |
|---|---:|---:|
| Pattern form (`43560bc7`) | 900.8 ns | 1.00 |
| Restored reader comparisons | 515.4 ns | 0.57 |

The cumulative bisection further narrowed the transition from 515.6 ns at `fa936cfa` to approximately 896 ns after this condition changed. The intervening commits only modify `Debug.Assert` expressions in Release builds.

Results:
- https://github.com/EgorBot/Benchmarks/issues/508#issuecomment-5321446863
- https://github.com/EgorBot/Benchmarks/issues/509#issuecomment-5322055785

> [!NOTE]
> This pull request description was prepared with GitHub Copilot.