### PR TITLE
Mark ProcessArchitecture as NonVersionable

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Runtime.InteropServices
 {
     public static partial class RuntimeInformation
@@ -26,29 +28,34 @@ namespace System.Runtime.InteropServices
         public static bool IsOSPlatform(OSPlatform osPlatform) => OperatingSystem.IsOSPlatform(osPlatform.Name);
 
         public static Architecture ProcessArchitecture
+        {
+            [NonVersionable]
+            get
+            {
 #if TARGET_X86
-            => Architecture.X86
+                return Architecture.X86;
 #elif TARGET_AMD64
-            => Architecture.X64
+                return Architecture.X64;
 #elif TARGET_ARMV6
-            => Architecture.Armv6
+                return Architecture.Armv6;
 #elif TARGET_ARM
-            => Architecture.Arm
+                return Architecture.Arm;
 #elif TARGET_ARM64
-            => Architecture.Arm64
+                return Architecture.Arm64;
 #elif TARGET_WASM
-            => Architecture.Wasm
+                return Architecture.Wasm;
 #elif TARGET_S390X
-            => Architecture.S390x
+                return Architecture.S390x;
 #elif TARGET_LOONGARCH64
-            => Architecture.LoongArch64
+                return Architecture.LoongArch64;
 #elif TARGET_POWERPC64
-            => Architecture.Ppc64le
+                return Architecture.Ppc64le;
 #elif TARGET_RISCV64
-            => Architecture.RiscV64
+                return Architecture.RiscV64;
 #else
 #error Unknown Architecture
 #endif
-        ;
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
@@ -30,32 +30,31 @@ namespace System.Runtime.InteropServices
         public static Architecture ProcessArchitecture
         {
             [NonVersionable]
-            get
-            {
+            get =>
 #if TARGET_X86
-                return Architecture.X86;
+                Architecture.X86
 #elif TARGET_AMD64
-                return Architecture.X64;
+                Architecture.X64
 #elif TARGET_ARMV6
-                return Architecture.Armv6;
+                Architecture.Armv6
 #elif TARGET_ARM
-                return Architecture.Arm;
+                Architecture.Arm
 #elif TARGET_ARM64
-                return Architecture.Arm64;
+                Architecture.Arm64
 #elif TARGET_WASM
-                return Architecture.Wasm;
+                Architecture.Wasm
 #elif TARGET_S390X
-                return Architecture.S390x;
+                Architecture.S390x
 #elif TARGET_LOONGARCH64
-                return Architecture.LoongArch64;
+                Architecture.LoongArch64
 #elif TARGET_POWERPC64
-                return Architecture.Ppc64le;
+                Architecture.Ppc64le
 #elif TARGET_RISCV64
-                return Architecture.RiscV64;
+                Architecture.RiscV64
 #else
 #error Unknown Architecture
 #endif
-            }
+            ;
         }
     }
 }


### PR DESCRIPTION
## Summary

- mark `RuntimeInformation.ProcessArchitecture` getter as `NonVersionable`
- allow ReadyToRun cross-module inlining to fold architecture-specific branches

## Testing

- compiled the modified source for every `TARGET_*` architecture branch
- verified `NonVersionableAttribute` is emitted on the getter

Fixes #129949