### PR TITLE
JIT: Simplify containment and NOP checks

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1849,7 +1849,7 @@ inline GenTree* Compiler::gtNewNothingNode()
 
 inline bool GenTree::IsNothingNode() const
 {
-    return OperIs(GT_NOP) && TypeIs(TYP_VOID);
+    return OperIs(GT_NOP);
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -20412,21 +20412,7 @@ bool GenTree::canBeContained() const
 bool GenTree::isContained() const
 {
     assert(OperIsLIR());
-    const bool isMarkedContained = ((gtFlags & GTF_CONTAINED) != 0);
-
-#ifdef DEBUG
-    if (!canBeContained())
-    {
-        assert(!isMarkedContained);
-    }
-
-    // if it's contained it can't be unused.
-    if (isMarkedContained)
-    {
-        assert(!IsUnusedValue());
-    }
-#endif // DEBUG
-    return isMarkedContained;
+    return (gtFlags & GTF_CONTAINED) != 0;
 }
 
 // return true if node is contained and an indir

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1939,12 +1939,6 @@ public:
 
     bool OperIsLIR() const
     {
-        if (OperIs(GT_NOP))
-        {
-            // NOPs may only be present in LIR if they do not produce a value.
-            return IsNothingNode();
-        }
-
         return (DebugOperKind() & DBK_NOTLIR) == 0;
     }
 

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1630,8 +1630,6 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
         // Verify that the node is allowed in LIR.
         assert(node->OperIsLIR());
 
-        // A node that is marked as contained must actually be containable, and it
-        // cannot also be marked as an unused value.
         if (node->isContained())
         {
             assert(node->canBeContained());

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1630,6 +1630,14 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
         // Verify that the node is allowed in LIR.
         assert(node->OperIsLIR());
 
+        // A node that is marked as contained must actually be containable, and it
+        // cannot also be marked as an unused value.
+        if (node->isContained())
+        {
+            assert(node->canBeContained());
+            assert(!node->IsUnusedValue());
+        }
+
         // Some nodes should never be marked unused, as they must be contained in the backend.
         // These may be marked as unused during dead code elimination traversal, but they *must* be subsequently
         // removed.


### PR DESCRIPTION
Avoids expensive `canBeContained` check on every `isContained` call. Moves both assertions into LIR::Range::CheckLIR, which already walks every node and is run after every phase that modifies LIR.

Also drop two checks that are no longer needed:

- OperIsLIR special cased GT_NOP to require IsNothingNode(). All NOPs are TYP_VOID now, which fgDebugCheckTypes asserts, so the general DBK_NOTLIR test is enough.
- IsNothingNode tested for TYP_VOID for the same reason.

Throughput on benchmarks.run for the checked JIT: -3.63% instructions retired.