### PR TITLE
[wasm] Don't deploy the NetCoreAppMinimum BinaryFormatter copy on browser/wasi

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Microsoft.Extensions.Hosting.Unit.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Microsoft.Extensions.Hosting.Unit.Tests.csproj
@@ -31,7 +31,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/libraries/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -51,6 +51,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
+++ b/src/libraries/System.Collections.Specialized/tests/System.Collections.Specialized.Tests.csproj
@@ -82,6 +82,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj" Private="true" SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj" Private="true" SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
   <ItemGroup>
     <RdXmlFile Include="default.rd.xml" />

--- a/src/libraries/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System.ComponentModel.Annotations.Tests.csproj
@@ -55,6 +55,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.ComponentModel.Primitives/tests/System.ComponentModel.Primitives.Tests.csproj
+++ b/src/libraries/System.ComponentModel.Primitives/tests/System.ComponentModel.Primitives.Tests.csproj
@@ -33,6 +33,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -177,7 +177,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\TestResx.resx">

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -118,6 +118,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -125,7 +125,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
   <!-- S.D.SqlClient isn't live built anymore. -->
   <ItemGroup>

--- a/src/libraries/System.Formats.Nrbf/tests/System.Formats.Nrbf.Tests.csproj
+++ b/src/libraries/System.Formats.Nrbf/tests/System.Formats.Nrbf.Tests.csproj
@@ -29,7 +29,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/libraries/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -59,6 +59,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -185,6 +185,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/libraries/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -49,6 +49,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -157,7 +157,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser'">

--- a/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/System.Resources.Extensions.BinaryFormat.Tests.csproj
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryFormatTests/System.Resources.Extensions.BinaryFormat.Tests.csproj
@@ -45,7 +45,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Resources.Extensions/tests/CompatTests/System.Resources.Extensions.Compat.Tests.csproj
+++ b/src/libraries/System.Resources.Extensions/tests/CompatTests/System.Resources.Extensions.Compat.Tests.csproj
@@ -31,7 +31,7 @@
         <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Windows.Extensions\src\System.Windows.Extensions.csproj" Condition="'$(TargetPlatformIdentifier)' == 'windows'" />
   </ItemGroup>
 

--- a/src/libraries/System.Resources.Extensions/tests/System.Resources.Extensions.Tests.csproj
+++ b/src/libraries/System.Resources.Extensions/tests/System.Resources.Extensions.Tests.csproj
@@ -31,7 +31,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Windows.Extensions\src\System.Windows.Extensions.csproj" Condition="'$(TargetPlatformIdentifier)' == 'windows'" />
   </ItemGroup>
 

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -58,7 +58,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Reflection.Metadata\src\System.Reflection.Metadata.csproj" />

--- a/src/libraries/System.Runtime.Serialization.Primitives/tests/System.Runtime.Serialization.Primitives.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Primitives/tests/System.Runtime.Serialization.Primitives.Tests.csproj
@@ -15,6 +15,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime/tests/System.Resources.ResourceManager.Tests/System.Resources.ResourceManager.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Resources.ResourceManager.Tests/System.Resources.ResourceManager.Tests.csproj
@@ -66,7 +66,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
   <!--
     MSBuild on .NET Core doesn't support non-string resources. See https://github.com/Microsoft/msbuild/issues/2221

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
@@ -387,7 +387,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
   <Import Project="$(CommonTestPath)ComplianceTests\GB18030\GB18030.Shared.projitems" />
 </Project>

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -943,6 +943,6 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/System.Text.RegularExpressions.Tests.csproj
@@ -96,7 +96,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
+++ b/src/libraries/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
@@ -28,7 +28,7 @@
     <!-- Reference the `NetCoreAppMinimum` build which has a functional BinaryFormatter and force a private copy to ensure it's not excluded -->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.Serialization.Formatters\src\System.Runtime.Serialization.Formatters.csproj"
                       Private="true"
-                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" />
+                      SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)" Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
## Summary

Test-infra only. Excludes the `NetCoreAppMinimum` private copy of `System.Runtime.Serialization.Formatters` from the app closure on **browser/wasi**, so those apps deploy the framework build instead.

Many test projects reference the `NetCoreAppMinimum` build of `System.Runtime.Serialization.Formatters` (`Private="true"`, `SetTargetFramework=$(NetCoreAppMinimum)`) to get a *functional* `BinaryFormatter`. BinaryFormatter is unsupported on browser/wasi (`PlatformDetection.IsBinaryFormatterSupported` is `false` for `IsBrowser`), so those tests are already skipped there and the private copy serves no purpose.

On self-contained wasm the private copy is the **only** `Formatters` deployed (it shadows the framework build). In official builds it carries `AssemblyVersion=10.0.0.0` (the `NetCoreAppMinimum` TFM), while the test IL is compiled against the current framework reference (`Version=11.0.0.0`). CoreCLR's strict assembly-version binding won't bind down, so un-gated serialization-infra tests fail at load, e.g.:

```
System.Tests.DateTimeTests.GetObjectData_Invoke_ReturnsExpected
System.IO.FileNotFoundException : Could not load file or assembly
'System.Runtime.Serialization.Formatters, Version=11.0.0.0, ...'
```

Mono passes only because its loader binds by simple name (version-agnostic).

## Fix

Gate the private reference to non-wasm in all affected test projects:

```xml
<ProjectReference Include="...System.Runtime.Serialization.Formatters.csproj"
                  Private="true"
                  SetTargetFramework="TargetFramework=$(NetCoreAppMinimum)"
                  Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi'" />
```

On browser/wasi the framework `net11.0` build is now deployed (`AssemblyVersion=11.0.0.0`), which satisfies the reference and keeps `SerializationInfo`/`FormatterConverter` functional; BinaryFormatter tests remain skipped as before. No behavioral change on other platforms.

## Verification

Reproduced and validated locally on CoreCLR browser-wasm (V8):

- **Before:** the deployed `System.Runtime.Serialization.Formatters.dll` came from `bin/System.Runtime.Serialization.Formatters/Release/net10.0/`.
- **After:** it comes from the runtime pack `bin/microsoft.netcore.app.runtime.browser-wasm/Release/runtimes/browser-wasm/lib/net11.0/` (framework build).
- `System.Tests.DateTimeTests` still passes (1372/1373; the 1 skip is a BinaryFormatter-gated test).

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.
