### PR TITLE
[wasm] Guard lookupNamedIntrinsic against null/helper method handles

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -11430,6 +11430,14 @@ GenTree* Compiler::impMathIntrinsic(CORINFO_METHOD_HANDLE method,
 //
 NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
 {
+    // A null (e.g. indirect call) or helper handle is not a metadata method and must not be passed to
+    // getMethodNameFromMetadata / getArrayIntrinsicID (they would index an invalid handle and trap).
+    // Neither is ever a named intrinsic.
+    if ((method == NO_METHOD_HANDLE) || (eeGetHelperNum(method) != CORINFO_HELP_UNDEF))
+    {
+        return NI_Illegal;
+    }
+
     const char* className              = nullptr;
     const char* namespaceName          = nullptr;
     const char* enclosingClassNames[2] = {nullptr};


### PR DESCRIPTION
## Summary

`crossgen2` crashes while producing the browser-wasm framework ReadyToRun images, when compiling `System.Linq.Parallel` (specifically the shared-generic instantiation `GC.AllocateUninitializedArray<Pair<double,long>>` / `<Pair<long,long>>`).

`Compiler::lookupNamedIntrinsic` is invoked with a **null method handle** (`NO_METHOD_HANDLE`, e.g. from an indirect call's `gtCallMethHnd`) and passes it straight to `getMethodNameFromMetadata` (and, on the fallback path, `getArrayIntrinsicID`). On the crossgen2 side these do `HandleToObject(ftn)` → `_handleToObject[index]` with `index = ((int)ftn - handleBase) / handleMultiplier`; for `ftn == 0` the index is a large negative value → `ArgumentOutOfRangeException`, surfaced as `CodeGenerationFailedException` (crossgen2 exits `0xE0434352`).

A null (or JIT helper) handle is never a named intrinsic, so `lookupNamedIntrinsic` now returns `NI_Illegal` early for both. This protects all ~30 call sites, several of which pass `call->gtCallMethHnd` on arbitrary calls (indirect → `NO_METHOD_HANDLE`; helper → odd `eeFindHelper` encoding).

The bug is latent on other targets that don't compile this exact tree shape; it reproduces on wasm because the framework version bubble (`--opt-cross-module:*`) R2R-compiles the shared-generic value-type instantiation.

Fixes #132505

## Validation

Rebuilt the wasm cross-jit (`clrjit_universal_wasm_x64`) with the guard and re-ran the exact framework R2R crossgen2 command: `System.Linq.Parallel.wasm` is now emitted successfully (exit 0) instead of crashing.

Root cause was confirmed by instrumenting crossgen2's `getMethodNameFromMetadata`, which reported `ftn=0x0` for the failing calls.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.