### PR TITLE
[release/10.0] JIT: only imply non-null assertions from exact-type assertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5852,7 +5852,8 @@ void Compiler::optImpliedByTypeOfAssertions(ASSERT_TP& activeAssertions)
 
             // impAssertion must be a Non Null assertion on lclNum
             if ((impAssertion->assertionKind != OAK_NOT_EQUAL) || (impAssertion->op1.kind != O1K_LCLVAR) ||
-                (impAssertion->op2.kind != O2K_CONST_INT) || (impAssertion->op1.vn != chkAssertion->op1.vn))
+                (impAssertion->op2.kind != O2K_CONST_INT) || (impAssertion->op2.u1.iconVal != 0) ||
+                (impAssertion->op1.vn != chkAssertion->op1.vn))
             {
                 continue;
             }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_132599/Runtime_132599.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_132599/Runtime_132599.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// optImpliedByTypeOfAssertions() treated *any* "lcl != <const>" assertion as a non-null
+// assertion, because it never checked that the constant was 0. The exact-type assertion
+// produced by the guarded devirtualization check on Type.Equals ("t is RuntimeType")
+// therefore activated the unrelated "t != typeof(Row)" assertion inside the devirtualized
+// block itself, and assertion prop folded the comparison to "not equal". Count() below
+// then stopped incrementing once the method reached tier-1/OSR.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Runtime_132599;
+
+public class Row
+{
+}
+
+public abstract class Holder
+{
+    public abstract Type Get();
+}
+
+public sealed class ObjHolder : Holder
+{
+    private readonly object _o;
+
+    public ObjHolder(object o) => _o = o;
+
+    // Guarded-devirtualized and inlined. The return spill temp loses the "exactly
+    // RuntimeType" class info, so the Type.Equals call below needs a guarded
+    // devirtualization of its own, which is what produces the exact-type assertion.
+    public override Type Get() => _o.GetType();
+}
+
+public class Runtime_132599
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Count(Holder h, int n)
+    {
+        int c = 0;
+        for (int i = 0; i < n; i++)
+        {
+            if (h.Get().Equals(typeof(Row)))
+            {
+                c++;
+            }
+        }
+        return c;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        // The loop has to be long enough for the method to tier up via OSR while it runs.
+        const int N = 1_000_000;
+
+        Holder h = new ObjHolder(new Row());
+        int actual = Count(h, N);
+
+        Assert.Equal(N, actual);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_132599/Runtime_132599.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_132599/Runtime_132599.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <CLRTestPriority>1</CLRTestPriority>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <!-- The issue reproduces only with tiered compilation and PGO enabled -->
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #132599 in release/10.0. There is no PR to backport: `main` is already unaffected because #123856 deleted `optImpliedByTypeOfAssertions` outright as a throughput cleanup, so the bug was fixed there by accident and never flagged for servicing.


## Customer Impact

- [x] Customer reported
- [ ] Found internally

Reported in #132599. Silent wrong code, no exception: enumerating a large OpenXML worksheet returned 0 rows (or a truncated count) once the method tiered up, so the customer's 1,000,000-row import quietly dropped data.

`optImpliedByTypeOfAssertions` treated *any* `lcl != <const>` assertion as a non-null assertion — it only checked `op2.kind == O2K_CONST_INT` and never that the constant was `0`. The exact-type assertion produced by the guarded devirtualization check on `Type.Equals` (`t is RuntimeType`) therefore activated the unrelated `t != typeof(Row)` assertion on the same VN, *inside the devirtualized block itself*. Assertion prop then folded the live comparison to a constant and dropped the matching arm:

```
VN relop based constant assertion prop in BB24:
Assertion index=#09: [002712] != 1230248688 (gcref)
...
Bashed to int constant: CNS_INT int 1
Conditional folded at BB24
BB24 becomes a BBJ_ALWAYS to BB06     <-- 'count++' block now unreachable
```

Any `virtualCall().Equals(typeof(T))` in a hot loop can hit this. Mitigations were `DOTNET_TieredPGO=0` or `DOTNET_JitEnableGuardedDevirtualization=0`.

## Regression

- [ ] Yes
- [x] No

Long-standing: the missing `iconVal == 0` check predates .NET 10. It became reachable in practice as GDV started producing exact-type assertions in more shapes.

## Testing

Added regression test `Runtime_132599`, reduced from the customer report to a self-contained 30-line case

## Risk

Low. The change only narrows an implication to the case the surrounding code already documents ("must be a Non Null assertion"), so it can only remove assertions that were never valid.
