### PR TITLE
Edit remarks section of HostApplicationBuilder's parameterless constructor

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
@@ -40,12 +40,10 @@ namespace Microsoft.Extensions.Hosting
         ///   <list type="bullet">
         ///     <item><description>set the <see cref="IHostEnvironment.ContentRootPath"/> to the result of <see cref="Directory.GetCurrentDirectory()"/></description></item>
         ///     <item><description>load host <see cref="IConfiguration"/> from "DOTNET_" prefixed environment variables</description></item>
-        ///     <item><description>load host <see cref="IConfiguration"/> from supplied command line args</description></item>
         ///     <item><description>load app <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostEnvironment.EnvironmentName"/>].json'</description></item>
         ///     <item><description>load app <see cref="IConfiguration"/> from '[<see cref="IHostEnvironment.ApplicationName"/>].settings.json' and '[<see cref="IHostEnvironment.ApplicationName"/>].settings.[<see cref="IHostEnvironment.EnvironmentName"/>].json' when <see cref="IHostEnvironment.ApplicationName"/> is not empty</description></item>
         ///     <item><description>load app <see cref="IConfiguration"/> from User Secrets when <see cref="IHostEnvironment.EnvironmentName"/> is 'Development' using the entry assembly</description></item>
         ///     <item><description>load app <see cref="IConfiguration"/> from environment variables</description></item>
-        ///     <item><description>load app <see cref="IConfiguration"/> from supplied command line args</description></item>
         ///     <item><description>configure the <see cref="ILoggerFactory"/> to log to the console, debug, and event source output</description></item>
         ///     <item><description>enables scope validation on the dependency injection container when <see cref="IHostEnvironment.EnvironmentName"/> is 'Development'</description></item>
         ///   </list>


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-api-docs/issues/13000

Removes two items from remarks section of HostApplicationBuilder's parameterless constructor.