### PR TITLE
Improve Utf8Parser UInt64 decimal performance

### DIFF
--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
@@ -178,6 +178,8 @@ namespace System.Buffers.Text.Tests
                 yield return new ParserTestData<ulong>("5$", 5, 'D', expectedSuccess: true) { ExpectedBytesConsumed = 1 };
                 yield return new ParserTestData<ulong>("5$", 5, 'x', expectedSuccess: true) { ExpectedBytesConsumed = 1 };
                 yield return new ParserTestData<ulong>("5faaccbb11223344f", 0, 'x', expectedSuccess: false);
+                yield return new ParserTestData<ulong>("00000000000000000000", 0, 'D', expectedSuccess: true);
+                yield return new ParserTestData<ulong>("1234567x901234567890", 1_234_567, 'D', expectedSuccess: true) { ExpectedBytesConsumed = 7 };
             }
         }
 

--- a/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
+++ b/src/libraries/System.Memory/tests/ParsersAndFormatters/Parser/TestData.Parser.Integer.cs
@@ -179,7 +179,10 @@ namespace System.Buffers.Text.Tests
                 yield return new ParserTestData<ulong>("5$", 5, 'x', expectedSuccess: true) { ExpectedBytesConsumed = 1 };
                 yield return new ParserTestData<ulong>("5faaccbb11223344f", 0, 'x', expectedSuccess: false);
                 yield return new ParserTestData<ulong>("00000000000000000000", 0, 'D', expectedSuccess: true);
+                yield return new ParserTestData<ulong>("123x5678901234567890", 123, 'D', expectedSuccess: true) { ExpectedBytesConsumed = 3 };
                 yield return new ParserTestData<ulong>("1234567x901234567890", 1_234_567, 'D', expectedSuccess: true) { ExpectedBytesConsumed = 7 };
+                yield return new ParserTestData<ulong>("12345678901x34567890", 12_345_678_901, 'D', expectedSuccess: true) { ExpectedBytesConsumed = 11 };
+                yield return new ParserTestData<ulong>("123456789012345x7890", 123_456_789_012_345, 'D', expectedSuccess: true) { ExpectedBytesConsumed = 15 };
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
@@ -292,61 +292,22 @@ namespace System.Buffers.Text
 
             nuint firstDigit = (uint)source[0] - '0';
             if ((uint)firstDigit > 9) { goto FalseExit; }
+
+            if (source.Length >= ParserHelpers.UInt64OverflowLength)
+            {
+                return TryParseUInt64DOverflow(source, firstDigit, out value, out bytesConsumed);
+            }
+
             ulong parsedValue = firstDigit;
 
-            // At this point, we successfully read a single digit character.
-            // The only failure condition from here on out is integer overflow.
-
             int idx = 1;
-            if (source.Length < ParserHelpers.UInt64OverflowLength)
+            while (true)
             {
-                // If the input span is short enough such that integer overflow isn't an issue,
-                // don't bother performing overflow checks. Just keep shifting in new digits
-                // until we see a non-digit character or until we've exhausted our input buffer.
-
-                while (true)
-                {
-                    if ((uint)idx >= (uint)source.Length) { break; } // EOF
-                    nuint nextChar = (uint)source[idx] - '0';
-                    if ((uint)nextChar > 9) { break; } // not a digit
-                    parsedValue = parsedValue * 10 + nextChar;
-                    idx++;
-                }
-            }
-            else
-            {
-                while (true)
-                {
-                    if ((uint)idx >= (uint)source.Length) { break; } // EOF
-                    nuint nextChar = (uint)source[idx] - '0';
-                    if ((uint)nextChar > 9) { break; } // not a digit
-                    idx++;
-
-                    // The const below is the smallest unsigned x for which "x * 10 + 9"
-                    // might overflow ulong.MaxValue. If the current accumulator is below
-                    // this const, there's no risk of overflowing.
-
-                    const ulong OverflowRisk = 0x1999_9999_9999_9999ul;
-
-                    if (parsedValue < OverflowRisk)
-                    {
-                        parsedValue = parsedValue * 10 + nextChar;
-                        continue;
-                    }
-
-                    // If the current accumulator is exactly equal to the const above,
-                    // then "accumulator * 10 + 5" is the highest we can go without overflowing
-                    // ulong.MaxValue. This also implies that if the current accumulator
-                    // is higher than the const above, there's no hope that we'll succeed,
-                    // so we may as well just fail now.
-
-                    if (parsedValue != OverflowRisk || (uint)nextChar > 5)
-                    {
-                        goto FalseExit;
-                    }
-
-                    parsedValue = OverflowRisk * 10 + nextChar;
-                }
+                if ((uint)idx >= (uint)source.Length) { break; } // EOF
+                nuint nextChar = (uint)source[idx] - '0';
+                if ((uint)nextChar > 9) { break; } // not a digit
+                parsedValue = parsedValue * 10 + nextChar;
+                idx++;
             }
 
             bytesConsumed = idx;
@@ -359,22 +320,38 @@ namespace System.Buffers.Text
             return false;
         }
 
-        // Keep the uncommon overflow path out of TryParseUInt64D so short inputs remain a leaf method.
+        // Keep the uncommon overflow path out of the short-input code in TryParseUInt64D.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static bool TryParseUInt64DOverflow(ReadOnlySpan<byte> source, out ulong value, out int bytesConsumed)
+        private static bool TryParseUInt64DOverflow(ReadOnlySpan<byte> source, nuint firstDigit, out ulong value, out int bytesConsumed)
         {
             uint first = BinaryPrimitives.ReadUInt32LittleEndian(source);
-            uint second = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(4));
-            uint third = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(8));
-            uint fourth = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(12));
-            if (!AreFourDigits(first) || !AreFourDigits(second) || !AreFourDigits(third) || !AreFourDigits(fourth))
+            ulong parsedValue;
+            int idx;
+
+            if (!AreFourDigits(first))
             {
-                return TryParseUInt64D(source, out value, out bytesConsumed);
+                parsedValue = firstDigit;
+                idx = 1;
+                goto ParseRemaining;
             }
 
-            ulong parsedValue = ((ulong)ParseFourDigits(first) * 10_000u + ParseFourDigits(second)) * 100_000_000 +
-                ParseFourDigits(third) * 10_000u + ParseFourDigits(fourth);
-            int idx = 16;
+            parsedValue = ParseFourDigits(first);
+            idx = 4;
+
+            uint second = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(4));
+            if (!AreFourDigits(second)) { goto ParseRemaining; }
+            parsedValue = parsedValue * 10_000 + ParseFourDigits(second);
+            idx = 8;
+
+            uint third = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(8));
+            if (!AreFourDigits(third)) { goto ParseRemaining; }
+            parsedValue = parsedValue * 10_000 + ParseFourDigits(third);
+            idx = 12;
+
+            uint fourth = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(12));
+            if (!AreFourDigits(fourth)) { goto ParseRemaining; }
+            parsedValue = parsedValue * 10_000 + ParseFourDigits(fourth);
+            idx = 16;
 
             while (true)
             {
@@ -401,9 +378,19 @@ namespace System.Buffers.Text
                 parsedValue = OverflowRisk * 10 + nextChar;
             }
 
+        Done:
             bytesConsumed = idx;
             value = parsedValue;
             return true;
+
+        ParseRemaining:
+            while (true)
+            {
+                nuint nextChar = (uint)source[idx] - '0';
+                if ((uint)nextChar > 9) { goto Done; }
+                parsedValue = parsedValue * 10 + nextChar;
+                idx++;
+            }
         }
 
         // Each byte is an ASCII digit iff neither boundary calculation sets its high bit.

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
@@ -278,6 +278,7 @@ namespace System.Buffers.Text
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool TryParseUInt64D(ReadOnlySpan<byte> source, out ulong value, out int bytesConsumed)
         {
             if (source.IsEmpty)
@@ -293,65 +294,43 @@ namespace System.Buffers.Text
             nuint firstDigit = (uint)source[0] - '0';
             if ((uint)firstDigit > 9) { goto FalseExit; }
 
-            if (source.Length >= ParserHelpers.UInt64OverflowLength)
+            ulong parsedValue = firstDigit;
+            int idx = 1;
+
+            if (source.Length == 1)
             {
-                return TryParseUInt64DOverflow(source, firstDigit, out value, out bytesConsumed);
+                goto Done;
             }
 
-            ulong parsedValue = firstDigit;
-
-            int idx = 1;
-            while (true)
+            // Parse the first four digits individually so early invalid inputs remain cheap.
+            while (idx < 4)
             {
-                if ((uint)idx >= (uint)source.Length) { break; } // EOF
+                if ((uint)idx >= (uint)source.Length) { goto Done; }
                 nuint nextChar = (uint)source[idx] - '0';
-                if ((uint)nextChar > 9) { break; } // not a digit
+                if ((uint)nextChar > 9) { goto Done; }
                 parsedValue = parsedValue * 10 + nextChar;
                 idx++;
             }
 
-            bytesConsumed = idx;
-            value = parsedValue;
-            return true;
-
-        FalseExit:
-            bytesConsumed = 0;
-            value = default;
-            return false;
-        }
-
-        // Keep the uncommon overflow path out of the short-input code in TryParseUInt64D.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static bool TryParseUInt64DOverflow(ReadOnlySpan<byte> source, nuint firstDigit, out ulong value, out int bytesConsumed)
-        {
-            uint first = BinaryPrimitives.ReadUInt32LittleEndian(source);
-            ulong parsedValue;
-            int idx;
-
-            if (!AreFourDigits(first))
-            {
-                parsedValue = firstDigit;
-                idx = 1;
-                goto ParseRemaining;
-            }
-
-            parsedValue = ParseFourDigits(first);
-            idx = 4;
-
+            if (source.Length < 8) { goto ParseRemainingBounded; }
             uint second = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(4));
             if (!AreFourDigits(second)) { goto ParseRemaining; }
             parsedValue = parsedValue * 10_000 + ParseFourDigits(second);
             idx = 8;
 
+            if (source.Length < 12) { goto ParseRemainingBounded; }
             uint third = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(8));
             if (!AreFourDigits(third)) { goto ParseRemaining; }
             parsedValue = parsedValue * 10_000 + ParseFourDigits(third);
             idx = 12;
 
+            if (source.Length < 16) { goto ParseRemainingBounded; }
             uint fourth = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(12));
             if (!AreFourDigits(fourth)) { goto ParseRemaining; }
             parsedValue = parsedValue * 10_000 + ParseFourDigits(fourth);
             idx = 16;
+
+            if (source.Length < ParserHelpers.UInt64OverflowLength) { goto ParseRemainingBounded; }
 
             while (true)
             {
@@ -370,12 +349,32 @@ namespace System.Buffers.Text
 
                 if (parsedValue != OverflowRisk || (uint)nextChar > 5)
                 {
-                    bytesConsumed = 0;
-                    value = default;
-                    return false;
+                    goto FalseExit;
                 }
 
                 parsedValue = OverflowRisk * 10 + nextChar;
+            }
+
+            goto Done;
+
+        ParseRemaining:
+            while (true)
+            {
+                nuint nextChar = (uint)source[idx] - '0';
+                if ((uint)nextChar > 9) { break; }
+                parsedValue = parsedValue * 10 + nextChar;
+                idx++;
+            }
+
+            goto Done;
+
+        ParseRemainingBounded:
+            while ((uint)idx < (uint)source.Length)
+            {
+                nuint nextChar = (uint)source[idx] - '0';
+                if ((uint)nextChar > 9) { break; }
+                parsedValue = parsedValue * 10 + nextChar;
+                idx++;
             }
 
         Done:
@@ -383,20 +382,18 @@ namespace System.Buffers.Text
             value = parsedValue;
             return true;
 
-        ParseRemaining:
-            while (true)
-            {
-                nuint nextChar = (uint)source[idx] - '0';
-                if ((uint)nextChar > 9) { goto Done; }
-                parsedValue = parsedValue * 10 + nextChar;
-                idx++;
-            }
+        FalseExit:
+            bytesConsumed = 0;
+            value = default;
+            return false;
         }
 
         // Each byte is an ASCII digit iff neither boundary calculation sets its high bit.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool AreFourDigits(uint value) =>
             (((value + 0x46464646u) | (value - 0x30303030u)) & 0x80808080u) == 0;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint ParseFourDigits(uint value)
         {
             value -= 0x30303030u;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.D.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
 namespace System.Buffers.Text
 {
     public static partial class Utf8Parser
@@ -354,6 +357,66 @@ namespace System.Buffers.Text
             bytesConsumed = 0;
             value = default;
             return false;
+        }
+
+        // Keep the uncommon overflow path out of TryParseUInt64D so short inputs remain a leaf method.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool TryParseUInt64DOverflow(ReadOnlySpan<byte> source, out ulong value, out int bytesConsumed)
+        {
+            uint first = BinaryPrimitives.ReadUInt32LittleEndian(source);
+            uint second = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(4));
+            uint third = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(8));
+            uint fourth = BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(12));
+            if (!AreFourDigits(first) || !AreFourDigits(second) || !AreFourDigits(third) || !AreFourDigits(fourth))
+            {
+                return TryParseUInt64D(source, out value, out bytesConsumed);
+            }
+
+            ulong parsedValue = ((ulong)ParseFourDigits(first) * 10_000u + ParseFourDigits(second)) * 100_000_000 +
+                ParseFourDigits(third) * 10_000u + ParseFourDigits(fourth);
+            int idx = 16;
+
+            while (true)
+            {
+                if ((uint)idx >= (uint)source.Length) { break; } // EOF
+                nuint nextChar = (uint)source[idx] - '0';
+                if ((uint)nextChar > 9) { break; } // not a digit
+                idx++;
+
+                const ulong OverflowRisk = 0x1999_9999_9999_9999ul;
+
+                if (parsedValue < OverflowRisk)
+                {
+                    parsedValue = parsedValue * 10 + nextChar;
+                    continue;
+                }
+
+                if (parsedValue != OverflowRisk || (uint)nextChar > 5)
+                {
+                    bytesConsumed = 0;
+                    value = default;
+                    return false;
+                }
+
+                parsedValue = OverflowRisk * 10 + nextChar;
+            }
+
+            bytesConsumed = idx;
+            value = parsedValue;
+            return true;
+        }
+
+        // Each byte is an ASCII digit iff neither boundary calculation sets its high bit.
+        private static bool AreFourDigits(uint value) =>
+            (((value + 0x46464646u) | (value - 0x30303030u)) & 0x80808080u) == 0;
+
+        private static uint ParseFourDigits(uint value)
+        {
+            value -= 0x30303030u;
+            return (value & 0xFF) * 1_000 +
+                ((value >> 8) & 0xFF) * 100 +
+                ((value >> 16) & 0xFF) * 10 +
+                (value >> 24);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
@@ -187,9 +187,7 @@ namespace System.Buffers.Text
         FastPath:
             if (standardFormat == default)
             {
-                return source.Length >= ParserHelpers.UInt64OverflowLength ?
-                    TryParseUInt64DOverflow(source, out value, out bytesConsumed) :
-                    TryParseUInt64D(source, out value, out bytesConsumed);
+                return TryParseUInt64D(source, out value, out bytesConsumed);
             }
 
             // There's small but measurable overhead when entering the switch block below.

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.cs
@@ -187,7 +187,9 @@ namespace System.Buffers.Text
         FastPath:
             if (standardFormat == default)
             {
-                return TryParseUInt64D(source, out value, out bytesConsumed);
+                return source.Length >= ParserHelpers.UInt64OverflowLength ?
+                    TryParseUInt64DOverflow(source, out value, out bytesConsumed) :
+                    TryParseUInt64D(source, out value, out bytesConsumed);
             }
 
             // There's small but measurable overhead when entering the switch block below.


### PR DESCRIPTION
Improves decimal `Utf8Parser.TryParse` throughput for `ulong` inputs long enough to require overflow checks.

The new long-input path validates and parses the first 16 digits four bytes at a time, then uses the existing overflow logic for the remaining bytes. Inputs with a non-digit in the first 16 bytes fall back to the existing parser. Dispatch happens above `TryParseUInt64D`, preserving its leaf codegen for common shorter inputs.

Local BenchmarkDotNet results on Windows x64, Intel Core i7-12700K, .NET 10 source-built baseline/candidate, R2R disabled, 1 launch / 5 warmups / 10 iterations:

| Input | Before | After | Ratio |
|---|---:|---:|---:|
| 4 digits | 1.082 ns | 1.062 ns | 0.98 |
| 9 digits | 3.047 ns | 2.981 ns | 0.98 |
| 10 digits | 3.554 ns | 3.356 ns | 0.94 |
| 19 digits | 7.764 ns | 7.901 ns | 1.02 |
| `ulong.MaxValue` | 10.561 ns | 6.587 ns | 0.62 |
| Overflow | 10.896 ns | 6.535 ns | 0.60 |
| 19 digits + invalid suffix | 10.126 ns | 6.357 ns | 0.63 |

Shorter cases were equivalent under the 5% Mann-Whitney threshold. No benchmark allocates.

Validation:
- Current main CoreLib Release build: 0 warnings, 0 errors
- 100,000 randomized `ulong` format/parse roundtrips
- 100,000 randomized malformed-byte comparisons against the previous parser
- Exhaustive repeated-byte digit validation
- Added long leading-zero and early-invalid-suffix test cases