### PR TITLE
fix: free data.values in rehash() to avoid memory leak

### DIFF
--- a/src/mono/mono/metadata/weak-hash.c
+++ b/src/mono/mono/metadata/weak-hash.c
@@ -268,6 +268,7 @@ rehash (MonoWeakHashTable *hash)
 		g_free (old_keys);
 	if (!(hash->gc_type & MONO_HASH_VALUE_GC))
 		g_free (old_values);
+	g_free (data.values);
 }
 
 /**


### PR DESCRIPTION
Memory allocated for data.values was never freed, which could lead to memory accumulation and eventually cause OOM and a process crash.

Add a g_free(data.values) call in rehash() to properly release the memory.

Found by Linux Verification Center (linuxtesting.org) with SVACE. .
    Signed-off-by: Artem Semenov <savoptik@altlinux.org>.