### PR TITLE
Disable ContextualReflection test on browser wasm

### DIFF
--- a/src/tests/Loader/ContextualReflection/ContextualReflection.csproj
+++ b/src/tests/Loader/ContextualReflection/ContextualReflection.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">true</CLRTestTargetUnsupported>
     <!-- Needed for UnloadabilityIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- The test uses AssemblyLoadContext (directly) to load the test assembly and its dependency that's part of the test again.

--- a/src/tests/Loader/ContextualReflection/ContextualReflection.csproj
+++ b/src/tests/Loader/ContextualReflection/ContextualReflection.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/131925 -->
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">true</CLRTestTargetUnsupported>
     <!-- Needed for UnloadabilityIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>


### PR DESCRIPTION
Disable `Loader/ContextualReflection/ContextualReflection.csproj` for the CoreCLR browser target while the current browser WASM failure is being fixed.

The condition matches existing Loader test exclusions and leaves the test enabled on other platforms and runtime flavors.

Failure: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1556516&view=logs&jobId=33e61842-dc67-597b-7c8a-3f9fed635f50&j=33e61842-dc67-597b-7c8a-3f9fed635f50&t=5acdffa7-c2c6-5987-ba0a-609e87f6a40b

Validation:
- `CLRTestTargetUnsupported=true` for `RuntimeFlavor=coreclr`, `TargetOS=browser`
- Property remains unset for `RuntimeFlavor=coreclr`, `TargetOS=windows`
- `src\tests\build.cmd -Test Loader\ContextualReflection\ContextualReflection.csproj x64 checked`

> [!NOTE]
> This pull request description was generated with GitHub Copilot.