### PR TITLE
Cleanup GC mode switching in the interpreter

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -232,8 +232,10 @@ LONG IgnoreCppExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo, PVOID pv)
         : EXCEPTION_EXECUTE_HANDLER;
 }
 
-void RethrowLastThrownObject()
+NOINLINE static void DECLSPEC_NORETURN RethrowLastThrownObject()
 {
+    WRAPPER_NO_CONTRACT;
+
     _ASSERTE(GetThread()->PreemptiveGCDisabled());
     GCX_COOP();
     OBJECTREF ohThrowable = GetThread()->LastThrownObject();

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -232,6 +232,14 @@ LONG IgnoreCppExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo, PVOID pv)
         : EXCEPTION_EXECUTE_HANDLER;
 }
 
+void RethrowLastThrownObject()
+{
+    _ASSERTE(GetThread()->PreemptiveGCDisabled());
+    GCX_COOP();
+    OBJECTREF ohThrowable = GetThread()->LastThrownObject();
+    DispatchManagedException(ohThrowable);
+}
+
 template<typename Function>
 std::invoke_result_t<Function> CallWithSEHWrapper(Function function)
 {
@@ -253,9 +261,7 @@ std::invoke_result_t<Function> CallWithSEHWrapper(Function function)
         // INSTALL_/UNINSTALL_UNWIND_AND_CONTINUE_HANDLER in the InterpExecMethod.
         // The managed ones are represented by SEH exception, which cannot be handled there
         // because it is not possible to handle both SEH and C++ exceptions in the same frame.
-        GCX_COOP_NO_DTOR();
-        OBJECTREF ohThrowable = GetThread()->LastThrownObject();
-        DispatchManagedException(ohThrowable);
+        RethrowLastThrownObject();
     }
     PAL_ENDTRY
 
@@ -285,10 +291,8 @@ void InvokeUnmanagedMethodWithTransition(MethodDesc *targetMethod, int8_t *stack
 
     PAL_TRY(Param *, pParam, &param)
     {
-        GCX_PREEMP_NO_DTOR();
         // WASM-TODO: Handle unmanaged calling conventions
-        InvokeManagedMethod(pParam->targetMethod, pParam->pArgs, pParam->pRet, pParam->callTarget, NULL);
-        GCX_PREEMP_NO_DTOR_END();
+        InvokeUnmanagedMethod(pParam->targetMethod, pParam->pArgs, pParam->pRet, pParam->callTarget);
     }
     PAL_EXCEPT_FILTER(IgnoreCppExceptionFilter)
     {
@@ -298,9 +302,7 @@ void InvokeUnmanagedMethodWithTransition(MethodDesc *targetMethod, int8_t *stack
         // INSTALL_/UNINSTALL_UNWIND_AND_CONTINUE_HANDLER in the InterpExecMethod.
         // The managed ones are represented by SEH exception, which cannot be handled there
         // because it is not possible to handle both SEH and C++ exceptions in the same frame.
-        GCX_COOP_NO_DTOR();
-        OBJECTREF ohThrowable = GetThread()->LastThrownObject();
-        DispatchManagedException(ohThrowable);
+        RethrowLastThrownObject();
     }
     PAL_ENDTRY
 
@@ -474,6 +476,9 @@ void InvokeManagedMethod(MethodDesc *pMD, int8_t *pArgs, int8_t *pRet, PCODE tar
 
 void InvokeUnmanagedMethod(MethodDesc *targetMethod, int8_t *pArgs, int8_t *pRet, PCODE callTarget)
 {
+    WRAPPER_NO_CONTRACT;
+
+    GCX_PREEMP();
     InvokeManagedMethod(targetMethod, pArgs, pRet, callTarget, NULL);
 }
 
@@ -4809,7 +4814,7 @@ do                                                                      \
     }
     catch (const ResumeAfterCatchException& ex)
     {
-        GCX_COOP_NO_DTOR();
+        _ASSERTE(GetThread()->PreemptiveGCDisabled());
         ex.GetResumeContext(&resumeSP, &resumeIP);
         _ASSERTE(resumeSP != 0 && resumeIP != 0);
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -481,14 +481,6 @@ void InvokeUnmanagedMethod(MethodDesc *targetMethod, int8_t *pArgs, int8_t *pRet
     InvokeManagedMethod(targetMethod, pArgs, pRet, callTarget, NULL);
 }
 
-void InvokeUnmanagedMethodInPreemptiveMode(MethodDesc *targetMethod, int8_t *pArgs, int8_t *pRet, PCODE callTarget)
-{
-    WRAPPER_NO_CONTRACT;
-
-    GCX_PREEMP();
-    InvokeUnmanagedMethod(targetMethod, pArgs, pRet, callTarget);
-}
-
 static NOINLINE CallStubHeader *InvokeDelegateInvokeMethodHelper(MethodDesc *pMDDelegateInvoke)
 {
     CONTRACTL
@@ -627,6 +619,14 @@ CallStubHeader *CreateNativeToInterpreterCallStub(InterpMethod* pInterpMethod)
     return pHeader;
 }
 #endif // !TARGET_WASM
+
+void InvokeUnmanagedMethodInPreemptiveMode(MethodDesc *targetMethod, int8_t *pArgs, int8_t *pRet, PCODE callTarget)
+{
+    WRAPPER_NO_CONTRACT;
+
+    GCX_PREEMP();
+    InvokeUnmanagedMethod(targetMethod, pArgs, pRet, callTarget);
+}
 
 #ifdef _DEBUG
 void DBG_PrintInterpreterStack()

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -218,6 +218,7 @@ static size_t CreateDispatchTokenForMethod(MethodDesc* pMD)
 // Call invoker helpers provided by platform.
 void InvokeManagedMethod(MethodDesc *pMD, int8_t *pArgs, int8_t *pRet, PCODE target, Object** pContinuationRet);
 void InvokeUnmanagedMethod(MethodDesc *targetMethod, int8_t *pArgs, int8_t *pRet, PCODE callTarget);
+void InvokeUnmanagedMethodInPreemptiveMode(MethodDesc *targetMethod, int8_t *pArgs, int8_t *pRet, PCODE callTarget);
 void InvokeCalliStub(PCODE ftn, InterpreterCalliCookie cookie, int8_t *pArgs, int8_t *pRet, Object** pContinuationRet);
 void InvokeUnmanagedCalli(PCODE ftn, InterpreterCalliCookie cookie, int8_t *pArgs, int8_t *pRet);
 void InvokeDelegateInvokeMethod(MethodDesc *pMDDelegateInvoke, int8_t *pArgs, int8_t *pRet, PCODE target, Object** pContinuationRet);
@@ -236,7 +237,6 @@ NOINLINE static void DECLSPEC_NORETURN RethrowLastThrownObject()
 {
     WRAPPER_NO_CONTRACT;
 
-    _ASSERTE(GetThread()->PreemptiveGCDisabled());
     GCX_COOP();
     OBJECTREF ohThrowable = GetThread()->LastThrownObject();
     DispatchManagedException(ohThrowable);
@@ -294,7 +294,7 @@ void InvokeUnmanagedMethodWithTransition(MethodDesc *targetMethod, int8_t *stack
     PAL_TRY(Param *, pParam, &param)
     {
         // WASM-TODO: Handle unmanaged calling conventions
-        InvokeUnmanagedMethod(pParam->targetMethod, pParam->pArgs, pParam->pRet, pParam->callTarget);
+        InvokeUnmanagedMethodInPreemptiveMode(pParam->targetMethod, pParam->pArgs, pParam->pRet, pParam->callTarget);
     }
     PAL_EXCEPT_FILTER(IgnoreCppExceptionFilter)
     {
@@ -478,10 +478,15 @@ void InvokeManagedMethod(MethodDesc *pMD, int8_t *pArgs, int8_t *pRet, PCODE tar
 
 void InvokeUnmanagedMethod(MethodDesc *targetMethod, int8_t *pArgs, int8_t *pRet, PCODE callTarget)
 {
+    InvokeManagedMethod(targetMethod, pArgs, pRet, callTarget, NULL);
+}
+
+void InvokeUnmanagedMethodInPreemptiveMode(MethodDesc *targetMethod, int8_t *pArgs, int8_t *pRet, PCODE callTarget)
+{
     WRAPPER_NO_CONTRACT;
 
     GCX_PREEMP();
-    InvokeManagedMethod(targetMethod, pArgs, pRet, callTarget, NULL);
+    InvokeUnmanagedMethod(targetMethod, pArgs, pRet, callTarget);
 }
 
 static NOINLINE CallStubHeader *InvokeDelegateInvokeMethodHelper(MethodDesc *pMDDelegateInvoke)


### PR DESCRIPTION
The interpreter uses GCX_COOP_NO_DTOR / GCX_PREEMP_NO_DTOR when calling compiled methods with SEH wrapper / unmanaged methods. Due to that, it needed to have forceful restoration of cooperative mode in the catch for ResumeAfterCatchException.
This change switches those usages to GCX_COOP() / GCX_PREEMP() instead. That removes the need to switch the GC mode explicitly in that catch. So I've replaced it by assert.