### PR TITLE
Remove cDAC fallback testing mode

### DIFF
--- a/eng/pipelines/diagnostics/sos-test-leg.yml
+++ b/eng/pipelines/diagnostics/sos-test-leg.yml
@@ -1,6 +1,6 @@
 # sos-test-leg.yml -- wraps the matrix + job + dep + artifact download +
 # standard postBuildSteps pattern used by the SOS-style test legs (cDAC,
-# cDAC_fallback, cDAC_verify, DAC) that run on windows_x64. Each of those legs
+# cDAC_verify, DAC) that run on windows_x64. Each of those legs
 # only differs in its `name` and `dacMode` value.
 #
 # AzDO tasks workaround:

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -3,8 +3,8 @@
 # Pipeline overview:
 #
 #   SOSTests           windows_x64 Release. One shared coreclr+libs build (-c Debug
-#                      -rc release -lc release -clrinterpreter) consumed by 4 SOS
-#                      legs that run on top of it: cDAC, cDAC_fallback, cDAC_verify, DAC.
+#                      -rc release -lc release -clrinterpreter) consumed by 3 SOS
+#                      legs that run on top of it: cDAC, cDAC_verify, DAC.
 #                      Each leg sets testInterpreter: true so interpreter coverage
 #                      is exercised inline (no separate Interpreter leg).
 #
@@ -177,13 +177,8 @@ extends:
           name: cDAC
           dacMode: cdac
 
-      # cDAC_fallback / cDAC_verify: the in-box DAC hosts the cDAC contract reader, with per-API fallback
-      # to the legacy DAC (fallback) or no fallback but still verifying against it (verify).
-      - template: /eng/pipelines/diagnostics/sos-test-leg.yml
-        parameters:
-          name: cDAC_fallback
-          dacMode: cdacfallback
-
+      # cDAC_verify: the in-box DAC hosts the cDAC contract reader without fallback,
+      # while still verifying against the legacy DAC.
       - template: /eng/pipelines/diagnostics/sos-test-leg.yml
         parameters:
           name: cDAC_verify

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/LegacyFallbackHelper.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/LegacyFallbackHelper.cs
@@ -11,15 +11,12 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 
 /// <summary>
 /// Controls whether delegation-only APIs can fall back to the legacy DAC implementation.
-/// When <c>CDAC_NO_FALLBACK=1</c> is set, only explicitly allowlisted methods may delegate.
+/// Only explicitly allowlisted methods may delegate.
 /// All fallback attempts are logged to stderr for capture by the test infrastructure.
 /// </summary>
 internal static class LegacyFallbackHelper
 {
-    private static readonly bool s_noFallback =
-        Environment.GetEnvironmentVariable("CDAC_NO_FALLBACK") == "1";
-
-    // Methods that are allowed to fall back even in no-fallback mode.
+    // Methods that are allowed to fall back.
     // Use the method name as it appears via [CallerMemberName].
     private static readonly HashSet<string> s_allowlist = new(StringComparer.Ordinal)
     {
@@ -36,8 +33,7 @@ internal static class LegacyFallbackHelper
 
     /// <summary>
     /// Returns <c>true</c> if the calling method is allowed to delegate to the legacy DAC.
-    /// In normal mode (no <c>CDAC_NO_FALLBACK</c>), always returns <c>true</c>.
-    /// In no-fallback mode, returns <c>true</c> only for allowlisted methods.
+    /// Returns <c>true</c> only for allowlisted methods.
     /// All fallback attempts (allowed and blocked) are logged to stderr.
     /// </summary>
     internal static bool CanFallback(
@@ -45,9 +41,6 @@ internal static class LegacyFallbackHelper
         [CallerFilePath] string file = "",
         [CallerLineNumber] int line = 0)
     {
-        if (!s_noFallback)
-            return true;
-
         if (s_allowlist.Contains(name) || s_fileAllowlist.Contains(Path.GetFileName(file)))
         {
             Console.Error.WriteLine($"[cDAC] Allowed fallback: {name} at {Path.GetFileName(file)}:{line}");


### PR DESCRIPTION
Once https://github.com/dotnet/diagnostics/pull/5972 merges, cDac verify mode should be a strictly stronger testing mode that includes all the same test coverage. No need to run both verify and fallback modes separately.