### PR TITLE
Defer unused CoreLib cache initialization

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -12,10 +12,13 @@ namespace System.Globalization
 {
     public partial class CompareInfo
     {
-        // Characters which require special handling are those in [0x00, 0x1F] and [0x7F, 0xFFFF] except \t\v\f
-        // Matches HighCharTable below.
-        private static readonly SearchValues<char> s_nonSpecialAsciiChars =
-            SearchValues.Create("\t\v\f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~");
+        private static class IcuSearchValues
+        {
+            // Characters which require special handling are those in [0x00, 0x1F] and [0x7F, 0xFFFF] except \t\v\f
+            // Matches HighCharTable below.
+            internal static readonly SearchValues<char> s_nonSpecialAsciiChars =
+                SearchValues.Create("\t\v\f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~");
+        }
 
         [NonSerialized]
         private bool _isAsciiEqualityOrdinal;
@@ -114,14 +117,14 @@ namespace System.Globalization
                 char* a = ap;
                 char* b = bp;
 
-                if (target.ContainsAnyExcept(s_nonSpecialAsciiChars))
+                if (target.ContainsAnyExcept(IcuSearchValues.s_nonSpecialAsciiChars))
                 {
                     goto InteropCall;
                 }
 
                 if (target.Length > source.Length)
                 {
-                    if (source.ContainsAnyExcept(s_nonSpecialAsciiChars))
+                    if (source.ContainsAnyExcept(IcuSearchValues.s_nonSpecialAsciiChars))
                     {
                         goto InteropCall;
                     }
@@ -197,7 +200,7 @@ namespace System.Globalization
                     ? source.Slice(endIndex)
                     : source.Slice(0, startIndex);
 
-                if (remainingSource.ContainsAnyExcept(s_nonSpecialAsciiChars))
+                if (remainingSource.ContainsAnyExcept(IcuSearchValues.s_nonSpecialAsciiChars))
                 {
                     goto InteropCall;
                 }
@@ -229,14 +232,14 @@ namespace System.Globalization
                 char* a = ap;
                 char* b = bp;
 
-                if (target.ContainsAnyExcept(s_nonSpecialAsciiChars))
+                if (target.ContainsAnyExcept(IcuSearchValues.s_nonSpecialAsciiChars))
                 {
                     goto InteropCall;
                 }
 
                 if (target.Length > source.Length)
                 {
-                    if (source.ContainsAnyExcept(s_nonSpecialAsciiChars))
+                    if (source.ContainsAnyExcept(IcuSearchValues.s_nonSpecialAsciiChars))
                     {
                         goto InteropCall;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -14,10 +14,25 @@ namespace System.Globalization
     {
         private static class IcuSearchValues
         {
-            // Characters which require special handling are those in [0x00, 0x1F] and [0x7F, 0xFFFF] except \t\v\f
-            // Matches HighCharTable below.
-            internal static readonly SearchValues<char> s_nonSpecialAsciiChars =
-                SearchValues.Create("\t\v\f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~");
+            // Characters which do not require special handling
+            internal static readonly SearchValues<char> s_nonSpecialAsciiChars = CreateNonSpecialAsciiChars();
+
+            private static SearchValues<char> CreateNonSpecialAsciiChars()
+            {
+                ReadOnlySpan<bool> highCharTable = HighCharTable;
+                Span<char> values = stackalloc char[highCharTable.Length];
+                int valueIndex = 0;
+
+                for (int i = 0; i < highCharTable.Length; i++)
+                {
+                    if (!highCharTable[i])
+                    {
+                        values[valueIndex++] = (char)i;
+                    }
+                }
+
+                return SearchValues.Create(values.Slice(0, valueIndex));
+            }
         }
 
         [NonSerialized]

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -15,7 +15,11 @@ namespace System.Text
     //
     internal static partial class EncodingTable
     {
-        private static readonly ConcurrentDictionary<string, int> s_nameToCodePage = new(StringComparer.OrdinalIgnoreCase);
+        private static class NameToCodePageCache
+        {
+            internal static readonly ConcurrentDictionary<string, int> s_nameToCodePage = new(StringComparer.OrdinalIgnoreCase);
+        }
+
         private static CodePageDataItem?[]? s_codePageToCodePageData;
 
         /*=================================GetCodePageFromName==========================
@@ -32,7 +36,7 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(name);
 
-            return s_nameToCodePage.GetOrAdd(name, InternalGetCodePageFromName);
+            return NameToCodePageCache.s_nameToCodePage.GetOrAdd(name, InternalGetCodePageFromName);
         }
 
         // Find the data item by binary searching the table.

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -15,11 +15,7 @@ namespace System.Text
     //
     internal static partial class EncodingTable
     {
-        private static class NameToCodePageCache
-        {
-            internal static readonly ConcurrentDictionary<string, int> s_nameToCodePage = new(StringComparer.OrdinalIgnoreCase);
-        }
-
+        private static ConcurrentDictionary<string, int>? s_nameToCodePage;
         private static CodePageDataItem?[]? s_codePageToCodePageData;
 
         /*=================================GetCodePageFromName==========================
@@ -36,7 +32,12 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(name);
 
-            return NameToCodePageCache.s_nameToCodePage.GetOrAdd(name, InternalGetCodePageFromName);
+            if (s_nameToCodePage == null)
+            {
+                Interlocked.CompareExchange(ref s_nameToCodePage, new(StringComparer.OrdinalIgnoreCase), null);
+            }
+
+            return s_nameToCodePage.GetOrAdd(name, InternalGetCodePageFromName);
         }
 
         // Find the data item by binary searching the table.


### PR DESCRIPTION
Moves the ICU-only `CompareInfo` search values and the `EncodingTable` name cache behind nested static holders. This preserves one-time initialization when those paths are used while allowing NativeAOT to trim them from applications that only need unrelated static state.

A locally built Release NativeAOT `win-x64` Hello World with `InvariantGlobalization=true` measured:

| Build | Executable | Delta |
| --- | ---: | ---: |
| `main` | 993,280 bytes | — |
| `CompareInfo` holder | 971,264 bytes | -22,016 bytes |
| Both holders | 968,704 bytes | -24,576 bytes |

The cumulative raw section changes are `.text` -12,800 bytes, `.rdata` -9,728 bytes, `.data` -1,024 bytes, `.pdata` -512 bytes, and `.reloc` -512 bytes. The final dependency graph no longer contains `SearchValues.Create`, `EncodingTable::.cctor`, or the `ConcurrentDictionary<string, int>` name-cache construction.

> [!NOTE]
> This pull request was prepared with GitHub Copilot.