### PR TITLE
Annotate MemoryCache trimming requirements

### DIFF
--- a/src/libraries/System.Runtime.Caching/ref/System.Runtime.Caching.cs
+++ b/src/libraries/System.Runtime.Caching/ref/System.Runtime.Caching.cs
@@ -105,10 +105,12 @@ namespace System.Runtime.Caching
     }
     public partial class MemoryCache : System.Runtime.Caching.ObjectCache, System.Collections.IEnumerable, System.IDisposable
     {
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Configuration files are not compatible with trimming.")]
         public MemoryCache(string name, System.Collections.Specialized.NameValueCollection config = null) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Configuration files are not compatible with trimming. The warning can be suppressed when ignoreConfigSection is true.")]
         public MemoryCache(string name, System.Collections.Specialized.NameValueCollection config, bool ignoreConfigSection) { }
         public long CacheMemoryLimit { get { throw null; } }
-        public static System.Runtime.Caching.MemoryCache Default { get { throw null; } }
+        public static System.Runtime.Caching.MemoryCache Default { [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Configuration files are not compatible with trimming.")] get { throw null; } }
         public override System.Runtime.Caching.DefaultCacheCapabilities DefaultCacheCapabilities { get { throw null; } }
         public override object this[string key] { get { throw null; } set { } }
         public override string Name { get { throw null; } }

--- a/src/libraries/System.Runtime.Caching/ref/System.Runtime.Caching.csproj
+++ b/src/libraries/System.Runtime.Caching/ref/System.Runtime.Caching.csproj
@@ -10,4 +10,8 @@
   <ItemGroup>
     <Compile Include="System.Runtime.Caching.cs" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
+++ b/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj
@@ -88,6 +88,10 @@ System.Runtime.Caching.ObjectCache</PackageDescription>
     <Compile Include="System\Runtime\Caching\PhysicalMemoryMonitor.Unix.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)System.Configuration.ConfigurationManager\src\System.Configuration.ConfigurationManager.csproj" />
   </ItemGroup>

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -261,6 +261,7 @@ namespace System.Runtime.Caching
 
         public static MemoryCache Default
         {
+            [RequiresUnreferencedCode("Configuration files are not compatible with trimming.")]
             get
             {
                 if (s_defaultCache == null)
@@ -319,6 +320,7 @@ namespace System.Runtime.Caching
             Init(null);
         }
 
+        [RequiresUnreferencedCode("Configuration files are not compatible with trimming.")]
         public MemoryCache(string name, NameValueCollection config = null)
         {
             ArgumentNullException.ThrowIfNull(name);
@@ -337,6 +339,7 @@ namespace System.Runtime.Caching
 
         // ignoreConfigSection is used when redirecting ASP.NET cache into the MemoryCache.  This avoids infinite recursion
         // due to the fact that the (ASP.NET) config system uses the cache, and the cache uses the config system.
+        [RequiresUnreferencedCode("Configuration files are not compatible with trimming. The warning can be suppressed when ignoreConfigSection is true.")]
         public MemoryCache(string name, NameValueCollection config, bool ignoreConfigSection)
         {
             ArgumentNullException.ThrowIfNull(name);

--- a/src/libraries/System.Runtime.Caching/tests/AdditionalCacheTests/AdditionalCacheTests.cs
+++ b/src/libraries/System.Runtime.Caching/tests/AdditionalCacheTests/AdditionalCacheTests.cs
@@ -3,6 +3,7 @@
 
 using Xunit;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Caching;
 
 namespace System.Runtime.Caching.Tests
@@ -11,6 +12,7 @@ namespace System.Runtime.Caching.Tests
     public class AdditionalCacheTests
     {
         [Fact]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The test intentionally exercises MemoryCache, and ILLink.Descriptors.xml roots the configuration constructor required by this scenario.")]
         public void DisposedCacheTest()
         {
             var mc = new MemoryCache("my disposed cache 1");

--- a/src/libraries/System.Runtime.Caching/tests/Common/PokerMemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/tests/Common/PokerMemoryCache.cs
@@ -31,6 +31,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Caching;
 using System.Text;
 
@@ -64,6 +65,7 @@ namespace MonoTests.Common
             }
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The tests intentionally exercise MemoryCache, and ILLink.Descriptors.xml roots the configuration constructor required by these scenarios.")]
         public PokerMemoryCache(string name, NameValueCollection config = null)
             : base(name, config)
         { }

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching.Tests.csproj
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching.Tests.csproj
@@ -21,6 +21,9 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <ProjectReference Include="..\src\System.Runtime.Caching.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Runtime.Caching" />
   </ItemGroup>

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -34,6 +34,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Caching;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,6 +48,7 @@ using Xunit.Abstractions;
 
 namespace MonoTests.System.Runtime.Caching
 {
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The tests intentionally exercise MemoryCache, and ILLink.Descriptors.xml roots the configuration constructor required by these scenarios.")]
     public class MemoryCacheTest
     {
         public static bool SupportsPhysicalMemoryMonitor
@@ -1497,6 +1499,7 @@ namespace MonoTests.System.Runtime.Caching
         }
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The tests intentionally exercise MemoryCache, and ILLink.Descriptors.xml roots the configuration constructor required by these scenarios.")]
     public class MemoryCacheTestExpires4
     {
         public static bool SupportsPhysicalMemoryMonitor => MemoryCacheTest.SupportsPhysicalMemoryMonitor;
@@ -1556,6 +1559,7 @@ namespace MonoTests.System.Runtime.Caching
         }
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "The tests intentionally exercise MemoryCache, and ILLink.Descriptors.xml roots the configuration constructor required by these scenarios.")]
     public class MemoryCacheTestExpires5
     {
         public static bool SupportsPhysicalMemoryMonitor => MemoryCacheTest.SupportsPhysicalMemoryMonitor;


### PR DESCRIPTION
`MemoryCache` reads its optional configuration through `ConfigurationManager`, which is not compatible with trimming. This can currently build without warnings and then fail at runtime in a NativeAOT application.

Annotate both public constructors and the `MemoryCache.Default` accessor with `RequiresUnreferencedCode` so unsupported usage produces IL2026 during build. The three-argument constructor notes that the warning can be suppressed when `ignoreConfigSection` is `true`. The runtime behavior remains unchanged.

The annotations are mirrored in the reference assembly. Existing tests suppress the warning because their linker descriptor preserves the configuration constructor required by those scenarios.

Validated with:

- `dotnet build ./src/System.Runtime.Caching.csproj --no-restore`
- `dotnet build /t:test ./tests/System.Runtime.Caching.Tests.csproj -f net11.0` - 46 tests, 0 failures, 1 existing platform skip
- `dotnet build ./tests/System.Runtime.Caching.Tests.csproj -f net481 --no-restore`
- `dotnet build ./tests/System.Runtime.Caching.Tests.csproj -f net11.0-windows --no-restore`
- A clean NativeAOT consumer build, which now reports the intended IL2026 warning

Fixes #102341
