### PR TITLE
Prevent ThreadPool dispatch from finishing an already-completed Task

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2422,7 +2422,22 @@ namespace System.Threading.Tasks
         /// double-invoke; derived internal tasks can override to customize their behavior,
         /// which is usually done by promises that want to reuse the same object as a queued work item.
         /// </summary>
-        internal virtual void ExecuteDirectly(Thread? threadPoolThread) => ExecuteEntryUnsafe(threadPoolThread);
+        internal virtual void ExecuteDirectly(Thread? threadPoolThread)
+        {
+            // ThreadPoolWorkQueue.Enqueue commits the work item before requesting a worker. If worker
+            // creation then fails, ScheduleAndStart may still Finish the task while it remains queued.
+            // When that item is later dequeued, skip execution so we do not Finish / RunContinuations again
+            // (which would throw InvalidCastException on the completion sentinel). See https://github.com/dotnet/runtime/issues/132492
+            //
+            // Only the base Task path is guarded: overrides of ExecuteDirectly (e.g. async state machines)
+            // keep full control. ExecuteEntryUnsafe stays unchecked for LongRunning / TryExecuteTaskInline.
+            if ((m_stateFlags & (int)TaskStateFlags.CompletedMask) != 0)
+            {
+                return;
+            }
+
+            ExecuteEntryUnsafe(threadPoolThread);
+        }
 
         internal void ExecuteEntryUnsafe(Thread? threadPoolThread) // used instead of ExecuteEntry() when we don't have to worry about double-execution prevent
         {

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/TaskScheduler/TaskSchedulerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/TaskScheduler/TaskSchedulerTests.cs
@@ -8,6 +8,7 @@ using System.Security;
 using System.Reflection;
 using System.Collections.Concurrent;
 using System.Linq;
+using Microsoft.DotNet.RemoteExecutor;
 
 namespace System.Threading.Tasks.Tests
 {
@@ -328,6 +329,72 @@ namespace System.Threading.Tasks.Tests
             Assert.Superset(new HashSet<Task>(queuedTasks), new HashSet<Task>(foundTasks));
 
             GC.KeepAlive(nonExecutingScheduler);
+        }
+
+        // Regression for https://github.com/dotnet/runtime/issues/132492:
+        // ScheduleAndStart may Finish a task that remains queued when worker creation fails after enqueue.
+        // ThreadPool dispatch must not execute / Finish that already-completed task again.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public static void AlreadyCompletedQueuedTask_ThreadPoolDispatch_DoesNotDoubleFinish()
+        {
+            if (RemoteExecutor.IsSupported)
+            {
+                // Child process: proves the dispatch path does not tear down the process with InvalidCastException.
+                RemoteExecutor.Invoke(static () => RunAlreadyCompletedQueuedTaskDispatchScenario()).Dispose();
+            }
+            else
+            {
+                RunAlreadyCompletedQueuedTaskDispatchScenario();
+            }
+        }
+
+        private static void RunAlreadyCompletedQueuedTaskDispatchScenario()
+        {
+            int bodyCount = 0;
+            int continuationCount = 0;
+
+            var task = new Task(() => Interlocked.Increment(ref bodyCount));
+            task.ContinueWith(
+                _ => Interlocked.Increment(ref continuationCount),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            try
+            {
+                // Stands in for CreateWorkerThread throwing after Enqueue committed the item:
+                // ScheduleAndStart catches, Finish()es the task (Faulted + continuations), and rethrows.
+                task.Start(new BuggyTaskScheduler());
+                Assert.Fail("Expected TaskSchedulerException from BuggyTaskScheduler.QueueTask");
+            }
+            catch (TaskSchedulerException)
+            {
+            }
+
+            Assert.Equal(TaskStatus.Faulted, task.Status);
+            Assert.True(task.IsCompleted);
+            Assert.Equal(0, Volatile.Read(ref bodyCount));
+            Assert.Equal(1, Volatile.Read(ref continuationCount));
+
+            MethodInfo? enqueue = typeof(ThreadPool).GetMethod(
+                "UnsafeQueueUserWorkItemInternal",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(enqueue);
+
+            // Place the already-completed task on the real ThreadPool queue (same as ThreadPoolTaskScheduler
+            // for non-LongRunning tasks). A genuine worker will DispatchWorkItem -> ExecuteDirectly.
+            enqueue!.Invoke(null, new object[] { task, false });
+
+            // Wait until the pool has processed subsequent work, proving our item was dequeued without crashing.
+            using (var drained = new ManualResetEventSlim(false))
+            {
+                ThreadPool.QueueUserWorkItem(_ => drained.Set());
+                Assert.True(drained.Wait(TimeSpan.FromSeconds(30)), "Timed out waiting for ThreadPool to drain");
+            }
+
+            Assert.Equal(TaskStatus.Faulted, task.Status);
+            Assert.Equal(0, Volatile.Read(ref bodyCount));
+            Assert.Equal(1, Volatile.Read(ref continuationCount));
         }
 
         private static bool DebuggerIsAttached { get { return Debugger.IsAttached; } }


### PR DESCRIPTION
Fixes #132492.

## Production failure
`ThreadPoolWorkQueue.Enqueue` commits the work item, then requests a worker. If `CreateWorkerThread` fails (OOM / thread-start), `Task.ScheduleAndStart` catches, calls `Finish`, and rethrows `TaskSchedulerException`. The task is already **Faulted** but still queued. A later worker dequeues it and `DispatchWorkItem` calls `ExecuteDirectly` → `ExecuteEntryUnsafe` (no completed-state guard). The second `FinishContinuations` exchanges `s_taskCompletionSentinel` for itself and `RunContinuations` throws `InvalidCastException` on a pool thread with no handler. That exception is not catchable at the original `Start` site.

## Why #115659 does not cover this
PR #115659 fixed `InternalRunSynchronously` so `Finish` runs only when `TryRunInline`/queue did **not** already accept the task. `ScheduleAndStart` still always `Finish`es on any `QueueTask` throw, including throws **after** a successful enqueue. Same sentinel class of bug, different entry point.

## Fix (B only)
On **base** `Task.ExecuteDirectly` (the ThreadPool Task dispatch path), return if `CompletedMask` is already set. `ExecuteEntryUnsafe` is unchanged so LongRunning / `TryExecuteTaskInline` keep their existing semantics. Runtime-async types that override `ExecuteDirectly` are unaffected.

This does **not** roll back portable thread-pool worker accounting after create failure (follow-up, not this PR).

## Tests
`AlreadyCompletedQueuedTask_ThreadPoolDispatch_DoesNotDoubleFinish` in `TaskSchedulerTests`: fault via `BuggyTaskScheduler`, enqueue the completed task with `UnsafeQueueUserWorkItemInternal`, assert the process survives, the body does not run, and the continuation does not run a second time. Uses `RemoteExecutor` when available.

## Test results on this machine
- **Passed (unpatched .NET 10.0.11):** issue repro — `TaskSchedulerException` handled, then unhandled `InvalidCastException` in `RunContinuations`, exit `0xE0434352`.
- **Blocked:** in-repo `System.Threading.Tasks.Tests` against this patch. Local testhost has no `coreclr.dll` (`clr.runtime` / native toolchain not available; Windows long paths disabled). CI should run `src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests`.