### PR TITLE
Don't build all JIT flavors for clr.aot

### DIFF
--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -20,8 +20,6 @@ The Native AOT toolchain can be currently built for Linux (x64/arm32/arm64), mac
 
 Once you build the repo, you can use the produced binaries in one of four ways specified below ("Using built binaries", "Building packages", "Convenience Visual Studio "repro" project", "Running tests").
 
-### Cross-compiling
-
 The native AOT compiler is a cross-compiler, however the default clr.aot subset passed to build[.cmd|.sh] will only build a flavor that can target the architecture of ILC itself. To build other codegen backends and enable crossbuilding, replace `clr.aot` with `clr.aot+clr.alljits` in the build script invocation.
 
 ### Using built binaries

--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -20,6 +20,10 @@ The Native AOT toolchain can be currently built for Linux (x64/arm32/arm64), mac
 
 Once you build the repo, you can use the produced binaries in one of four ways specified below ("Using built binaries", "Building packages", "Convenience Visual Studio "repro" project", "Running tests").
 
+### Cross-compiling
+
+The native AOT compiler is a cross-compiler, however the default clr.aot subset passed to build[.cmd|.sh] will only build a flavor that can target the architecture of ILC itself. To build other codegen backends and enable crossbuilding, replace `clr.aot` with `clr.aot+clr.alljits` in the build script invocation.
+
 ### Using built binaries
 
 In this workflow, you have a project file that you want to `dotnet publish`, but you want to use your own build of the compiler/runtime/framework. You need to be using a daily build of the .NET SDK downloaded from the dotnet/sdk repo. It's typically enough to just download the daily build ZIP file, unpack it, and make sure the unpacked directory is the first thing in your PATH. Don't forget to add a NuGet.config as specified by the dotnet/sdk repo- you'll hit restore issues otherwise.

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -121,7 +121,7 @@
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(RuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 
-    <DefaultNativeAotSubsets>clr.alljits+clr.tools+clr.nativeaotlibs+clr.nativeaotruntime</DefaultNativeAotSubsets>
+    <DefaultNativeAotSubsets>clr.jit+clr.tools+clr.nativeaotlibs+clr.nativeaotruntime</DefaultNativeAotSubsets>
 
     <_MonoAotCrossSubsets Condition="'$(MonoCrossAOTTargetOS)' != ''">mono.aotcross</_MonoAotCrossSubsets>
 

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -216,7 +216,7 @@
     <SubsetName Include="Clr.ILTools" Description="The CoreCLR IL tools (ilasm/ildasm)." />
     <SubsetName Include="Clr.Runtime" Description="The CoreCLR .NET runtime. Includes clr.jit, clr.iltools, clr.hosts." />
     <SubsetName Include="Clr.Native" Description="All CoreCLR native non-test components, including the runtime, jits, and other native tools. Includes clr.hosts, clr.runtime, clr.jit, clr.alljits, clr.paltests, clr.iltools, clr.nativeaotruntime, clr.spmi." />
-    <SubsetName Include="Clr.Aot" Description="Everything needed for Native AOT workloads, including clr.alljits, clr.tools, clr.nativeaotlibs, and clr.nativeaotruntime" />
+    <SubsetName Include="Clr.Aot" Description="Everything needed for Native AOT workloads, including clr.jit, clr.tools, clr.nativeaotlibs, and clr.nativeaotruntime" />
     <SubsetName Include="Clr.NativeAotLibs" Description="The CoreCLR native AOT CoreLib and other low level class libraries." />
     <SubsetName Include="Clr.NativeAotRuntime" Description="The stripped-down CoreCLR native AOT runtime." />
     <SubsetName Include="Clr.CrossArchTools" Description="The cross-targeted CoreCLR tools." />


### PR DESCRIPTION
After #131666 we should be able to get away with clr.jit. If one needs to crossbuild, they'll need to add clr.alljits, but that's not a mainstream scenario. Should shave the same number of minutes as what is in #131666.