### PR TITLE
Avoid an allocation on every `GetOrCreateComInterfaceForObject` call

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -812,9 +812,8 @@ namespace System.Runtime.InteropServices
         /// </remarks>
         private readonly struct CreateManagedObjectWrapperState(ComWrappers comWrappers, CreateComInterfaceFlags flags)
         {
-            public ComWrappers ComWrappers { get; } = comWrappers;
-
-            public CreateComInterfaceFlags Flags { get; } = flags;
+            public readonly ComWrappers ComWrappers = comWrappers;
+            public readonly CreateComInterfaceFlags Flags = flags;
         }
 
         private static void RegisterManagedObjectWrapperForDiagnostics(object instance, ManagedObjectWrapperHolder wrapper)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -800,16 +800,6 @@ namespace System.Runtime.InteropServices
             return managedObjectWrapper.ComIp;
         }
 
-        /// <summary>
-        /// The state needed to create a <see cref="ManagedObjectWrapperHolder"/> for a given object.
-        /// </summary>
-        /// <param name="comWrappers">The <see cref="ComWrappers"/> instance creating the wrapper.</param>
-        /// <param name="flags">The flags to create the wrapper with.</param>
-        /// <remarks>
-        /// This is a struct so that passing it costs nothing. The value is passed on every call, including the ones
-        /// that find a wrapper that already exists and never invoke the factory, so an object here would be garbage
-        /// produced by every single transition of a managed object into native code.
-        /// </remarks>
         private readonly struct CreateManagedObjectWrapperState(ComWrappers comWrappers, CreateComInterfaceFlags flags)
         {
             public readonly ComWrappers ComWrappers = comWrappers;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -790,14 +790,31 @@ namespace System.Runtime.InteropServices
 
             ManagedObjectWrapperHolder managedObjectWrapper = _managedObjectWrapperTable.GetOrAdd(instance, static (c, state) =>
             {
-                ManagedObjectWrapper* value = state.This.CreateManagedObjectWrapper(c, state.flags);
+                ManagedObjectWrapper* value = state.ComWrappers.CreateManagedObjectWrapper(c, state.Flags);
                 return new ManagedObjectWrapperHolder(value, c);
-            }, new { This = this, flags });
+            }, new CreateManagedObjectWrapperState(this, flags));
 
             managedObjectWrapper.AddRef();
             RegisterManagedObjectWrapperForDiagnostics(instance, managedObjectWrapper);
 
             return managedObjectWrapper.ComIp;
+        }
+
+        /// <summary>
+        /// The state needed to create a <see cref="ManagedObjectWrapperHolder"/> for a given object.
+        /// </summary>
+        /// <param name="comWrappers">The <see cref="ComWrappers"/> instance creating the wrapper.</param>
+        /// <param name="flags">The flags to create the wrapper with.</param>
+        /// <remarks>
+        /// This is a struct so that passing it costs nothing. The value is passed on every call, including the ones
+        /// that find a wrapper that already exists and never invoke the factory, so an object here would be garbage
+        /// produced by every single transition of a managed object into native code.
+        /// </remarks>
+        private readonly struct CreateManagedObjectWrapperState(ComWrappers comWrappers, CreateComInterfaceFlags flags)
+        {
+            public ComWrappers ComWrappers { get; } = comWrappers;
+
+            public CreateComInterfaceFlags Flags { get; } = flags;
         }
 
         private static void RegisterManagedObjectWrapperForDiagnostics(object instance, ManagedObjectWrapperHolder wrapper)


### PR DESCRIPTION
`ComWrappers.GetOrCreateComInterfaceForObject` passes the state its `ConditionalWeakTable.GetOrAdd` factory needs as an anonymous type:

```csharp
ManagedObjectWrapperHolder managedObjectWrapper = _managedObjectWrapperTable.GetOrAdd(instance, static (c, state) =>
{
    ManagedObjectWrapper* value = state.This.CreateManagedObjectWrapper(c, state.flags);
    return new ManagedObjectWrapperHolder(value, c);
}, new { This = this, flags });
```

Anonymous types are classes, so that's 32 bytes allocated on every call. The factory only runs when the object doesn't have a wrapper yet, and in practice almost every call finds one that already exists, so nearly all of it is garbage that never gets used. This is the path every managed object takes on its way into native code, so it adds up.

`GetOrAdd<TArg>` doesn't constrain `TArg` (it even allows ref structs), so a small struct works here and costs nothing to pass:

```csharp
private readonly struct CreateManagedObjectWrapperState(ComWrappers comWrappers, CreateComInterfaceFlags flags)
{
    public ComWrappers ComWrappers { get; } = comWrappers;

    public CreateComInterfaceFlags Flags { get; } = flags;
}
```

No behaviour change, no API change.

## Benchmarks

Release runtime, x64, two alternating passes per build. The allocation numbers were identical across runs.

| Scenario | main | this PR | |
|---|---:|---:|---:|
| Wrapper already exists, 8000 distinct objects | 90.30 ns, 32 B | **71.18 ns, 0 B** | **−21%** |
| Wrapper already exists, same object each time | 37.35 ns, 32 B | **34.37 ns, 0 B** | **−8%** |
| Wrapper has to be created | 598.4 ns, 138 B | **575.7 ns, 106 B** | −4% |

The lookup path is allocation free now. The first row gains more than the second because the garbage was also costing GC pressure and cache misses, not just the allocation itself. The creation row is within noise on time, since it's dominated by building the wrapper, but it still drops the 32 bytes.

## Testing

`ComWrappersTests`, `ComWrappersTestsBuiltInComDisabled`, `GcRestrictedCalloutReversePInvoke`, `GlobalInstanceMarshallingTests`, `GlobalInstanceMarshallingTestsBuiltInComDisabled`, `GlobalInstanceTrackerSupportTests_TargetWindows` and `WeakReferenceTest` all pass against the modified CoreLib, built Checked.

> [!NOTE]
> Parts of this pull request description were generated with GitHub Copilot. All benchmark numbers in it were measured locally.