### PR TITLE
JIT: Mark GT_LCLHEAP with GTF_CALL and GTF_GLOB_REF

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8590,6 +8590,7 @@ bool GenTree::OperRequiresCallFlag(Compiler* comp) const
         case GT_CALL:
         case GT_GCPOLL:
         case GT_KEEPALIVE:
+        case GT_LCLHEAP:
         case GT_ASYNC_CONTINUATION:
         case GT_RETURN_SUSPEND:
         case GT_PATCHPOINT:
@@ -8936,6 +8937,7 @@ bool GenTree::OperRequiresGlobRefFlag(Compiler* comp) const
         case GT_CMPXCHG:
         case GT_MEMORYBARRIER:
         case GT_KEEPALIVE:
+        case GT_LCLHEAP:
         case GT_ASYNC_CONTINUATION:
         case GT_RETURN_SUSPEND:
         case GT_PATCHPOINT:
@@ -9013,7 +9015,6 @@ bool GenTree::OperSupportsOrderingSideEffect() const
         case GT_MOD:
         case GT_UMOD:
         case GT_CATCH_ARG:
-        case GT_LCLHEAP:
         case GT_ASYNC_CONTINUATION:
         case GT_RETURN_SUSPEND:
         case GT_PATCHPOINT:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -9013,6 +9013,7 @@ bool GenTree::OperSupportsOrderingSideEffect() const
         case GT_MOD:
         case GT_UMOD:
         case GT_CATCH_ARG:
+        case GT_LCLHEAP:
         case GT_ASYNC_CONTINUATION:
         case GT_RETURN_SUSPEND:
         case GT_PATCHPOINT:

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10364,9 +10364,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         }
 
                         op1 = gtNewOperNode(GT_LCLHEAP, TYP_I_IMPL, op2);
-                        // We do not model stack overflow from localloc as an exception side effect.
+                        // We do not model stack overflow from localloc as an exception side effect,
+                        // but we do need an ordering side effect: the allocation must stay pinned
+                        // below the check that dominates it, since that check is what bounds its size.
                         // Obviously, we don't want locallocs to be CSE'd.
-                        op1->gtFlags |= GTF_DONT_CSE;
+                        op1->gtFlags |= GTF_DONT_CSE | GTF_ORDER_SIDEEFF;
 
                         // Request stack security for this method.
                         setNeedsGSSecurityCookie();

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10365,10 +10365,12 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                         op1 = gtNewOperNode(GT_LCLHEAP, TYP_I_IMPL, op2);
                         // We do not model stack overflow from localloc as an exception side effect,
-                        // but we do need an ordering side effect: the allocation must stay pinned
-                        // below the check that dominates it, since that check is what bounds its size.
+                        // but the allocation must not be reordered with, or made to execute under a
+                        // different condition than, the code around it: the dominating check is
+                        // typically what bounds its size. Mark it as a call and global reference,
+                        // much as is done for GT_KEEPALIVE.
                         // Obviously, we don't want locallocs to be CSE'd.
-                        op1->gtFlags |= GTF_DONT_CSE | GTF_ORDER_SIDEEFF;
+                        op1->gtFlags |= GTF_DONT_CSE | GTF_CALL | GTF_GLOB_REF;
 
                         // Request stack security for this method.
                         setNeedsGSSecurityCookie();

--- a/src/tests/JIT/Regression/JitBlue/Runtime_132243/Runtime_132243.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_132243/Runtime_132243.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Runtime_132243;
+
+public class Runtime_132243
+{
+    private const int MaxLocalBufferLength = 261;
+
+    // The guarding branch is what bounds the allocation size, so the localloc must not be
+    // made unconditional - that is what the interop string marshalling stubs rely on.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static nint AllocateGuarded(int size)
+    {
+        unsafe
+        {
+            byte* buffer = null;
+            if (size <= MaxLocalBufferLength)
+            {
+                byte* stackBuffer = stackalloc byte[size];
+                buffer = stackBuffer;
+            }
+
+            return (nint)buffer;
+        }
+    }
+
+    [Fact]
+    public static void ConditionalLocallocIsNotSpeculated()
+    {
+        Assert.NotEqual(0, AllocateGuarded(16));
+        Assert.Equal(0, AllocateGuarded(int.MaxValue / 2));
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -129,6 +129,7 @@
     <Compile Include="JitBlue\Runtime_122237\Runtime_122237.cs" />
     <Compile Include="JitBlue\Runtime_131716\Runtime_131716.cs" />
     <Compile Include="JitBlue\Runtime_132268\Runtime_132268.cs" />
+    <Compile Include="JitBlue\Runtime_132243\Runtime_132243.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Fixes #132243.

`GT_LCLHEAP` stopped carrying any effect flags in #125362, so if-conversion started converting the conditional `localloc` in the interop string marshalling stubs into an unconditional one feeding a `SELECT`:

```asm
imul     edi, dword ptr [SystemMaxDBCSCharSize]   ; bufSize (~11MB for a 5.5MB string)
...                                               ; probe + rsp adjust: stack overflow here
cmp      edi, 261                                 ; check happens after the damage
cmovg    r8, qword ptr [rbp+0x38]                 ; only discards the pointer
```

The guarding branch is what bounds the allocation size, so the `localloc` must not be reordered with, or made to execute under a different condition than, the surrounding code. This marks `GT_LCLHEAP` with `GTF_CALL | GTF_GLOB_REF`, the same way `GT_KEEPALIVE` is handled, and adds it to `OperRequiresCallFlag`/`OperRequiresGlobRefFlag` so the flags are not scrubbed by `gtUpdateNodeOperSideEffects`.

Repros in pure managed code too:

```csharp
byte* buffer = null;
if (size <= 261) { byte* tmp = stackalloc byte[size]; buffer = tmp; }
return (nint)buffer;   // AllocateGuarded(int.MaxValue / 2) => stack overflow
```

Local diffs: benchmarks.run +11, aspnet2 +141, libraries.pmi -71, realworld -8 bytes; linux-arm64 aspnet2 +72 bytes. SPMI replay clean.