### PR TITLE
JIT: check LIR unused values in the post-phase checks

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -247,8 +247,6 @@ void CodeGen::genCodeForBlock(BasicBlock* block)
     JITDUMPEXEC(block->dspBlockHeader(true, true));
     JITDUMPEXEC(m_compiler->fgDispBBLiveness(block));
 
-    assert(LIR::AsRange(block).CheckLIR(m_compiler));
-
     // Figure out which registers hold variables on entry to this block
 
     regSet.ClearMaskVars();

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4930,6 +4930,8 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     }
 #endif
 
+    INDEBUG(activePhaseChecks |= PhaseChecks::CHECK_LIR_UNUSED_VALUES);
+
     // rationalize trees
     Rationalizer rat(this); // PHASE_RATIONALIZE
     rat.Run();
@@ -5003,6 +5005,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     // Now that lowering is completed we can proceed to perform register allocation
     //
+    // LSRA may insert nodes without users to model register saves/restores.
+    //
+    INDEBUG(activePhaseChecks &= ~PhaseChecks::CHECK_LIR_UNUSED_VALUES);
+
     auto regAllocPhase = [this] {
         m_regAlloc->doRegisterAllocation();
     };

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4930,7 +4930,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     }
 #endif
 
-    INDEBUG(activePhaseChecks |= PhaseChecks::CHECK_LIR_UNUSED_VALUES);
+    activePhaseChecks |= PhaseChecks::CHECK_LIR_UNUSED_VALUES;
 
     // rationalize trees
     Rationalizer rat(this); // PHASE_RATIONALIZE
@@ -5007,7 +5007,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     // LSRA may insert nodes without users to model register saves/restores.
     //
-    INDEBUG(activePhaseChecks &= ~PhaseChecks::CHECK_LIR_UNUSED_VALUES);
+    activePhaseChecks &= ~PhaseChecks::CHECK_LIR_UNUSED_VALUES;
 
     auto regAllocPhase = [this] {
         m_regAlloc->doRegisterAllocation();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1517,8 +1517,9 @@ enum class PhaseChecks : unsigned int
     CHECK_LIKELIHOODS   = 1 << 5, // profile data likelihood integrity
     CHECK_PROFILE       = 1 << 6, // profile data full integrity
     CHECK_PROFILE_FLAGS = 1 << 7, // blocks with profile-derived weights have BBF_PROF_WEIGHT flag set
-    CHECK_LINKED_LOCALS = 1 << 8, // check linked list of locals
-    CHECK_FG_INIT_BLOCK = 1 << 9, // flow graph has an init block
+    CHECK_LINKED_LOCALS = 1 << 8,  // check linked list of locals
+    CHECK_FG_INIT_BLOCK = 1 << 9,  // flow graph has an init block
+    CHECK_LIR_UNUSED_VALUES = 1 << 10, // LIR values with no user are marked as unused
 };
 
 inline constexpr PhaseChecks operator ~(PhaseChecks a)

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -106,8 +106,6 @@ void DecomposeLongs::DecomposeRangeHelper()
     {
         node = DecomposeNode(node);
     }
-
-    assert(Range().CheckLIR(m_compiler, true));
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3678,12 +3678,6 @@ void Compiler::fgDebugCheckFlagsHelper(GenTree* tree, GenTreeFlags actualFlags, 
 //
 void Compiler::fgDebugCheckNodeLinks(BasicBlock* block, Statement* stmt)
 {
-    // LIR blocks are checked using BasicBlock::CheckLIR().
-    if (block->IsLIR())
-    {
-        LIR::AsRange(block).CheckLIR(this);
-        // TODO: return?
-    }
 
     assert(fgNodeThreading != NodeThreading::None);
 
@@ -3940,7 +3934,7 @@ void Compiler::fgDebugCheckLinks(bool morphTrees)
     {
         if (block->IsLIR())
         {
-            LIR::AsRange(block).CheckLIR(this);
+            LIR::AsRange(block).CheckLIR(this, hasFlag(activePhaseChecks, PhaseChecks::CHECK_LIR_UNUSED_VALUES));
         }
         else
         {

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4853,14 +4853,6 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication /* = false */, bool isPh
             fgDispHandlerTab();
         }
 
-        if (compRationalIRForm)
-        {
-            for (BasicBlock* const block : Blocks())
-            {
-                LIR::AsRange(block).CheckLIR(this);
-            }
-        }
-
         fgVerifyHandlerTab();
         // Make sure that the predecessor lists are accurate
         fgDebugCheckBBlist();

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -9638,7 +9638,6 @@ bool Lowering::CheckBlock(Compiler* compiler, BasicBlock* block)
         CheckNode(compiler, node);
     }
 
-    assert(blockRange.CheckLIR(compiler, true));
     return true;
 }
 #endif

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -2471,8 +2471,6 @@ PhaseStatus Rationalizer::DoPhase()
         }
 
         block->SetFirstStmt(nullptr);
-
-        assert(BlockRange().CheckLIR(m_compiler, true));
     }
 
     m_compiler->compRationalIRForm = true;


### PR DESCRIPTION
CheckLIR's checkUnusedValues checking was only done by direct calls from Rationalizer, DecomposeLongs and Lowering, while the post-phase checks ran it without. Meanwhile codegen, fgUpdateFlowGraph and fgDebugCheckNodeLinks called CheckLIR again with checking that the post-phase checks already do.

Add CHECK_LIR_UNUSED_VALUES, enabled from rationalization until register allocation, and have fgDebugCheckLinks pass it on to CheckLIR. All six direct CheckLIR calls can then go away.

The check cannot stay on for LSRA since it inserts nodes without users to model register saves/restores.

Throughput on benchmarks.run for the checked JIT: -6.03% instructions retired, -5.59% wall clock.