### PR TITLE
Fix ILVerify validation for delegates with boxed value type targets

### DIFF
--- a/src/coreclr/tools/ILVerification.Tests/ILTests/FtnTests.il
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/FtnTests.il
@@ -93,7 +93,7 @@
         ret
     }
 
-    .method public hidebysig static void StaticMethodString(string param) cil managed 
+    .method public hidebysig static void StaticMethodString(string param) cil managed
     {
         ret
     }
@@ -277,6 +277,42 @@
         newobj      instance void class [System.Runtime]System.Func`2<int32, int32>::.ctor(object, native int)
         ldc.i4.0
         callvirt    instance !1 class [System.Runtime]System.Func`2<int32, int32>::Invoke(!0)
+        pop
+        ret
+    }
+
+    .method static public hidebysig void LdvirtFtn.BoxedValueTypeObjectMethodClosed_Valid() cil managed
+    {
+        ldc.i4.s   42
+        box        [System.Runtime]System.Int32
+        dup
+        ldvirtftn  instance string [System.Runtime]System.Object::ToString()
+        newobj     instance void class [System.Runtime]System.Func`1<string>::.ctor(object, native int)
+        callvirt   instance !0 class [System.Runtime]System.Func`1<string>::Invoke()
+        pop
+        ret
+    }
+
+    .method static public hidebysig void LdvirtFtn.BoxedValueTypeInterfaceMethodClosed_Valid() cil managed
+    {
+        ldc.i4.s   42
+        box        [System.Runtime]System.Int32
+        dup
+        ldvirtftn  instance int32 class [System.Runtime]System.IComparable`1<int32>::CompareTo(!0)
+        newobj     instance void class [System.Runtime]System.Func`2<int32, int32>::.ctor(object, native int)
+        ldc.i4.0
+        callvirt   instance !1 class [System.Runtime]System.Func`2<int32, int32>::Invoke(!0)
+        pop
+        ret
+    }
+
+    // a boxed int32 is not a valid target for an instance method on an unrelated class
+    .method static public hidebysig void LdFtn.BoxedValueTypeForTestClassInstance_Invalid_DelegateCtor() cil managed
+    {
+        ldc.i4.s   42
+        box        [System.Runtime]System.Int32
+        ldftn      instance void TestClass::InstanceMethod()
+        newobj     instance void [System.Runtime]System.Action::.ctor(object, native int)
         pop
         ret
     }

--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -1131,7 +1131,7 @@ namespace Internal.IL
                 VerificationError(VerifierError.DelegatePattern);
         }
 
-        bool IsDelegateAssignable(MethodDesc targetMethod, TypeDesc delegateType, TypeDesc firstArg)
+        bool IsDelegateAssignable(MethodDesc targetMethod, TypeDesc delegateType, StackValue firstArg)
         {
             var invokeMethod = delegateType.GetMethod("Invoke"u8, null);
             if (invokeMethod == null)
@@ -1177,23 +1177,19 @@ namespace Internal.IL
 
             int consumedArgs = 0;
 
-            TypeDesc firstInvokeArg;
             if (isOpenDelegate)
             {
                 // If we're looking at an open delegate but the caller has provided a target it's not a match.
-                if (firstArg != null)
+                if (firstArg.Type != null)
                     return false;
 
-                firstInvokeArg = invokeSignature[0];
                 consumedArgs++;
             }
             else
             {
                 // If we're looking at a closed delegate but the caller has not provided a target it's not a match.
-                if (firstArg == null)
+                if (firstArg.Type == null)
                     return false;
-
-                firstInvokeArg = firstArg;
             }
 
             TypeDesc firstTargetArg;
@@ -1219,7 +1215,14 @@ namespace Internal.IL
                     firstTargetArg = firstTargetArg.MakeByRefType();
             }
 
-            if (!IsAssignable(firstInvokeArg, firstTargetArg))
+            // For a closed delegate it is the target pushed on the stack, so compare against the stack value itself:
+            // it keeps track of boxed value types, which are object references and assignable to anything they can be cast to
+            // (e.g. a boxed int32 target for ToString()).
+            bool firstArgAssignable = isOpenDelegate
+                ? IsAssignable(invokeSignature[0], firstTargetArg)
+                : IsAssignable(firstArg, StackValue.CreateObjRef(firstTargetArg));
+
+            if (!firstArgAssignable)
                 return false;
 
             // We better have same number of remaining args
@@ -1608,7 +1611,7 @@ namespace Internal.IL
 
                 CheckDelegateCreation(actualFtn, actualObj);
 
-                if (!IsDelegateAssignable(actualFtn.Method, methodType, actualObj.Type))
+                if (!IsDelegateAssignable(actualFtn.Method, methodType, actualObj))
                     VerificationError(VerifierError.DelegateCtor);
             }
             else


### PR DESCRIPTION
Fixes #96695

Preserve the target `StackValue` when validating closed delegates so ILVerify recognizes boxed value types as object references.
Add tests for `System.Object` and interface methods on boxed value types.