### PR TITLE
Fix profiler nongcheap test with GC segments on 64 bit

### DIFF
--- a/src/tests/profiler/native/nongcheap/nongcheap.cpp
+++ b/src/tests/profiler/native/nongcheap/nongcheap.cpp
@@ -91,7 +91,7 @@ HRESULT NonGcHeapProfiler::GarbageCollectionFinished()
 
     std::vector<uint64_t> segment_starts;
     std::vector<uint64_t> segment_ends;
-    const int MAX_SEGMENTS = 16;
+    const int MAX_SEGMENTS = 256;
     COR_PRF_NONGC_HEAP_RANGE nongc_segments[MAX_SEGMENTS];
     COR_PRF_GC_GENERATION_RANGE gc_segments[MAX_SEGMENTS];
     ULONG segCount;


### PR DESCRIPTION
The test has hardcoded limit of 16 segments, but with GC in segments mode, there are 80 segments. This change fixes the test by raising the hardcoded limit to 256.

Contributes to #131449