### PR TITLE
Remove forced inlining from Span<T>.ToArray

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -221,7 +221,7 @@ namespace System.Collections.Immutable
             if (length == 0)
             {
                 // Avoid allocating an array.
-                return Create<T>();
+                return ImmutableArray<T>.Empty;
             }
 
             var array = new T[length];
@@ -247,7 +247,7 @@ namespace System.Collections.Immutable
 
             if (length == 0)
             {
-                return Create<T>();
+                return ImmutableArray<T>.Empty;
             }
 
             if (start == 0 && length == items.Length)
@@ -278,7 +278,7 @@ namespace System.Collections.Immutable
 
             if (length == 0)
             {
-                return Create<TResult>();
+                return ImmutableArray<TResult>.Empty;
             }
 
             var array = new TResult[length];
@@ -312,7 +312,7 @@ namespace System.Collections.Immutable
 
             if (length == 0)
             {
-                return Create<TResult>();
+                return ImmutableArray<TResult>.Empty;
             }
 
             var array = new TResult[length];
@@ -346,7 +346,7 @@ namespace System.Collections.Immutable
 
             if (length == 0)
             {
-                return Create<TResult>();
+                return ImmutableArray<TResult>.Empty;
             }
 
             var array = new TResult[length];
@@ -384,7 +384,7 @@ namespace System.Collections.Immutable
 
             if (length == 0)
             {
-                return Create<TResult>();
+                return ImmutableArray<TResult>.Empty;
             }
 
             var array = new TResult[length];
@@ -403,7 +403,7 @@ namespace System.Collections.Immutable
         /// <returns>A new builder.</returns>
         public static ImmutableArray<T>.Builder CreateBuilder<T>()
         {
-            return Create<T>().ToBuilder();
+            return ImmutableArray<T>.Empty.ToBuilder();
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -434,7 +434,6 @@ namespace System
         /// allocates, so should generally be avoided, however it is sometimes
         /// necessary to bridge the gap with APIs written in terms of arrays.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T[] ToArray()
         {
             if (IsEmpty)


### PR DESCRIPTION
Fixes #119713.

## Summary

`Span<T>.ToArray()` is currently marked with `AggressiveInlining`, while
`ReadOnlySpan<T>.ToArray()` is not.

This change removes the forced-inlining hint from `Span<T>.ToArray()` and
allows the JIT to make its normal profitability decision.

## Rationale

Existing JIT-diff experiments discussed in #119713 evaluated both ways of
making the two implementations consistent.

Adding `AggressiveInlining` to `ReadOnlySpan<T>.ToArray()` resulted in
substantially more code-size churn, including multiple regressions.

By comparison, removing `AggressiveInlining` from `Span<T>.ToArray()` had a
much smaller code-size impact.

Given that `ToArray()` allocates and does not necessarily benefit from being
forcibly inlined at every call site, removing the hint is the more conservative
way to make the implementations consistent.

The runtime behavior of `ToArray()` is unchanged.

## Validation

The code change is limited to removing the `AggressiveInlining` attribute.

The JIT-diff experiments referenced in the issue discussion are:

- MihuBot/runtime-utils#2120
- MihuBot/runtime-utils#2121

Credit to @xtqqczze for running the JIT-diff experiments used to evaluate the
tradeoff.