### PR TITLE
SuperPMI: speed up reportMetadata metric lookup

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
@@ -1109,7 +1109,7 @@ void MyICJI::reportMetadata(const char* key, const void* value, size_t length)
     // The JIT reports metrics in the order they are declared in jitmetadatalist.h,
     // so resume the search where the previous one matched instead of always scanning
     // from the start. In practice this matches on the first comparison.
-    size_t index = metricSearchStart;
+    size_t index = m_metricSearchStart;
     for (size_t i = 0; i < count; i++)
     {
         const MetricEntry& entry = s_metrics[index];
@@ -1122,7 +1122,7 @@ void MyICJI::reportMetadata(const char* key, const void* value, size_t length)
 
         if (strcmp(key, entry.Name) == 0)
         {
-            metricSearchStart = index;
+            m_metricSearchStart = index;
             entry.Store(jitInstance->mc->cr, value, length);
             return;
         }

--- a/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
@@ -1086,15 +1086,47 @@ void MyICJI::reportMetadata(const char* key, const void* value, size_t length)
         return;
     }
 
-#define JITMETADATAINFO(name, type, flags)
-#define JITMETADATAMETRIC(name, type, flags) \
-    if ((strcmp(key, #name) == 0) && (length == sizeof(type)))   \
-    {                                                            \
-        memcpy(&jitInstance->mc->cr->name, value, sizeof(type)); \
-        return;                                                  \
-    }
+    struct MetricEntry
+    {
+        const char* Name;
+        void (*Store)(CompileResult* cr, const void* value, size_t length);
+    };
 
+    static const MetricEntry s_metrics[] = {
+#define JITMETADATAINFO(name, type, flags)
+#define JITMETADATAMETRIC(name, type, flags)                                                                           \
+    {#name, [](CompileResult* cr, const void* value, size_t length) {                                                  \
+         if (length == sizeof(type))                                                                                   \
+         {                                                                                                             \
+             cr->name = *static_cast<const type*>(value);                                                              \
+         }                                                                                                             \
+     }},
 #include "jitmetadatalist.h"
+    };
+
+    const size_t count = sizeof(s_metrics) / sizeof(s_metrics[0]);
+
+    // The JIT reports metrics in the order they are declared in jitmetadatalist.h,
+    // so resume the search where the previous one matched instead of always scanning
+    // from the start. In practice this matches on the first comparison.
+    size_t index = metricSearchStart;
+    for (size_t i = 0; i < count; i++)
+    {
+        const MetricEntry& entry = s_metrics[index];
+
+        index++;
+        if (index == count)
+        {
+            index = 0;
+        }
+
+        if (strcmp(key, entry.Name) == 0)
+        {
+            metricSearchStart = index;
+            entry.Store(jitInstance->mc->cr, value, length);
+            return;
+        }
+    }
 }
 
 /*-------------------------- Misc ---------------------------------------*/

--- a/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
@@ -1104,7 +1104,7 @@ void MyICJI::reportMetadata(const char* key, const void* value, size_t length)
 #include "jitmetadatalist.h"
     };
 
-    const size_t count = sizeof(s_metrics) / sizeof(s_metrics[0]);
+    const size_t count = ArrLen(s_metrics);
 
     // The JIT reports metrics in the order they are declared in jitmetadatalist.h,
     // so resume the search where the previous one matched instead of always scanning

--- a/src/coreclr/tools/superpmi/superpmi/icorjitinfo.h
+++ b/src/coreclr/tools/superpmi/superpmi/icorjitinfo.h
@@ -17,6 +17,10 @@ class MyICJI : public ICorJitInfo
 public:
     // Added extras... todo add padding to detect corruption?
     JitInstance* jitInstance;
+
+    // Index to start the next search for a reported metric at. See
+    // MyICJI::reportMetadata.
+    size_t metricSearchStart = 0;
 };
 
 ICorJitInfo* InitICorJitInfo(JitInstance* jitInstance);

--- a/src/coreclr/tools/superpmi/superpmi/icorjitinfo.h
+++ b/src/coreclr/tools/superpmi/superpmi/icorjitinfo.h
@@ -18,9 +18,10 @@ public:
     // Added extras... todo add padding to detect corruption?
     JitInstance* jitInstance;
 
+private:
     // Index to start the next search for a reported metric at. See
     // MyICJI::reportMetadata.
-    size_t metricSearchStart = 0;
+    size_t m_metricSearchStart = 0;
 };
 
 ICorJitInfo* InitICorJitInfo(JitInstance* jitInstance);


### PR DESCRIPTION
This was quadratic overall, so as we grew the number of metadata entries this became worse and worse.

Start the search for the metadata where the previous entry was found. In practice this makes things linear overall since SuperPMI and the JIT agree on the order of the metrics.

Reduces wall clock time for release-mode superpmi by 2.8% (because superpmi sets `DOTNET_JitReportMetrics=1`) and checked-mode superpmi by ~0.5%.