### PR TITLE
fix: free buffer on ferror in mono_seq_point_data_read

### DIFF
--- a/src/mono/mono/metadata/seq-points-data.c
+++ b/src/mono/mono/metadata/seq-points-data.c
@@ -412,6 +412,7 @@ mono_seq_point_data_read (SeqPointData *data, char *path)
 	size_t len = fread(buffer_orig, fsize, 1, f);
 	if (ferror(f)) {
 		fclose(f);
+		g_free (buffer);
 		return FALSE;
 	}
 	g_assert (len == fsize || (len < GLONG_TO_ULONG(fsize) && feof(f)));


### PR DESCRIPTION
The function mono_seq_point_data_read leaked memory when an error occurred during fread: the buffer allocated via monoeg_malloc was not freed if ferror(f) returned true. Repeated failures could accumulate and lead to OOM, potentially causing a crash.

Solution: add a call to g_free(buffer) before returning FALSE when ferror(f) is detected.

Found by Linux Verification Center (linuxtesting.org) with SVACE.
    Signed-off-by: Artem Semenov <savoptik@altlinux.org>.