### PR TITLE
Stop generating static restore binlogs

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
-    <GenerateRestoreUseStaticGraphEvaluationBinlog>true</GenerateRestoreUseStaticGraphEvaluationBinlog>
   </PropertyGroup>
   <ItemGroup>
     <ProjectToBuild Include="$(RepoRoot)Build.proj" />


### PR DESCRIPTION
## Summary

- Stop unconditionally generating the nested static-graph restore binlog.
- Keep static-graph restore enabled.
- Continue producing the normal outer build binlog when `-bl` or `-bln` is requested.

## Motivation

A fully cached restore still evaluates the complete restore graph, and recording every project evaluation and import in the nested binlog adds substantial overhead. This binlog was enabled in 2020 for diagnostics, but it is generated even when it is not needed.

For an immediate no-op restore on this machine:

| Scenario | Before | After |
| --- | ---: | ---: |
| `./build.sh -restore -v:q` | 50.35 s | 26.69 s |
| `./build.sh -restore -v:q -bln <path>` | 46.19 s | 26.78 s |

The latter still writes the requested outer build binlog; only the nested static-graph restore binlog is omitted.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
