### PR TITLE
Implement SocketsHttpHandler.InitialHttp2MaxConcurrentStreams

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -476,6 +476,7 @@ namespace System.Net.Http
         public bool EnableMultipleHttp2Connections { get { throw null; } set { } }
         public bool EnableMultipleHttp3Connections { get { throw null; } set { } }
         public System.TimeSpan Expect100ContinueTimeout { get { throw null; } set { } }
+        public int InitialHttp2MaxConcurrentStreams { get { throw null; } set { } }
         public int InitialHttp2StreamWindowSize { get { throw null; } set { } }
         [System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute("browser")]
         public static bool IsSupported { get { throw null; } }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
@@ -148,6 +148,12 @@ namespace System.Net.Http
             set => throw new PlatformNotSupportedException();
         }
 
+        public int InitialHttp2MaxConcurrentStreams
+        {
+            get => throw new PlatformNotSupportedException();
+            set => throw new PlatformNotSupportedException();
+        }
+
         public TimeSpan KeepAlivePingDelay
         {
             get => throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -21,5 +21,10 @@ namespace System.Net.Http
         // Should not be confused with Http2Connection.DefaultInitialWindowSize, which defines the RFC default.
         // Unlike that value, DefaultInitialHttp2StreamWindowSize might be changed in the future.
         public const int DefaultInitialHttp2StreamWindowSize = 65535;
+
+        // This is the default value for SocketsHttpHandler.InitialHttp2MaxConcurrentStreams.
+        // It defines how many concurrent streams a new HTTP/2 connection may use before it
+        // observes the server's SETTINGS_MAX_CONCURRENT_STREAMS value.
+        public const int DefaultInitialHttp2MaxConcurrentStreams = 100;
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -25,6 +25,10 @@ namespace System.Net.Http
         // This is the default value for SocketsHttpHandler.InitialHttp2MaxConcurrentStreams.
         // It defines how many concurrent streams a new HTTP/2 connection may use before it
         // observes the server's SETTINGS_MAX_CONCURRENT_STREAMS value.
+        // 100 is the lowest limit servers are recommended to advertise by
+        // https://www.rfc-editor.org/rfc/rfc9113.html#section-6.5.2 ("It is recommended that this
+        // value be no smaller than 100, so as to not unnecessarily limit parallelism"), which makes
+        // it a safe assumption for servers we haven't talked to yet.
         public const int DefaultInitialHttp2MaxConcurrentStreams = 100;
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
@@ -486,18 +486,6 @@ namespace System.Net.Http
             {
                 Debug.Assert(initialRequestWaiter is not null, "Expect request for a new connection");
 
-                if (Settings._initialHttp2MaxConcurrentStreams == 0 && !connection.InitialSettingsReceived.Task.IsCompleted)
-                {
-                    // The connection has no available streams only because we haven't received the server's SETTINGS
-                    // frame yet (SocketsHttpHandler.InitialHttp2MaxConcurrentStreams is set to 0).
-                    // Wait for the server to advertise its stream limit before deciding that the connection is unusable.
-                    // The connection stays marked as pending, so we won't inject more connections in the meantime.
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Waiting for the server's SETTINGS frame before using the new HTTP2 connection.");
-
-                    _ = WaitForInitialSettingsAsync(connection, initialRequestWaiter); // ignore returned task
-                    return;
-                }
-
                 // The new connection could not handle even one request, either because it shut down before we could use it for any requests,
                 // or because it immediately set the max concurrent streams limit to 0.
                 // We don't want to get stuck in a loop where we keep trying to create new connections for the same request.
@@ -520,14 +508,6 @@ namespace System.Net.Http
 
                 // We need to wait until the connection is usable again.
                 DisableHttp2Connection(connection);
-            }
-
-            async Task WaitForInitialSettingsAsync(Http2Connection connection, HttpConnectionWaiter<Http2Connection?> initialRequestWaiter)
-            {
-                // Ignore any failures - the connection will be seen as shut down when we return it below.
-                await ((Task)connection.InitialSettingsReceived.Task).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-
-                ReturnHttp2Connection(connection, isNewConnection: true, initialRequestWaiter);
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http2.cs
@@ -486,6 +486,18 @@ namespace System.Net.Http
             {
                 Debug.Assert(initialRequestWaiter is not null, "Expect request for a new connection");
 
+                if (Settings._initialHttp2MaxConcurrentStreams == 0 && !connection.InitialSettingsReceived.Task.IsCompleted)
+                {
+                    // The connection has no available streams only because we haven't received the server's SETTINGS
+                    // frame yet (SocketsHttpHandler.InitialHttp2MaxConcurrentStreams is set to 0).
+                    // Wait for the server to advertise its stream limit before deciding that the connection is unusable.
+                    // The connection stays marked as pending, so we won't inject more connections in the meantime.
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Waiting for the server's SETTINGS frame before using the new HTTP2 connection.");
+
+                    _ = WaitForInitialSettingsAsync(connection, initialRequestWaiter); // ignore returned task
+                    return;
+                }
+
                 // The new connection could not handle even one request, either because it shut down before we could use it for any requests,
                 // or because it immediately set the max concurrent streams limit to 0.
                 // We don't want to get stuck in a loop where we keep trying to create new connections for the same request.
@@ -508,6 +520,14 @@ namespace System.Net.Http
 
                 // We need to wait until the connection is usable again.
                 DisableHttp2Connection(connection);
+            }
+
+            async Task WaitForInitialSettingsAsync(Http2Connection connection, HttpConnectionWaiter<Http2Connection?> initialRequestWaiter)
+            {
+                // Ignore any failures - the connection will be seen as shut down when we return it below.
+                await ((Task)connection.InitialSettingsReceived.Task).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+
+                ReturnHttp2Connection(connection, isNewConnection: true, initialRequestWaiter);
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -54,7 +54,10 @@ namespace System.Net.Http
         internal uint _lastSeenHttp3MaxHeaderListSize;
 
         // Same as the above, but for SETTINGS_MAX_CONCURRENT_STREAMS.
-        internal uint _lastSeenHttp2MaxConcurrentStreams = Http2Connection.InitialMaxConcurrentStreams;
+        // Unlike the values above, this one starts out at SocketsHttpHandler.InitialHttp2MaxConcurrentStreams,
+        // and we only ever memorize server-advertised values that are lower than that. That is, the setting
+        // acts as the upper bound for what every new connection starts with.
+        internal uint _lastSeenHttp2MaxConcurrentStreams;
 
         /// <summary>Options specialized and cached for this pool and its key.</summary>
         private readonly SslClientAuthenticationOptions? _sslOptionsHttp11;
@@ -85,6 +88,7 @@ namespace System.Net.Http
             _proxyUri = proxyUri;
             _maxHttp11Connections = Settings._maxConnectionsPerServer;
             _telemetryServerAddress = telemetryServerAddress;
+            _lastSeenHttp2MaxConcurrentStreams = (uint)Settings._initialHttp2MaxConcurrentStreams;
 
             // The only case where 'host' will not be set is if this is a Proxy connection pool. In that case the
             // connection targets the proxy itself, so use the proxy's host and port for the origin authority.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers.Binary;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers.Binary;
@@ -80,9 +80,6 @@ namespace System.Net.Http
         private int _queuedFireAndForgetFrames;
 
         private const int MaxStreamId = int.MaxValue;
-
-        // Temporary workaround for request burst handling on connection start.
-        internal const int InitialMaxConcurrentStreams = 100;
 
         private static ReadOnlySpan<byte> Http2ConnectionPreface => "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"u8;
 
@@ -870,7 +867,13 @@ namespace System.Net.Http
                     switch ((SettingId)settingId)
                     {
                         case SettingId.MaxConcurrentStreams:
-                            _pool._lastSeenHttp2MaxConcurrentStreams = settingValue;
+                            // Only memorize the value for future connections if it's lower than what we're
+                            // configured to start with. SocketsHttpHandler.InitialHttp2MaxConcurrentStreams
+                            // acts as the upper bound for what every new connection starts with.
+                            if (settingValue < (uint)_pool.Settings._initialHttp2MaxConcurrentStreams)
+                            {
+                                _pool._lastSeenHttp2MaxConcurrentStreams = settingValue;
+                            }
                             ChangeMaxConcurrentStreams(settingValue);
                             maxConcurrentStreamsReceived = true;
                             break;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -874,6 +874,7 @@ namespace System.Net.Http
                             {
                                 _pool._lastSeenHttp2MaxConcurrentStreams = settingValue;
                             }
+
                             ChangeMaxConcurrentStreams(settingValue);
                             maxConcurrentStreamsReceived = true;
                             break;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -870,7 +870,7 @@ namespace System.Net.Http
                             // Only memorize the value for future connections if it's lower than what we're
                             // configured to start with. SocketsHttpHandler.InitialHttp2MaxConcurrentStreams
                             // acts as the upper bound for what every new connection starts with.
-                            if (settingValue < (uint)_pool.Settings._initialHttp2MaxConcurrentStreams)
+                            if (settingValue < _pool.Settings._initialHttp2MaxConcurrentStreams)
                             {
                                 _pool._lastSeenHttp2MaxConcurrentStreams = settingValue;
                             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -73,6 +73,8 @@ namespace System.Net.Http
         // Http2 flow control settings:
         internal int _initialHttp2StreamWindowSize = HttpHandlerDefaults.DefaultInitialHttp2StreamWindowSize;
 
+        internal int _initialHttp2MaxConcurrentStreams = HttpHandlerDefaults.DefaultInitialHttp2MaxConcurrentStreams;
+
         internal ClientCertificateOption _clientCertificateOptions;
 
         public HttpConnectionSettings()
@@ -130,6 +132,7 @@ namespace System.Net.Http
                 _plaintextStreamFilter = _plaintextStreamFilter,
                 _shouldEvictConnection = _shouldEvictConnection,
                 _initialHttp2StreamWindowSize = _initialHttp2StreamWindowSize,
+                _initialHttp2MaxConcurrentStreams = _initialHttp2MaxConcurrentStreams,
                 _activityHeadersPropagator = _activityHeadersPropagator,
                 _defaultCredentialsUsedForProxy = _proxy != null && (_proxy.Credentials == CredentialCache.DefaultCredentials || _defaultProxyCredentials == CredentialCache.DefaultCredentials),
                 _defaultCredentialsUsedForServer = _credentials == CredentialCache.DefaultCredentials,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -299,6 +299,43 @@ namespace System.Net.Http
         }
 
         /// <summary>
+        /// Gets or sets the maximum number of concurrent HTTP/2 streams a new connection may use before it observes
+        /// the server's <c>SETTINGS_MAX_CONCURRENT_STREAMS</c> value.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// HTTP/2 allows the client to send requests as soon as the connection is established, before the server has
+        /// advertised how many concurrent streams it is willing to accept. Sending more requests than the server allows
+        /// may cause those requests to fail, or trigger server-side abuse mitigations.
+        /// Lowering this value avoids exceeding the server limit at the cost of reduced concurrency until the
+        /// server's <c>SETTINGS</c> frame is received.
+        /// </para>
+        /// <para>
+        /// If a previous connection in the same connection pool advertised a lower limit,
+        /// that lower value is used instead for new connections.
+        /// </para>
+        /// <para>
+        /// Setting this property to 0 means that no requests will be sent on a new connection
+        /// until the server's <c>SETTINGS</c> frame is received.
+        /// </para>
+        /// <para>
+        /// The value must be greater than or equal to 0. Defaults to 100.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">The value is negative.</exception>
+        public int InitialHttp2MaxConcurrentStreams
+        {
+            get => _settings._initialHttp2MaxConcurrentStreams;
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
+
+                CheckDisposedOrStarted();
+                _settings._initialHttp2MaxConcurrentStreams = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the keep alive ping delay. The client will send a keep alive ping to the server if it
         /// doesn't receive any frames on a connection for this period of time. This property is used together with
         /// <see cref="SocketsHttpHandler.KeepAlivePingTimeout"/> to close broken connections.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -304,15 +304,18 @@ namespace System.Net.Http
         /// </summary>
         /// <remarks>
         /// <para>
-        /// HTTP/2 allows the client to send requests as soon as the connection is established, before the server has
-        /// advertised how many concurrent streams it is willing to accept. Sending more requests than the server allows
-        /// may cause those requests to fail, or trigger server-side abuse mitigations.
-        /// Lowering this value avoids exceeding the server limit at the cost of reduced concurrency until the
-        /// server's <c>SETTINGS</c> frame is received.
+        /// HTTP/2 lets the client start sending requests as soon as the connection is established, before the server
+        /// has advertised how many concurrent streams it accepts. Until that <c>SETTINGS</c> frame arrives, the client
+        /// optimistically allows up to this many streams, after which the server's value takes over.
         /// </para>
         /// <para>
-        /// If a previous connection in the same connection pool advertised a lower limit,
-        /// that lower value is used instead for new connections.
+        /// The default suits virtually all deployments and most users never need to change it. It is intended for the
+        /// small subset of deployments where the server is known ahead of time to use a lower concurrency limit, and
+        /// starting a connection with a matching value avoids the brief burst of requests above that limit.
+        /// </para>
+        /// <para>
+        /// If an earlier connection to the same host advertised a lower limit,
+        /// that lower value is used instead for new connections to that host.
         /// </para>
         /// <para>
         /// The value must be greater than or equal to 1. Defaults to 100.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -315,20 +315,16 @@ namespace System.Net.Http
         /// that lower value is used instead for new connections.
         /// </para>
         /// <para>
-        /// Setting this property to 0 means that no requests will be sent on a new connection
-        /// until the server's <c>SETTINGS</c> frame is received.
-        /// </para>
-        /// <para>
-        /// The value must be greater than or equal to 0. Defaults to 100.
+        /// The value must be greater than or equal to 1. Defaults to 100.
         /// </para>
         /// </remarks>
-        /// <exception cref="ArgumentOutOfRangeException">The value is negative.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The value is zero or negative.</exception>
         public int InitialHttp2MaxConcurrentStreams
         {
             get => _settings._initialHttp2MaxConcurrentStreams;
             set
             {
-                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
 
                 CheckDisposedOrStarted();
                 _settings._initialHttp2MaxConcurrentStreams = value;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -3695,7 +3695,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData(0)]
         [InlineData(1)]
         [InlineData(42)]
         [InlineData(int.MaxValue)]
@@ -3712,10 +3711,11 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
+        [InlineData(0)]
         [InlineData(-1)]
         [InlineData(-42)]
         [InlineData(int.MinValue)]
-        public void InitialHttp2MaxConcurrentStreams_NegativeValue_ThrowsArgumentOutOfRangeException(int value)
+        public void InitialHttp2MaxConcurrentStreams_InvalidValue_ThrowsArgumentOutOfRangeException(int value)
         {
             using var handler = new SocketsHttpHandler();
             Assert.Throws<ArgumentOutOfRangeException>(() => handler.InitialHttp2MaxConcurrentStreams = value);
@@ -4241,7 +4241,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
-        [InlineData(0)]
         [InlineData(1)]
         [InlineData(3)]
         public async Task InitialHttp2MaxConcurrentStreams_LimitsStreamsUsedBeforeSettingsFrameIsReceived(int initialLimit)
@@ -4274,27 +4273,6 @@ namespace System.Net.Http.Functional.Tests
 
             await SendResponses(connection, streamIds);
             await VerifySendTasks(sendTasks);
-        }
-
-        [ConditionalFact(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
-        public async Task InitialHttp2MaxConcurrentStreams_ZeroAndConnectionClosedBeforeSettings_RequestFails()
-        {
-            using Http2LoopbackServer server = Http2LoopbackServer.CreateServer();
-
-            using SocketsHttpHandler handler = CreateHandler();
-            handler.EnableMultipleHttp2Connections = false;
-            handler.InitialHttp2MaxConcurrentStreams = 0;
-            using HttpClient client = CreateHttpClient(handler);
-
-            Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
-
-            Http2LoopbackConnection connection = await server.AcceptConnectionAsync().WaitAsync(TestHelper.PassingTestTimeout);
-            await connection.ReadSettingsAsync().WaitAsync(TestHelper.PassingTestTimeout);
-
-            // Tear the connection down without ever advertising our stream limit.
-            await connection.DisposeAsync();
-
-            await Assert.ThrowsAsync<HttpRequestException>(() => sendTask).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [ConditionalFact(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -4263,13 +4263,13 @@ namespace System.Net.Http.Functional.Tests
             await connection.ReadSettingsAsync().WaitAsync(TestHelper.PassingTestTimeout);
 
             // Only 'initialLimit' requests may be sent before we advertise our own limit.
-            var streamIds = new List<int>(await ReadRequestHeadersAsync(connection, initialLimit));
+            var streamIds = new List<int>(await AcceptRequests(connection, initialLimit));
             await AssertNoRequestHeadersSentAsync(connection);
 
             // Advertise a higher limit. The remaining requests should now be sent.
             await connection.SendSettingsAsync(ackTimeout: null, [new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 100 }]);
 
-            streamIds.AddRange(await ReadRequestHeadersAsync(connection, RequestCount - initialLimit));
+            streamIds.AddRange(await AcceptRequests(connection, RequestCount - initialLimit));
 
             await SendResponses(connection, streamIds);
             await VerifySendTasks(sendTasks);
@@ -4342,38 +4342,20 @@ namespace System.Net.Http.Functional.Tests
             await using Http2LoopbackConnection connection = await server.AcceptConnectionAsync().WaitAsync(TestHelper.PassingTestTimeout);
             await connection.ReadSettingsAsync().WaitAsync(TestHelper.PassingTestTimeout);
 
-            var streamIds = new List<int>(await ReadRequestHeadersAsync(connection, expectedStreamsOnNewConnection));
+            var streamIds = new List<int>(await AcceptRequests(connection, expectedStreamsOnNewConnection));
             await AssertNoRequestHeadersSentAsync(connection);
 
             await connection.SendSettingsAsync(ackTimeout: null, [new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 100 }]);
 
-            streamIds.AddRange(await ReadRequestHeadersAsync(connection, RequestCount - expectedStreamsOnNewConnection));
+            streamIds.AddRange(await AcceptRequests(connection, RequestCount - expectedStreamsOnNewConnection));
 
             await SendResponses(connection, streamIds);
             await VerifySendTasks(sendTasks);
         }
 
-        private static async Task<int[]> ReadRequestHeadersAsync(Http2LoopbackConnection connection, int count)
-        {
-            var streamIds = new List<int>(count);
-
-            while (streamIds.Count < count)
-            {
-                Frame frame = await connection.ReadFrameAsync(TestHelper.PassingTestTimeout).ConfigureAwait(false);
-                Assert.NotNull(frame);
-
-                if (frame.Type == FrameType.Headers)
-                {
-                    streamIds.Add(frame.StreamId);
-                }
-            }
-
-            return streamIds.ToArray();
-        }
-
         private static async Task AssertNoRequestHeadersSentAsync(Http2LoopbackConnection connection)
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
 
             while (true)
             {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -3695,6 +3695,34 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(42)]
+        [InlineData(int.MaxValue)]
+        public void InitialHttp2MaxConcurrentStreams_GetSet_Roundtrips(int value)
+        {
+            using var handler = new SocketsHttpHandler();
+            Assert.Equal(100, handler.InitialHttp2MaxConcurrentStreams); // default value
+
+            handler.InitialHttp2MaxConcurrentStreams = value;
+            Assert.Equal(value, handler.InitialHttp2MaxConcurrentStreams);
+
+            handler.InitialHttp2MaxConcurrentStreams = 100;
+            Assert.Equal(100, handler.InitialHttp2MaxConcurrentStreams);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(-42)]
+        [InlineData(int.MinValue)]
+        public void InitialHttp2MaxConcurrentStreams_NegativeValue_ThrowsArgumentOutOfRangeException(int value)
+        {
+            using var handler = new SocketsHttpHandler();
+            Assert.Throws<ArgumentOutOfRangeException>(() => handler.InitialHttp2MaxConcurrentStreams = value);
+            Assert.Equal(100, handler.InitialHttp2MaxConcurrentStreams);
+        }
+
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task AfterDisposeSendAsync_GettersUsable_SettersThrow(bool dispose)
@@ -3737,6 +3765,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Null(handler.ConnectCallback);
                 Assert.Null(handler.PlaintextStreamFilter);
                 Assert.Equal(HttpClientHandlerTestBase.DefaultInitialWindowSize, handler.InitialHttp2StreamWindowSize);
+                Assert.Equal(100, handler.InitialHttp2MaxConcurrentStreams);
 
                 Assert.Throws(expectedExceptionType, () => handler.AllowAutoRedirect = false);
                 Assert.Throws(expectedExceptionType, () => handler.AutomaticDecompression = DecompressionMethods.GZip);
@@ -3759,6 +3788,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Throws(expectedExceptionType, () => handler.ConnectCallback = (context, token) => default);
                 Assert.Throws(expectedExceptionType, () => handler.PlaintextStreamFilter = (context, token) => default);
                 Assert.Throws(expectedExceptionType, () => handler.InitialHttp2StreamWindowSize = 128 * 1024);
+                Assert.Throws(expectedExceptionType, () => handler.InitialHttp2MaxConcurrentStreams = 1);
             }
         }
     }
@@ -4208,6 +4238,180 @@ namespace System.Net.Http.Functional.Tests
             server.Dispose();
             await acceptTask.ConfigureAwait(false);
             await Task.WhenAll(connectionTasks).ConfigureAwait(false);
+        }
+
+        [ConditionalTheory(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(3)]
+        public async Task InitialHttp2MaxConcurrentStreams_LimitsStreamsUsedBeforeSettingsFrameIsReceived(int initialLimit)
+        {
+            const int RequestCount = 5;
+
+            using Http2LoopbackServer server = Http2LoopbackServer.CreateServer();
+
+            using SocketsHttpHandler handler = CreateHandler();
+            handler.EnableMultipleHttp2Connections = false;
+            handler.InitialHttp2MaxConcurrentStreams = initialLimit;
+            using HttpClient client = CreateHttpClient(handler);
+
+            var sendTasks = new List<Task<HttpResponseMessage>>();
+            AcquireAllStreamSlots(server, client, sendTasks, RequestCount);
+
+            await using Http2LoopbackConnection connection = await server.AcceptConnectionAsync().WaitAsync(TestHelper.PassingTestTimeout);
+
+            // Read the client's SETTINGS frame, but don't send ours yet.
+            await connection.ReadSettingsAsync().WaitAsync(TestHelper.PassingTestTimeout);
+
+            // Only 'initialLimit' requests may be sent before we advertise our own limit.
+            var streamIds = new List<int>(await ReadRequestHeadersAsync(connection, initialLimit));
+            await AssertNoRequestHeadersSentAsync(connection);
+
+            // Advertise a higher limit. The remaining requests should now be sent.
+            await connection.SendSettingsAsync(ackTimeout: null, [new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 100 }]);
+
+            streamIds.AddRange(await ReadRequestHeadersAsync(connection, RequestCount - initialLimit));
+
+            await SendResponses(connection, streamIds);
+            await VerifySendTasks(sendTasks);
+        }
+
+        [ConditionalFact(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
+        public async Task InitialHttp2MaxConcurrentStreams_ZeroAndConnectionClosedBeforeSettings_RequestFails()
+        {
+            using Http2LoopbackServer server = Http2LoopbackServer.CreateServer();
+
+            using SocketsHttpHandler handler = CreateHandler();
+            handler.EnableMultipleHttp2Connections = false;
+            handler.InitialHttp2MaxConcurrentStreams = 0;
+            using HttpClient client = CreateHttpClient(handler);
+
+            Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
+
+            Http2LoopbackConnection connection = await server.AcceptConnectionAsync().WaitAsync(TestHelper.PassingTestTimeout);
+            await connection.ReadSettingsAsync().WaitAsync(TestHelper.PassingTestTimeout);
+
+            // Tear the connection down without ever advertising our stream limit.
+            await connection.DisposeAsync();
+
+            await Assert.ThrowsAsync<HttpRequestException>(() => sendTask).WaitAsync(TestHelper.PassingTestTimeout);
+        }
+
+        [ConditionalFact(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
+        public async Task InitialHttp2MaxConcurrentStreams_HigherServerLimit_NotMemorizedForNewConnections()
+        {
+            const int InitialLimit = 1;
+
+            // The server advertises more streams than we're configured to start with.
+            // We must not memorize that higher value - the property is the upper bound for every new connection.
+            await TestMaxConcurrentStreamsMemoizationAsync(InitialLimit, [100], expectedStreamsOnNewConnection: InitialLimit);
+        }
+
+        [ConditionalFact(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
+        public async Task InitialHttp2MaxConcurrentStreams_LowerServerLimit_MemorizedForNewConnections()
+        {
+            const int ServerLimit = 2;
+
+            // The server advertised fewer streams than we're configured to start with, so we remember the lower value.
+            await TestMaxConcurrentStreamsMemoizationAsync(initialLimit: 5, [ServerLimit], expectedStreamsOnNewConnection: ServerLimit);
+        }
+
+        [ConditionalFact(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
+        public async Task InitialHttp2MaxConcurrentStreams_LowerServerLimitFollowedByHigherOne_LowerLimitStaysMemorized()
+        {
+            const int LowerServerLimit = 2;
+
+            // A subsequent connection where the server advertises more streams than we're configured to start with
+            // must not undo the lower limit we memorized before.
+            await TestMaxConcurrentStreamsMemoizationAsync(initialLimit: 5, [LowerServerLimit, 100], expectedStreamsOnNewConnection: LowerServerLimit);
+        }
+
+        private async Task TestMaxConcurrentStreamsMemoizationAsync(int initialLimit, uint[] serverLimits, int expectedStreamsOnNewConnection)
+        {
+            const int RequestCount = 6;
+
+            using Http2LoopbackServer server = Http2LoopbackServer.CreateServer();
+            server.AllowMultipleConnections = true;
+
+            using SocketsHttpHandler handler = CreateHandler();
+            handler.EnableMultipleHttp2Connections = false;
+            handler.InitialHttp2MaxConcurrentStreams = initialLimit;
+            using HttpClient client = CreateHttpClient(handler);
+
+            // Establish connections where the server advertises its limit, then shut them down.
+            foreach (uint serverLimit in serverLimits)
+            {
+                Task<HttpResponseMessage> warmUpTask = client.GetAsync(server.Address);
+
+                Http2LoopbackConnection warmUpConnection = await server.EstablishConnectionAsync(timeout: null, ackTimeout: TimeSpan.FromSeconds(10),
+                    new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = serverLimit }).WaitAsync(TestHelper.PassingTestTimeout);
+
+                (int warmUpStreamId, _) = await warmUpConnection.ReadAndParseRequestHeaderAsync().WaitAsync(TestHelper.PassingTestTimeout);
+                await warmUpConnection.SendDefaultResponseAsync(warmUpStreamId).WaitAsync(TestHelper.PassingTestTimeout);
+                using (HttpResponseMessage warmUpResponse = await warmUpTask.WaitAsync(TestHelper.PassingTestTimeout))
+                {
+                    Assert.True(warmUpResponse.IsSuccessStatusCode);
+                }
+
+                await warmUpConnection.ShutdownIgnoringErrorsAsync(warmUpStreamId).WaitAsync(TestHelper.PassingTestTimeout);
+                await warmUpConnection.DisposeAsync();
+            }
+
+            // The next requests must be served by a new connection, which starts off with the memorized limit.
+            var sendTasks = new List<Task<HttpResponseMessage>>();
+            AcquireAllStreamSlots(server, client, sendTasks, RequestCount);
+
+            await using Http2LoopbackConnection connection = await server.AcceptConnectionAsync().WaitAsync(TestHelper.PassingTestTimeout);
+            await connection.ReadSettingsAsync().WaitAsync(TestHelper.PassingTestTimeout);
+
+            var streamIds = new List<int>(await ReadRequestHeadersAsync(connection, expectedStreamsOnNewConnection));
+            await AssertNoRequestHeadersSentAsync(connection);
+
+            await connection.SendSettingsAsync(ackTimeout: null, [new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 100 }]);
+
+            streamIds.AddRange(await ReadRequestHeadersAsync(connection, RequestCount - expectedStreamsOnNewConnection));
+
+            await SendResponses(connection, streamIds);
+            await VerifySendTasks(sendTasks);
+        }
+
+        private static async Task<int[]> ReadRequestHeadersAsync(Http2LoopbackConnection connection, int count)
+        {
+            var streamIds = new List<int>(count);
+
+            while (streamIds.Count < count)
+            {
+                Frame frame = await connection.ReadFrameAsync(TestHelper.PassingTestTimeout).ConfigureAwait(false);
+                Assert.NotNull(frame);
+
+                if (frame.Type == FrameType.Headers)
+                {
+                    streamIds.Add(frame.StreamId);
+                }
+            }
+
+            return streamIds.ToArray();
+        }
+
+        private static async Task AssertNoRequestHeadersSentAsync(Http2LoopbackConnection connection)
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+            while (true)
+            {
+                Frame frame;
+                try
+                {
+                    frame = await connection.ReadFrameAsync(cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                Assert.NotNull(frame);
+                Assert.NotEqual(FrameType.Headers, frame.Type);
+            }
         }
 
         [ConditionalFact(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]


### PR DESCRIPTION
Implements #132457 for .NET 12. Potential backports to 11 will follow later.

0 is technically also a valid value for this property, but I blocked it for now since it requires a bit of extra code (see bae3040bf57a54e021a1a24fecb6589581f974c4), while I don't see a good realistic scenario rn. We can always add support for it back later if someone cares.