### PR TITLE
[release/10.0] Fix transition from monomorphic to polymorphic VSD

### DIFF
--- a/src/coreclr/vm/arm/stubs.cpp
+++ b/src/coreclr/vm/arm/stubs.cpp
@@ -862,8 +862,10 @@ void ResolveHolder::Initialize(ResolveHolder* pResolveHolderRX,
 
     // ResolveStub._failEntryPoint(r0:MethodToken, r1, r2, r3, r4:IndirectionCellAndFlags)
     // {
-    //     if(--*(this._pCounter) < 0) r4 = r4 | SDF_ResolveBackPatch;
-    //     this._resolveEntryPoint(r0, r1, r2, r3, r4);
+    //     if (--*(this._pCounter) >= 0)
+    //         return this._resolveEntryPoint(r0, r1, r2, r3, r4);
+    //     r4 = r4 | SDF_ResolveBackPatch;
+    //     return this._slowEntryPoint(r0, r1, r2, r3, r4);
     // }
 
     // The following macro relies on this entry point being DWORD-aligned. We've already asserted that the
@@ -899,23 +901,26 @@ void ResolveHolder::Initialize(ResolveHolder* pResolveHolderRX,
     // pop {r5}
     _stub._failEntryPoint[n++] = 0xbc20;
 
-    // bge resolveEntryPoint
-    _stub._failEntryPoint[n++] = 0xda01;
+    // bge resolveEntryPointBranch
+    _stub._failEntryPoint[n++] = 0xda02;
 
     // or r4, r4, SDF_ResolveBackPatch
     _ASSERTE(SDF_ResolveBackPatch < 256);
     _stub._failEntryPoint[n++] = 0xf044;
     _stub._failEntryPoint[n++] = 0x0400 | SDF_ResolveBackPatch;
 
-    // resolveEntryPoint:
+    // b _slowEntryPoint
+    offset = (WORD)(offsetof(ResolveStub, _slowEntryPoint) - (offsetof(ResolveStub, _failEntryPoint) + sizeof(*ResolveStub::_failEntryPoint) * (n + 2)));
+    _ASSERTE((offset & 1) == 0);
+    offset = (offset >> 1) & 0x07ff;
+    _stub._failEntryPoint[n++] = 0xe000 | offset;
+
+    // resolveEntryPointBranch:
     // b _resolveEntryPoint
     offset = (WORD)(offsetof(ResolveStub, _resolveEntryPoint) - (offsetof(ResolveStub, _failEntryPoint) + sizeof(*ResolveStub::_failEntryPoint) * (n + 2)));
     _ASSERTE((offset & 1) == 0);
     offset = (offset >> 1) & 0x07ff;
     _stub._failEntryPoint[n++] = 0xe000 | offset;
-
-    // nop for alignment
-    _stub._failEntryPoint[n++] = 0xbf00;
 
     _ASSERTE(n == ResolveStub::failEntryPointLen);
 

--- a/src/coreclr/vm/arm64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/arm64/virtualcallstubcpu.hpp
@@ -344,8 +344,10 @@ struct ResolveHolder
          _ASSERTE(n == ResolveStub::slowEntryPointLen);
          // ResolveStub._failEntryPoint(x0:MethodToken, x1,.., x7 and x8, x11:IndirectionCellAndFlags)
          // {
-         //     if(--*(this._pCounter) < 0) x11 = x11 | SDF_ResolveBackPatch;
-         //     this._resolveEntryPoint(x0, [x1..x7 and x8]);
+         //     if (--*(this._pCounter) >= 0)
+         //         return this._resolveEntryPoint(x0, [x1..x7 and x8]);
+         //     x11 = x11 | SDF_ResolveBackPatch;
+         //     return this._slowEntryPoint(x0, [x1..x7 and x8]);
          // }
 
 #undef PC_REL_OFFSET //NOTE Offset can be negative
@@ -379,8 +381,10 @@ struct ResolveHolder
          _ASSERTE(SDF_ResolveBackPatch == 0x1);
          _stub._failEntryPoint[n++] = 0xB240016B;
 
-         //;;b resolveEntryPoint:
-         offset = PC_REL_OFFSET(_resolveEntryPoint);
+         // Force the slow path to observe SDF_ResolveBackPatch. A hit in the
+         // inline resolve cache branches directly to the target without
+         // processing the flag.
+         offset = PC_REL_OFFSET(_slowEntryPoint);
          _stub._failEntryPoint[n++] = 0x14000000 | ((offset>>2) & 0x3FFFFFF);
 
          _ASSERTE(n == ResolveStub::failEntryPointLen);

--- a/src/coreclr/vm/loongarch64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/loongarch64/virtualcallstubcpu.hpp
@@ -302,8 +302,10 @@ struct ResolveHolder
 
         // ResolveStub._failEntryPoint(a0:MethodToken, a1,.., a7, t8:IndirectionCellAndFlags)
         // {
-        //     if(--*(this._pCounter) < 0) t8 = t8 | SDF_ResolveBackPatch;
-        //     this._resolveEntryPoint(a0, [a1..a7]);
+        //     if (--*(this._pCounter) >= 0)
+        //         return this._resolveEntryPoint(a0, [a1..a7]);
+        //     t8 = t8 | SDF_ResolveBackPatch;
+        //     return this._slowEntryPoint(a0, [a1..a7]);
         // }
 //#undef PC_REL_OFFSET
 //#define PC_REL_OFFSET(_member, _index) (((INT32)(offsetof(ResolveStub, _member) - (offsetof(ResolveStub, _failEntryPoint[_index])))) & 0xffff)
@@ -324,16 +326,16 @@ struct ResolveHolder
         _stub._failEntryPoint[4] = 0x298001b5;
 
         _ASSERTE(SDF_ResolveBackPatch == 0x1);
-        // ;; ori $t8,$t8, $r21 >=0 ? SDF_ResolveBackPatch:0;
+        // ;; $r21 = $r21 < 0 ? SDF_ResolveBackPatch : 0;
         // 	slti $r21,$r21,0
         _stub._failEntryPoint[5] = 0x020002b5;
-        // 	xori $r21,$r21,1
-        _stub._failEntryPoint[6] = 0x03c006b5;
+        // 	beq  $r21,$r0,_resolveEntryPoint
+        _stub._failEntryPoint[6] = 0x5bff92a0;
         // 	or  $t8,$t8,$r21
         _stub._failEntryPoint[7] = 0x00155694;
 
-        // 	b	_resolveEntryPoint   //pc-120=pc+4 -resolveEntryPointLen*4 -slowEntryPointLen*4 -failEntryPointLen*4;
-        _stub._failEntryPoint[8] = 0x53ff8bff;
+        // 	b	_slowEntryPoint
+        _stub._failEntryPoint[8] = 0x53ffd3ff;
 
         _ASSERTE(9 == ResolveStub::failEntryPointLen);
          _stub._pCounter = counterAddr;

--- a/src/coreclr/vm/riscv64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/riscv64/virtualcallstubcpu.hpp
@@ -306,8 +306,10 @@ struct ResolveHolder
 
         // ResolveStub._failEntryPoint(a0:MethodToken, a1,.., a7, t5:IndirectionCellAndFlags)
         // {
-        //     if(--*(this._pCounter) < 0) t5 = t5 | SDF_ResolveBackPatch;
-        //     this._resolveEntryPoint(a0, [a1..a7]);
+        //     if (--*(this._pCounter) >= 0)
+        //         return this._resolveEntryPoint(a0, [a1..a7]);
+        //     t5 = t5 | SDF_ResolveBackPatch;
+        //     return this._slowEntryPoint(a0, [a1..a7]);
         // }
 //#undef PC_REL_OFFSET
 //#define PC_REL_OFFSET(_member, _index) (((INT32)(offsetof(ResolveStub, _member) - (offsetof(ResolveStub, _failEntryPoint[_index])))) & 0xffff)
@@ -328,16 +330,16 @@ struct ResolveHolder
         _stub._failEntryPoint[4] = 0x01f32023;
 
         static_assert_no_msg(SDF_ResolveBackPatch == 0x1);
-        // ;; ori t5, t5, t6 >=0 ? SDF_ResolveBackPatch:0;
+        // ;; t6 = t6 < 0 ? SDF_ResolveBackPatch : 0;
         // 	slti t6, t6, 0
         _stub._failEntryPoint[5] = 0x000faf93;
-        // 	xori t6, t6, 1
-        _stub._failEntryPoint[6] = 0x001fcf93;
+        // 	beq t6, x0, _resolveEntryPoint
+        _stub._failEntryPoint[6] = 0xf80f84e3;
         // 	or  t5, t5, t6
         _stub._failEntryPoint[7] = 0x01ff6f33;
 
-        // 	j	_resolveEntryPoint   // pc - 128 = pc + 4 - resolveEntryPointLen * 4 - slowEntryPointLen * 4 - failEntryPointLen * 4;
-        _stub._failEntryPoint[8] = 0xf81ff06f;
+        // 	j	_slowEntryPoint
+        _stub._failEntryPoint[8] = 0xfd1ff06f;
 
         static_assert_no_msg(9 == ResolveStub::failEntryPointLen);
         _stub._pCounter = counterAddr;


### PR DESCRIPTION
Manual backport of #132544 to `release/10.0`.

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Perf issue on arm64 on many core machines.

## Regression

- [ ] Yes
- [x] No

Arm64 VSD implementation has diverged from x64 for a long time, and was able to get trapped in a continually mispredicting mode. The shared misprediction counter writes were causing a high amount of cache coherence overhead, seriously limiting scaling.

## Testing

Verified with user app on 32 core Arm64 HW (via manual patch on top of 10.0.11).

## Risk

Low. Arm64 (and other arches) now use exact same logic as x64.
