### PR TITLE
Use acquire reads for cast cache entries

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs
@@ -157,29 +157,21 @@ namespace System.Runtime.CompilerServices
                 // we must read in this order: version -> [entry parts] -> version
                 // if version is odd or changes, the entry is inconsistent and thus ignored
                 uint version = Volatile.Read(ref pEntry._version);
-                nuint entrySource = pEntry._source;
+                nuint entrySource = Volatile.Read(ref pEntry._source);
                 // mask the lower version bit to make it even.
                 // This way we can check if version is odd or changing in just one compare.
                 version &= unchecked((uint)~1);
 
                 if (entrySource == source)
                 {
-                    // we do ordinary reads of the entry parts and
-                    // Volatile.ReadBarrier() before reading the version
-                    nuint entryTargetAndResult = pEntry._targetAndResult;
+                    // Acquire reads of both entry parts ensure that the second version
+                    // read happens after the entry has been read.
+                    nuint entryTargetAndResult = Volatile.Read(ref pEntry._targetAndResult);
                     // target never has its lower bit set.
                     // a matching entryTargetAndResult would the have same bits, except for the lowest one, which is the result.
                     entryTargetAndResult ^= target;
                     if (entryTargetAndResult <= 1)
                     {
-                        // make sure the second read of 'version' happens after reading 'source' and 'targetAndResults'
-                        //
-                        // We can either:
-                        // - use acquires for both _source and _targetAndResults or
-                        // - issue a load barrier before reading _version
-                        // benchmarks on available hardware (Jan 2020) show that use of a read barrier is cheaper.
-                        Volatile.ReadBarrier();
-
                         if (version != pEntry._version)
                         {
                             // oh, so close, the entry is in inconsistent state.


### PR DESCRIPTION
Replace the explicit read barrier in `CastCache.TryGet` with acquire reads of the source and target/result fields.

The lookup uses a versioned entry:

1. acquire-read the version;
2. read the source and target/result payload;
3. re-read the version and reject the entry if it changed.

The existing implementation uses ordinary loads followed by `Volatile.ReadBarrier()`. On ARM64 this emits `dmb ishld` in the hot cast-cache lookup path. Making the payload reads acquire operations preserves the required ordering of the final version check without the standalone barrier.

#### ARM64 code generation

The meothod body changes from ordinary loads plus `dmb ishld` to acquire loads. With RCpc available, the relevant sequence is now:

```asm
ldapr   w6, [x5]       // version
ldapur  x7, [x5, #8]   // source
...
ldapur  x7, [x5, #16]  // target/result
...
ldr     w0, [x5]       // final version check
```

There is no `dmb` in the generated method. On x64, volatile reads require no additional hardware instruction.

#### Validation

- `build.cmd -s clr -c Release -arch arm64`
- Tested on a 32 core app running on new Arm64 hw (the `dmb ishld` was a bottleneck)