### PR TITLE
Fix browser-wasm sfx pack NU5118 collision from stale prior Mono build artifacts

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -225,6 +225,27 @@
       <ExcludeNativeLibrariesRuntimeFiles Condition="'$(TargetsWasi)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR'"
                                           Include="$(LibrariesNativeArtifactsPath)libSystem.IO.Compression.Native.a;
                                                    $(LibrariesNativeArtifactsPath)libz.a" />
+
+      <!-- Same situation on browser with CoreCLR: these libraries are always installed to both
+           LibrariesNativeArtifactsPath (the top-level, flavor-agnostic native artifacts directory
+           shared with Mono, whose contents can be stale leftovers from a Mono build in the same
+           tree) and LibrariesSharedFrameworkDir/CoreCLRSharedFrameworkDir, from where the
+           browser+CoreCLR-specific LibrariesRuntimeFiles/RuntimeFiles items below already pick
+           them up. Exclude the top-level copies to avoid duplicate publish output files. -->
+      <ExcludeNativeLibrariesRuntimeFiles Condition="'$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'CoreCLR'"
+                                          Include="$(LibrariesNativeArtifactsPath)icudt.dat;
+                                                   $(LibrariesNativeArtifactsPath)icudt_CJK.dat;
+                                                   $(LibrariesNativeArtifactsPath)icudt_EFIGS.dat;
+                                                   $(LibrariesNativeArtifactsPath)icudt_no_CJK.dat;
+                                                   $(LibrariesNativeArtifactsPath)libicudata.a;
+                                                   $(LibrariesNativeArtifactsPath)libicui18n.a;
+                                                   $(LibrariesNativeArtifactsPath)libicuuc.a;
+                                                   $(LibrariesNativeArtifactsPath)libSystem.Globalization.Native.a;
+                                                   $(LibrariesNativeArtifactsPath)libSystem.IO.Compression.Native.a;
+                                                   $(LibrariesNativeArtifactsPath)libSystem.Native.a;
+                                                   $(LibrariesNativeArtifactsPath)libSystem.Native.TimeZoneData.a;
+                                                   $(LibrariesNativeArtifactsPath)libSystem.Native.TimeZoneData.Invariant.a;
+                                                   $(LibrariesNativeArtifactsPath)libz.a" />
       <LibrariesRuntimeFiles Include="
         $(LibrariesNativeArtifactsPath)*.dat;
         $(LibrariesNativeArtifactsPath)*.dll;


### PR DESCRIPTION
## Problem

Building `./build.sh mono+libs -os browser -c Release` followed by `./build.sh clr+libs+host+packs -os browser -c Release` in the same worktree fails the `Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj` pack step with NU5118 duplicate-file errors (13 distinct colliding basenames, ~26 error lines).

Reproduced on macOS arm64 on current `main` in a clean worktree.

## Root cause

`$(LibrariesNativeArtifactsPath)` (`artifacts/bin/native/<tfm>-browser-Release-wasm/`) is a flavor-agnostic directory shared between Mono and CoreCLR builds — it has no `RuntimeFlavor` segment in its path.

- Mono's CMake `STATIC_LIB_DESTINATION` resolves to the top level of this directory, so a completed Mono build leaves real files there: `libSystem.Native.a`, ICU libraries/data, `libSystem.Globalization.Native.a`, `libSystem.IO.Compression.Native.a`, `libz.a`, etc.
- A from-scratch CoreCLR browser build never populates that top-level location for these same libraries, because `BUILD_LIBS_NATIVE_BROWSER` (set only when `TargetsBrowser=true && RuntimeFlavor=CoreCLR`, see `eng/native.wasm.targets`) redirects CoreCLR's CMake `STATIC_LIB_DESTINATION` to a different absolute path entirely.
- `eng/liveBuilds.targets` already has `ExcludeNativeLibrariesRuntimeFiles` entries to guard against exactly this class of problem for AppleMobile/Android and WASI, but **no equivalent entry existed for `TargetOS==browser && RuntimeFlavor==CoreCLR`**.
- As a result, CoreCLR's generic top-level glob (`$(LibrariesNativeArtifactsPath)*.a`, etc.) picks up the stale Mono-produced files left behind by the prior build. These collide with the same basenames already legitimately included via `$(LibrariesSharedFrameworkDir)`/`$(CoreCLRSharedFrameworkDir)` — the correct sources for these libraries on browser+CoreCLR — because both map to the same flat `runtimes/browser-wasm/native/<name>` package path.

This is why the failure is order-dependent: it only reproduces when a Mono build has previously "poisoned" the shared artifacts directory.

## Fix

Add a new `ExcludeNativeLibrariesRuntimeFiles` entry in `eng/liveBuilds.targets`, conditioned on `'$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'CoreCLR'`, excluding the 13 affected basenames from the generic top-level glob — mirroring the existing AppleMobile/Android and WASI precedent in the same file exactly.

These files are never legitimately produced at the top-level location in a CoreCLR build (only via a stale prior Mono build), and remain available via the existing `LibrariesSharedFrameworkDir`/`CoreCLRSharedFrameworkDir` sources, so this is a safe, no-op change for the from-scratch single-flavor case.

## Validation

- Reproduced the failure on a clean worktree: 26 NU5118 errors after `mono+libs -os browser -c Release` then `clr+libs+host+packs -os browser -c Release`.
- Applied the fix and re-ran `clr+libs+host+packs -os browser -c Release` against the same Mono-poisoned artifacts tree: build succeeded, 0 errors/warnings, 0 NU5118 occurrences.
- Verified via `unzip -l` on the resulting `Microsoft.NETCore.App.Runtime.browser-wasm` nupkg that all 13 previously-colliding files are present exactly once at `runtimes/browser-wasm/native/<name>`.
- Traced the CMake install rules confirming these files remain available via the legitimate `sharedFramework` install paths in a from-scratch CoreCLR-only build (not just after a prior Mono build), so this exclude does not risk dropping needed files in the single-flavor case.

> [!NOTE]
> This PR description and the associated change were authored with GitHub Copilot assistance.