### PR TITLE
[mono][interp] Intrinsify Vector128.Store/StoreUnsafe on wasm

### DIFF
--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
@@ -7454,5 +7454,121 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
             Assert.Throws<ArgumentOutOfRangeException>(() => Vector128<int>.Zero.GetElement(index));
             Assert.Throws<ArgumentOutOfRangeException>(() => Vector128<int>.Zero.WithElement(index, 1));
         }
+
+        private enum StoreKind
+        {
+            Store,
+            StoreUnsafe,
+            StoreUnsafeWithOffset,
+        }
+
+        /// <summary>
+        /// Stores a vector holding a distinct byte per lane at every alignment from 0 to 15 and checks
+        /// the whole buffer, so a wrong store destination, a reversed operand pair, or a byte written
+        /// outside the 16-byte window is caught rather than masked by a uniform fill.
+        /// </summary>
+        private static unsafe void ValidateStore<T>(StoreKind kind)
+            where T : unmanaged
+        {
+            const int Guard = 16;
+            const int MaxAlignmentOffset = 16;
+            const byte Filler = 0x5A;
+
+            byte[] pattern = new byte[Vector128<byte>.Count];
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                pattern[i] = (byte)(0xA0 + i);
+            }
+
+            Vector128<T> vector = Vector128.Create<byte>(new ReadOnlySpan<byte>(pattern)).As<byte, T>();
+
+            byte[] buffer = new byte[Guard + MaxAlignmentOffset + pattern.Length + Guard];
+            byte[] expected = new byte[buffer.Length];
+
+            for (int offset = 0; offset < MaxAlignmentOffset; offset++)
+            {
+                Array.Fill(buffer, Filler);
+                Array.Fill(expected, Filler);
+                pattern.CopyTo(expected, Guard + offset);
+
+                fixed (byte* pBuffer = buffer)
+                {
+                    T* destination = (T*)(pBuffer + Guard + offset);
+
+                    switch (kind)
+                    {
+                        case StoreKind.Store:
+                            vector.Store(destination);
+                            break;
+
+                        case StoreKind.StoreUnsafe:
+                            vector.StoreUnsafe(ref *destination);
+                            break;
+
+                        case StoreKind.StoreUnsafeWithOffset:
+                            // Bias the destination backwards and let the element offset undo it, so a
+                            // dropped offset argument shows up as a wrongly placed store.
+                            vector.StoreUnsafe(ref *(destination - 1), elementOffset: 1);
+                            break;
+
+                        default:
+                            throw new InvalidOperationException($"Unexpected {nameof(StoreKind)}: {kind}");
+                    }
+                }
+
+                Assert.Equal(expected, buffer);
+            }
+        }
+
+        [Fact]
+        public unsafe void Vector128StoreUnalignedTest()
+        {
+            ValidateStore<byte>(StoreKind.Store);
+            ValidateStore<sbyte>(StoreKind.Store);
+            ValidateStore<short>(StoreKind.Store);
+            ValidateStore<ushort>(StoreKind.Store);
+            ValidateStore<int>(StoreKind.Store);
+            ValidateStore<uint>(StoreKind.Store);
+            ValidateStore<long>(StoreKind.Store);
+            ValidateStore<ulong>(StoreKind.Store);
+            ValidateStore<float>(StoreKind.Store);
+            ValidateStore<double>(StoreKind.Store);
+            ValidateStore<nint>(StoreKind.Store);
+            ValidateStore<nuint>(StoreKind.Store);
+        }
+
+        [Fact]
+        public unsafe void Vector128StoreUnsafeUnalignedTest()
+        {
+            ValidateStore<byte>(StoreKind.StoreUnsafe);
+            ValidateStore<sbyte>(StoreKind.StoreUnsafe);
+            ValidateStore<short>(StoreKind.StoreUnsafe);
+            ValidateStore<ushort>(StoreKind.StoreUnsafe);
+            ValidateStore<int>(StoreKind.StoreUnsafe);
+            ValidateStore<uint>(StoreKind.StoreUnsafe);
+            ValidateStore<long>(StoreKind.StoreUnsafe);
+            ValidateStore<ulong>(StoreKind.StoreUnsafe);
+            ValidateStore<float>(StoreKind.StoreUnsafe);
+            ValidateStore<double>(StoreKind.StoreUnsafe);
+            ValidateStore<nint>(StoreKind.StoreUnsafe);
+            ValidateStore<nuint>(StoreKind.StoreUnsafe);
+        }
+
+        [Fact]
+        public unsafe void Vector128StoreUnsafeElementOffsetUnalignedTest()
+        {
+            ValidateStore<byte>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<sbyte>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<short>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<ushort>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<int>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<uint>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<long>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<ulong>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<float>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<double>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<nint>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<nuint>(StoreKind.StoreUnsafeWithOffset);
+        }
     }
 }

--- a/src/mono/mono/mini/interp/interp-simd.c
+++ b/src/mono/mono/mini/interp/interp-simd.c
@@ -805,7 +805,11 @@ interp_packedsimd_load32x2_u (gpointer res, gpointer addr_of_addr) {
 static void
 interp_packedsimd_store (gpointer res, gpointer addr_of_addr, gpointer vec) {
 	// HACK: Result is unused because Store has a void return value
-	**(v128_t **)addr_of_addr = *(v128_t *)vec;
+	// wasm_v128_store stores through a packed struct, so an unaligned destination is well-defined.
+	//  Assigning through a v128_t* instead would claim 16-byte alignment we don't have: both
+	//  PackedSimd.Store and Vector128.StoreUnsafe accept arbitrarily aligned destinations.
+	//  This mirrors interp_packedsimd_load128, which already uses wasm_v128_load.
+	wasm_v128_store (*(void **)addr_of_addr, *(v128_t *)vec);
 }
 
 #define INDIRECT_STORE_LANE(lane_type) \

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -198,11 +198,8 @@ static guint16 packedsimd_alias_methods [] = {
 	SN_ShiftRightLogical,
 	SN_Sqrt,
 	SN_SquareRoot,
-	// NOTE: Store/StoreUnsafe are deliberately absent. PackedSimd.Store's operands are reversed
-	//  relative to Vector128's - PackedSimd.Store(T* address, Vector128<T> source) versus
-	//  Vector128.Store(this Vector128<T> source, T* destination) - and this path only renames
-	//  the method, with emit_common_simd_epilogue assigning sregs in signature order. Aliasing
-	//  them would pass the vector where the destination address is expected and corrupt memory.
+	SN_Store,
+	SN_StoreUnsafe,
 	SN_Subtract,
 	SN_SubtractSaturate,
 	SN_Truncate,
@@ -1201,6 +1198,9 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 	const char *cmethod_name = cmethod->name;
 	int id = lookup_intrins (sri_packedsimd_methods, sizeof (sri_packedsimd_methods), cmethod_name);
 	MonoClass *vector_klass;
+	// Set when the aliased Vector128 method takes its operands in the opposite order from the
+	//  PackedSimd method we are lowering to. See SN_Store below.
+	gboolean swap_operands = FALSE;
 
 	bool is_packedsimd = strcmp (m_class_get_name (cmethod->klass), "PackedSimd") == 0;
 	if (is_packedsimd) {
@@ -1358,6 +1358,26 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 			case SN_SquareRoot:
 				cmethod_name = "Sqrt";
 				break;
+			case SN_Store:
+			case SN_StoreUnsafe:
+				// PackedSimd.Store (T* address, Vector128<T> source) takes its operands in the
+				//  opposite order from Vector128.Store (this Vector128<T> source, T* destination)
+				//  and Vector128.StoreUnsafe (this Vector128<T> source, ref T destination), so the
+				//  sregs have to be swapped once the epilogue has assigned them in signature order.
+				// The three-argument StoreUnsafe (source, destination, elementOffset) has no
+				//  PackedSimd counterpart, so leave it for managed code. Store is registered for
+				//  every element type, so also confirm the shape we are about to reorder: sregs [1]
+				//  is dereferenced as the destination address, so require it to be a raw address
+				//  (T* or ref T) rather than merely pointer-sized. Anything else falls back to
+				//  managed code, which is always correct if slower.
+				if ((csignature->param_count != 2) ||
+					(csignature->ret->type != MONO_TYPE_VOID) ||
+					!(m_type_is_byref (csignature->params [1]) ||
+					  (csignature->params [1]->type == MONO_TYPE_PTR)))
+					return FALSE;
+				swap_operands = TRUE;
+				cmethod_name = "Store";
+				break;
 			case SN_Add:
 			case SN_AddSaturate:
 			case SN_AndNot:
@@ -1418,6 +1438,12 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 
 opcode_added:
 	emit_common_simd_epilogue (td, vector_klass, csignature, vector_size, TRUE);
+	if (swap_operands) {
+		// The epilogue assigned the sregs in signature order; see SN_Store above.
+		gint32 tmp = td->last_ins->sregs [0];
+		td->last_ins->sregs [0] = td->last_ins->sregs [1];
+		td->last_ins->sregs [1] = tmp;
+	}
 	return TRUE;
 }
 


### PR DESCRIPTION
Rebased onto `main` now that #132500 has merged; this is a single commit touching 3 files.


## Problem

`Vector128.Store` and `Vector128.StoreUnsafe` were deliberately left out of the PackedSimd alias table because their operands are reversed relative to the method they would lower to:

```
PackedSimd.Store  (T* address, Vector128<T> source)
Vector128.Store   (this Vector128<T> source, T* destination)
```

The alias path only renames the method, and `emit_common_simd_epilogue` assigns sregs in signature order, so aliasing them as-is would have passed the vector where the destination address is expected. They therefore fell back to managed code, which routes through `Unsafe.WriteUnaligned` — an intrinsic the interpreter does not implement — making a documented-as-fast API roughly six times slower than the PackedSimd equivalent.

## Fix

Add them to the alias table and swap the two sregs after the epilogue has run. sregs are var indices consumed positionally by `MINT_SIMD_INTRINS_P_PP` (`interp.c:6141`), so the swap is a permutation: it changes their order, not the set of vars used, leaving liveness and refcounting unaffected. It runs during IL→IR generation, before every optimization pass.

It also matches what the jiterpreter already expects — `SimdIntrinsic3.StoreANY` in `jiterpreter-trace-generator.ts` loads arg 2 as the address and arg 3 as the vector.

`Store` is registered for every element type (`ANY`), so the reorder is guarded on the shape actually being a store: two parameters, void return, and a raw address (`T*` or `ref T`) as the second parameter. The three-argument `StoreUnsafe(source, destination, elementOffset)` has no PackedSimd counterpart and is rejected by the parameter count, falling back to managed code as before.

`System.Numerics.Vector.Store`/`StoreUnsafe` share the identical shape and route through the same emit path, so they are lowered too. `StoreAligned`/`StoreAlignedNonTemporal` are absent from the alias table and continue to fall back to managed code — importantly, since `StoreAligned` has a runtime alignment check that must throw.

### Alignment

`interp_packedsimd_store` assigned through a `v128_t*`, claiming 16-byte alignment that neither `PackedSimd.Store` nor `Vector128.StoreUnsafe` guarantee. It now uses `wasm_v128_store`, which stores through a `__packed__ __may_alias__` struct. This mirrors `interp_packedsimd_load128`'s existing use of `wasm_v128_load`, and matches the jiterpreter's `v128_store` with an alignment hint of 1. Misaligned access is well-defined at the wasm ISA level, so this was C UB rather than a live bug.

## Measurements

browser-wasm under V8, interpreter, 1,000,000 iterations, 2 warmups, best of 5, same harness before and after on the same machine:

| Operation | Before | After | Speedup |
|---|---|---|---|
| `Vector128.Store<int>` | 3.243 ns | 0.521 ns | **6.2x** |
| `Vector128.StoreUnsafe<int>` | 3.253 ns | 0.518 ns | **6.3x** |
| `PackedSimd.Store<int>` (control) | 0.485 ns | 0.527 ns | unchanged |

The control's ~8% drift bounds run-to-run noise; the 6x is far outside it. No loop-overhead baseline is subtracted — an empty-loop control measured *higher* than the store loops, since the jiterpreter doesn't trace it.

## Validation

- browser-wasm `mono+libs` Release: 0 errors, 0 warnings
- native osx-arm64 `mono` Release: 0 errors, 0 warnings
- `System.Runtime.Intrinsics`: **13024/13024** passing (13021 baseline + 3 new)
- `System.Numerics.Vectors`: **7449/7449** passing
- IR (`MONO_VERBOSE_METHOD`): `simd_intrins_p_pp [74 <- 73 72], 191` — descending sregs confirm the swap; the three-argument overload still emits a managed `call`
- `System.Numerics.Vector<T>.StoreUnsafe` likewise emits `simd_intrins_p_pp [19 <- 18 14], 191`

## Tests

Three tests covering `Store`, `StoreUnsafe`, and `StoreUnsafe` with an element offset, across twelve element types, at every 16-byte alignment, with guard bytes on both sides so a misplaced or oversized store is caught. The element-offset arm uses `StoreUnsafe(ref *(destination - 1), elementOffset: 1)` so a dropped offset argument shows up as a misplaced store. They pass on an unmodified runtime as well, so they validate behavior rather than implementation.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.

