### PR TITLE
forbid cache entry size changes after it's disposed

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheEntryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheEntryExtensions.cs
@@ -136,6 +136,11 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <param name="entry">The <see cref="ICacheEntry"/>.</param>
         /// <param name="size">The size to set on the <paramref name="entry"/>.</param>
         /// <returns>The <see cref="ICacheEntry"/> for chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is negative.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// The <paramref name="entry"/> has already been disposed and its implementation does not allow the
+        /// size to change afterwards.
+        /// </exception>
         public static ICacheEntry SetSize(
             this ICacheEntry entry,
             long size)
@@ -155,6 +160,10 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <param name="entry">The <see cref="ICacheEntry"/>.</param>
         /// <param name="options">Set the values of these options on the <paramref name="entry"/>.</param>
         /// <returns>The <see cref="ICacheEntry"/> for chaining.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The <paramref name="entry"/> has already been disposed and its implementation does not allow
+        /// <see cref="ICacheEntry.Size"/> to change afterwards.
+        /// </exception>
         public static ICacheEntry SetOptions(this ICacheEntry entry, MemoryCacheEntryOptions options)
         {
             ArgumentNullException.ThrowIfNull(options);

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheEntryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheEntryExtensions.cs
@@ -168,11 +168,13 @@ namespace Microsoft.Extensions.Caching.Memory
         {
             ArgumentNullException.ThrowIfNull(options);
 
+            // Apply Size first because some implementations reject it after disposal. If that happens,
+            // none of the other options should have been changed.
+            entry.Size = options.Size;
             entry.AbsoluteExpiration = options.AbsoluteExpiration;
             entry.AbsoluteExpirationRelativeToNow = options.AbsoluteExpirationRelativeToNow;
             entry.SlidingExpiration = options.SlidingExpiration;
             entry.Priority = options.Priority;
-            entry.Size = options.Size;
 
             if (options.ExpirationTokensDirect is { } expirationTokens)
             {

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/ICacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/ICacheEntry.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Caching.Memory
 {
     /// <summary>
     /// Represents an entry in the <see cref="IMemoryCache"/> implementation.
-    /// When Disposed, is committed to the cache.
+    /// When disposed, the entry is committed to the cache if a <see cref="Value"/> has been set.
     /// </summary>
     public interface ICacheEntry : IDisposable
     {

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/ICacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/ICacheEntry.cs
@@ -58,6 +58,13 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <summary>
         /// Gets or set the size of the cache entry value.
         /// </summary>
+        /// <remarks>
+        /// The size is used by <see cref="IMemoryCache"/> implementations that enforce a size limit, and is
+        /// read both when the entry is added to the cache and when it is removed from it. Implementations
+        /// are therefore free to reject a change made after the entry has been disposed; <c>MemoryCache</c>
+        /// throws an <see cref="InvalidOperationException"/> in that case, whether or not the entry was
+        /// ultimately committed to the cache.
+        /// </remarks>
         long? Size { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -151,6 +151,8 @@ namespace Microsoft.Extensions.Caching.Memory
 
         internal long Size => _size;
 
+        internal bool IsDisposed => _isDisposed;
+
         long? ICacheEntry.Size
         {
             get => _size < 0 ? null : _size;
@@ -159,6 +161,11 @@ namespace Microsoft.Extensions.Caching.Memory
                 if (value < 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(value)} must be non-negative.");
+                }
+
+                if (_isDisposed)
+                {
+                    throw new InvalidOperationException(SR.Format(SR.CacheEntrySetAfterDispose, nameof(ICacheEntry.Size)));
                 }
 
                 _size = value ?? NotSet;

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -122,6 +122,11 @@ namespace Microsoft.Extensions.Caching.Memory
 
         internal void SetEntry(CacheEntry entry)
         {
+            // Size accounting adds entry.Size here and subtracts it again on removal, so the entry must
+            // already be frozen against further size changes by the time it gets here. CacheEntry.Dispose
+            // sets _isDisposed before calling in, which is what makes those two reads agree.
+            Debug.Assert(entry.IsDisposed, "Entry must be disposed before it is committed to the cache.");
+
             if (_disposed)
             {
                 // No-op instead of throwing since this is called during CacheEntry.Dispose

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/Resources/Strings.resx
@@ -121,6 +121,6 @@
     <value>Cache entry must specify a value for {0} when {1} is set.</value>
   </data>
   <data name="CacheEntrySetAfterDispose" xml:space="preserve">
-    <value>The value of {0} cannot be changed after the cache entry has been disposed. Disposing a cache entry commits it to the cache.</value>
+    <value>The value of {0} cannot be changed after the cache entry has been disposed. Set {0} before disposing the entry.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/Resources/Strings.resx
@@ -120,4 +120,7 @@
   <data name="CacheEntryHasEmptySize" xml:space="preserve">
     <value>Cache entry must specify a value for {0} when {1} is set.</value>
   </data>
+  <data name="CacheEntrySetAfterDispose" xml:space="preserve">
+    <value>The value of {0} cannot be changed after the cache entry has been disposed. Disposing a cache entry commits it to the cache.</value>
+  </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -40,6 +40,82 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData(10L)]
+        public void SettingSizeAfterEntryIsDisposedThrows(long? sizeLimit)
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = sizeLimit });
+
+            ICacheEntry cacheEntry = cache.CreateEntry("key");
+            cacheEntry.Size = 5;
+            cacheEntry.Value = "value";
+            cacheEntry.Dispose();
+
+            Assert.Throws<InvalidOperationException>(() => { cacheEntry.Size = 6; });
+            Assert.Throws<InvalidOperationException>(() => { cacheEntry.SetSize(6); });
+            Assert.Throws<InvalidOperationException>(() => { cacheEntry.Size = null; });
+            Assert.Throws<InvalidOperationException>(() => cacheEntry.SetOptions(new MemoryCacheEntryOptions { Size = 6 }));
+            Assert.Equal(5L, cacheEntry.Size);
+        }
+
+        [Fact]
+        public void SettingSizeAfterEntryIsDisposedValidatesArgumentBeforeState()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
+
+            ICacheEntry cacheEntry = cache.CreateEntry("key");
+            cacheEntry.Size = 5;
+            cacheEntry.Value = "value";
+            cacheEntry.Dispose();
+
+            // A negative size is reported as an argument problem whichever route is used, so the property
+            // and the SetSize extension agree rather than differing on which check runs first.
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cacheEntry.Size = -1; });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { cacheEntry.SetSize(-1); });
+        }
+
+        [Fact]
+        public void SettingSizeAfterEntryIsDisposedWithoutValueThrows()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
+
+            // Disposing without setting Value never commits the entry, but the size is frozen regardless.
+            ICacheEntry cacheEntry = cache.CreateEntry("key");
+            cacheEntry.Size = 5;
+            cacheEntry.Dispose();
+
+            Assert.Throws<InvalidOperationException>(() => { cacheEntry.Size = 6; });
+            Assert.Equal(0, cache.Count);
+            AssertCacheSize(0, cache);
+        }
+
+        [Fact]
+        public void SettingSizeAfterEntryIsDisposedDoesNotSkewCacheSize()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
+
+            ICacheEntry cacheEntry = cache.CreateEntry("key");
+            cacheEntry.Size = 4;
+            cacheEntry.Value = "value";
+            cacheEntry.Dispose();
+
+            AssertCacheSize(4, cache);
+
+            Assert.Throws<InvalidOperationException>(() => { cacheEntry.Size = 2; });
+            AssertCacheSize(4, cache);
+
+            cache.Remove("key");
+            AssertCacheSize(0, cache);
+
+            // The cache is not latched: an entry needing the whole limit is still admitted, which a skewed
+            // total would have refused.
+            cache.Set("key2", "value2", new MemoryCacheEntryOptions { Size = 10 });
+
+            Assert.Equal("value2", cache.Get("key2"));
+            AssertCacheSize(10, cache);
+        }
+
         [Fact]
         public void CacheWithSizeLimitAddingEntryWithoutSizeThrows()
         {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -60,6 +60,99 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        public void SettingOptionsAfterEntryIsDisposedDoesNotChangeOtherOptions()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
+
+            ICacheEntry cacheEntry = cache.CreateEntry("key");
+            cacheEntry.AbsoluteExpiration = DateTimeOffset.MaxValue;
+            cacheEntry.SlidingExpiration = TimeSpan.FromMinutes(5);
+            cacheEntry.Priority = CacheItemPriority.NeverRemove;
+            cacheEntry.Size = 5;
+            cacheEntry.Value = "value";
+            cacheEntry.Dispose();
+
+            DateTimeOffset? absoluteExpiration = cacheEntry.AbsoluteExpiration;
+            TimeSpan? absoluteExpirationRelativeToNow = cacheEntry.AbsoluteExpirationRelativeToNow;
+            TimeSpan? slidingExpiration = cacheEntry.SlidingExpiration;
+            CacheItemPriority priority = cacheEntry.Priority;
+
+            var replacementOptions = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpiration = DateTimeOffset.MaxValue.AddDays(-1),
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(2),
+                SlidingExpiration = TimeSpan.FromMinutes(1),
+                Priority = CacheItemPriority.Low,
+                Size = 6,
+            };
+
+            Assert.Throws<InvalidOperationException>(() => cacheEntry.SetOptions(replacementOptions));
+            Assert.Equal(absoluteExpiration, cacheEntry.AbsoluteExpiration);
+            Assert.Equal(absoluteExpirationRelativeToNow, cacheEntry.AbsoluteExpirationRelativeToNow);
+            Assert.Equal(slidingExpiration, cacheEntry.SlidingExpiration);
+            Assert.Equal(priority, cacheEntry.Priority);
+            Assert.Equal(5L, cacheEntry.Size);
+        }
+
+        [Fact]
+        public void SettingSizeCapturedByGetOrCreateAfterEntryIsDisposedThrows()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
+            ICacheEntry? capturedEntry = null;
+
+            string? value = cache.GetOrCreate("key", entry =>
+            {
+                capturedEntry = entry;
+                entry.Size = 4;
+                return "value";
+            });
+
+            Assert.Equal("value", value);
+
+            ICacheEntry cacheEntry = Assert.IsAssignableFrom<ICacheEntry>(capturedEntry);
+            Assert.Throws<InvalidOperationException>(() => { cacheEntry.Size = 2; });
+            AssertCacheSize(4, cache);
+
+            cache.Remove("key");
+            AssertCacheSize(0, cache);
+        }
+
+        [Fact]
+        public void SettingSizeAfterNestedGetOrCreateWithLinkedTrackingThrows()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions
+            {
+                SizeLimit = 10,
+                TrackLinkedCacheEntries = true,
+            });
+            ICacheEntry? capturedEntry = null;
+
+            string? value = cache.GetOrCreate("outer", outerEntry =>
+            {
+                outerEntry.Size = 4;
+                return cache.GetOrCreate("inner", innerEntry =>
+                {
+                    capturedEntry = innerEntry;
+                    innerEntry.Size = 3;
+                    return "value";
+                });
+            });
+
+            Assert.Equal("value", value);
+            Assert.Equal("value", cache.Get("outer"));
+            Assert.Equal("value", cache.Get("inner"));
+
+            ICacheEntry cacheEntry = Assert.IsAssignableFrom<ICacheEntry>(capturedEntry);
+            Assert.Throws<InvalidOperationException>(() => { cacheEntry.Size = 2; });
+            AssertCacheSize(7, cache);
+
+            cache.Remove("inner");
+            AssertCacheSize(4, cache);
+            cache.Remove("outer");
+            AssertCacheSize(0, cache);
+        }
+
+        [Fact]
         public void SettingSizeAfterEntryIsDisposedValidatesArgumentBeforeState()
         {
             var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });


### PR DESCRIPTION
Fixes #88733

## Problem

`MemoryCache` maintains its total size incrementally: it adds `entry.Size` when an entry is committed and subtracts it when the entry is removed. `ICacheEntry.Size` stayed writable after disposal, so those two reads could return different values, and the difference is never reconciled. The total drifts permanently, per mutation.

It is easy to hit by accident. `GetOrCreate` disposes the entry in a `using` block, so a size written from a continuation or callback lands after the cache has already counted it.

## Fix

`ICacheEntry.Size` now throws `InvalidOperationException` once the entry has been disposed, per the triage conclusion in the issue.

Disposal is the trigger rather than commitment because `CacheEntry.Dispose` sets `_isDisposed` before calling `MemoryCache.SetEntry`, the only commit path. The flag is therefore strictly earlier than every size read the cache makes, so freezing there is a conservative superset of the danger window. A `Debug.Assert` in `SetEntry` pins that invariant against future refactors. It also removes an existing hazard in the admission CAS loop, which re-read `entry.Size` on each of up to 100 iterations and could validate one value while committing another.

## Migration

Compute the size before creating the entry, or use `GetOrCreateAsync` so the factory is awaited and the size is known before the entry is committed.

## Breaking change

Behavioural break on a shipping public API: code that previously corrupted the cache silently now throws. Breaking-change doc not yet filed.
