### PR TITLE
JIT: remove duplicate node uniqueness check

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3948,7 +3948,6 @@ void Compiler::fgDebugCheckLinks(bool morphTrees)
         }
     }
 
-    fgDebugCheckNodesUniqueness();
     fgDebugCheckSsa();
 }
 


### PR DESCRIPTION
Phase::PostPhase runs fgDebugCheckNodesUniqueness under CHECK_UNIQUE and then fgDebugCheckLinks under CHECK_IR, which ran it a second time. CHECK_UNIQUE is enabled before importation and CHECK_IR only after morph, so CHECK_IR is never active without CHECK_UNIQUE and the inner call is always redundant.

Checked JIT instructions retired:

```
  benchmarks.run                -5.82%
  benchmarks.run_pgo            -5.57%
  benchmarks.run_pgo_optrepeat  -5.82%
  libraries.pmi                 -5.54%
```

benchmarks.run replay wall clock: 67.38s -> 65.11s (-3.37%).