### PR TITLE
Fix ILLink.Tasks output path in source-only builds

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -21,9 +21,9 @@
     <!-- Don't use the TFM but a short form of it without the version to simulate the package layout. -->
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath Condition="'$(TargetFramework)' == '$(NetCoreAppToolCurrent)'">$(OutputPath)net\</OutputPath>
-    <OutputPath Condition="'$(TargetFramework)' == '$(NetFrameworkToolCurrent)'">$(OutputPath)netframework\</OutputPath>
+    <OutputPath Condition="'$(NetFrameworkToolCurrent)' != '' and '$(TargetFramework)' == '$(NetFrameworkToolCurrent)'">$(OutputPath)netframework\</OutputPath>
     <IntermediateOutputPath Condition="'$(TargetFramework)' == '$(NetCoreAppToolCurrent)'">$(IntermediateOutputPath)net\</IntermediateOutputPath>
-    <IntermediateOutputPath Condition="'$(TargetFramework)' == '$(NetFrameworkToolCurrent)'">$(IntermediateOutputPath)netframework\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(NetFrameworkToolCurrent)' != '' and '$(TargetFramework)' == '$(NetFrameworkToolCurrent)'">$(IntermediateOutputPath)netframework\</IntermediateOutputPath>
   </PropertyGroup>
 
   <!-- Include the illink.runtimeconfig.pack.json file (which depends on the runtimeversion being built)


### PR DESCRIPTION
`ILLink.Tasks` multi-targets `$(NetCoreAppToolCurrent);$(NetFrameworkToolCurrent)` and
rewrites `OutputPath`/`IntermediateOutputPath` into `net\` / `netframework\` subfolders
so the build output mirrors the NuGet package layout.

In a source-only build (`/p:DotNetBuildSourceOnly=true`), `Directory.Build.props` blanks
`NetFrameworkToolCurrent` so that only the .NET Core TFM is built. But the
`netframework` conditions compare against `$(TargetFramework)`, which is *also* empty
during the **outer** (TFM-dispatching) build. `'' == ''` evaluates to true, so the outer
build's paths incorrectly picked up a `netframework` suffix:

| | before | after |
|---|---|---|
| outer, normal build | `artifacts/bin/ILLink.Tasks/Debug/` | unchanged |
| outer, source-only | `artifacts/bin/ILLink.Tasks/Debug/netframework/` | `artifacts/bin/ILLink.Tasks/Debug/` |
| inner `net11.0` | `.../Debug/net/` | unchanged |
| inner `net472` | `.../Debug/netframework/` | unchanged |

Guard both conditions on `NetFrameworkToolCurrent` being non-empty. This matches the fix
already applied to the mono task projects in #132402.

This is latent today — no consumer reads the outer `$(OutputPath)` (they all hardcode the
`net` subfolder) — but it's a trap for anything that adds such a consumer later, e.g. a
`GetFilesToPackage`-style target.

> [!NOTE]
> This PR description was generated by GitHub Copilot.
