### PR TITLE
Handle transient file system errors during active polling

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -842,25 +842,25 @@ namespace Microsoft.Extensions.FileProviders.Physical
             {
                 IPollingChangeToken token = item.Key;
 
-                if (!token.HasChanged)
-                {
-                    continue;
-                }
-
-                if (!changeTokens.TryRemove(token, out _))
-                {
-                    // Move on if we couldn't remove the item.
-                    continue;
-                }
-
-                // We're already on a background thread, don't need to spawn a background Task to cancel the CTS
+                // This runs on a timer callback, so an exception escaping here is unhandled and takes the process down.
                 try
                 {
+                    if (!token.HasChanged)
+                    {
+                        continue;
+                    }
+
+                    if (!changeTokens.TryRemove(token, out _))
+                    {
+                        // Move on if we couldn't remove the item.
+                        continue;
+                    }
+
+                    // We're already on a background thread, don't need to spawn a background Task to cancel the CTS
                     token.CancellationTokenSource!.Cancel();
                 }
                 catch
                 {
-
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -842,21 +842,33 @@ namespace Microsoft.Extensions.FileProviders.Physical
             {
                 IPollingChangeToken token = item.Key;
 
-                // This runs on a timer callback, so an exception escaping here is unhandled and takes the process down.
+                // This runs on a timer callback, so an unexpected exception escaping here is unhandled
+                // and takes the process down. Only expected file system failures are contained below.
+                bool hasChanged;
                 try
                 {
-                    if (!token.HasChanged)
-                    {
-                        continue;
-                    }
+                    hasChanged = token.HasChanged;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
+                {
+                    // Leave the token registered so that it is polled again after the file system recovers.
+                    continue;
+                }
 
-                    if (!changeTokens.TryRemove(token, out _))
-                    {
-                        // Move on if we couldn't remove the item.
-                        continue;
-                    }
+                if (!hasChanged)
+                {
+                    continue;
+                }
 
-                    // We're already on a background thread, don't need to spawn a background Task to cancel the CTS
+                if (!changeTokens.TryRemove(token, out _))
+                {
+                    // Move on if we couldn't remove the item.
+                    continue;
+                }
+
+                // We're already on a background thread, don't need to spawn a background Task to cancel the CTS
+                try
+                {
                     token.CancellationTokenSource!.Cancel();
                 }
                 catch

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Security;
 using System.Threading;
 using Microsoft.Extensions.Primitives;
 
@@ -46,23 +47,31 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         private DateTime GetLastWriteTimeUtc()
         {
-            _fileInfo.Refresh();
-
-            if (_fileInfo.Exists)
+            try
             {
-                return FileSystemInfoHelper.GetFileLinkTargetLastWriteTimeUtc(_fileInfo) ?? _fileInfo.LastWriteTimeUtc;
+                _fileInfo.Refresh();
+
+                if (_fileInfo.Exists)
+                {
+                    return FileSystemInfoHelper.GetFileLinkTargetLastWriteTimeUtc(_fileInfo) ?? _fileInfo.LastWriteTimeUtc;
+                }
+
+                // This is not thread-safe, but that's not an issue since DirectoryInfos are cheap and interchangeable.
+                _directoryInfo ??= new DirectoryInfo(_fileInfo.FullName);
+                _directoryInfo.Refresh();
+
+                if (_directoryInfo.Exists)
+                {
+                    return _directoryInfo.LastWriteTimeUtc;
+                }
+
+                return DateTime.MinValue;
             }
-
-            // This is not thread-safe, but that's not an issue since DirectoryInfos are cheap and interchangeable.
-            _directoryInfo ??= new DirectoryInfo(_fileInfo.FullName);
-            _directoryInfo.Refresh();
-
-            if (_directoryInfo.Exists)
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
             {
-                return _directoryInfo.LastWriteTimeUtc;
+                // Treat a transient file system failure as no change and retry on the next poll.
+                return _previousWriteTimeUtc;
             }
-
-            return DateTime.MinValue;
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingWildCardChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingWildCardChangeToken.cs
@@ -115,10 +115,53 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         private bool CalculateChanges()
         {
-            PatternMatchingResult result;
             try
             {
-                result = _matcher.Execute(_directoryInfo);
+                PatternMatchingResult result = _matcher.Execute(_directoryInfo);
+                IOrderedEnumerable<FilePatternMatch> files = result.Files.OrderBy(f => f.Path, StringComparer.Ordinal);
+                using (var sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256))
+                {
+                    foreach (FilePatternMatch file in files)
+                    {
+                        DateTime lastWriteTimeUtc = GetLastWriteUtc(file.Path);
+                        if (_previousHash is not null && _lastScanTimeUtc < lastWriteTimeUtc)
+                        {
+                            // _lastScanTimeUtc is the greatest timestamp that any last writes could have been.
+                            // If a file has a newer timestamp than this value, it must've changed.
+                            // A non-null hash means a scan completed, so there is something to compare against.
+                            return true;
+                        }
+
+                        ComputeHash(sha256, file.Path, lastWriteTimeUtc);
+                    }
+
+#if NET
+                    Span<byte> currentHash = stackalloc byte[256 / 8];
+                    sha256.GetHashAndReset(currentHash);
+                    if (_previousHash is null)
+                    {
+                        _previousHash = currentHash.ToArray(); // First run
+                    }
+                    else if (!_previousHash.AsSpan().SequenceEqual(currentHash))
+                    {
+                        return true;
+                    }
+#else
+                    byte[] currentHash = sha256.GetHashAndReset();
+                    if (_previousHash is null)
+                    {
+                        _previousHash = currentHash; // First run
+                    }
+                    else if (!_previousHash.AsSpan().SequenceEqual(currentHash.AsSpan()))
+                    {
+                        return true;
+                    }
+#endif
+
+                    _lastScanTimeUtc = Clock.UtcNow;
+                }
+
+                return false;
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
             {
@@ -127,51 +170,6 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 _lastScanTimeUtc = Clock.UtcNow;
                 return false;
             }
-
-            IOrderedEnumerable<FilePatternMatch> files = result.Files.OrderBy(f => f.Path, StringComparer.Ordinal);
-            using (var sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256))
-            {
-                foreach (FilePatternMatch file in files)
-                {
-                    DateTime lastWriteTimeUtc = GetLastWriteUtc(file.Path);
-                    if (_previousHash is not null && _lastScanTimeUtc < lastWriteTimeUtc)
-                    {
-                        // _lastScanTimeUtc is the greatest timestamp that any last writes could have been.
-                        // If a file has a newer timestamp than this value, it must've changed.
-                        // A non-null hash means a scan completed, so there is something to compare against.
-                        return true;
-                    }
-
-                    ComputeHash(sha256, file.Path, lastWriteTimeUtc);
-                }
-
-#if NET
-                Span<byte> currentHash = stackalloc byte[256 / 8];
-                sha256.GetHashAndReset(currentHash);
-                if (_previousHash is null)
-                {
-                    _previousHash = currentHash.ToArray(); // First run
-                }
-                else if (!_previousHash.AsSpan().SequenceEqual(currentHash))
-                {
-                    return true;
-                }
-#else
-                byte[] currentHash = sha256.GetHashAndReset();
-                if (_previousHash is null)
-                {
-                    _previousHash = currentHash; // First run
-                }
-                else if (!_previousHash.AsSpan().SequenceEqual(currentHash.AsSpan()))
-                {
-                    return true;
-                }
-#endif
-
-                _lastScanTimeUtc = Clock.UtcNow;
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingWildCardChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingWildCardChangeToken.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Security.Cryptography;
 using System.Threading;
 using Microsoft.Extensions.FileSystemGlobbing;
@@ -114,7 +115,18 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
         private bool CalculateChanges()
         {
-            PatternMatchingResult result = _matcher.Execute(_directoryInfo);
+            PatternMatchingResult result;
+            try
+            {
+                result = _matcher.Execute(_directoryInfo);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
+            {
+                // The directory couldn't be scanned, for example because a network share went down or
+                // the directory became inaccessible. Report no change and try again on the next poll.
+                _lastScanTimeUtc = Clock.UtcNow;
+                return false;
+            }
 
             IOrderedEnumerable<FilePatternMatch> files = result.Files.OrderBy(f => f.Path, StringComparer.Ordinal);
             using (var sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256))
@@ -122,10 +134,11 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 foreach (FilePatternMatch file in files)
                 {
                     DateTime lastWriteTimeUtc = GetLastWriteUtc(file.Path);
-                    if (_lastScanTimeUtc.Ticks != 0 && _lastScanTimeUtc < lastWriteTimeUtc)
+                    if (_previousHash is not null && _lastScanTimeUtc < lastWriteTimeUtc)
                     {
                         // _lastScanTimeUtc is the greatest timestamp that any last writes could have been.
                         // If a file has a newer timestamp than this value, it must've changed.
+                        // A non-null hash means a scan completed, so there is something to compare against.
                         return true;
                     }
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFilesWatcherTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFilesWatcherTests.cs
@@ -408,6 +408,34 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
 
             // The token that failed stays registered so it is polled again and can recover.
             Assert.Equal(new[] { token1 }, tokens.Keys.OfType<TestPollingChangeToken>());
+
+            token1.PollingException = null;
+            token1.HasChanged = true;
+            PhysicalFilesWatcher.RaiseChangeEvents(tokens);
+
+            Assert.True(cts1.IsCancellationRequested);
+            Assert.Empty(tokens);
+        }
+
+        [Fact]
+        public void RaiseChangeEvents_PropagatesUnexpectedPollingException()
+        {
+            // Arrange
+            var cts = new CancellationTokenSource();
+            var token = new TestPollingChangeToken
+            {
+                PollingException = new InvalidOperationException(),
+                CancellationTokenSource = cts,
+            };
+            var tokens = new ConcurrentDictionary<IPollingChangeToken, IPollingChangeToken>
+            {
+                [token] = token,
+            };
+
+            // Act and assert
+            Assert.Throws<InvalidOperationException>(() => PhysicalFilesWatcher.RaiseChangeEvents(tokens));
+            Assert.Contains(token, tokens.Keys);
+            Assert.False(cts.IsCancellationRequested);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFilesWatcherTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFilesWatcherTests.cs
@@ -384,6 +384,33 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
         }
 
         [Fact]
+        public void RaiseChangeEvents_KeepsPollingRemainingTokens_WhenATokenFailsToPoll()
+        {
+            // Arrange
+            var cts1 = new CancellationTokenSource();
+            var cts2 = new CancellationTokenSource();
+
+            var token1 = new TestPollingChangeToken { Id = 1, PollingException = new IOException("Host is down"), CancellationTokenSource = cts1 };
+            var token2 = new TestPollingChangeToken { Id = 2, HasChanged = true, CancellationTokenSource = cts2 };
+
+            var tokens = new ConcurrentDictionary<IPollingChangeToken, IPollingChangeToken>
+            {
+                [token1] = token1,
+                [token2] = token2,
+            };
+
+            // Act
+            PhysicalFilesWatcher.RaiseChangeEvents(tokens);
+
+            // Assert
+            Assert.False(cts1.IsCancellationRequested);
+            Assert.True(cts2.IsCancellationRequested);
+
+            // The token that failed stays registered so it is polled again and can recover.
+            Assert.Equal(new[] { token1 }, tokens.Keys.OfType<TestPollingChangeToken>());
+        }
+
+        [Fact]
         [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS, "System.IO.FileSystem.Watcher is not supported on Browser/iOS/tvOS")]
         public void GetOrAddFilePathChangeToken_AddsPollingChangeTokenWithCancellationToken_WhenActiveCallbackIsTrue()
         {
@@ -964,11 +991,20 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
 
         private class TestPollingChangeToken : IPollingChangeToken
         {
+            private bool _hasChanged;
+
             public int Id { get; set; }
 
             public CancellationTokenSource CancellationTokenSource { get; set; }
 
-            public bool HasChanged { get; set; }
+            // When set, polling the token fails with this exception.
+            public Exception PollingException { get; set; }
+
+            public bool HasChanged
+            {
+                get => PollingException is null ? _hasChanged : throw PollingException;
+                set => _hasChanged = value;
+            }
 
             public bool ActiveChangeCallbacks => throw new NotImplementedException();
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PollingWildCardChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PollingWildCardChangeTokenTest.cs
@@ -215,6 +215,46 @@ namespace Microsoft.Extensions.FileProviders.Physical
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [MemberData(nameof(DirectoryScanFailures))]
+        public void HasChanged_ReturnsFalseIfFileTimestampCannotBeRead(Exception exception)
+        {
+            // Arrange
+            var filePath = "1.txt";
+            var directoryInfo = new Mock<DirectoryInfoBase>();
+            directoryInfo.Setup(d => d.EnumerateFileSystemInfos())
+                .Returns(new[] { CreateFile(filePath) });
+            var clock = new TestClock();
+            var token = new TestablePollingWildCardChangeToken(directoryInfo.Object, "**/*.txt", clock);
+            int initialReadCount = token.LastWriteCount;
+            token.LastWriteException = exception;
+
+            // Act - 1
+            clock.Increment();
+            var result1 = token.HasChanged;
+
+            // Assert - 1
+            Assert.False(result1);
+            Assert.Equal(initialReadCount + 1, token.LastWriteCount);
+
+            // Act - 2: the polling interval is still honored while the failure persists.
+            var result2 = token.HasChanged;
+
+            // Assert - 2
+            Assert.False(result2);
+            Assert.Equal(initialReadCount + 1, token.LastWriteCount);
+
+            // Act - 3: timestamp reads recover and changes made during the failure are detected.
+            token.LastWriteException = null;
+            token.FileTimestampLookup[filePath] = clock.UtcNow.AddMilliseconds(1);
+            clock.Increment();
+            var result3 = token.HasChanged;
+
+            // Assert - 3
+            Assert.True(result3);
+        }
+
+        // Moq heavily utilizes RefEmit, which does not work on most aot workloads
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void HasChanged_ReturnsTrueIfFilesChangedWhileTheDirectoryCouldNotBeScanned()
         {
@@ -293,8 +333,18 @@ namespace Microsoft.Extensions.FileProviders.Physical
             public Dictionary<string, DateTime> FileTimestampLookup { get; } =
                 new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
 
+            public Exception LastWriteException { get; set; }
+
+            public int LastWriteCount { get; private set; }
+
             protected override DateTime GetLastWriteUtc(string path)
             {
+                LastWriteCount++;
+                if (LastWriteException is not null)
+                {
+                    throw LastWriteException;
+                }
+
                 DateTime value;
                 if (!FileTimestampLookup.TryGetValue(path, out value))
                 {

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PollingWildCardChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PollingWildCardChangeTokenTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
 using Microsoft.Extensions.FileProviders.Physical.Internal;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Moq;
@@ -171,6 +172,102 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
             // Assert - 2
             Assert.True(result2);
+        }
+
+        public static TheoryData<Exception> DirectoryScanFailures => new TheoryData<Exception>
+        {
+            new IOException("Host is down"),
+            new UnauthorizedAccessException(),
+            new SecurityException(),
+        };
+
+        // Moq heavily utilizes RefEmit, which does not work on most aot workloads
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [MemberData(nameof(DirectoryScanFailures))]
+        public void HasChanged_ReturnsFalseIfTheDirectoryCannotBeScanned(Exception exception)
+        {
+            // Arrange
+            var directoryInfo = new Mock<DirectoryInfoBase>();
+            directoryInfo.Setup(d => d.EnumerateFileSystemInfos())
+                .Returns(new[] { CreateFile("1.txt") });
+            var clock = new TestClock();
+            var token = new TestablePollingWildCardChangeToken(directoryInfo.Object, "**/*.txt", clock);
+
+            var scanCount = 0;
+            directoryInfo.Setup(d => d.EnumerateFileSystemInfos())
+                .Callback(() => scanCount++)
+                .Throws(exception);
+
+            // Act - 1
+            clock.Increment();
+            var result1 = token.HasChanged;
+
+            // Assert - 1
+            Assert.False(result1);
+            Assert.Equal(1, scanCount);
+
+            // Act - 2: the polling interval is still honored while the failure persists.
+            var result2 = token.HasChanged;
+
+            // Assert - 2
+            Assert.False(result2);
+            Assert.Equal(1, scanCount);
+        }
+
+        // Moq heavily utilizes RefEmit, which does not work on most aot workloads
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        public void HasChanged_ReturnsTrueIfFilesChangedWhileTheDirectoryCouldNotBeScanned()
+        {
+            // Arrange
+            var filePath1 = "1.txt";
+            var filePath2 = "2.txt";
+            var directoryInfo = new Mock<DirectoryInfoBase>();
+            directoryInfo.Setup(d => d.EnumerateFileSystemInfos())
+                .Returns(new[] { CreateFile(filePath1) });
+            var clock = new TestClock();
+            var token = new TestablePollingWildCardChangeToken(directoryInfo.Object, "**/*.txt", clock);
+
+            // Act - 1
+            directoryInfo.Setup(d => d.EnumerateFileSystemInfos())
+                .Throws(new IOException("Host is down"));
+            clock.Increment();
+            var result1 = token.HasChanged;
+
+            // Assert - 1
+            Assert.False(result1);
+
+            // Act - 2: the directory can be scanned again and a file was added in the meantime.
+            directoryInfo.Setup(d => d.EnumerateFileSystemInfos())
+                .Returns(new[] { CreateFile(filePath1), CreateFile(filePath2) });
+            clock.Increment();
+            var result2 = token.HasChanged;
+
+            // Assert - 2
+            Assert.True(result2);
+        }
+
+        // Moq heavily utilizes RefEmit, which does not work on most aot workloads
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        public void HasChanged_ReturnsFalseOnTheFirstScanThatSucceedsIfTheDirectoryCouldNotBeScannedWhenCreated()
+        {
+            // Arrange
+            var filePath = "1.txt";
+            var directoryInfo = new Mock<DirectoryInfoBase>();
+            directoryInfo.Setup(d => d.EnumerateFileSystemInfos())
+                .Throws(new IOException("Host is down"));
+            var clock = new TestClock();
+            var token = new TestablePollingWildCardChangeToken(directoryInfo.Object, "**/*.txt", clock);
+
+            // Act: the directory can be scanned again. Its files are seen for the first time and carry a
+            // timestamp later than the failed scan, but without a baseline that isn't a change.
+            directoryInfo.Setup(d => d.EnumerateFileSystemInfos())
+                .Returns(new[] { CreateFile(filePath) });
+            token.FileTimestampLookup[filePath] = clock.UtcNow.AddMilliseconds(1);
+            clock.Increment();
+            var result = token.HasChanged;
+
+            // Assert
+            Assert.False(result);
         }
 
         private static FileInfoBase CreateFile(string filePath)


### PR DESCRIPTION
Fixes #95631.

Active polling could terminate the process when a wildcard scan of an unavailable file system threw from the timer callback. A failure during token re-registration could also silently lose the watch.

This change:

- isolates each token poll so failures neither escape the timer callback nor prevent other tokens from being processed;
- treats expected directory-scan failures as no change, retaining the last successful hash so changes during an outage are detected after recovery;
- requires an existing baseline hash before using the timestamp fast path, preventing a false notification after an initial failed scan.