### PR TITLE
Add security comment to DictionaryWrapper.cs

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Collections/Specialized/DictionaryWrapper.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Collections/Specialized/DictionaryWrapper.cs
@@ -19,6 +19,9 @@ namespace System.Collections.Specialized
             get => _contents[key];
             set
             {
+                // Per .NET's published security baselines, the shape and contents of the environment block are trusted,
+                // and we do not police its shape or contents. That responsibility always lies with the caller. Our check
+                // below is purely hygienic and should not be misconstrued as a primary security mitigation.
                 Validate(nameof(key), key);
                 Validate(nameof(value), value);
 


### PR DESCRIPTION
The logic newly added to `System.Diagnostics.Process` appears to be security-sensitive, but it is not. This deserves a source code clarification.

Ref: https://github.com/dotnet/core/blob/main/Documentation/security-foundations/baseline-security-assumptions.md#22-environment-variables-are-trusted-as-a-control-plane-mechanism