### PR TITLE
Normalize LDAP search filters on Unix

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.DirectoryServices.Protocols
 {
@@ -100,8 +102,117 @@ namespace System.DirectoryServices.Protocols
                 //-1 means no time limit
                 searchTimeout.tv_sec = -1;
 
+            // Windows LDAP accepts redundant parentheses and backslash-escaped spaces that OpenLDAP rejects.
+            filter = NormalizeFilter(filter);
             return Interop.Ldap.ldap_search(ldapHandle, dn, scope, filter, attributes, attributeOnly, servercontrol, clientcontrol, searchTimeout, sizelimit, ref messageNumber);
         }
+
+        private static string NormalizeFilter(string filter)
+        {
+            if (string.IsNullOrEmpty(filter))
+            {
+                return filter;
+            }
+
+            bool hasEscapedSpace = filter.Contains("\\ ", StringComparison.Ordinal);
+            bool hasNestedParentheses = filter.Contains("((", StringComparison.Ordinal);
+
+            if (!hasEscapedSpace && !hasNestedParentheses)
+            {
+                return filter;
+            }
+
+            bool[] redundantParentheses = hasNestedParentheses ? FindRedundantParentheses(filter) : null;
+
+            if (!hasEscapedSpace && redundantParentheses is null)
+            {
+                return filter;
+            }
+
+            var builder = new StringBuilder(filter.Length);
+
+            for (int i = 0; i < filter.Length; i++)
+            {
+                if (redundantParentheses?[i] == true)
+                {
+                    continue;
+                }
+
+                char current = filter[i];
+
+                if (current == '\\' && i + 1 < filter.Length)
+                {
+                    char escaped = filter[++i];
+
+                    if (escaped != ' ')
+                    {
+                        builder.Append(current);
+                    }
+
+                    builder.Append(escaped);
+                }
+                else
+                {
+                    builder.Append(current);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool[] FindRedundantParentheses(string filter)
+        {
+            var openParentheses = new Stack<int>();
+            int[] closingParentheses = new int[filter.Length];
+
+            for (int i = 0; i < filter.Length; i++)
+            {
+                char current = filter[i];
+
+                if (current == '\\' && i + 1 < filter.Length)
+                {
+                    i++;
+                }
+                else if (current == '(')
+                {
+                    openParentheses.Push(i);
+                }
+                else if (current == ')')
+                {
+                    if (openParentheses.Count == 0)
+                    {
+                        return null;
+                    }
+
+                    closingParentheses[openParentheses.Pop()] = i;
+                }
+            }
+
+            if (openParentheses.Count != 0)
+            {
+                return null;
+            }
+
+            bool[] redundantParentheses = null;
+
+            for (int i = 0; i + 1 < filter.Length; i++)
+            {
+                int closingParenthesis = closingParentheses[i];
+
+                if (filter[i] == '(' &&
+                    filter[i + 1] == '(' &&
+                    closingParenthesis > i + 2 &&
+                    closingParentheses[i + 1] == closingParenthesis - 1)
+                {
+                    redundantParentheses ??= new bool[filter.Length];
+                    redundantParentheses[i] = true;
+                    redundantParentheses[closingParenthesis] = true;
+                }
+            }
+
+            return redundantParentheses;
+        }
+
         internal static int SetBoolOption(ConnectionHandle ld, LdapOption option, bool value) => Interop.Ldap.ldap_set_option_bool(ld, option, value);
 
         // This option is not supported in Linux, so it would most likely throw.

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -194,6 +194,32 @@ namespace System.DirectoryServices.Protocols.Tests
             return new LocalConnectionState(connection, server);
         }
 
+        [Theory]
+        [InlineData("(&(objectClass=domain)(dc=test))")]
+        [InlineData("((objectClass=*))")]
+        [InlineData("(&((objectClass=domain))((((dc=test)))))")]
+        [InlineData("(description=Domain\\ Controllers)")]
+        [InlineData("(description=Domain\\20Controllers)")]
+        public void SearchRequest_WindowsCompatibleFilter_ReturnsMatchingEntry(string filter)
+        {
+            using LdapTestServer server = StartLocalServer(out int port);
+            using LdapConnection connection = GetLocalConnection(port);
+
+            var modifyRequest = new ModifyRequest(
+                server.BaseDn,
+                DirectoryAttributeOperation.Add,
+                "description",
+                "Domain Controllers");
+            ModifyResponse modifyResponse = (ModifyResponse)connection.SendRequest(modifyRequest);
+            Assert.Equal(ResultCode.Success, modifyResponse.ResultCode);
+
+            var searchRequest = new SearchRequest(server.BaseDn, filter, SearchScope.Base);
+            SearchResponse searchResponse = (SearchResponse)connection.SendRequest(searchRequest);
+
+            Assert.Equal(ResultCode.Success, searchResponse.ResultCode);
+            Assert.Single(searchResponse.Entries);
+        }
+
         [InlineData(true)]
         [InlineData(false)]
         [Theory]


### PR DESCRIPTION
Fixes #127168
Fixes #127175

## Summary

- normalize redundant LDAP filter parentheses before passing search filters to OpenLDAP
- treat the Windows-compatible `\ ` escape as a literal space while preserving other escape sequences
- add local LDAP server coverage for top-level and nested redundant parentheses, escaped spaces, and standard RFC 4515 filters

## Testing

- verified the three regression cases failed with `LdapException: The search filter is invalid` before the implementation change
- built `System.DirectoryServices.Protocols.Tests.csproj` for `net11.0-osx` with 0 warnings and 0 errors
- ran the complete non-OuterLoop `System.DirectoryServices.Protocols.Tests` suite: 645 passed, 0 failed, 0 skipped

The macOS test run exercises the same Unix `LdapPal.Linux.cs` implementation and OpenLDAP behavior as Linux.

## AI assistance

I used OpenAI Codex to help investigate, implement, and test this change. I reviewed the final diff and all test results before submission.
