### PR TITLE
Fix TypeMap failure in CI

### DIFF
--- a/src/tests/Interop/TypeMap/TypeMapApp.cs
+++ b/src/tests/Interop/TypeMap/TypeMapApp.cs
@@ -327,7 +327,7 @@ public class TypeMap
         IReadOnlyDictionary<Type, Type> proxyMap = TypeMapping.GetOrCreateProxyTypeMapping<BlobOnlyAttributeTypeNames>();
         Assert.Equal(typeof(S1), proxyMap[typeof(C1)]);
         Assert.Equal(typeof(C1), proxyMap[typeof(S1)]);
-        Assert.Equal(typeof(Lib5Type1), proxyMap[typeof(Lib5Proxy1)]);
+        Assert.Equal(typeof(Lib5Proxy1), proxyMap[new Lib5Type1().GetType()]);
     }
 
     [Fact]


### PR DESCRIPTION
Looks like https://github.com/dotnet/runtime/commit/00ecce5765b9fb65c001c641fda946e548995663 is causing issues in CI.

Fix the blob-only TypeMap test to query its proxy mapping in the correct source -> proxy direction. Use `new Lib5Type1().GetType()` so NativeAOT trimming retains the source entry.

Investigated and fixed by Copilot.