### PR TITLE
JIT: remove duplicate fgDebugCheckLinks calls

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -6807,10 +6807,6 @@ PhaseStatus Compiler::optAssertionPropMain()
         return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
     }
 
-#ifdef DEBUG
-    fgDebugCheckLinks();
-#endif
-
     // Allocate the bits for the predicate sensitive dataflow analysis
     bbJtrueAssertionOut    = optInitAssertionDataflowFlags();
     ASSERT_TP* jumpDestGen = optComputeAssertionGen();

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4601,10 +4601,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         DoPhase(this, PHASE_COMPUTE_DOMINATORS, &Compiler::fgComputeDominators);
     }
 
-#ifdef DEBUG
-    fgDebugCheckLinks();
-#endif
-
     // Decide the kind of code we want to generate. Done here, after the second
     // round of empty-EH removal above, so that EH eliminated post-morph doesn't
     // force fully-interruptible codegen / a frame pointer.

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1419,10 +1419,6 @@ PhaseStatus LinearScan::doRegisterAllocation()
 
     DBEXEC(VERBOSE, TupleStyleDump(LSRA_DUMP_POST));
 
-#ifdef DEBUG
-    m_compiler->fgDebugCheckLinks();
-#endif
-
     m_compiler->compRegAllocDone = true;
 
     // If edge resolution didn't create new blocks,

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -1086,8 +1086,6 @@ void Compiler::optValnumCSE_InitDataFlow()
         }
     }
 
-    fgDebugCheckLinks();
-
 #endif // DEBUG
 }
 


### PR DESCRIPTION
Phase::PostPhase already runs fgDebugCheckLinks after every phase that reports changes, so the four direct calls only repeat that work:

- LSRA calls it at the end of doRegisterAllocation, and the post-phase check for PHASE_LINEAR_SCAN then runs it again on the same IR
- compCompile calls it between two phases
- optAssertionPropMain and optValnumCSE_InitDataFlow call it mid-phase

Detection is unchanged; only the attribution gets coarser, in that corruption introduced mid-phase is now reported at the end of the phase.

Phase::PostPhase is now the only caller.

Throughput on benchmarks.run for the checked JIT: -4.35% instructions retired, -2.4% wall clock.