### PR TITLE
Remove unnecessary NoWarn for CS9368

### DIFF
--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -41,8 +41,6 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
     <NoWarn>$(NoWarn),0419,0649</NoWarn>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <Nullable>enable</Nullable>
     <Features>$(Features);runtime-async=on</Features>
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Bcl.Memory/src/Microsoft.Bcl.Memory.csproj
+++ b/src/libraries/Microsoft.Bcl.Memory/src/Microsoft.Bcl.Memory.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.1;netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <DefineConstants>$(DefineConstants);MICROSOFT_BCL_MEMORY</DefineConstants>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides Base64Url, Utf8, Index, and Range types support for .NET Framework and .NET Standard.</PackageDescription>

--- a/src/libraries/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.csproj
+++ b/src/libraries/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Memory/src/System.Memory.csproj
+++ b/src/libraries/System.Memory/src/System.Memory.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <ContractTypesPartiallyMoved>true</ContractTypesPartiallyMoved>
     <!-- ArrayBufferWriter is publicly exposed from the System.Memory ref and only it should define this constant as true.  -->

--- a/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.csproj
+++ b/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>

--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.csproj
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.csproj
@@ -7,8 +7,6 @@
     <!-- disable warnings about obsolete APIs,
         Type has no accessible constructors which use only CLS-compliant types -->
     <NoWarn>$(NoWarn);0809;0618;CS3015</NoWarn>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <StrongNameKeyId>SilverlightPlatform</StrongNameKeyId>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <DefineConstants Condition="'$(WasmEnableThreads)' == 'true'">$(DefineConstants);FEATURE_WASM_MANAGED_THREADS</DefineConstants>

--- a/src/libraries/System.Reflection.Emit.Lightweight/ref/System.Reflection.Emit.Lightweight.csproj
+++ b/src/libraries/System.Reflection.Emit.Lightweight/ref/System.Reflection.Emit.Lightweight.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.csproj
@@ -4,8 +4,6 @@
          to its own obsolete API. -->
     <!-- Nullability of parameter 'name' doesn't match overridden member -->
     <NoWarn>$(NoWarn);618;CS8765</NoWarn>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <Features>$(Features);updated-memory-safety-rules</Features>

--- a/src/libraries/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
+++ b/src/libraries/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <ContractTypesPartiallyMoved>true</ContractTypesPartiallyMoved>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.csproj
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <Features>$(Features);updated-memory-safety-rules</Features>
   </PropertyGroup>

--- a/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.csproj
+++ b/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Runtime/ref/System.Runtime.csproj
+++ b/src/libraries/System.Runtime/ref/System.Runtime.csproj
@@ -6,8 +6,6 @@
     <!-- disable warnings about obsolete APIs,
         Type has no accessible constructors which use only CLS-compliant types -->
     <NoWarn>$(NoWarn);0809;0618;CS3015</NoWarn>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <Features>$(Features);updated-memory-safety-rules</Features>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>

--- a/src/libraries/System.Text.Encoding.Extensions/ref/System.Text.Encoding.Extensions.csproj
+++ b/src/libraries/System.Text.Encoding.Extensions/ref/System.Text.Encoding.Extensions.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.csproj
+++ b/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Threading.ThreadPool.WebAssembly.Threading/ref/System.Threading.ThreadPool.WebAssembly.Threading.csproj
+++ b/src/libraries/System.Threading.ThreadPool.WebAssembly.Threading/ref/System.Threading.ThreadPool.WebAssembly.Threading.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <AssemblyName>System.Threading.ThreadPool</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <!-- tell references.targets to bump the assembly file version -->
     <IsExperimentalRefAssembly>true</IsExperimentalRefAssembly>

--- a/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.csproj
+++ b/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -32,8 +32,6 @@
     <ExcludeMscorlibFacade>true</ExcludeMscorlibFacade>
     <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
     <NoWarn>$(NoWarn),0419,0649</NoWarn>
-    <!-- https://github.com/dotnet/dotnet/issues/5640 -->
-    <NoWarn>$(NoWarn);CS9368</NoWarn>
     <Nullable>enable</Nullable>
 
     <!-- Ignore all previous constants since SPCL is sensitive to what is defined and the Sdk adds some by default -->


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/126409.

The CS9368 warning is not reported by roslyn since https://github.com/dotnet/roslyn/pull/83295.