### PR TITLE
Improve StringBuilder.ToString() exception message for inconsistent state

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -335,7 +335,7 @@ namespace System.Text
                     // Check that we will not overrun our boundaries.
                     if ((uint)(chunkLength + chunkOffset) > (uint)result.Length || (uint)chunkLength > (uint)sourceArray.Length)
                     {
-                        throw new ArgumentOutOfRangeException(nameof(chunkLength), SR.ArgumentOutOfRange_IndexMustBeLessOrEqual);
+                        throw new ArgumentOutOfRangeException(null, SR.InvalidOperation_ConcurrentOperationsNotSupported);
                     }
 
                     Buffer.Memmove(


### PR DESCRIPTION
Fixes #131674.

### Summary

When internal chunk boundaries are inconsistent (typically due to concurrent modification), `StringBuilder.ToString()` previously threw an `ArgumentOutOfRangeException` with `chunkLength` as the parameter name. 

While the exception type is kept for compatibility, the message and parameter name are corrected. This PR updates the exception to use a clear, dedicated resource string indicating internal state corruption rather than a fictitious method parameter.

### Changes
- Updated bounds validation in `StringBuilder.ToString()` to throw `ArgumentOutOfRangeException` with `null` parameter name and a proper descriptive message (`SR.InvalidOperation_ConcurrentOperationsNotSupported`).