### PR TITLE
fix: mono/metadata: free result to avoid memory leak in find_method_slow

### DIFF
--- a/src/mono/mono/metadata/unsafe-accessor.c
+++ b/src/mono/mono/metadata/unsafe-accessor.c
@@ -114,8 +114,10 @@ find_method_slow (MonoClass *klass, const char *name, const char *qname, const c
 		      (name && !strcmp (m->name, name))))
 			continue;
 		msig = mono_method_signature_checked (m, error);
-		if (!is_ok (error)) //bail out if we hit a loader error
+		if (!is_ok (error)) { //bail out if we hit a loader error
+			g_free (result);
 			return NULL;
+		}
 
 		if (!msig)
 			continue;
@@ -131,6 +133,7 @@ find_method_slow (MonoClass *klass, const char *name, const char *qname, const c
 				if (ignore_cmods) {
 					MethodLookupResultInfo *precise_match = find_method_slow (klass, name, qname, fqname, sig, FALSE, error);
 					if (precise_match->m)
+					g_free (result);
 						return precise_match;
 				}
 				mono_error_set_generic_error (error, "System.Reflection", "AmbiguousMatchException", "Ambiguity in binding of UnsafeAccessorAttribute.");

--- a/src/mono/mono/metadata/unsafe-accessor.c
+++ b/src/mono/mono/metadata/unsafe-accessor.c
@@ -132,9 +132,10 @@ find_method_slow (MonoClass *klass, const char *name, const char *qname, const c
 			if (matched) {
 				if (ignore_cmods) {
 					MethodLookupResultInfo *precise_match = find_method_slow (klass, name, qname, fqname, sig, FALSE, error);
-					if (precise_match->m)
-					g_free (result);
+					if (precise_match->m) {
+						g_free (result);
 						return precise_match;
+					}
 				}
 				mono_error_set_generic_error (error, "System.Reflection", "AmbiguousMatchException", "Ambiguity in binding of UnsafeAccessorAttribute.");
 				result->i = -1;


### PR DESCRIPTION
The function find_method_slow allocated memory for 'result' but did not free it in all error-handling paths, leading to a memory leak. This could accumulate over repeated failures and eventually cause OOM conditions and crashes.

Fix by ensuring 'result' is freed before returning NULL on loader errors, and also freeing it when a precise match is found during ambiguous binding resolution.

Found by Linux Verification Center (linuxtesting.org) with SVACE.
    Signed-off-by: Artem Semenov <savoptik@altlinux.org>.