### PR TITLE
[release/11.0-rc1] [mono][interp] Intrinsify Vector128.Store/StoreUnsafe on wasm

### DIFF
--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
@@ -7299,5 +7299,121 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
                 Assert.Equal(expected, actual[i]);
             }
         }
+
+        private enum StoreKind
+        {
+            Store,
+            StoreUnsafe,
+            StoreUnsafeWithOffset,
+        }
+
+        /// <summary>
+        /// Stores a vector holding a distinct byte per lane at every alignment from 0 to 15 and checks
+        /// the whole buffer, so a wrong store destination, a reversed operand pair, or a byte written
+        /// outside the 16-byte window is caught rather than masked by a uniform fill.
+        /// </summary>
+        private static unsafe void ValidateStore<T>(StoreKind kind)
+            where T : unmanaged
+        {
+            const int Guard = 16;
+            const int MaxAlignmentOffset = 16;
+            const byte Filler = 0x5A;
+
+            byte[] pattern = new byte[Vector128<byte>.Count];
+            for (int i = 0; i < pattern.Length; i++)
+            {
+                pattern[i] = (byte)(0xA0 + i);
+            }
+
+            Vector128<T> vector = Vector128.Create<byte>(new ReadOnlySpan<byte>(pattern)).As<byte, T>();
+
+            byte[] buffer = new byte[Guard + MaxAlignmentOffset + pattern.Length + Guard];
+            byte[] expected = new byte[buffer.Length];
+
+            for (int offset = 0; offset < MaxAlignmentOffset; offset++)
+            {
+                Array.Fill(buffer, Filler);
+                Array.Fill(expected, Filler);
+                pattern.CopyTo(expected, Guard + offset);
+
+                fixed (byte* pBuffer = buffer)
+                {
+                    T* destination = (T*)(pBuffer + Guard + offset);
+
+                    switch (kind)
+                    {
+                        case StoreKind.Store:
+                            vector.Store(destination);
+                            break;
+
+                        case StoreKind.StoreUnsafe:
+                            vector.StoreUnsafe(ref *destination);
+                            break;
+
+                        case StoreKind.StoreUnsafeWithOffset:
+                            // Bias the destination backwards and let the element offset undo it, so a
+                            // dropped offset argument shows up as a wrongly placed store.
+                            vector.StoreUnsafe(ref *(destination - 1), elementOffset: 1);
+                            break;
+
+                        default:
+                            throw new InvalidOperationException($"Unexpected {nameof(StoreKind)}: {kind}");
+                    }
+                }
+
+                Assert.Equal(expected, buffer);
+            }
+        }
+
+        [Fact]
+        public unsafe void Vector128StoreUnalignedTest()
+        {
+            ValidateStore<byte>(StoreKind.Store);
+            ValidateStore<sbyte>(StoreKind.Store);
+            ValidateStore<short>(StoreKind.Store);
+            ValidateStore<ushort>(StoreKind.Store);
+            ValidateStore<int>(StoreKind.Store);
+            ValidateStore<uint>(StoreKind.Store);
+            ValidateStore<long>(StoreKind.Store);
+            ValidateStore<ulong>(StoreKind.Store);
+            ValidateStore<float>(StoreKind.Store);
+            ValidateStore<double>(StoreKind.Store);
+            ValidateStore<nint>(StoreKind.Store);
+            ValidateStore<nuint>(StoreKind.Store);
+        }
+
+        [Fact]
+        public unsafe void Vector128StoreUnsafeUnalignedTest()
+        {
+            ValidateStore<byte>(StoreKind.StoreUnsafe);
+            ValidateStore<sbyte>(StoreKind.StoreUnsafe);
+            ValidateStore<short>(StoreKind.StoreUnsafe);
+            ValidateStore<ushort>(StoreKind.StoreUnsafe);
+            ValidateStore<int>(StoreKind.StoreUnsafe);
+            ValidateStore<uint>(StoreKind.StoreUnsafe);
+            ValidateStore<long>(StoreKind.StoreUnsafe);
+            ValidateStore<ulong>(StoreKind.StoreUnsafe);
+            ValidateStore<float>(StoreKind.StoreUnsafe);
+            ValidateStore<double>(StoreKind.StoreUnsafe);
+            ValidateStore<nint>(StoreKind.StoreUnsafe);
+            ValidateStore<nuint>(StoreKind.StoreUnsafe);
+        }
+
+        [Fact]
+        public unsafe void Vector128StoreUnsafeElementOffsetUnalignedTest()
+        {
+            ValidateStore<byte>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<sbyte>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<short>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<ushort>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<int>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<uint>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<long>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<ulong>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<float>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<double>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<nint>(StoreKind.StoreUnsafeWithOffset);
+            ValidateStore<nuint>(StoreKind.StoreUnsafeWithOffset);
+        }
     }
 }

--- a/src/mono/mono/mini/interp/interp-simd.c
+++ b/src/mono/mono/mini/interp/interp-simd.c
@@ -805,7 +805,11 @@ interp_packedsimd_load32x2_u (gpointer res, gpointer addr_of_addr) {
 static void
 interp_packedsimd_store (gpointer res, gpointer addr_of_addr, gpointer vec) {
 	// HACK: Result is unused because Store has a void return value
-	**(v128_t **)addr_of_addr = *(v128_t *)vec;
+	// wasm_v128_store stores through a packed struct, so an unaligned destination is well-defined.
+	//  Assigning through a v128_t* instead would claim 16-byte alignment we don't have: both
+	//  PackedSimd.Store and Vector128.StoreUnsafe accept arbitrarily aligned destinations.
+	//  This mirrors interp_packedsimd_load128, which already uses wasm_v128_load.
+	wasm_v128_store (*(void **)addr_of_addr, *(v128_t *)vec);
 }
 
 #define INDIRECT_STORE_LANE(lane_type) \

--- a/src/mono/mono/mini/interp/transform-simd.c
+++ b/src/mono/mono/mini/interp/transform-simd.c
@@ -196,11 +196,8 @@ static guint16 packedsimd_alias_methods [] = {
 	SN_ShiftRightLogical,
 	SN_Sqrt,
 	SN_SquareRoot,
-	// NOTE: Store/StoreUnsafe are deliberately absent. PackedSimd.Store's operands are reversed
-	//  relative to Vector128's - PackedSimd.Store(T* address, Vector128<T> source) versus
-	//  Vector128.Store(this Vector128<T> source, T* destination) - and this path only renames
-	//  the method, with emit_common_simd_epilogue assigning sregs in signature order. Aliasing
-	//  them would pass the vector where the destination address is expected and corrupt memory.
+	SN_Store,
+	SN_StoreUnsafe,
 	SN_Subtract,
 	SN_SubtractSaturate,
 	SN_Truncate,
@@ -1124,6 +1121,9 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 	const char *cmethod_name = cmethod->name;
 	int id = lookup_intrins (sri_packedsimd_methods, sizeof (sri_packedsimd_methods), cmethod_name);
 	MonoClass *vector_klass;
+	// Set when the aliased Vector128 method takes its operands in the opposite order from the
+	//  PackedSimd method we are lowering to. See SN_Store below.
+	gboolean swap_operands = FALSE;
 
 	bool is_packedsimd = strcmp (m_class_get_name (cmethod->klass), "PackedSimd") == 0;
 	if (is_packedsimd) {
@@ -1281,6 +1281,26 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 			case SN_SquareRoot:
 				cmethod_name = "Sqrt";
 				break;
+			case SN_Store:
+			case SN_StoreUnsafe:
+				// PackedSimd.Store (T* address, Vector128<T> source) takes its operands in the
+				//  opposite order from Vector128.Store (this Vector128<T> source, T* destination)
+				//  and Vector128.StoreUnsafe (this Vector128<T> source, ref T destination), so the
+				//  sregs have to be swapped once the epilogue has assigned them in signature order.
+				// The three-argument StoreUnsafe (source, destination, elementOffset) has no
+				//  PackedSimd counterpart, so leave it for managed code. Store is registered for
+				//  every element type, so also confirm the shape we are about to reorder: sregs [1]
+				//  is dereferenced as the destination address, so require it to be a raw address
+				//  (T* or ref T) rather than merely pointer-sized. Anything else falls back to
+				//  managed code, which is always correct if slower.
+				if ((csignature->param_count != 2) ||
+					(csignature->ret->type != MONO_TYPE_VOID) ||
+					!(m_type_is_byref (csignature->params [1]) ||
+					  (csignature->params [1]->type == MONO_TYPE_PTR)))
+					return FALSE;
+				swap_operands = TRUE;
+				cmethod_name = "Store";
+				break;
 			case SN_Add:
 			case SN_AddSaturate:
 			case SN_AndNot:
@@ -1341,6 +1361,12 @@ emit_sri_packedsimd (TransformData *td, MonoMethod *cmethod, MonoMethodSignature
 
 opcode_added:
 	emit_common_simd_epilogue (td, vector_klass, csignature, vector_size, TRUE);
+	if (swap_operands) {
+		// The epilogue assigned the sregs in signature order; see SN_Store above.
+		gint32 tmp = td->last_ins->sregs [0];
+		td->last_ins->sregs [0] = td->last_ins->sregs [1];
+		td->last_ins->sregs [1] = tmp;
+	}
 	return TRUE;
 }
 


### PR DESCRIPTION
Manual backport of #132502 to `release/11.0-rc1`.

## Why this needed a manual backport

The automatic cherry-pick conflicted in two files:

- **`transform-simd.c`** — resolved by first landing the prerequisite, #132525 (backport of #132500). Once that merged, this file auto-merged with no hand edits.
- **`Vector128Tests.cs`** — a pure placement conflict. #132502's tests were appended after `Vector128GetElementVariableOutOfRangeTest`, which comes from #132499 and is not on this branch. The three Store tests are self-contained, so they were appended at the end of the class instead. No #132499 tests were pulled in.

Every added and removed line in this commit is byte-identical to upstream `be1c680` — only hunk headers and line numbers differ.

## Depends on #132525

This backport is only effective because #132525 already merged. On `release/11.0-rc1` before that fix, `packedsimd_alias_methods` was mis-sorted, and since `lookup_intrins()` binary-searches the table, `Store`, `StoreUnsafe`, `Subtract` and `SubtractSaturate` were all unreachable. Simulating `mono_binary_search` against the pre-#132525 table confirms this — so #132502 on its own would have been a silent no-op.

With #132525 merged, the resulting table is strictly sorted and all 49 entries resolve; `Store` and `StoreUnsafe` land at indices 29 and 30.

## Original change

`PackedSimd.Store(T* address, Vector128<T> source)` takes its operands in the opposite order from `Vector128.Store(this Vector128<T> source, T* destination)`, and the alias path only renames the method — `emit_common_simd_epilogue` assigns sregs in signature order. This adds them to the alias table and swaps the two sregs after the epilogue, guarded on the shape actually being a store (two parameters, void return, raw address as the second parameter). The three-argument `StoreUnsafe(source, destination, elementOffset)` has no PackedSimd counterpart and still falls back to managed code.

`interp_packedsimd_store` also switches from assigning through a `v128_t*` to `wasm_v128_store`, which does not claim 16-byte alignment that neither API guarantees.

Upstream measured ~6.2x on `Vector128.Store<int>` and ~6.3x on `Vector128.StoreUnsafe<int>` under the interpreter.

## Local validation

- `./build.sh clr+libs -rc release` — 0 errors, 0 warnings
- `System.Runtime.Intrinsics.Tests` — **13011/13011 passing, 0 failed**, including the three new tests: `Vector128StoreUnalignedTest`, `Vector128StoreUnsafeUnalignedTest`, `Vector128StoreUnsafeElementOffsetUnalignedTest`

The count is 13011 rather than upstream's 13024 because the #132499 and #132496 tests are not on this branch.

Not validated locally: the `interp-simd.c` change is wasm-only, so a native osx-arm64 build does not exercise it. It is byte-identical to the upstream commit, which passed full CI.

> [!NOTE]
> This pull request was authored with the assistance of GitHub Copilot.