### PR TITLE
Move handling of WASM Function section entries to dependency graph

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/INodeWithTypeSignature.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/INodeWithTypeSignature.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Internal.TypeSystem;
+using ILCompiler.DependencyAnalysis.Wasm;
+using Internal.JitInterface;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -10,6 +12,22 @@ namespace ILCompiler.DependencyAnalysis
         bool IsUnmanagedCallersOnly { get; }
         bool IsAsyncCall { get; }
         bool HasGenericContextArg { get; }
+    }
+
+    internal static class NodeWithTypeSignatureExtensions
+    {
+        public static WasmFuncType GetWasmFunctionType(this INodeWithTypeSignature node)
+        {
+            WasmLowering.LoweringFlags flags = WasmLowering.LoweringFlags.None;
+            if (node.HasGenericContextArg)
+                flags |= WasmLowering.LoweringFlags.HasGenericContextArg;
+            if (node.IsAsyncCall)
+                flags |= WasmLowering.LoweringFlags.IsAsyncCall;
+            if (node.IsUnmanagedCallersOnly)
+                flags |= WasmLowering.LoweringFlags.IsUnmanagedCallersOnly;
+
+            return WasmLowering.GetSignature(node.Signature, flags).FuncType;
+        }
     }
 
     public interface IMethodCodeNodeWithTypeSignature : IMethodNode, INodeWithTypeSignature

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/NodeFactory.Wasm.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/NodeFactory.Wasm.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Frozen;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Internal.Text;
 
@@ -34,23 +36,37 @@ namespace ILCompiler.DependencyAnalysis
 
         private NodeCache<WasmFunctionEntryNodeCacheKey, WasmFunctionEntryNode> _wasmFunctionEntryCache;
 
-        public WasmFunctionEntryNode WasmFunctionEntry(INodeWithTypeSignature methodCodeNode, WasmTypeNode typeNode, int? funcletIndex = null)
+        public WasmFunctionEntryNode WasmFunctionEntry(ObjectNode methodCodeNode, WasmTypeNode typeNode, int? funcletIndex = null)
         {
             return _wasmFunctionEntryCache.GetOrAdd(new WasmFunctionEntryNodeCacheKey(methodCodeNode, typeNode, funcletIndex));
         }
 
-        public struct WasmFunctionEntryNodeCacheKey
+        public readonly struct WasmFunctionEntryNodeCacheKey : IEquatable<WasmFunctionEntryNodeCacheKey>
         {
-            public readonly INodeWithTypeSignature MethodCodeNode;
+            public readonly ObjectNode MethodCodeNode;
             public readonly WasmTypeNode Type;
-            public int? FuncletIndex;
+            public readonly int? FuncletIndex;
 
-            public WasmFunctionEntryNodeCacheKey(INodeWithTypeSignature methodCodeNode, WasmTypeNode type, int? funcletIndex = null)
+            public WasmFunctionEntryNodeCacheKey(ObjectNode methodCodeNode, WasmTypeNode type, int? funcletIndex = null)
             {
                 MethodCodeNode = methodCodeNode;
                 Type = type;
                 FuncletIndex = funcletIndex;
             }
+
+            public bool Equals(WasmFunctionEntryNodeCacheKey other) =>
+                ReferenceEquals(MethodCodeNode, other.MethodCodeNode) &&
+                ReferenceEquals(Type, other.Type) &&
+                FuncletIndex == other.FuncletIndex;
+
+            public override bool Equals(object obj) =>
+                obj is WasmFunctionEntryNodeCacheKey other && Equals(other);
+
+            public override int GetHashCode() =>
+                HashCode.Combine(
+                    RuntimeHelpers.GetHashCode(MethodCodeNode),
+                    RuntimeHelpers.GetHashCode(Type),
+                    FuncletIndex);
         }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/NodeFactory.Wasm.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/NodeFactory.Wasm.cs
@@ -31,5 +31,26 @@ namespace ILCompiler.DependencyAnalysis
 
             return globals[symbolName];
         }
+
+        private NodeCache<WasmFunctionEntryNodeCacheKey, WasmFunctionEntryNode> _wasmFunctionEntryCache;
+
+        public WasmFunctionEntryNode WasmFunctionEntry(INodeWithTypeSignature methodCodeNode, WasmTypeNode typeNode, int? funcletIndex = null)
+        {
+            return _wasmFunctionEntryCache.GetOrAdd(new WasmFunctionEntryNodeCacheKey(methodCodeNode, typeNode, funcletIndex));
+        }
+
+        public struct WasmFunctionEntryNodeCacheKey
+        {
+            public readonly INodeWithTypeSignature MethodCodeNode;
+            public readonly WasmTypeNode Type;
+            public int? FuncletIndex;
+
+            public WasmFunctionEntryNodeCacheKey(INodeWithTypeSignature methodCodeNode, WasmTypeNode type, int? funcletIndex = null)
+            {
+                MethodCodeNode = methodCodeNode;
+                Type = type;
+                FuncletIndex = funcletIndex;
+            }
+        }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNode.cs
@@ -74,7 +74,7 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies ??= new DependencyList();
 
                 dependencies.Add(
-                    factory.WasmFunctionEntry(wasmFunctionNode, factory.WasmTypeNode(wasmFunctionNode.GetWasmFunctionType())),
+                    factory.WasmFunctionEntry(this, factory.WasmTypeNode(wasmFunctionNode.GetWasmFunctionType())),
                     "Wasm function entry");
 
                 if (wasmFunctionNode is INodeWithFunclets nodeWithFunclets)
@@ -90,7 +90,7 @@ namespace ILCompiler.DependencyAnalysis
                             _ => new WasmFuncType(new([pointerType, pointerType]), new([])),
                         };
                         dependencies.Add(
-                            factory.WasmFunctionEntry(wasmFunctionNode, factory.WasmTypeNode(funcletType), funcletIndex: i),
+                            factory.WasmFunctionEntry(this, factory.WasmTypeNode(funcletType), funcletIndex: i),
                             "Wasm funclet function entry");
                     }
                 }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNode.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 
 using ILCompiler.DependencyAnalysisFramework;
+using ILCompiler.DependencyAnalysis.Wasm;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -68,12 +69,31 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            if (factory.Target.IsWasm && this is IMethodCodeNodeWithTypeSignature wasmMethodCodeNode)
+            if (factory.Target.IsWasm && this is INodeWithTypeSignature wasmFunctionNode)
             {
                 dependencies ??= new DependencyList();
 
-                WasmTypeNode wasmTypeNode = factory.WasmTypeNode(wasmMethodCodeNode.Method);
-                dependencies.Add(wasmTypeNode, "Wasm Method Code Nodes Require Signature");
+                dependencies.Add(
+                    factory.WasmFunctionEntry(wasmFunctionNode, factory.WasmTypeNode(wasmFunctionNode.GetWasmFunctionType())),
+                    "Wasm function entry");
+
+                if (wasmFunctionNode is INodeWithFunclets nodeWithFunclets)
+                {
+                    WasmValueType pointerType = factory.Target.PointerSize == 8 ? WasmValueType.I64 : WasmValueType.I32;
+                    FuncletKind[] funcletKinds = nodeWithFunclets.GetFuncletKinds();
+                    for (int i = 0; i < funcletKinds.Length; i++)
+                    {
+                        WasmFuncType funcletType = funcletKinds[i] switch
+                        {
+                            FuncletKind.CatchOrFilterHandler or FuncletKind.Filter => new WasmFuncType(
+                                new([pointerType, pointerType, pointerType]), new([pointerType])),
+                            _ => new WasmFuncType(new([pointerType, pointerType]), new([])),
+                        };
+                        dependencies.Add(
+                            factory.WasmFunctionEntry(wasmFunctionNode, factory.WasmTypeNode(funcletType), funcletIndex: i),
+                            "Wasm funclet function entry");
+                    }
+                }
             }
 
             if (dependencies == null)

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -63,6 +63,8 @@ namespace ILCompiler.DependencyAnalysis
                                                        // e.g. in R2R scenarios as an offset from $imageBase
         WASM_TABLE_INDEX_REL_I32   = 0x20A,  // Wasm: a table index encoded as a 4-byte uint32 relative to the tableBase of the R2R image
         WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB = 0x20B, // Wasm: an exception tag index encoded as a 5-byte varuint32. Used to refer to the CoreCLR restore context exception tag.
+        WASM_FUNCTION_COUNT_SLEB = 0x1003, // Wasm: For webcil only, the total count of functions emitted that should be copied via the fillWebcilTable exported method
+
 
         //
         // Relocation operators related to TLS access
@@ -680,6 +682,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.WASM_TABLE_INDEX_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
+                case RelocType.WASM_FUNCTION_COUNT_SLEB:
                     DwarfHelper.WritePaddedSLEB128(new Span<byte>((byte*)location, WASM_PADDED_RELOC_SIZE_32), value);
                     return;
                 case RelocType.WASM_TABLE_INDEX_I32:
@@ -713,6 +716,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.WASM_TABLE_INDEX_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
+                case RelocType.WASM_FUNCTION_COUNT_SLEB:
                     DwarfHelper.WriteSLEB128(new Span<byte>((byte*)location, WASM_PADDED_RELOC_SIZE_32), value);
                     return (int)DwarfHelper.SizeOfSLEB128(value);
                 default:
@@ -762,6 +766,7 @@ namespace ILCompiler.DependencyAnalysis
                 RelocType.WASM_TABLE_INDEX_I32 => 4,
                 RelocType.WASM_TABLE_INDEX_REL_I32 => 4,
                 RelocType.WASM_TABLE_INDEX_I64 => 8,
+                RelocType.WASM_FUNCTION_COUNT_SLEB => WASM_PADDED_RELOC_SIZE_32,
 
                 _ => throw new NotSupportedException(),
             };
@@ -780,6 +785,7 @@ namespace ILCompiler.DependencyAnalysis
                 RelocType.WASM_MEMORY_ADDR_REL_LEB or
                 RelocType.WASM_MEMORY_ADDR_REL_SLEB or
                 RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB => true,
+                RelocType.WASM_FUNCTION_COUNT_SLEB => true,
                 _ => false,
             };
         }
@@ -799,6 +805,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.WASM_TABLE_INDEX_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
+                case RelocType.WASM_FUNCTION_COUNT_SLEB:
                     return (int)DwarfHelper.SizeOfSLEB128(resolvedValue);
                 default:
                     Debug.Fail("Invalid reloc type");
@@ -863,6 +870,7 @@ namespace ILCompiler.DependencyAnalysis
                     bool isStype = (relocType is RelocType.IMAGE_REL_BASED_RISCV64_PCREL_S);
                     return GetRiscV64AuipcCombo((uint*)location, isStype);
                 case RelocType.WASM_TYPE_INDEX_LEB:
+                    return (long)DwarfHelper.ReadULEB128(new ReadOnlySpan<byte>(location, WASM_PADDED_RELOC_SIZE_32));
                 case RelocType.WASM_GLOBAL_INDEX_LEB:
                     // These wasm relocs do not have offsets, just targets
                     return 0;
@@ -874,6 +882,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.WASM_TABLE_INDEX_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
+                case RelocType.WASM_FUNCTION_COUNT_SLEB:
                     return DwarfHelper.ReadSLEB128(new ReadOnlySpan<byte>(location, WASM_PADDED_RELOC_SIZE_32));
                 case RelocType.WASM_TABLE_INDEX_I32:
                 case RelocType.WASM_TABLE_INDEX_REL_I32:

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
@@ -114,6 +114,11 @@ namespace ILCompiler.DependencyAnalysis
             // Wasm type signatures (need to be emitted some time before the unordered phase)
             //
             WasmTypeNode,
+
+            //
+            // Webcil spec methods need to be emitted first in the code section
+            //
+            WebcilDefaultMethodNode,
         }
 
         public class EmbeddedObjectNodeComparer : IComparer<EmbeddedObjectNode>

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WebcilDefaultMethodNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WebcilDefaultMethodNode.cs
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using ILCompiler.DependencyAnalysis.ARM;
+using ILCompiler.DependencyAnalysis.ARM64;
+using ILCompiler.DependencyAnalysis.LoongArch64;
+using ILCompiler.DependencyAnalysis.RiscV64;
+using ILCompiler.DependencyAnalysis.Wasm;
+using ILCompiler.DependencyAnalysis.X64;
+using ILCompiler.DependencyAnalysis.X86;
+using ILCompiler.ObjectWriter;
+using ILCompiler.ObjectWriter.WasmInstructions;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public enum WebcilDefaultMethodKind
+    {
+        GetWebcilSize,
+        FillWebcilTable,
+        GetWebcilPayload
+    }
+
+    /// <summary>
+    /// Represents a default method that is emitted into the Webcil code section. These methods are part of the webcil spec.
+    /// </summary>
+    internal sealed class WebcilDefaultMethodNode : AssemblyStubNode, INodeWithTypeSignature
+    {
+        private readonly WebcilDefaultMethodKind _kind;
+        private readonly MethodSignature _signature;
+
+        public override ObjectNodeSection GetSection(NodeFactory factory)
+        {
+            return ObjectNodeSection.WasmCodeSection;
+        }
+
+        public override bool IsShareable => true;
+
+        public WebcilDefaultMethodNode(WebcilDefaultMethodKind kind, NodeFactory factory)
+        {
+            _kind = kind;
+            TypeDesc @void = factory.TypeSystemContext.GetWellKnownType(Internal.TypeSystem.WellKnownType.Void);
+            TypeDesc @int = factory.TypeSystemContext.GetWellKnownType(Internal.TypeSystem.WellKnownType.Int32);
+            _signature = _kind switch
+            {
+                WebcilDefaultMethodKind.GetWebcilSize=> new MethodSignature(MethodSignatureFlags.Static, 0, @void, new TypeDesc[] { @int }),
+                WebcilDefaultMethodKind.FillWebcilTable => new MethodSignature(MethodSignatureFlags.Static, 0, @void, Array.Empty<TypeDesc>()),
+                WebcilDefaultMethodKind.GetWebcilPayload => new MethodSignature(MethodSignatureFlags.Static, 0, @void, new TypeDesc[] { @int, @int }),
+                _ => throw new NotImplementedException(),
+            };
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(_kind switch
+            {
+                WebcilDefaultMethodKind.GetWebcilSize => "getWebcilSize",
+                WebcilDefaultMethodKind.FillWebcilTable => "fillWebcilTable",
+                WebcilDefaultMethodKind.GetWebcilPayload => "getWebcilPayload",
+                _ => throw new NotImplementedException(),
+            });
+        }
+
+        public override int ClassCode => (int)ObjectNodeOrder.WebcilDefaultMethodNode;
+
+        protected internal override int Phase => (int)ObjectNodePhase.Ordered;
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            var otherNode = (WebcilDefaultMethodNode)other;
+            return _kind.CompareTo(otherNode._kind);
+        }
+
+        protected override void EmitCode(NodeFactory factory, ref WasmEmitter instructionEncoder, bool relocsOnly)
+        {
+            var body = _kind switch
+            {
+                WebcilDefaultMethodKind.GetWebcilSize => GetWebcilSize,
+                WebcilDefaultMethodKind.FillWebcilTable => FillWebcilTable(factory), // TODO: Pass in table size
+                WebcilDefaultMethodKind.GetWebcilPayload => GetWebcilPayload,
+                _ => throw new NotImplementedException(),
+            };
+            instructionEncoder.FunctionBody = body;
+        }
+
+        static WasmFunctionBody GetWebcilSize = new WasmFunctionBody(
+            new WasmFuncType(new([WasmValueType.I32]), new([])), // (func (destPtr i32) (result))
+                [
+                    Local.Get(0), // (local.get $destPtr)
+                    I32.Const(0),
+                    I32.Const(4),
+                    Memory.Init(0)
+                ]
+        );
+
+        WasmFunctionBody FillWebcilTable(NodeFactory factory) => new WasmFunctionBody(
+            new WasmFuncType(new([]), new([])), // (func)
+            GetFillWebcilTableInstructions(I32.ConstFunctionCount(factory.WasmFunctionCount))
+        );
+
+        internal static WasmExpr[] GetFillWebcilTableInstructions(WasmExpr functionCount) =>
+        [
+            Global.Get(WebCilObjectWriter.TableBaseGlobalIndex),
+            I32.Const(0),
+            functionCount,
+            Table.Init(0, 0)
+        ];
+
+        private static WasmFunctionBody GetWebcilPayload => new WasmFunctionBody(
+            new WasmFuncType(new([WasmValueType.I32, WasmValueType.I32]), new([])), // (func ($d i32) ($n i32))
+                [
+                    Local.Get(0), // (local.get $d)
+                    I32.Const(0),
+                    Local.Get(1), // (local.get $n)
+                    Memory.Init(1),
+                    Local.Get(1),
+                    I32.Const(32),
+                    I32.Ge_s,
+                    Block.If(WasmBlockType.Empty),
+                    Local.Get(0), // (local.get $d)
+                    Global.Get(WebCilObjectWriter.TableBaseGlobalIndex), // (global.get $tableBase)
+                    I32.Store((ulong)WebcilEncoder.TableBaseOffset), // i32.store offset=TableBaseOffset
+                    Block.End
+                ]
+        );
+
+        public MethodSignature Signature => _signature;
+
+        // This is called from wasm at load time, not from managed code, and should not have their signatures modified
+        // in lowering to wasm, so mark with UnmanagedCallersOnly
+        public bool IsUnmanagedCallersOnly => true;
+
+        public bool IsAsyncCall => false;
+
+        public bool HasGenericContextArg => false;
+
+        protected override string GetName(NodeFactory context) => $"WebcilDefaultMethod: {_kind}";
+
+        // This node only exists on WASM.
+        protected override void EmitCode(NodeFactory factory, ref X64Emitter instructionEncoder, bool relocsOnly) => throw new PlatformNotSupportedException();
+        protected override void EmitCode(NodeFactory factory, ref X86Emitter instructionEncoder, bool relocsOnly) => throw new PlatformNotSupportedException();
+        protected override void EmitCode(NodeFactory factory, ref ARMEmitter instructionEncoder, bool relocsOnly) => throw new PlatformNotSupportedException();
+        protected override void EmitCode(NodeFactory factory, ref ARM64Emitter instructionEncoder, bool relocsOnly) => throw new PlatformNotSupportedException();
+        protected override void EmitCode(NodeFactory factory, ref LoongArch64Emitter instructionEncoder, bool relocsOnly) => throw new PlatformNotSupportedException();
+        protected override void EmitCode(NodeFactory factory, ref RiscV64Emitter instructionEncoder, bool relocsOnly) => throw new PlatformNotSupportedException();
+    }
+
+    internal class WasmFunctionCountNode : ObjectNode, ISymbolDefinitionNode
+    {
+        public override bool IsShareable => true;
+
+        public override int ClassCode => unchecked((int)0x92b11dff);
+
+        public int Offset => 0;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public void AppendMangledName(ILCompiler.NameMangler nameMangler, Utf8StringBuilder sb) => sb.Append("WasmFunctionCountNode");
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            return new ObjectData(
+                data: [],
+                relocs: [],
+                alignment: 1,
+                definedSymbols: [this]);
+        }
+
+        public override ObjectNodeSection GetSection(NodeFactory factory) => ObjectNodeSection.WasmCodeSection;
+        protected override string GetName(NodeFactory context) => $"WasmFunctionCountNode";
+    }
+}

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WebcilDefaultMethodNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WebcilDefaultMethodNode.cs
@@ -86,7 +86,7 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         static WasmFunctionBody GetWebcilSize = new WasmFunctionBody(
-            new WasmFuncType(new([WasmValueType.I32]), new([])), // (func (destPtr i32) (result))
+            new WasmFuncType(new([WasmValueType.I32]), new([])), // (func (destPtr i32))
                 [
                     Local.Get(0), // (local.get $destPtr)
                     I32.Const(0),

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/WasmFunctionEntryNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/WasmFunctionEntryNode.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using ILCompiler.ObjectWriter;
+using System;
 using System.Diagnostics;
+
+using ILCompiler.ObjectWriter;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -11,13 +13,14 @@ namespace ILCompiler.DependencyAnalysis
     //
     public class WasmFunctionEntryNode : ObjectNode
     {
-        private readonly INodeWithTypeSignature _methodCodeNode;
+        private readonly ObjectNode _methodCodeNode;
         private readonly WasmTypeNode _wasmTypeNode;
         private readonly int? _funcletIndex;
 
-        public WasmFunctionEntryNode(INodeWithTypeSignature methodCodeNode, WasmTypeNode wasmTypeNode, int? funcletIndex = null)
+        public WasmFunctionEntryNode(ObjectNode methodCodeNode, WasmTypeNode wasmTypeNode, int? funcletIndex = null)
         {
             Debug.Assert(funcletIndex is null || methodCodeNode is INodeWithFunclets);
+            Debug.Assert(methodCodeNode is INodeWithTypeSignature);
             _methodCodeNode = methodCodeNode;
             _wasmTypeNode = wasmTypeNode;
             _funcletIndex = funcletIndex;
@@ -25,11 +28,20 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool IsShareable => false;
 
-        public override int ClassCode => unchecked((int)0xbd3183bc86);
+        public override int ClassCode => unchecked((int)0xbd3183bc);
 
         public override bool StaticDependenciesAreComputed => true;
 
         public override ObjectNodeSection GetSection(NodeFactory factory) => WasmObjectNodeSection.FunctionSection;
+
+        public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
+        {
+            if (_methodCodeNode.ShouldSkipEmittingObjectNode(factory))
+                return true;
+
+            return _methodCodeNode is ISymbolNode symbolNode &&
+                factory.ObjectInterner.GetDeduplicatedSymbol(factory, symbolNode) != symbolNode;
+        }
 
         protected override string GetName(NodeFactory factory)
             => $"Wasm Function Entry: {_methodCodeNode} -> {_wasmTypeNode}";
@@ -50,16 +62,14 @@ namespace ILCompiler.DependencyAnalysis
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
             WasmFunctionEntryNode o = (WasmFunctionEntryNode)other;
-            int result = comparer.Compare((ISortableNode)_methodCodeNode, (ISortableNode)o._methodCodeNode);
+            int result = SortableDependencyNode.CompareImpl(
+                _methodCodeNode,
+                o._methodCodeNode,
+                comparer);
             if (result != 0)
                 return result;
 
-            if (_funcletIndex.HasValue && !o._funcletIndex.HasValue)
-                return 1;
-            else if (!_funcletIndex.HasValue && o._funcletIndex.HasValue)
-                return -1;
-            else
-                return _funcletIndex.Value.CompareTo(o._funcletIndex.Value);
+            return Nullable.Compare(_funcletIndex, o._funcletIndex);
         }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/WasmFunctionEntryNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/WasmFunctionEntryNode.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using ILCompiler.ObjectWriter;
+using System.Diagnostics;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    //
+    // Represents an entry in the Function section, which correlates a Code section entry to its type signature, e.g. "(i32, i32) -> (i64)".
+    //
+    public class WasmFunctionEntryNode : ObjectNode
+    {
+        private readonly INodeWithTypeSignature _methodCodeNode;
+        private readonly WasmTypeNode _wasmTypeNode;
+        private readonly int? _funcletIndex;
+
+        public WasmFunctionEntryNode(INodeWithTypeSignature methodCodeNode, WasmTypeNode wasmTypeNode, int? funcletIndex = null)
+        {
+            Debug.Assert(funcletIndex is null || methodCodeNode is INodeWithFunclets);
+            _methodCodeNode = methodCodeNode;
+            _wasmTypeNode = wasmTypeNode;
+            _funcletIndex = funcletIndex;
+        }
+
+        public override bool IsShareable => false;
+
+        public override int ClassCode => unchecked((int)0xbd3183bc86);
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override ObjectNodeSection GetSection(NodeFactory factory) => WasmObjectNodeSection.FunctionSection;
+
+        protected override string GetName(NodeFactory factory)
+            => $"Wasm Function Entry: {_methodCodeNode} -> {_wasmTypeNode}";
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            Relocation[] relocs = [new Relocation(RelocType.WASM_TYPE_INDEX_LEB, 0, _wasmTypeNode)];
+            byte[] data = new byte[Relocation.GetSize(RelocType.WASM_TYPE_INDEX_LEB)];
+
+            return new ObjectData(
+                   data: data,
+                   relocs: relocs,
+                   alignment: 1,
+                   definedSymbols: []);
+        }
+
+        // We need to have the exact same order as the code emitted for these functions
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            WasmFunctionEntryNode o = (WasmFunctionEntryNode)other;
+            int result = comparer.Compare((ISortableNode)_methodCodeNode, (ISortableNode)o._methodCodeNode);
+            if (result != 0)
+                return result;
+
+            if (_funcletIndex.HasValue && !o._funcletIndex.HasValue)
+                return 1;
+            else if (!_funcletIndex.HasValue && o._funcletIndex.HasValue)
+                return -1;
+            else
+                return _funcletIndex.Value.CompareTo(o._funcletIndex.Value);
+        }
+    }
+}

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmSection.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmSection.cs
@@ -286,19 +286,6 @@ namespace ILCompiler.ObjectWriter
         }
     }
 
-    internal sealed class WasmFunctionSection : WasmSection<int>
-    {
-        public WasmFunctionSection(Stream stream, Utf8String name, int sectionIndex)
-            : base(WasmSectionType.Function, stream, name, sectionIndex)
-        {
-        }
-
-        protected override void WriteEntryCore(SectionWriter writer, int typeIndex)
-        {
-            writer.WriteULEB128((ulong)typeIndex);
-        }
-    }
-
     internal sealed class WasmGlobalSection : WasmSection<WasmGlobal>
     {
         public WasmGlobalSection(Stream stream, Utf8String name, int sectionIndex)

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
@@ -359,6 +359,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
 
                 case RelocType.WASM_TABLE_INDEX_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
+                case RelocType.WASM_FUNCTION_COUNT_SLEB:
                     DwarfHelper.WritePaddedSLEB128(buffer.Slice(0, relocSize), 0);
                     break;
 
@@ -843,6 +844,13 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         public static WasmExpr ConstRVA(ISymbolNode symbolNode)
         {
             return new WasmLEBConstantReloc(WasmExprKind.I32Const, symbolNode, RelocType.WASM_MEMORY_ADDR_REL_SLEB);
+        }
+        public static WasmExpr ConstFunctionCount(ISymbolNode functionCountSymbol)
+        {
+            return new WasmLEBConstantReloc(
+                WasmExprKind.I32Const,
+                functionCountSymbol,
+                RelocType.WASM_FUNCTION_COUNT_SLEB);
         }
 
         public static WasmExpr Add => new WasmBinaryExpr(WasmExprKind.I32Add);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -166,7 +166,6 @@ namespace ILCompiler.ObjectWriter
                 return;
             }
 
-            WasmValueType pointerType = _nodeFactory.Target.PointerSize == 8 ? WasmValueType.I64 : WasmValueType.I32;
             string mangledNodeName = nodeWithFunclets.GetMangledName(_nodeFactory.NameMangler);
 
             // The method itself is already registered by the ObjectWriter, but we must register the funclet names

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -114,7 +114,7 @@ namespace ILCompiler.ObjectWriter
                 {
                     WasmSectionType.Type or WasmSectionType.Code => new WasmExternallyCountedSection(sectionType, sectionStream, sectionName, sectionIndex),
                     WasmSectionType.Import => new WasmImportSection(sectionStream, sectionName, sectionIndex),
-                    WasmSectionType.Function => new WasmFunctionSection(sectionStream, sectionName, sectionIndex),
+                    WasmSectionType.Function => new WasmExternallyCountedSection(sectionType, sectionStream, sectionName, sectionIndex),
                     WasmSectionType.Global => new WasmGlobalSection(sectionStream, sectionName, sectionIndex),
                     WasmSectionType.Export => new WasmExportSection(sectionStream, sectionName, sectionIndex),
                     WasmSectionType.Element => new WasmElementSection(sectionStream, sectionName, sectionIndex),
@@ -143,8 +143,15 @@ namespace ILCompiler.ObjectWriter
 
         private protected override void RecordMethodDeclaration(INodeWithTypeSignature node)
         {
-            WriteSignatureIndexForFunction(node);
-            RegisterFunctionSymbol(new Utf8String(node.GetMangledName(_nodeFactory.NameMangler)));
+            Utf8String functionName = GetMangledName(node);
+            RegisterFunctionSymbol(functionName);
+
+            Utf8String alternateName = _nodeFactory.GetSymbolAlternateName(node, out _);
+            if (!alternateName.IsNull)
+            {
+                _wasmSymbolManager.AddAlias(ExternCName(alternateName), functionName);
+            }
+
             if (node is INodeWithFunclets nodeWithFunclets)
             {
                 RecordFunclets(nodeWithFunclets);
@@ -162,22 +169,11 @@ namespace ILCompiler.ObjectWriter
             WasmValueType pointerType = _nodeFactory.Target.PointerSize == 8 ? WasmValueType.I64 : WasmValueType.I32;
             string mangledNodeName = nodeWithFunclets.GetMangledName(_nodeFactory.NameMangler);
 
+            // The method itself is already registered by the ObjectWriter, but we must register the funclet names
             for (int i = 0; i < funcletKinds.Length; i++)
             {
-                WasmFuncType funcletSignature = GetFuncletType(funcletKinds[i], pointerType);
                 RegisterFunctionSymbol(new Utf8String($"{mangledNodeName}_funclet_{i}"));
-                RegisterStubIndexAndSignature(funcletSignature);
             }
-        }
-
-        private static WasmFuncType GetFuncletType(FuncletKind funcletKind, WasmValueType pointerType)
-        {
-            return funcletKind switch
-            {
-                FuncletKind.CatchOrFilterHandler or FuncletKind.Filter => new WasmFuncType(
-                    new([pointerType, pointerType, pointerType]), new([pointerType])), // (FP, SP, EXN) -> RESULT
-                _ => new WasmFuncType(new([pointerType, pointerType]), new([])), // (FP, SP) -> void
-            };
         }
 
         private void WriteFunctionEntry(int signatureIndex)
@@ -186,18 +182,6 @@ namespace ILCompiler.ObjectWriter
                 WasmObjectNodeSection.FunctionSection,
                 out SectionWriter writer);
             section.WriteEntry(writer, signatureIndex);
-        }
-
-        private void WriteSignatureIndexForFunction(INodeWithTypeSignature node)
-        {
-            WasmFuncType signature = WasmLowering.GetSignature(node).FuncType;
-            Utf8String key = signature.GetMangledName(_nodeFactory.NameMangler);
-            if (!_wasmSymbolManager.TryGetSymbol(key, out WasmSymbol signatureSymbol))
-            {
-                throw new InvalidOperationException($"Signature index of {key} not found for function: {node.ToString()}");
-            }
-
-            WriteFunctionEntry(signatureSymbol.Index);
         }
 
         /// <summary>
@@ -381,10 +365,13 @@ namespace ILCompiler.ObjectWriter
                 .SetEntryCount(_wasmSymbolManager.GetDefinitionCount(WasmIndexSpace.Type));
             _sections.GetSection<WasmExternallyCountedSection>(ObjectNodeSection.WasmCodeSection.Name)
                 .SetEntryCount(MethodCount);
+            _sections.GetSection<WasmExternallyCountedSection>(WasmObjectNodeSection.FunctionSection.Name)
+                .SetEntryCount(MethodCount);
 
-            Debug.Assert(_sections.GetSection<WasmFunctionSection>(WasmObjectNodeSection.FunctionSection.Name).EntryCount == MethodCount);
-            Debug.Assert(_sections.GetSection<WasmImportSection>(WasmObjectNodeSection.ImportSection.Name).EntryCount == _wasmSymbolManager.GetImportCount());
-            Debug.Assert(_sections.GetSection<WasmGlobalSection>(WasmObjectNodeSection.GlobalSection.Name).EntryCount == _wasmSymbolManager.GetDefinitionCount(WasmIndexSpace.Global));
+            Debug.Assert(!_sections.Contains(WasmObjectNodeSection.ImportSection.Name)
+                || _sections.GetSection<WasmImportSection>(WasmObjectNodeSection.ImportSection.Name).EntryCount == _wasmSymbolManager.GetImportCount());
+            Debug.Assert(!_sections.Contains(WasmObjectNodeSection.GlobalSection.Name)
+                || _sections.GetSection<WasmGlobalSection>(WasmObjectNodeSection.GlobalSection.Name).EntryCount == _wasmSymbolManager.GetDefinitionCount(WasmIndexSpace.Global));
         }
     }
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -143,14 +143,7 @@ namespace ILCompiler.ObjectWriter
 
         private protected override void RecordMethodDeclaration(INodeWithTypeSignature node)
         {
-            Utf8String functionName = GetMangledName(node);
-            RegisterFunctionSymbol(functionName);
-
-            Utf8String alternateName = _nodeFactory.GetSymbolAlternateName(node, out _);
-            if (!alternateName.IsNull)
-            {
-                _wasmSymbolManager.AddAlias(ExternCName(alternateName), functionName);
-            }
+            RegisterFunctionSymbol(new Utf8String(node.GetMangledName(_nodeFactory.NameMangler)));
 
             if (node is INodeWithFunclets nodeWithFunclets)
             {
@@ -177,10 +170,8 @@ namespace ILCompiler.ObjectWriter
 
         private void WriteFunctionEntry(int signatureIndex)
         {
-            WasmFunctionSection section = GetOrCreateSection<WasmFunctionSection>(
-                WasmObjectNodeSection.FunctionSection,
-                out SectionWriter writer);
-            section.WriteEntry(writer, signatureIndex);
+            SectionWriter writer = GetOrCreateSection(WasmObjectNodeSection.FunctionSection);
+            writer.WriteULEB128((ulong)signatureIndex);
         }
 
         /// <summary>

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
@@ -620,7 +620,7 @@ namespace ILCompiler.ObjectWriter
 #endif
         }
 
-        private unsafe int ResolveReloc(int sectionIndex, MemoryStream sourceStream, long srcPos, MemoryStream destStream, long destPos, SymbolicRelocation reloc,  byte[] relocScratchBuffer, bool shrink = false)
+        private unsafe int ResolveReloc(int sectionIndex, Stream sourceStream, long srcPos, MemoryStream destStream, long destPos, SymbolicRelocation reloc, byte[] relocScratchBuffer, bool shrink = false)
         {
             WebcilSection? curSectionAsWebcil = null;
             uint webcilVirtualStart = 0;
@@ -838,6 +838,12 @@ namespace ILCompiler.ObjectWriter
                 return;
             }
 
+            if (shrink && _sections[sectionIndex] is WasmSection { Type: WasmSectionType.Function })
+            {
+                ResolveFunctionSectionRelocations(sectionIndex, sectionStream, dstStream, relocs);
+                return;
+            }
+
             byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
 
             // Otherwise, we can resolve relocations on top of the copied in section stream, since the size and layout of the stream won't be changing.
@@ -849,6 +855,40 @@ namespace ILCompiler.ObjectWriter
                 ResolveReloc(sectionIndex, dstStream, srcPos: sectionStart + reloc.Offset, dstStream, destPos: sectionStart + reloc.Offset, reloc, relocScratchBuffer);
             }
             dstStream.Position = sectionStream.Length + startPos;
+        }
+
+        // The entire section is relocs, so we can shrink each reloc and skip copying any data between them.
+        private void ResolveFunctionSectionRelocations(
+            int sectionIndex,
+            Stream sourceStream,
+            MemoryStream destinationStream,
+            List<SymbolicRelocation> relocs)
+        {
+            byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
+            relocs.Sort((left, right) => left.Offset.CompareTo(right.Offset));
+
+            sourceStream.Position = 0;
+
+            foreach (SymbolicRelocation reloc in relocs)
+            {
+                Debug.Assert(sourceStream.Position != reloc.Offset,
+                    $"Unexpected data in the WASM Function section between offsets {sourceStream.Position} and {reloc.Offset}.");
+
+                ResolveReloc(
+                    sectionIndex,
+                    sourceStream,
+                    reloc.Offset,
+                    destinationStream,
+                    destinationStream.Position,
+                    reloc,
+                    relocScratchBuffer,
+                    shrink: true);
+
+                sourceStream.Position = reloc.Offset + Relocation.GetSize(reloc.Type);
+            }
+
+            Debug.Assert(sourceStream.Position == sourceStream.Length,
+                $"Unexpected trailing data in the WASM Function section at offset {sourceStream.Position}.");
         }
 #nullable disable
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
@@ -87,44 +87,6 @@ namespace ILCompiler.ObjectWriter
             ]);
         }
 
-        static WasmFunctionBody GetWebcilSize = new WasmFunctionBody(
-            new WasmFuncType(new([WasmValueType.I32]), new([])), // (func (destPtr i32) (result))
-                [
-                    Local.Get(0), // (local.get $destPtr)
-                    I32.Const(0),
-                    I32.Const(4),
-                    Memory.Init(0)
-                ]
-        );
-
-        WasmFunctionBody FillWebcilTable(int tableSize) => new WasmFunctionBody(
-            new WasmFuncType(new([]), new([])), // (func)
-                [
-                    Global.Get(WebCilObjectWriter.TableBaseGlobalIndex),
-                    I32.Const(0),
-                    I32.Const(tableSize),
-                    Table.Init(0, 0)
-                ]
-        );
-
-        WasmFunctionBody GetWebcilPayload => new WasmFunctionBody(
-            new WasmFuncType(new([WasmValueType.I32, WasmValueType.I32]), new([])), // (func ($d i32) ($n i32))
-                [
-                    Local.Get(0), // (local.get $d)
-                    I32.Const(0),
-                    Local.Get(1), // (local.get $n)
-                    Memory.Init(1),
-                    Local.Get(1),
-                    I32.Const(32),
-                    I32.Ge_s,
-                    Block.If(WasmBlockType.Empty),
-                    Local.Get(0), // (local.get $d)
-                    Global.Get(WebCilObjectWriter.TableBaseGlobalIndex), // (global.get $tableBase)
-                    I32.Store((ulong)WebcilEncoder.TableBaseOffset), // i32.store offset=TableBaseOffset
-                    Block.End
-                ]
-        );
-
         private long ResolveSymbolRVA(WebcilSection[] sections, SymbolDefinition definition)
         {
             for (int i = 0; i < sections.Length; i++)
@@ -244,12 +206,6 @@ namespace ILCompiler.ObjectWriter
 
         private protected override void EmitSectionsAndLayout()
         {
-            int totalMethodCount = MethodCount + 3;
-            InsertWasmStub(new Utf8String("getWebcilSize"), GetWebcilSize);
-            InsertWasmStub(new Utf8String("getWebcilPayload"), GetWebcilPayload);
-            InsertWasmStub(new Utf8String("fillWebcilTable"), FillWebcilTable(totalMethodCount));
-            Debug.Assert(MethodCount == totalMethodCount);
-
             WriteDataCountSection();
         }
 
@@ -824,6 +780,13 @@ namespace ILCompiler.ObjectWriter
                         {
                             Relocation.WriteValue(reloc.Type, pData, symbol.Index + addend);
                         }
+                        break;
+                    }
+                    case RelocType.WASM_FUNCTION_COUNT_SLEB:
+                    {
+                        // We should only be using this in methods that can be shrunk at this point.
+                        Debug.Assert(shrink);
+                        actualLength = Relocation.WriteVariableLengthValue(reloc.Type, pData, MethodCount);
                         break;
                     }
                     default:

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
@@ -871,7 +871,7 @@ namespace ILCompiler.ObjectWriter
 
             foreach (SymbolicRelocation reloc in relocs)
             {
-                Debug.Assert(sourceStream.Position != reloc.Offset,
+                Debug.Assert(sourceStream.Position == reloc.Offset,
                     $"Unexpected data in the WASM Function section between offsets {sourceStream.Position} and {reloc.Offset}.");
 
                 ResolveReloc(

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -630,6 +630,10 @@ namespace ILCompiler.DependencyAnalysis
             {
                 return new WasmTypeNode(key);
             });
+            _wasmFunctionEntryCache = new NodeCache<WasmFunctionEntryNodeCacheKey, WasmFunctionEntryNode>(key =>
+            {
+                return new WasmFunctionEntryNode(key.MethodCodeNode, key.Type, key.FuncletIndex);
+            });
 
             NativeLayout = new NativeLayoutHelper(this);
         }
@@ -1628,6 +1632,10 @@ namespace ILCompiler.DependencyAnalysis
         public WasmTypeNode WasmTypeNode(MethodDesc desc)
         {
             return _wasmTypeNodes.GetOrAdd(WasmLowering.GetSignature(desc).FuncType);
+        }
+        public WasmTypeNode WasmTypeNode(WasmFuncType type)
+        {
+            return _wasmTypeNodes.GetOrAdd(type);
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -330,6 +330,7 @@
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\ShadowMethodNode.cs" Link="Compiler\DependencyAnalysis\ShadowMethodNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\SortableDependencyNode.cs" Link="Compiler\DependencyAnalysis\SortableDependencyNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\WasmTypeNode.cs" Link="Compiler\DependencyAnalysis\WasmTypeNode.cs" />
+    <Compile Include="..\..\Common\Compiler\DependencyAnalysis\WasmFunctionEntryNode.cs" Link="Compiler\DependencyAnalysis\WasmFunctionEntryNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\WasmWellKnownGlobalSymbolNode.cs" Link="Compiler\DependencyAnalysis\WasmWellKnownGlobalSymbolNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\NodeFactory.Wasm.cs" Link="Compiler\DependencyAnalysis\NodeFactory.Wasm.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\INodeWithTypeSignature.cs" Link="Compiler\DependencyAnalysis\INodeWithTypeSignature.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -138,6 +138,9 @@ public class R2RTestSuites
 
             Assert.True(WasmR2RAssert.WasmIndexSpacesHaveExpectedEntries(webcilReader, out string indexDiagnostic), indexDiagnostic);
             Assert.True(
+                WasmR2RAssert.WasmFunctionSectionMatchesCode(webcilReader, out string functionSectionDiagnostic),
+                functionSectionDiagnostic);
+            Assert.True(
                 WasmR2RAssert.FillWebcilTableUsesDefinedFunctionCount(webcilReader, out string functionCountDiagnostic),
                 functionCountDiagnostic);
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -137,6 +137,9 @@ public class R2RTestSuites
                 method.SignatureString.Contains("CatchException", StringComparison.Ordinal)));
 
             Assert.True(WasmR2RAssert.WasmIndexSpacesHaveExpectedEntries(webcilReader, out string indexDiagnostic), indexDiagnostic);
+            Assert.True(
+                WasmR2RAssert.FillWebcilTableUsesDefinedFunctionCount(webcilReader, out string functionCountDiagnostic),
+                functionCountDiagnostic);
 
             // The wasm JIT references the ABI well-known globals via maximally padded WASM_GLOBAL_INDEX_LEB
             // relocations that the R2R object writer must self-resolve to the fixed global

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/Webcil/WasmWebcilModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/Webcil/WasmWebcilModule.cs
@@ -60,4 +60,9 @@ public static class WasmWebcilModule
             return -1;
         }
     }
+
+    public static void AlwaysThrows()
+    {
+        throw new InvalidOperationException();
+    }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
@@ -129,6 +129,27 @@ internal static class WasmR2RAssert
         return failures.Count == 0;
     }
 
+    public static bool WasmFunctionSectionMatchesCode(WebcilImageReader reader, out string diagnostic)
+    {
+        if (!reader.IsWasmWrapped)
+        {
+            diagnostic = "Expected a WASM-wrapped Webcil image.";
+            return false;
+        }
+
+        int functionCount = ReadWasmFunctionTypeIndices(reader);
+        uint codeCount = ReadWasmSectionEntryCount(reader, WasmSectionKind.Code);
+        if ((uint)functionCount != codeCount)
+        {
+            diagnostic =
+                $"The WASM Function section has {functionCount} entries, but the Code section has {codeCount} entries.";
+            return false;
+        }
+
+        diagnostic = $"The WASM Function and Code sections contain {codeCount} entries.";
+        return true;
+    }
+
     public static bool FillWebcilTableUsesDefinedFunctionCount(WebcilImageReader reader, out string diagnostic)
     {
         if (!reader.IsWasmWrapped)
@@ -139,13 +160,6 @@ internal static class WasmR2RAssert
 
         var failures = new List<string>();
         uint functionCount = ReadWasmSectionEntryCount(reader, WasmSectionKind.Function);
-        uint codeCount = ReadWasmSectionEntryCount(reader, WasmSectionKind.Code);
-        if (functionCount != codeCount)
-        {
-            failures.Add(
-                $"The WASM Function section has {functionCount} entries, but the Code section has {codeCount} entries.");
-        }
-
         Dictionary<(string Module, string Name), WasmImportIndex> imports = ReadWasmImports(reader);
         uint importedFunctionCount = CountWasmImports(imports, WasmImportKind.Function);
         Dictionary<string, WasmExportIndex> exports = ReadWasmExports(reader);
@@ -434,6 +448,36 @@ internal static class WasmR2RAssert
             return 0;
 
         return ReadWasmUleb32(image, ref offset, sectionEnd);
+    }
+
+    private static int ReadWasmFunctionTypeIndices(WebcilImageReader reader)
+    {
+        ReadOnlySpan<byte> image = reader.GetEntireImage().AsSpan();
+        if (!TryGetWasmSectionBounds(image, WasmSectionKind.Function, out int offset, out int sectionEnd))
+            return 0;
+
+        uint entryCount = ReadWasmUleb32(image, ref offset, sectionEnd);
+        for (uint i = 0; i < entryCount; i++)
+        {
+            int entryOffset = offset;
+            uint typeIndex = ReadWasmUleb32(image, ref offset, sectionEnd);
+            if (offset - entryOffset != GetWasmUleb32Size(typeIndex))
+                throw new BadImageFormatException($"WASM Function-section type index {typeIndex} is not minimally encoded.");
+        }
+
+        if (offset != sectionEnd)
+            throw new BadImageFormatException("WASM Function section contains trailing data.");
+
+        return checked((int)entryCount);
+    }
+
+    private static int GetWasmUleb32Size(uint value)
+    {
+        int size = 1;
+        while ((value >>= 7) != 0)
+            size++;
+
+        return size;
     }
 
     private static Dictionary<string, WasmExportIndex> ReadWasmExports(WebcilImageReader reader)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
@@ -1,11 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+extern alias crossgen2;
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using crossgen2::ILCompiler.DependencyAnalysis;
+using crossgen2::ILCompiler.ObjectWriter.WasmInstructions;
 using ILCompiler.Reflection.ReadyToRun;
 
 namespace ILCompiler.ReadyToRun.Tests.TestCasesRunner;
@@ -121,6 +125,74 @@ internal static class WasmR2RAssert
 
         diagnostic = failures.Count == 0
             ? "WASM imports, definitions, exports, names, and instruction references use the expected per-kind indices."
+            : string.Join(Environment.NewLine, failures);
+        return failures.Count == 0;
+    }
+
+    public static bool FillWebcilTableUsesDefinedFunctionCount(WebcilImageReader reader, out string diagnostic)
+    {
+        if (!reader.IsWasmWrapped)
+        {
+            diagnostic = "Expected a WASM-wrapped Webcil image.";
+            return false;
+        }
+
+        var failures = new List<string>();
+        uint functionCount = ReadWasmSectionEntryCount(reader, WasmSectionKind.Function);
+        uint codeCount = ReadWasmSectionEntryCount(reader, WasmSectionKind.Code);
+        if (functionCount != codeCount)
+        {
+            failures.Add(
+                $"The WASM Function section has {functionCount} entries, but the Code section has {codeCount} entries.");
+        }
+
+        Dictionary<(string Module, string Name), WasmImportIndex> imports = ReadWasmImports(reader);
+        uint importedFunctionCount = CountWasmImports(imports, WasmImportKind.Function);
+        Dictionary<string, WasmExportIndex> exports = ReadWasmExports(reader);
+        if (!exports.TryGetValue("fillWebcilTable", out WasmExportIndex fillWebcilTableExport))
+        {
+            failures.Add("Expected WASM function export 'fillWebcilTable' was not found.");
+        }
+        else if (fillWebcilTableExport.Kind != WasmImportKind.Function)
+        {
+            failures.Add(
+                $"WASM export 'fillWebcilTable' was {fillWebcilTableExport.Kind}; expected Function.");
+        }
+        else if (fillWebcilTableExport.Index < importedFunctionCount)
+        {
+            failures.Add(
+                $"WASM export 'fillWebcilTable' refers to imported function index {fillWebcilTableExport.Index}.");
+        }
+        else
+        {
+            int functionIndex = checked((int)(fillWebcilTableExport.Index - importedFunctionCount));
+            WebcilImageReader.WasmFunctionInfo? function = reader.GetWasmFunctionBody(functionIndex);
+            if (function is null)
+            {
+                failures.Add(
+                    $"WASM export 'fillWebcilTable' refers to missing Code-section entry {functionIndex}.");
+            }
+            else
+            {
+                ReadOnlySpan<byte> instructions = function.Value.Image.AsSpan().Slice(
+                    function.Value.InstructionOffset, function.Value.InstructionLength);
+                WasmInstructionGroup expectedInstructions = new(
+                    WebcilDefaultMethodNode.GetFillWebcilTableInstructions(I32.Const(functionCount)));
+                byte[] expectedBytes = new byte[expectedInstructions.EncodeSize()];
+                int bytesWritten = expectedInstructions.Encode(expectedBytes);
+                Debug.Assert(bytesWritten == expectedBytes.Length);
+
+                if (!instructions.SequenceEqual(expectedBytes))
+                {
+                    failures.Add(
+                        $"fillWebcilTable body was {Convert.ToHexString(instructions)}; " +
+                        $"expected {Convert.ToHexString(expectedBytes)} for {functionCount} functions.");
+                }
+            }
+        }
+
+        diagnostic = failures.Count == 0
+            ? $"fillWebcilTable initializes {functionCount} table entries, matching the Function and Code sections."
             : string.Join(Environment.NewLine, failures);
         return failures.Count == 0;
     }
@@ -578,6 +650,7 @@ internal static class WasmR2RAssert
         Global = 6,
         Export = 7,
         Element = 9,
+        Code = 10,
         Tag = 13,
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -286,6 +286,8 @@ namespace ILCompiler.DependencyAnalysis
             return _genericReadyToRunHelpersFromType.GetOrAdd(new ReadyToRunGenericHelperKey(id, target, dictionaryOwner));
         }
 
+        public ISymbolNode WasmFunctionCount { get; } = new WasmFunctionCountNode();
+
         private struct ReadyToRunGenericHelperKey : IEquatable<ReadyToRunGenericHelperKey>
         {
             public readonly object Target;
@@ -552,6 +554,11 @@ namespace ILCompiler.DependencyAnalysis
             _wasmTypeNodes = new(key =>
             {
                 return new WasmTypeNode(key);
+            });
+
+            _wasmFunctionEntryCache = new(key =>
+            {
+                return new WasmFunctionEntryNode(key.MethodCodeNode, key.Type, key.FuncletIndex);
             });
         }
 
@@ -1268,6 +1275,13 @@ namespace ILCompiler.DependencyAnalysis
                 graph.AddRoot(Win32ResourcesNode, "Win32 Resources are placed if not empty");
 
             MetadataManager.AttachToDependencyGraph(graph, this);
+
+            if (Target.IsWasm)
+            {
+                graph.AddRoot(new WebcilDefaultMethodNode(WebcilDefaultMethodKind.GetWebcilSize, this), "Webcil default method is always generated");
+                graph.AddRoot(new WebcilDefaultMethodNode(WebcilDefaultMethodKind.GetWebcilPayload, this), "Webcil default method is always generated");
+                graph.AddRoot(new WebcilDefaultMethodNode(WebcilDefaultMethodKind.FillWebcilTable, this), "Webcil default method is always generated");
+            }
         }
 
         private void Graph_ComputingDependencyPhaseChange(int newPhase)
@@ -1456,6 +1470,11 @@ namespace ILCompiler.DependencyAnalysis
 
         private NodeCache<WasmUnboxingStubKey, WasmUnboxingStubNode> _wasmUnboxingStubs;
         private NodeCache<MethodDesc, WasmUnboxingStubTargetNode> _wasmUnboxingStubTargets;
+
+        public WasmTypeNode WasmTypeNode(WasmFuncType type)
+        {
+            return _wasmTypeNodes.GetOrAdd(type);
+        }
 
         public WasmTypeNode WasmTypeNode(CorInfoWasmType[] types)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -111,6 +111,7 @@
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\ShadowMethodNode.cs" Link="Compiler\DependencyAnalysis\ShadowMethodNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\SortableDependencyNode.cs" Link="Compiler\DependencyAnalysis\SortableDependencyNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\WasmTypeNode.cs" Link="Compiler\DependencyAnalysis\WasmTypeNode.cs" />
+    <Compile Include="..\..\Common\Compiler\DependencyAnalysis\WasmFunctionEntryNode.cs" Link="Compiler\DependencyAnalysis\WasmFunctionEntryNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\WasmWellKnownGlobalSymbolNode.cs" Link="Compiler\DependencyAnalysis\WasmWellKnownGlobalSymbolNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\NodeFactory.Wasm.cs" Link="Compiler\DependencyAnalysis\NodeFactory.Wasm.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\Target_ARM64\AddrMode.cs" Link="Compiler\DependencyAnalysis\Target_ARM64\AddrMode.cs" />
@@ -130,6 +131,7 @@
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\Target_RiscV64\TargetRegisterMap.cs" Link="Compiler\DependencyAnalysis\Target_RiscV64\TargetRegisterMap.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\Target_Wasm\WasmEmitter.cs" Link="Compiler\DependencyAnalysis\Target_Wasm\WasmEmitter.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\Target_Wasm\WasmTypes.cs" Link="Compiler\DependencyAnalysis\Target_Wasm\WasmTypes.cs" />
+    <Compile Include="..\..\Common\Compiler\DependencyAnalysis\Target_Wasm\WebcilDefaultMethodNode.cs" Link="Compiler\DependencyAnalysis\Target_Wasm\WebcilDefaultMethodNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\Target_X64\AddrMode.cs" Link="Compiler\DependencyAnalysis\Target_X64\AddrMode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\Target_X64\Register.cs" Link="Compiler\DependencyAnalysis\Target_X64\Register.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\Target_X64\TargetRegisterMap.cs" Link="Compiler\DependencyAnalysis\Target_X64\TargetRegisterMap.cs" />


### PR DESCRIPTION
This PR adds ObjectNodes representing the entries in the Function section of WASM modules. They are dependencies of all INodeWithTypeSignature, and entries are also created for each function of INodeWithFunclets. The ordering of entries in the Function section kept aligned with the code nodes by sorting the FunctionEntryNodes by their `_methodCodeNode`, then by their funclet index. The ObjectData for the nodes is a single reloc to the index of the `WasmTypeNode`.

Since the webcil functions `getWebcilSize`, `fillWebcilTable`, and `getWebcilPayload` are inserted as stubs in the ObjectWriter, they had to be moved to the dependency graph as well. I made them a new subclass of `AssemblyStubNode` and added them as roots when compiling a webcil module. They sort themselves ahead of all other method nodes.

`fillWebcilTable` required knowing the size of the table as a constant, so a new reloc type was created, `WASM_FUNCTON_COUNT_SLEB` that represents the number of entries in the Code and Function sections of the module, and a new Node was created to be the target of this reloc, `WasmFunctionCountNode`.

The relocs for the section are shrunk thanks to the work done in https://github.com/dotnet/runtime/pull/132029.

In the end, this makes the Function section fit into the dependency graph ObjectNode model, but likely is less performant. The existing system for emitting the Function section isn't particularly convoluted or confusing, so I'm not sure this is really a net positive, but the work is done, so I thought I'd create the PR for discussion.