### PR TITLE
Exclude desktop-only Security test from mobile builds

### DIFF
--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -135,7 +135,7 @@
   </ItemGroup>
 
   <!-- Compiled on desktop only: crashes Apple-mobile CoreCLR at startup due to R2R IL-body stripping. -->
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows' or '$(TargetPlatformIdentifier)' == 'unix' or '$(TargetPlatformIdentifier)' == 'osx'">
+  <ItemGroup Condition="'$(TargetsMobile)' != 'true'">
     <Compile Include="SslAuthenticationOptionsTests.Desktop.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- exclude `SslAuthenticationOptionsTests.Desktop.cs` from all mobile builds
- use `TargetsMobile` because tvOS builds this project as `net11.0-unix`, making the previous `TargetPlatformIdentifier == 'unix'` condition ineffective

Follow-up to #131922 and #132277.

## Validation

- `./build.sh clr+libs -rc release`
- `System.Net.Security.Unit.Tests`: 134 total, 0 failed, 3 skipped
- MSBuild compile matrix: excluded on tvOS, Android, and browser; included on Linux, macOS, and Windows
- fixed tvOS build binlog contains no `SslAuthenticationOptionsTests.Desktop.cs` compile input

> [!NOTE]
> This pull request was prepared with GitHub Copilot assistance and reviewed by the submitting developer.