### PR TITLE
JIT: turn MEASURE_NOWAY off by default

### DIFF
--- a/src/coreclr/jit/error.h
+++ b/src/coreclr/jit/error.h
@@ -83,12 +83,11 @@ extern void ANALYZER_NORETURN noWayAssertBodyConditional(const char* cond, const
 // Define MEASURE_NOWAY to 1 to enable code to count and rank individual noway_assert calls by occurrence.
 // These asserts would be dynamically executed, but not necessarily fail. The provides some insight into
 // the dynamic prevalence of these (if not a direct measure of their cost), which exist in non-DEBUG as
-// well as DEBUG builds.
-#ifdef DEBUG
-#define MEASURE_NOWAY 1
-#else // !DEBUG
+// well as DEBUG builds. This is off by default, including in DEBUG builds, to avoid bloating every
+// noway_assert.
+#ifndef MEASURE_NOWAY
 #define MEASURE_NOWAY 0
-#endif // !DEBUG
+#endif // !MEASURE_NOWAY
 
 #if MEASURE_NOWAY
 extern void RecordNowayAssertGlobal(const char* filename, unsigned line, const char* condStr);

--- a/src/coreclr/jit/error.h
+++ b/src/coreclr/jit/error.h
@@ -81,13 +81,13 @@ extern void ANALYZER_NORETURN noWayAssertBodyConditional();
 extern void ANALYZER_NORETURN noWayAssertBodyConditional(const char* cond, const char* file, unsigned line);
 
 // Define MEASURE_NOWAY to 1 to enable code to count and rank individual noway_assert calls by occurrence.
-// These asserts would be dynamically executed, but not necessarily fail. The provides some insight into
+// These asserts would be dynamically executed, but not necessarily fail. This provides some insight into
 // the dynamic prevalence of these (if not a direct measure of their cost), which exist in non-DEBUG as
 // well as DEBUG builds. This is off by default, including in DEBUG builds, to avoid bloating every
 // noway_assert.
 #ifndef MEASURE_NOWAY
 #define MEASURE_NOWAY 0
-#endif // !MEASURE_NOWAY
+#endif // !defined(MEASURE_NOWAY)
 
 #if MEASURE_NOWAY
 extern void RecordNowayAssertGlobal(const char* filename, unsigned line, const char* condStr);

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -659,10 +659,10 @@ RELEASE_CONFIG_STRING(TailCallOpt, "TailCallOpt")
 // If set, allow fast tail calls; otherwise allow only helper-based calls for explicit tail calls.
 RELEASE_CONFIG_INTEGER(FastTailCalls, "FastTailCalls", 1)
 
-// Set to 1 to measure noway_assert usage. Only valid if MEASURE_NOWAY is defined.
+// Set to 1 to measure noway_assert usage. Only valid if MEASURE_NOWAY is defined to 1.
 RELEASE_CONFIG_INTEGER(JitMeasureNowayAssert, "JitMeasureNowayAssert", 0)
 
-// Set to file to write noway_assert usage to a file (if not set: stdout). Only valid if MEASURE_NOWAY is defined.
+// Set to file to write noway_assert usage to a file (if not set: stdout). Only valid if MEASURE_NOWAY is defined to 1.
 RELEASE_CONFIG_STRING(JitMeasureNowayAssertFile, "JitMeasureNowayAssertFile")
 
 CONFIG_INTEGER(EnableExtraSuperPmiQueries, "EnableExtraSuperPmiQueries", 0) // Make extra queries to somewhat


### PR DESCRIPTION
MEASURE_NOWAY was enabled in every DEBUG build, expanding every noway_assert to an unconditional out-of-line RecordNowayAssertGlobal call that immediately returns because JitMeasureNowayAssert defaults to 0. Require it to be defined to 1 manually when measuring instead.

Checked JIT instructions retired:

  benchmarks.run                -3.75%
  benchmarks.run_pgo            -3.65%
  benchmarks.run_pgo_optrepeat  -3.75%
  libraries.pmi                 -3.63%

benchmarks.run replay wall clock: 67.38s -> 65.59s (-2.66%).