### PR TITLE
Memmove: handle overlapping forward copies in managed code

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -151,9 +151,9 @@ namespace System
 
         // The maximum block size to for BulkMoveWithWriteBarrierInternal FCall. This is required to avoid GC starvation.
 #if DEBUG // Stress the mechanism in debug builds
-        private const uint BulkMoveWithWriteBarrierChunk = 0x400;
+        internal const uint BulkMoveWithWriteBarrierChunk = 0x400;
 #else
-        private const uint BulkMoveWithWriteBarrierChunk = 0x4000;
+        internal const uint BulkMoveWithWriteBarrierChunk = 0x4000;
 #endif
 
         internal static void BulkMoveWithWriteBarrier(ref byte destination, ref byte source, nuint byteCount)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace System
 {
@@ -25,6 +26,14 @@ namespace System
 #endif
         private const nuint ZeroMemoryNativeThreshold = 1024;
 
+        // The platform's forward memmove ('rep movsb' on x86) loses most of its throughput when the source
+        // and the destination are less than a cache line apart, which is exactly what a shift by a single
+        // array element looks like. Copy those overlapping buffers ourselves instead.
+        private const nuint MemmoveOverlappedNativeMinDistance = 64;
+
+        // Largest block handed to the platform's memmove when the buffers overlap: big enough for it to
+        // amortize its own set-up cost, small enough to keep it away from non-temporal stores.
+        private const nuint MemmoveOverlappedNativeChunk = 32 * 1024;
 
 #if HAS_CUSTOM_BLOCKS
         [StructLayout(LayoutKind.Sequential, Size = 16)]
@@ -235,12 +244,146 @@ namespace System
                 return;
             }
 
+            // 'dest' below 'src' means the data is shifted towards the start of the buffer, which is by
+            // far the most common overlapping shape (List<T>.RemoveAt/RemoveRange, Queue<T>, overlapping
+            // Span<T>.CopyTo, ...). Such a copy can run in strictly ascending order, which lets us pick a
+            // better strategy than blindly handing it to the platform's memmove. Shifts towards the end of
+            // the buffer keep using memmove, whose backward copy loop doesn't have the problems below.
+            if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
+            {
+                MemmoveOverlappedForward(ref dest, ref src, len);
+                return;
+            }
+
         PInvoke:
             // Implicit nullchecks
             Debug.Assert(len > 0);
             _ = Unsafe.ReadUnaligned<byte>(ref dest);
             _ = Unsafe.ReadUnaligned<byte>(ref src);
             MemmoveNative(ref dest, ref src, len);
+        }
+
+        // Copies overlapping buffers where 'dest' is at a lower address than 'src', i.e. the data is
+        // shifted towards the start of the buffer. Both of the platform memmove's problems with this
+        // shape come from it being tuned for disjoint buffers, so we route around them here.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void MemmoveOverlappedForward(ref byte dest, ref byte src, nuint len)
+        {
+            Debug.Assert(len > 0);
+
+            nuint distance = (nuint)Unsafe.ByteOffset(ref dest, ref src);
+
+            // A forward 'rep movsb' loses most of its throughput when it has to feed itself, i.e. when the
+            // two buffers are less than a cache line apart - which is precisely a shift by one element. And
+            // below the cut-off the non-overlapping paths use, the QCall costs more than the copy itself.
+            // Targets that never call into the platform's memmove (MemmoveNativeThreshold is unbounded
+            // there) consequently always take this path, just like their non-overlapping copies do.
+            if (Vector128.IsHardwareAccelerated &&
+                (len <= MemmoveNativeThreshold || distance < MemmoveOverlappedNativeMinDistance))
+            {
+                CopyForwardVectorized(ref dest, ref src, len);
+                return;
+            }
+
+            // Implicit nullchecks
+            _ = Unsafe.ReadUnaligned<byte>(ref dest);
+            _ = Unsafe.ReadUnaligned<byte>(ref src);
+
+            // Large copies make memmove switch to non-temporal stores, which is exactly wrong here: the
+            // lines it pushes out of the cache are the ones the rest of the copy is about to read back.
+            // Feeding it one chunk at a time keeps it on its cached - and far faster - copy loop. Walking
+            // the chunks from the start is safe because 'dest' trails 'src'.
+            while (len > MemmoveOverlappedNativeChunk)
+            {
+                MemmoveNative(ref dest, ref src, MemmoveOverlappedNativeChunk);
+                dest = ref Unsafe.Add(ref dest, MemmoveOverlappedNativeChunk);
+                src = ref Unsafe.Add(ref src, MemmoveOverlappedNativeChunk);
+                len -= MemmoveOverlappedNativeChunk;
+            }
+
+            MemmoveNative(ref dest, ref src, len);
+        }
+
+        // Copies 'src' to 'dest' in strictly ascending order, so a byte is always read before the copy can
+        // overwrite it. That also rules out the "copy a final block anchored at the end of the buffer"
+        // trick the non-overlapping paths use - that block may already have been rewritten by then.
+        private static void CopyForwardVectorized(ref byte dest, ref byte src, nuint len)
+        {
+            Debug.Assert(Vector128.IsHardwareAccelerated);
+
+            // The blocks are addressed off 'dest'/'src' with constant offsets rather than off a running
+            // index so that targets with load/store-pair instructions can fold them (arm64 'ldp'/'stp').
+            if (Vector256.IsHardwareAccelerated)
+            {
+                while (len >= 128)
+                {
+                    // All of the blocks are loaded before any of them is stored, so a store can never
+                    // clobber source bytes that this iteration still has to read.
+                    Vector256<byte> block0 = Vector256.LoadUnsafe(ref src);
+                    Vector256<byte> block1 = Vector256.LoadUnsafe(ref src, 32);
+                    Vector256<byte> block2 = Vector256.LoadUnsafe(ref src, 64);
+                    Vector256<byte> block3 = Vector256.LoadUnsafe(ref src, 96);
+                    Vector256.StoreUnsafe(block0, ref dest);
+                    Vector256.StoreUnsafe(block1, ref dest, 32);
+                    Vector256.StoreUnsafe(block2, ref dest, 64);
+                    Vector256.StoreUnsafe(block3, ref dest, 96);
+                    dest = ref Unsafe.Add(ref dest, 128);
+                    src = ref Unsafe.Add(ref src, 128);
+                    len -= 128;
+                }
+
+                while (len >= 32)
+                {
+                    Vector256.StoreUnsafe(Vector256.LoadUnsafe(ref src), ref dest);
+                    dest = ref Unsafe.Add(ref dest, 32);
+                    src = ref Unsafe.Add(ref src, 32);
+                    len -= 32;
+                }
+            }
+            else
+            {
+                while (len >= 64)
+                {
+                    Vector128<byte> block0 = Vector128.LoadUnsafe(ref src);
+                    Vector128<byte> block1 = Vector128.LoadUnsafe(ref src, 16);
+                    Vector128<byte> block2 = Vector128.LoadUnsafe(ref src, 32);
+                    Vector128<byte> block3 = Vector128.LoadUnsafe(ref src, 48);
+                    Vector128.StoreUnsafe(block0, ref dest);
+                    Vector128.StoreUnsafe(block1, ref dest, 16);
+                    Vector128.StoreUnsafe(block2, ref dest, 32);
+                    Vector128.StoreUnsafe(block3, ref dest, 48);
+                    dest = ref Unsafe.Add(ref dest, 64);
+                    src = ref Unsafe.Add(ref src, 64);
+                    len -= 64;
+                }
+            }
+
+            // Drain the remainder with progressively smaller blocks, each one picking up exactly where the
+            // previous one ended. Every block is a single load followed by a single store, so no partial
+            // block can be written before the bytes it overlaps have been read.
+            while (len >= 16)
+            {
+                Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref src), ref dest);
+                dest = ref Unsafe.Add(ref dest, 16);
+                src = ref Unsafe.Add(ref src, 16);
+                len -= 16;
+            }
+
+            while (len >= 4)
+            {
+                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<uint>(ref src));
+                dest = ref Unsafe.Add(ref dest, 4);
+                src = ref Unsafe.Add(ref src, 4);
+                len -= 4;
+            }
+
+            while (len != 0)
+            {
+                dest = src;
+                dest = ref Unsafe.Add(ref dest, 1);
+                src = ref Unsafe.Add(ref src, 1);
+                len--;
+            }
         }
 
         // Non-inlinable wrapper around the QCall that avoids polluting the fast path

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -11,7 +11,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 
 namespace System
 {
@@ -27,16 +26,17 @@ namespace System
         private const nuint ZeroMemoryNativeThreshold = 1024;
 
 #if (TARGET_AMD64 || TARGET_ARM64) && !MONO
-        // Blocks are copied with a constant-length Memmove, which the JIT unrolls into "load the whole block
-        // into registers, then store it" - correct for any overlap. 64 bytes fits its unrolling budget on
-        // every target here, and bounds re-entry: a shorter length is finished without calling Memmove.
-        private const nuint MemmoveOverlappedBlock = 64;
+        // Blocks are copied with a constant-length Memmove, which the JIT expands into "load the whole
+        // block into registers, then store it" - correct for any overlap. 64 bytes fits its unrolling
+        // budget on every target here, and bounds re-entry: a block-sized call skips the loop below and
+        // is finished by the tail, which never calls Memmove back.
+        private const nuint OverlappedBlockSize = 64;
 
         // Aligning the destination only pays for the extra leading block on larger copies.
-        private const nuint MemmoveOverlappedAlignThreshold = 2048;
+        private const nuint OverlappedAlignThreshold = 2048;
 
-        // Past this the platform memmove's backward loop is about twice as fast as a managed descending one.
-        private const nuint MemmoveOverlappedBackwardThreshold = 256;
+        // Past this the platform memmove's backward loop beats a managed descending one.
+        private const nuint OverlappedBackwardThreshold = 256;
 #endif
 
 #if HAS_CUSTOM_BLOCKS
@@ -47,10 +47,8 @@ namespace System
         private struct Block64 {}
 #endif // HAS_CUSTOM_BLOCKS
 
-        // Too big to be worth inlining: it burns a lot of the caller's budget, and keeping the call is also
-        // what lets the JIT unroll it when the length is constant.
         [Intrinsic] // Unrolled for small constant lengths
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.NoInlining)] // keeping the call is what lets the JIT unroll it
         internal static void Memmove(ref byte dest, ref byte src, nuint len)
         {
             // P/Invoke into the native version when the buffers are overlapping.
@@ -252,16 +250,19 @@ namespace System
             }
 
 #if (TARGET_AMD64 || TARGET_ARM64) && !MONO
-            // memmove's forward loop is tuned for disjoint buffers: 'rep movsb' collapses when they are less
-            // than a cache line apart, and the non-temporal stores it uses for large copies evict the lines
-            // the rest of the copy reads back. Its backward loop has neither problem and beats us above 256.
+            // We're better off here than calling the platform memmove: for short copies the P/Invoke alone
+            // costs more than the copy, and its forward loop is tuned for disjoint buffers - 'rep movsb'
+            // collapses when the buffers are less than a cache line apart, and the non-temporal stores it
+            // uses for large copies evict the lines the rest of the copy reads back. Its backward loop has
+            // neither problem, so long right shifts are left to it.
             if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
             {
+                // dest is below src, so copying upwards never overwrites a byte we still have to read.
                 CopyOverlappedForward(ref dest, ref src, len);
                 return;
             }
 
-            if (len <= MemmoveOverlappedBackwardThreshold)
+            if (len <= OverlappedBackwardThreshold)
             {
                 CopyOverlappedBackward(ref dest, ref src, len);
                 return;
@@ -277,16 +278,19 @@ namespace System
         }
 
 #if (TARGET_AMD64 || TARGET_ARM64) && !MONO
-        // Blocks run in strictly ascending order, so a store can never reach a source byte a later block
-        // still has to read. That also rules out the trailing "block anchored at the end of the buffer"
-        // shortcut the non-overlapping paths use - those bytes would already have been rewritten.
+        // Every step below either is a constant-length Memmove, which the JIT expands so that the whole
+        // block is loaded before any of it is stored, or a single load feeding a single store, where the
+        // data dependency does the same for one register's worth. Steps then run in strictly ascending,
+        // non-overlapping order, so a store can never reach a source byte a later step has to read. That
+        // also rules out the trailing "block anchored at the end of the buffer" shortcut the
+        // non-overlapping paths use - those bytes may already have been rewritten.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CopyOverlappedForward(ref byte dest, ref byte src, nuint len)
         {
             Debug.Assert(len > 0);
 
             // Only one of the two can be aligned, and an unaligned store costs more than an unaligned load.
-            if (len >= MemmoveOverlappedAlignThreshold)
+            if (len >= OverlappedAlignThreshold)
             {
                 nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);
                 if (head != 64)
@@ -298,87 +302,100 @@ namespace System
                 }
             }
 
-            // The JIT unrolls a constant-length Memmove up to four vector registers wide, so take the widest
-            // block it will still expand. Bigger blocks also mean fewer boundaries where a store and the
-            // next block's load land in the same cache line, which is what a tight overlap is sensitive to.
-            if (Vector512.IsHardwareAccelerated)
+            while (len > OverlappedBlockSize)
             {
-                while (len > 256)
-                {
-                    Memmove(ref dest, ref src, 256);
-                    dest = ref Unsafe.Add(ref dest, 256);
-                    src = ref Unsafe.Add(ref src, 256);
-                    len -= 256;
-                }
-            }
-            else if (Vector256.IsHardwareAccelerated)
-            {
-                while (len > 128)
-                {
-                    Memmove(ref dest, ref src, 128);
-                    dest = ref Unsafe.Add(ref dest, 128);
-                    src = ref Unsafe.Add(ref src, 128);
-                    len -= 128;
-                }
-            }
-
-            while (len > MemmoveOverlappedBlock)
-            {
-                Memmove(ref dest, ref src, MemmoveOverlappedBlock);
-                dest = ref Unsafe.Add(ref dest, MemmoveOverlappedBlock);
-                src = ref Unsafe.Add(ref src, MemmoveOverlappedBlock);
-                len -= MemmoveOverlappedBlock;
+                Memmove(ref dest, ref src, OverlappedBlockSize);
+                dest = ref Unsafe.Add(ref dest, OverlappedBlockSize);
+                src = ref Unsafe.Add(ref src, OverlappedBlockSize);
+                len -= OverlappedBlockSize;
             }
 
             CopyOverlappedForwardTail(ref dest, ref src, len);
         }
 
-        // Mirror image: blocks run in strictly descending order, walking down from the end.
+        // Mirror image: steps run in strictly descending order, walking down from the end.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CopyOverlappedBackward(ref byte dest, ref byte src, nuint len)
         {
             Debug.Assert(len > 0);
 
-            while (len > MemmoveOverlappedBlock)
+            while (len > OverlappedBlockSize)
             {
-                len -= MemmoveOverlappedBlock;
-                Memmove(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len), MemmoveOverlappedBlock);
+                len -= OverlappedBlockSize;
+                Memmove(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len), OverlappedBlockSize);
             }
 
-            while (len >= sizeof(ulong))
-            {
-                len -= sizeof(ulong);
-                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref src, len)));
-            }
+            CopyOverlappedBackwardTail(ref dest, ref src, len);
+        }
 
-            while (len != 0)
+        // Finishes at most OverlappedBlockSize bytes, ascending. Deliberately doesn't call Memmove - this
+        // is where a block the JIT didn't expand comes back around, so calling it again is what recursion
+        // would look like. One step per set bit of len, so the steps tile the range without overlapping.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopyOverlappedForwardTail(ref byte dest, ref byte src, nuint len)
+        {
+            Debug.Assert(len <= OverlappedBlockSize);
+
+            while (len >= 16)
             {
-                len--;
-                Unsafe.Add(ref dest, len) = Unsafe.Add(ref src, len);
+                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<Block16>(ref src));
+                dest = ref Unsafe.Add(ref dest, 16);
+                src = ref Unsafe.Add(ref src, 16);
+                len -= 16;
+            }
+            if ((len & 8) != 0)
+            {
+                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<ulong>(ref src));
+                dest = ref Unsafe.Add(ref dest, 8);
+                src = ref Unsafe.Add(ref src, 8);
+            }
+            if ((len & 4) != 0)
+            {
+                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<uint>(ref src));
+                dest = ref Unsafe.Add(ref dest, 4);
+                src = ref Unsafe.Add(ref src, 4);
+            }
+            if ((len & 2) != 0)
+            {
+                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<ushort>(ref src));
+                dest = ref Unsafe.Add(ref dest, 2);
+                src = ref Unsafe.Add(ref src, 2);
+            }
+            if ((len & 1) != 0)
+            {
+                dest = src;
             }
         }
 
-        // Finishes at most MemmoveOverlappedBlock bytes. Deliberately doesn't call Memmove - this is where a
-        // call the JIT didn't unroll lands, so calling it again is what recursion would look like. Every step
-        // is one load feeding one store, so the ordering comes from the data dependency.
-        private static void CopyOverlappedForwardTail(ref byte dest, ref byte src, nuint len)
+        // Mirror image: the steps tile the range from the end downwards.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopyOverlappedBackwardTail(ref byte dest, ref byte src, nuint len)
         {
-            Debug.Assert(len <= MemmoveOverlappedBlock);
+            Debug.Assert(len <= OverlappedBlockSize);
 
-            while (len >= sizeof(ulong))
+            while (len >= 16)
             {
-                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<ulong>(ref src));
-                dest = ref Unsafe.Add(ref dest, sizeof(ulong));
-                src = ref Unsafe.Add(ref src, sizeof(ulong));
-                len -= sizeof(ulong);
+                len -= 16;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<Block16>(ref Unsafe.Add(ref src, len)));
             }
-
-            while (len != 0)
+            if ((len & 8) != 0)
+            {
+                len -= 8;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref src, len)));
+            }
+            if ((len & 4) != 0)
+            {
+                len -= 4;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref src, len)));
+            }
+            if ((len & 2) != 0)
+            {
+                len -= 2;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, len)));
+            }
+            if ((len & 1) != 0)
             {
                 dest = src;
-                dest = ref Unsafe.Add(ref dest, 1);
-                src = ref Unsafe.Add(ref src, 1);
-                len--;
             }
         }
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -11,7 +11,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 
 namespace System
 {
@@ -26,25 +25,19 @@ namespace System
 #endif
         private const nuint ZeroMemoryNativeThreshold = 1024;
 
-        // Block size used by the overlapping copies below. Each block is copied with a constant-length
-        // Memmove, which the JIT unrolls into "load the whole block into registers, then store it" - the
-        // one shape that stays correct however the two buffers overlap. That unrolling has a target
-        // dependent budget of four vector registers, and 64 bytes is within it even where those are only
-        // 16 bytes wide. Keeping the block this small also bounds re-entry: should the JIT not unroll the
-        // call after all, it arrives back here with a length that is handled without another Memmove, so
-        // these routines cannot recurse.
+#if TARGET_AMD64 || TARGET_ARM64
+        // Overlapping copies are done in blocks of this size with a constant-length Memmove, which the JIT
+        // unrolls into "load the whole block into registers, then store it" - correct for any overlap. 64
+        // bytes stays within its unrolling budget everywhere, and bounds re-entry: a call it didn't unroll
+        // comes back with a length the tail handles without calling Memmove again, so these can't recurse.
         private const nuint MemmoveOverlappedBlock = 64;
 
-        // Copy size at which aligning the destination of an overlapping forward copy starts to pay for the
-        // extra leading block. Below it the alignment prologue costs more than the misaligned stores it
-        // avoids.
+        // Aligning the destination only pays for the extra leading block on larger copies.
         private const nuint MemmoveOverlappedAlignThreshold = 2048;
 
-        // The platform memmove's backward copy loop stays about twice as fast as a managed descending one:
-        // a descending stream defeats the hardware prefetcher, and unlike the forward direction, aligning
-        // the destination doesn't recover it. So a copy towards the end of the buffer is only done here
-        // while it is short enough for the QCall itself to dominate.
+        // Past this the platform memmove's backward loop is about twice as fast as a managed descending one.
         private const nuint MemmoveOverlappedBackwardThreshold = 256;
+#endif
 
 #if HAS_CUSTOM_BLOCKS
         [StructLayout(LayoutKind.Sequential, Size = 16)]
@@ -255,29 +248,24 @@ namespace System
                 return;
             }
 
-            if (Vector128.IsHardwareAccelerated)
+#if TARGET_AMD64 || TARGET_ARM64
+            // The platform memmove's forward loop is tuned for disjoint buffers: 'rep movsb' collapses when
+            // they are less than a cache line apart - a shift by one element - and the non-temporal stores it
+            // uses for large copies evict the lines the rest of the copy reads back. Its backward loop has
+            // neither problem and outruns a managed descending one, so that direction is only handled here
+            // while the QCall dominates the copy.
+            if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
             {
-                // 'dest' below 'src' means the data is shifted towards the start of the buffer, which is by
-                // far the most common overlapping shape (List<T>.RemoveAt/RemoveRange, Queue<T>, overlapping
-                // Span<T>.CopyTo, ...). Those are always copied here: the platform memmove's forward loop is
-                // tuned for disjoint buffers and both of the tricks it uses backfire on an in-place shift.
-                // 'rep movsb' collapses when the two buffers are less than a cache line apart, and the
-                // non-temporal stores it switches to for large copies evict the very lines the rest of the
-                // copy is about to read back.
-                if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
-                {
-                    CopyOverlappedForward(ref dest, ref src, len);
-                    return;
-                }
-
-                // 'dest' above 'src'. The platform memmove's backward loop has neither problem and outruns a
-                // managed descending loop, so this is only worth doing while the QCall dominates the copy.
-                if (len <= MemmoveOverlappedBackwardThreshold)
-                {
-                    CopyOverlappedBackward(ref dest, ref src, len);
-                    return;
-                }
+                CopyOverlappedForward(ref dest, ref src, len);
+                return;
             }
+
+            if (len <= MemmoveOverlappedBackwardThreshold)
+            {
+                CopyOverlappedBackward(ref dest, ref src, len);
+                return;
+            }
+#endif
 
         PInvoke:
             // Implicit nullchecks
@@ -287,47 +275,41 @@ namespace System
             MemmoveNative(ref dest, ref src, len);
         }
 
-        // Copies overlapping buffers where 'dest' is at a lower address than 'src', i.e. the data is
-        // shifted towards the start of the buffer. Blocks run in strictly ascending order, so a store can
-        // never reach a source byte a later block still has to read. That also rules out the "copy a final
-        // block anchored at the end of the buffer" trick the non-overlapping paths use - by the time such a
-        // block ran, the bytes it reads would already have been rewritten.
+#if TARGET_AMD64 || TARGET_ARM64
+        // Blocks run in strictly ascending order, so a store can never reach a source byte a later block
+        // still has to read. That also rules out the "copy a final block anchored at the end of the buffer"
+        // trick the non-overlapping paths use - those bytes would already have been rewritten.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CopyOverlappedForward(ref byte dest, ref byte src, nuint len)
         {
             Debug.Assert(len > 0);
 
-            if (len > MemmoveOverlappedBlock)
+            // An unaligned store costs more than an unaligned load, and an overlapping copy can only ever
+            // have one of the two aligned.
+            if (len >= MemmoveOverlappedAlignThreshold)
             {
-                // Align the destination. An unaligned store costs more than an unaligned load, and an
-                // overlapping copy can only ever have one of the two aligned.
-                if (len >= MemmoveOverlappedAlignThreshold)
+                nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);
+                if (head != 64)
                 {
-                    nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);
-                    if (head != 64)
-                    {
-                        CopyOverlappedForwardTail(ref dest, ref src, head);
-                        dest = ref Unsafe.Add(ref dest, head);
-                        src = ref Unsafe.Add(ref src, head);
-                        len -= head;
-                    }
+                    CopyOverlappedForwardTail(ref dest, ref src, head);
+                    dest = ref Unsafe.Add(ref dest, head);
+                    src = ref Unsafe.Add(ref src, head);
+                    len -= head;
                 }
+            }
 
-                do
-                {
-                    Memmove(ref dest, ref src, MemmoveOverlappedBlock);
-                    dest = ref Unsafe.Add(ref dest, MemmoveOverlappedBlock);
-                    src = ref Unsafe.Add(ref src, MemmoveOverlappedBlock);
-                    len -= MemmoveOverlappedBlock;
-                }
-                while (len > MemmoveOverlappedBlock);
+            while (len > MemmoveOverlappedBlock)
+            {
+                Memmove(ref dest, ref src, MemmoveOverlappedBlock);
+                dest = ref Unsafe.Add(ref dest, MemmoveOverlappedBlock);
+                src = ref Unsafe.Add(ref src, MemmoveOverlappedBlock);
+                len -= MemmoveOverlappedBlock;
             }
 
             CopyOverlappedForwardTail(ref dest, ref src, len);
         }
 
-        // Copies overlapping buffers where 'dest' is at a higher address than 'src', i.e. the data is
-        // shifted towards the end of the buffer. Mirror image of the above, walking down from the end.
+        // Mirror image: blocks run in strictly descending order, walking down from the end.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CopyOverlappedBackward(ref byte dest, ref byte src, nuint len)
         {
@@ -339,102 +321,43 @@ namespace System
                 Memmove(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len), MemmoveOverlappedBlock);
             }
 
-            CopyOverlappedBackwardTail(ref dest, ref src, len);
+            while (len >= sizeof(ulong))
+            {
+                len -= sizeof(ulong);
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref src, len)));
+            }
+
+            while (len != 0)
+            {
+                len--;
+                Unsafe.Add(ref dest, len) = Unsafe.Add(ref src, len);
+            }
         }
 
-        // The two routines below finish a copy of at most MemmoveOverlappedBlock bytes. They deliberately
-        // don't call Memmove: they are where an un-unrolled Memmove from the loops above lands, so calling
-        // it again is what recursion would look like. Every step is a single load followed by a single
-        // store of the same width, so the ordering the copy depends on comes from the data dependency
-        // rather than from how the register allocator happened to schedule a wider block.
+        // Finishes at most MemmoveOverlappedBlock bytes. Deliberately doesn't call Memmove - this is where a
+        // call the JIT didn't unroll lands, so calling it again is what recursion would look like. Every step
+        // is one load feeding one store, so the ordering comes from the data dependency.
         private static void CopyOverlappedForwardTail(ref byte dest, ref byte src, nuint len)
         {
             Debug.Assert(len <= MemmoveOverlappedBlock);
 
-            while (len >= 16)
+            while (len >= sizeof(ulong))
             {
-                Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref src), ref dest);
-                dest = ref Unsafe.Add(ref dest, 16);
-                src = ref Unsafe.Add(ref src, 16);
-                len -= 16;
+                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<ulong>(ref src));
+                dest = ref Unsafe.Add(ref dest, sizeof(ulong));
+                src = ref Unsafe.Add(ref src, sizeof(ulong));
+                len -= sizeof(ulong);
             }
 
-            if ((len & 8) != 0)
-            {
-                CopyStep8(ref dest, ref src);
-                dest = ref Unsafe.Add(ref dest, 8);
-                src = ref Unsafe.Add(ref src, 8);
-            }
-
-            if ((len & 4) != 0)
-            {
-                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<uint>(ref src));
-                dest = ref Unsafe.Add(ref dest, 4);
-                src = ref Unsafe.Add(ref src, 4);
-            }
-
-            if ((len & 2) != 0)
-            {
-                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<ushort>(ref src));
-                dest = ref Unsafe.Add(ref dest, 2);
-                src = ref Unsafe.Add(ref src, 2);
-            }
-
-            if ((len & 1) != 0)
+            while (len != 0)
             {
                 dest = src;
+                dest = ref Unsafe.Add(ref dest, 1);
+                src = ref Unsafe.Add(ref src, 1);
+                len--;
             }
         }
-
-        private static void CopyOverlappedBackwardTail(ref byte dest, ref byte src, nuint len)
-        {
-            Debug.Assert(len <= MemmoveOverlappedBlock);
-
-            while (len >= 16)
-            {
-                len -= 16;
-                Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref Unsafe.Add(ref src, len)), ref Unsafe.Add(ref dest, len));
-            }
-
-            if ((len & 8) != 0)
-            {
-                len -= 8;
-                CopyStep8(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
-            }
-
-            if ((len & 4) != 0)
-            {
-                len -= 4;
-                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref src, len)));
-            }
-
-            if ((len & 2) != 0)
-            {
-                len -= 2;
-                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, len)));
-            }
-
-            if ((len & 1) != 0)
-            {
-                Debug.Assert(len == 1);
-                dest = src;
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void CopyStep8(ref byte dest, ref byte src)
-        {
-#if TARGET_64BIT
-            Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<ulong>(ref src));
-#else
-            // Two independent halves: both are read before either is written, so this stays correct for a
-            // backward copy whose buffers are less than 8 bytes apart.
-            uint lower = Unsafe.ReadUnaligned<uint>(ref src);
-            uint upper = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref src, 4));
-            Unsafe.WriteUnaligned(ref dest, lower);
-            Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, 4), upper);
 #endif
-        }
 
         // Non-inlinable wrapper around the QCall that avoids polluting the fast path
         // with P/Invoke prolog/epilog.

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -251,7 +251,7 @@ namespace System
             }
 
 #if (TARGET_AMD64 || TARGET_ARM64) && !MONO
-            // Handle left shifts in managed code under the threshold. 
+            // Handle left shifts in managed code under the threshold.
             // Right shifts had no issues on all tested platforms with the platform memmove.
             if (Vector128.IsHardwareAccelerated &&
                 len <= OverlappedForwardThreshold && (nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
@@ -267,8 +267,7 @@ namespace System
             _ = Unsafe.ReadUnaligned<byte>(ref dest);
             _ = Unsafe.ReadUnaligned<byte>(ref src);
 #if !MONO
-            // The GC transition costs more than a copy this size. Bounded by the same chunk
-            // BulkMoveWithWriteBarrier uses: that is how long the GC can be held off waiting for us.
+            // Skip the GC transition for small copies.
             if (len <= Buffer.BulkMoveWithWriteBarrierChunk)
             {
                 MemmoveNativeNoGCTransition(ref dest, ref src, len);
@@ -287,8 +286,8 @@ namespace System
         {
             Debug.Assert(len > 0);
 
-            // Align the destination - only one side can be, and stores suffer more than loads. Worth the
-            // extra leading block only on larger copies.
+            // Align the destination - only one side can be, and stores suffer more than loads.
+            // Worth the extra leading block only on larger copies.
             if (len >= 2048)
             {
                 nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -25,11 +25,10 @@ namespace System
 #endif
         private const nuint ZeroMemoryNativeThreshold = 1024;
 
-#if TARGET_AMD64 || TARGET_ARM64
-        // Overlapping copies are done in blocks of this size with a constant-length Memmove, which the JIT
-        // unrolls into "load the whole block into registers, then store it" - correct for any overlap. 64
-        // bytes stays within its unrolling budget everywhere, and bounds re-entry: a call it didn't unroll
-        // comes back with a length the tail handles without calling Memmove again, so these can't recurse.
+#if (TARGET_AMD64 || TARGET_ARM64) && !MONO
+        // Blocks are copied with a constant-length Memmove, which the JIT unrolls into "load the whole block
+        // into registers, then store it" - correct for any overlap. 64 bytes fits its unrolling budget on
+        // every target here, and bounds re-entry: a shorter length is finished without calling Memmove.
         private const nuint MemmoveOverlappedBlock = 64;
 
         // Aligning the destination only pays for the extra leading block on larger copies.
@@ -248,12 +247,10 @@ namespace System
                 return;
             }
 
-#if TARGET_AMD64 || TARGET_ARM64
-            // The platform memmove's forward loop is tuned for disjoint buffers: 'rep movsb' collapses when
-            // they are less than a cache line apart - a shift by one element - and the non-temporal stores it
-            // uses for large copies evict the lines the rest of the copy reads back. Its backward loop has
-            // neither problem and outruns a managed descending one, so that direction is only handled here
-            // while the QCall dominates the copy.
+#if (TARGET_AMD64 || TARGET_ARM64) && !MONO
+            // memmove's forward loop is tuned for disjoint buffers: 'rep movsb' collapses when they are less
+            // than a cache line apart, and the non-temporal stores it uses for large copies evict the lines
+            // the rest of the copy reads back. Its backward loop has neither problem and beats us above 256.
             if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
             {
                 CopyOverlappedForward(ref dest, ref src, len);
@@ -275,17 +272,16 @@ namespace System
             MemmoveNative(ref dest, ref src, len);
         }
 
-#if TARGET_AMD64 || TARGET_ARM64
+#if (TARGET_AMD64 || TARGET_ARM64) && !MONO
         // Blocks run in strictly ascending order, so a store can never reach a source byte a later block
-        // still has to read. That also rules out the "copy a final block anchored at the end of the buffer"
-        // trick the non-overlapping paths use - those bytes would already have been rewritten.
+        // still has to read. That also rules out the trailing "block anchored at the end of the buffer"
+        // shortcut the non-overlapping paths use - those bytes would already have been rewritten.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CopyOverlappedForward(ref byte dest, ref byte src, nuint len)
         {
             Debug.Assert(len > 0);
 
-            // An unaligned store costs more than an unaligned load, and an overlapping copy can only ever
-            // have one of the two aligned.
+            // Only one of the two can be aligned, and an unaligned store costs more than an unaligned load.
             if (len >= MemmoveOverlappedAlignThreshold)
             {
                 nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -26,6 +26,15 @@ namespace System
 #endif
         private const nuint ZeroMemoryNativeThreshold = 1024;
 
+        // Block size used by the overlapping copies below. Each block is copied with a constant-length
+        // Memmove, which the JIT unrolls into "load the whole block into registers, then store it" - the
+        // one shape that stays correct however the two buffers overlap. That unrolling has a target
+        // dependent budget of four vector registers, and 64 bytes is within it even where those are only
+        // 16 bytes wide. Keeping the block this small also bounds re-entry: should the JIT not unroll the
+        // call after all, it arrives back here with a length that is handled without another Memmove, so
+        // these routines cannot recurse.
+        private const nuint MemmoveOverlappedBlock = 64;
+
         // Copy size at which aligning the destination of an overlapping forward copy starts to pay for the
         // extra leading block. Below it the alignment prologue costs more than the misaligned stores it
         // avoids.
@@ -257,7 +266,7 @@ namespace System
                 // copy is about to read back.
                 if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
                 {
-                    CopyForwardVectorized(ref dest, ref src, len);
+                    CopyOverlappedForward(ref dest, ref src, len);
                     return;
                 }
 
@@ -265,7 +274,7 @@ namespace System
                 // managed descending loop, so this is only worth doing while the QCall dominates the copy.
                 if (len <= MemmoveOverlappedBackwardThreshold)
                 {
-                    CopyBackwardVectorized(ref dest, ref src, len);
+                    CopyOverlappedBackward(ref dest, ref src, len);
                     return;
                 }
             }
@@ -278,113 +287,81 @@ namespace System
             MemmoveNative(ref dest, ref src, len);
         }
 
-        // Copies overlapping buffers where 'dest' is at a lower address than 'src'. The blocks run in
-        // strictly ascending order, so a byte is always read before the copy can overwrite it. That also
-        // rules out the "copy a final block anchored at the end of the buffer" trick the non-overlapping
-        // paths use - by the time that block ran, the bytes it reads would already have been rewritten.
+        // Copies overlapping buffers where 'dest' is at a lower address than 'src', i.e. the data is
+        // shifted towards the start of the buffer. Blocks run in strictly ascending order, so a store can
+        // never reach a source byte a later block still has to read. That also rules out the "copy a final
+        // block anchored at the end of the buffer" trick the non-overlapping paths use - by the time such a
+        // block ran, the bytes it reads would already have been rewritten.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void CopyForwardVectorized(ref byte dest, ref byte src, nuint len)
+        private static void CopyOverlappedForward(ref byte dest, ref byte src, nuint len)
         {
             Debug.Assert(len > 0);
-            Debug.Assert(Vector128.IsHardwareAccelerated);
 
-            // Align the destination. An unaligned store costs more than an unaligned load, and an
-            // overlapping copy can only ever have one of the two aligned.
-            if (len >= MemmoveOverlappedAlignThreshold)
+            if (len > MemmoveOverlappedBlock)
             {
-                nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);
-                if (head != 64)
+                // Align the destination. An unaligned store costs more than an unaligned load, and an
+                // overlapping copy can only ever have one of the two aligned.
+                if (len >= MemmoveOverlappedAlignThreshold)
                 {
-                    CopyBlocksForward(ref dest, ref src, head);
-                    dest = ref Unsafe.Add(ref dest, head);
-                    src = ref Unsafe.Add(ref src, head);
-                    len -= head;
+                    nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);
+                    if (head != 64)
+                    {
+                        CopyOverlappedForwardTail(ref dest, ref src, head);
+                        dest = ref Unsafe.Add(ref dest, head);
+                        src = ref Unsafe.Add(ref src, head);
+                        len -= head;
+                    }
                 }
+
+                do
+                {
+                    Memmove(ref dest, ref src, MemmoveOverlappedBlock);
+                    dest = ref Unsafe.Add(ref dest, MemmoveOverlappedBlock);
+                    src = ref Unsafe.Add(ref src, MemmoveOverlappedBlock);
+                    len -= MemmoveOverlappedBlock;
+                }
+                while (len > MemmoveOverlappedBlock);
             }
 
-            // The blocks are addressed off 'dest'/'src' with constant offsets rather than off a running
-            // index so that targets with load/store-pair instructions can fold them (arm64 'ldp'/'stp').
-            if (Vector256.IsHardwareAccelerated)
-            {
-                while (len >= 128)
-                {
-                    CopyBlock128(ref dest, ref src);
-                    dest = ref Unsafe.Add(ref dest, 128);
-                    src = ref Unsafe.Add(ref src, 128);
-                    len -= 128;
-                }
-            }
-            else
-            {
-                while (len >= 64)
-                {
-                    CopyBlock64(ref dest, ref src);
-                    dest = ref Unsafe.Add(ref dest, 64);
-                    src = ref Unsafe.Add(ref src, 64);
-                    len -= 64;
-                }
-            }
-
-            CopyBlocksForward(ref dest, ref src, len);
+            CopyOverlappedForwardTail(ref dest, ref src, len);
         }
 
-        // Copies overlapping buffers where 'dest' is at a higher address than 'src'. Mirror image of the
-        // above: the blocks run in strictly descending order, walking down from the end of the buffer.
+        // Copies overlapping buffers where 'dest' is at a higher address than 'src', i.e. the data is
+        // shifted towards the end of the buffer. Mirror image of the above, walking down from the end.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void CopyBackwardVectorized(ref byte dest, ref byte src, nuint len)
+        private static void CopyOverlappedBackward(ref byte dest, ref byte src, nuint len)
         {
             Debug.Assert(len > 0);
-            Debug.Assert(Vector128.IsHardwareAccelerated);
 
-            if (Vector256.IsHardwareAccelerated)
+            while (len > MemmoveOverlappedBlock)
             {
-                while (len >= 128)
-                {
-                    len -= 128;
-                    CopyBlock128(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
-                }
-            }
-            else
-            {
-                while (len >= 64)
-                {
-                    len -= 64;
-                    CopyBlock64(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
-                }
+                len -= MemmoveOverlappedBlock;
+                Memmove(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len), MemmoveOverlappedBlock);
             }
 
-            CopyBlocksBackward(ref dest, ref src, len);
+            CopyOverlappedBackwardTail(ref dest, ref src, len);
         }
 
-        // Copies fewer than 128 bytes, largest block first, so that the blocks run in ascending order.
-        private static void CopyBlocksForward(ref byte dest, ref byte src, nuint len)
+        // The two routines below finish a copy of at most MemmoveOverlappedBlock bytes. They deliberately
+        // don't call Memmove: they are where an un-unrolled Memmove from the loops above lands, so calling
+        // it again is what recursion would look like. Every step is a single load followed by a single
+        // store of the same width, so the ordering the copy depends on comes from the data dependency
+        // rather than from how the register allocator happened to schedule a wider block.
+        private static void CopyOverlappedForwardTail(ref byte dest, ref byte src, nuint len)
         {
-            Debug.Assert(len < 128);
+            Debug.Assert(len <= MemmoveOverlappedBlock);
 
-            if ((len & 64) != 0)
+            while (len >= 16)
             {
-                CopyBlock64(ref dest, ref src);
-                dest = ref Unsafe.Add(ref dest, 64);
-                src = ref Unsafe.Add(ref src, 64);
-            }
-
-            if ((len & 32) != 0)
-            {
-                CopyBlock32(ref dest, ref src);
-                dest = ref Unsafe.Add(ref dest, 32);
-                src = ref Unsafe.Add(ref src, 32);
-            }
-
-            if ((len & 16) != 0)
-            {
-                CopyBlock16(ref dest, ref src);
+                Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref src), ref dest);
                 dest = ref Unsafe.Add(ref dest, 16);
                 src = ref Unsafe.Add(ref src, 16);
+                len -= 16;
             }
 
             if ((len & 8) != 0)
             {
-                CopyBlock8(ref dest, ref src);
+                CopyStep8(ref dest, ref src);
                 dest = ref Unsafe.Add(ref dest, 8);
                 src = ref Unsafe.Add(ref src, 8);
             }
@@ -409,33 +386,20 @@ namespace System
             }
         }
 
-        // Copies fewer than 128 bytes, largest block first, so that the blocks run in descending order.
-        private static void CopyBlocksBackward(ref byte dest, ref byte src, nuint len)
+        private static void CopyOverlappedBackwardTail(ref byte dest, ref byte src, nuint len)
         {
-            Debug.Assert(len < 128);
+            Debug.Assert(len <= MemmoveOverlappedBlock);
 
-            if ((len & 64) != 0)
-            {
-                len -= 64;
-                CopyBlock64(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
-            }
-
-            if ((len & 32) != 0)
-            {
-                len -= 32;
-                CopyBlock32(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
-            }
-
-            if ((len & 16) != 0)
+            while (len >= 16)
             {
                 len -= 16;
-                CopyBlock16(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
+                Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref Unsafe.Add(ref src, len)), ref Unsafe.Add(ref dest, len));
             }
 
             if ((len & 8) != 0)
             {
                 len -= 8;
-                CopyBlock8(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
+                CopyStep8(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
             }
 
             if ((len & 4) != 0)
@@ -457,76 +421,18 @@ namespace System
             }
         }
 
-        // Every block below is fully loaded before any of it is stored, so it can be copied in either
-        // direction without one of its own stores clobbering source bytes it still has to read.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void CopyBlock128(ref byte dest, ref byte src)
-        {
-            Debug.Assert(Vector256.IsHardwareAccelerated);
-
-            Vector256<byte> block0 = Vector256.LoadUnsafe(ref src);
-            Vector256<byte> block1 = Vector256.LoadUnsafe(ref src, 32);
-            Vector256<byte> block2 = Vector256.LoadUnsafe(ref src, 64);
-            Vector256<byte> block3 = Vector256.LoadUnsafe(ref src, 96);
-            Vector256.StoreUnsafe(block0, ref dest);
-            Vector256.StoreUnsafe(block1, ref dest, 32);
-            Vector256.StoreUnsafe(block2, ref dest, 64);
-            Vector256.StoreUnsafe(block3, ref dest, 96);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void CopyBlock64(ref byte dest, ref byte src)
-        {
-            if (Vector256.IsHardwareAccelerated)
-            {
-                Vector256<byte> block0 = Vector256.LoadUnsafe(ref src);
-                Vector256<byte> block1 = Vector256.LoadUnsafe(ref src, 32);
-                Vector256.StoreUnsafe(block0, ref dest);
-                Vector256.StoreUnsafe(block1, ref dest, 32);
-            }
-            else
-            {
-                Vector128<byte> block0 = Vector128.LoadUnsafe(ref src);
-                Vector128<byte> block1 = Vector128.LoadUnsafe(ref src, 16);
-                Vector128<byte> block2 = Vector128.LoadUnsafe(ref src, 32);
-                Vector128<byte> block3 = Vector128.LoadUnsafe(ref src, 48);
-                Vector128.StoreUnsafe(block0, ref dest);
-                Vector128.StoreUnsafe(block1, ref dest, 16);
-                Vector128.StoreUnsafe(block2, ref dest, 32);
-                Vector128.StoreUnsafe(block3, ref dest, 48);
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void CopyBlock32(ref byte dest, ref byte src)
-        {
-            if (Vector256.IsHardwareAccelerated)
-            {
-                Vector256.StoreUnsafe(Vector256.LoadUnsafe(ref src), ref dest);
-            }
-            else
-            {
-                Vector128<byte> block0 = Vector128.LoadUnsafe(ref src);
-                Vector128<byte> block1 = Vector128.LoadUnsafe(ref src, 16);
-                Vector128.StoreUnsafe(block0, ref dest);
-                Vector128.StoreUnsafe(block1, ref dest, 16);
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void CopyBlock16(ref byte dest, ref byte src) =>
-            Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref src), ref dest);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void CopyBlock8(ref byte dest, ref byte src)
+        private static void CopyStep8(ref byte dest, ref byte src)
         {
 #if TARGET_64BIT
             Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<ulong>(ref src));
 #else
-            uint block0 = Unsafe.ReadUnaligned<uint>(ref src);
-            uint block1 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref src, 4));
-            Unsafe.WriteUnaligned(ref dest, block0);
-            Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, 4), block1);
+            // Two independent halves: both are read before either is written, so this stays correct for a
+            // backward copy whose buffers are less than 8 bytes apart.
+            uint lower = Unsafe.ReadUnaligned<uint>(ref src);
+            uint upper = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref src, 4));
+            Unsafe.WriteUnaligned(ref dest, lower);
+            Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, 4), upper);
 #endif
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace System
 {
@@ -28,7 +29,7 @@ namespace System
 #if (TARGET_AMD64 || TARGET_ARM64) && !MONO
         // Blocks are copied with a constant-length Memmove, which the JIT expands into "load the whole
         // block into registers, then store it" - correct for any overlap. 64 bytes fits its unrolling
-        // budget on every target here, and bounds re-entry: a block-sized call skips the loop below and
+        // budget on every target here, and bounds re-entry: a block-sized call skips the loops below and
         // is finished by the tail, which never calls Memmove back.
         private const nuint OverlappedBlockSize = 64;
 
@@ -37,6 +38,15 @@ namespace System
 
         // Past this the platform memmove's backward loop beats a managed descending one.
         private const nuint OverlappedBackwardThreshold = 256;
+
+#if TARGET_ARM64
+        // What makes the platform memmove worth replacing for long forward copies is 'rep movsb', which
+        // is x86-only: arm64 uses a plain vector loop that has no such cliff and is well tuned, so past
+        // this size it wins. Below it the P/Invoke is still the dominant cost and we come out ahead.
+        private const nuint OverlappedForwardThreshold = 1024;
+#else
+        private const nuint OverlappedForwardThreshold = nuint.MaxValue;
+#endif
 #endif
 
 #if HAS_CUSTOM_BLOCKS
@@ -255,17 +265,28 @@ namespace System
             // collapses when the buffers are less than a cache line apart, and the non-temporal stores it
             // uses for large copies evict the lines the rest of the copy reads back. Its backward loop has
             // neither problem, so long right shifts are left to it.
-            if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
+            //
+            // Gated on SIMD being available, which is what the blocks below are expanded into. It folds
+            // away under the JIT, R2R and AOT; it is only false in the interpreter-only mode, where the
+            // blocks would each cost a call and the platform memmove is the better deal.
+            if (Vector128.IsHardwareAccelerated)
             {
-                // dest is below src, so copying upwards never overwrites a byte we still have to read.
-                CopyOverlappedForward(ref dest, ref src, len);
-                return;
-            }
-
-            if (len <= OverlappedBackwardThreshold)
-            {
-                CopyOverlappedBackward(ref dest, ref src, len);
-                return;
+                if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
+                {
+                    // dest is below src, so copying upwards never overwrites a byte we still have to read.
+                    // Note the 'else': once we know the buffers overlap this way, a length over the
+                    // threshold has to fall through to the platform memmove, not to the backward copy.
+                    if (len <= OverlappedForwardThreshold)
+                    {
+                        CopyOverlappedForward(ref dest, ref src, len);
+                        return;
+                    }
+                }
+                else if (len <= OverlappedBackwardThreshold)
+                {
+                    CopyOverlappedBackward(ref dest, ref src, len);
+                    return;
+                }
             }
 #endif
 
@@ -299,6 +320,31 @@ namespace System
                     dest = ref Unsafe.Add(ref dest, head);
                     src = ref Unsafe.Add(ref src, head);
                     len -= head;
+                }
+            }
+
+            // Take the widest block the JIT will still expand: its budget is four vector registers, so
+            // 256 bytes under AVX512 and 128 under AVX2. Wider blocks mean fewer loop iterations, and
+            // fewer boundaries where one block's store and the next block's load share a cache line,
+            // which is what a tight overlap is sensitive to. arm64 tops out at the 64-byte loop below.
+            if (Vector512.IsHardwareAccelerated)
+            {
+                while (len > 256)
+                {
+                    Memmove(ref dest, ref src, 256);
+                    dest = ref Unsafe.Add(ref dest, 256);
+                    src = ref Unsafe.Add(ref src, 256);
+                    len -= 256;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated)
+            {
+                while (len > 128)
+                {
+                    Memmove(ref dest, ref src, 128);
+                    dest = ref Unsafe.Add(ref dest, 128);
+                    src = ref Unsafe.Add(ref src, 128);
+                    len -= 128;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -45,7 +45,9 @@ namespace System
         // this size it wins. Below it the P/Invoke is still the dominant cost and we come out ahead.
         private const nuint OverlappedForwardThreshold = 1024;
 #else
-        private const nuint OverlappedForwardThreshold = nuint.MaxValue;
+        // ulong rather than nuint because nuint.MaxValue is not a compile-time constant, same as
+        // MemmoveNativeThreshold above. The comparison widens to ulong and folds away.
+        private const ulong OverlappedForwardThreshold = ulong.MaxValue;
 #endif
 #endif
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -26,14 +26,9 @@ namespace System
 #endif
         private const nuint ZeroMemoryNativeThreshold = 1024;
 
-        // The platform's forward memmove ('rep movsb' on x86) loses most of its throughput when the source
-        // and the destination are less than a cache line apart, which is exactly what a shift by a single
-        // array element looks like. Copy those overlapping buffers ourselves instead.
-        private const nuint MemmoveOverlappedNativeMinDistance = 64;
-
-        // Largest block handed to the platform's memmove when the buffers overlap: big enough for it to
-        // amortize its own set-up cost, small enough to keep it away from non-temporal stores.
-        private const nuint MemmoveOverlappedNativeChunk = 32 * 1024;
+        // Copy size at which aligning the destination of an overlapping copy starts to pay for the extra
+        // leading block. Below it the alignment prologue costs more than the misaligned stores it avoids.
+        private const nuint MemmoveOverlappedAlignThreshold = 2048;
 
 #if HAS_CUSTOM_BLOCKS
         [StructLayout(LayoutKind.Sequential, Size = 16)]
@@ -246,12 +241,15 @@ namespace System
 
             // 'dest' below 'src' means the data is shifted towards the start of the buffer, which is by
             // far the most common overlapping shape (List<T>.RemoveAt/RemoveRange, Queue<T>, overlapping
-            // Span<T>.CopyTo, ...). Such a copy can run in strictly ascending order, which lets us pick a
-            // better strategy than blindly handing it to the platform's memmove. Shifts towards the end of
-            // the buffer keep using memmove, whose backward copy loop doesn't have the problems below.
-            if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
+            // Span<T>.CopyTo, ...). Such a copy can run in strictly ascending order, so we do it ourselves
+            // rather than handing it to the platform's memmove, whose forward copy loop is tuned for
+            // disjoint buffers: 'rep movsb' collapses when the two buffers are less than a cache line
+            // apart, and the non-temporal stores it switches to for large copies push out exactly the
+            // lines the rest of the copy is about to read back. Shifts towards the end of the buffer keep
+            // using memmove, whose backward copy loop doesn't have either problem.
+            if (Vector128.IsHardwareAccelerated && (nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
             {
-                MemmoveOverlappedForward(ref dest, ref src, len);
+                CopyForwardVectorized(ref dest, ref src, len);
                 return;
             }
 
@@ -263,53 +261,51 @@ namespace System
             MemmoveNative(ref dest, ref src, len);
         }
 
-        // Copies overlapping buffers where 'dest' is at a lower address than 'src', i.e. the data is
-        // shifted towards the start of the buffer. Both of the platform memmove's problems with this
-        // shape come from it being tuned for disjoint buffers, so we route around them here.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void MemmoveOverlappedForward(ref byte dest, ref byte src, nuint len)
-        {
-            Debug.Assert(len > 0);
-
-            nuint distance = (nuint)Unsafe.ByteOffset(ref dest, ref src);
-
-            // A forward 'rep movsb' loses most of its throughput when it has to feed itself, i.e. when the
-            // two buffers are less than a cache line apart - which is precisely a shift by one element. And
-            // below the cut-off the non-overlapping paths use, the QCall costs more than the copy itself.
-            // Targets that never call into the platform's memmove (MemmoveNativeThreshold is unbounded
-            // there) consequently always take this path, just like their non-overlapping copies do.
-            if (Vector128.IsHardwareAccelerated &&
-                (len <= MemmoveNativeThreshold || distance < MemmoveOverlappedNativeMinDistance))
-            {
-                CopyForwardVectorized(ref dest, ref src, len);
-                return;
-            }
-
-            // Implicit nullchecks
-            _ = Unsafe.ReadUnaligned<byte>(ref dest);
-            _ = Unsafe.ReadUnaligned<byte>(ref src);
-
-            // Large copies make memmove switch to non-temporal stores, which is exactly wrong here: the
-            // lines it pushes out of the cache are the ones the rest of the copy is about to read back.
-            // Feeding it one chunk at a time keeps it on its cached - and far faster - copy loop. Walking
-            // the chunks from the start is safe because 'dest' trails 'src'.
-            while (len > MemmoveOverlappedNativeChunk)
-            {
-                MemmoveNative(ref dest, ref src, MemmoveOverlappedNativeChunk);
-                dest = ref Unsafe.Add(ref dest, MemmoveOverlappedNativeChunk);
-                src = ref Unsafe.Add(ref src, MemmoveOverlappedNativeChunk);
-                len -= MemmoveOverlappedNativeChunk;
-            }
-
-            MemmoveNative(ref dest, ref src, len);
-        }
-
         // Copies 'src' to 'dest' in strictly ascending order, so a byte is always read before the copy can
         // overwrite it. That also rules out the "copy a final block anchored at the end of the buffer"
         // trick the non-overlapping paths use - that block may already have been rewritten by then.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CopyForwardVectorized(ref byte dest, ref byte src, nuint len)
         {
+            Debug.Assert(len > 0);
             Debug.Assert(Vector128.IsHardwareAccelerated);
+
+            // Align the destination. An unaligned store costs more than an unaligned load, and an
+            // overlapping copy can only ever have one of the two aligned. The leading bytes have to be
+            // copied ascending as well, so unlike the non-overlapping paths this can't be done with a
+            // single oversized leading block - that block would read source bytes it just overwrote.
+            if (len >= MemmoveOverlappedAlignThreshold)
+            {
+                nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);
+                if (head != 64)
+                {
+                    len -= head;
+
+                    while (head >= 16)
+                    {
+                        Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref src), ref dest);
+                        dest = ref Unsafe.Add(ref dest, 16);
+                        src = ref Unsafe.Add(ref src, 16);
+                        head -= 16;
+                    }
+
+                    while (head >= 4)
+                    {
+                        Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<uint>(ref src));
+                        dest = ref Unsafe.Add(ref dest, 4);
+                        src = ref Unsafe.Add(ref src, 4);
+                        head -= 4;
+                    }
+
+                    while (head != 0)
+                    {
+                        dest = src;
+                        dest = ref Unsafe.Add(ref dest, 1);
+                        src = ref Unsafe.Add(ref src, 1);
+                        head--;
+                    }
+                }
+            }
 
             // The blocks are addressed off 'dest'/'src' with constant offsets rather than off a running
             // index so that targets with load/store-pair instructions can fold them (arm64 'ldp'/'stp').

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace System
 {
@@ -46,7 +47,10 @@ namespace System
         private struct Block64 {}
 #endif // HAS_CUSTOM_BLOCKS
 
+        // Too big to be worth inlining: it burns a lot of the caller's budget, and keeping the call is also
+        // what lets the JIT unroll it when the length is constant.
         [Intrinsic] // Unrolled for small constant lengths
+        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void Memmove(ref byte dest, ref byte src, nuint len)
         {
             // P/Invoke into the native version when the buffers are overlapping.
@@ -291,6 +295,30 @@ namespace System
                     dest = ref Unsafe.Add(ref dest, head);
                     src = ref Unsafe.Add(ref src, head);
                     len -= head;
+                }
+            }
+
+            // The JIT unrolls a constant-length Memmove up to four vector registers wide, so take the widest
+            // block it will still expand. Bigger blocks also mean fewer boundaries where a store and the
+            // next block's load land in the same cache line, which is what a tight overlap is sensitive to.
+            if (Vector512.IsHardwareAccelerated)
+            {
+                while (len > 256)
+                {
+                    Memmove(ref dest, ref src, 256);
+                    dest = ref Unsafe.Add(ref dest, 256);
+                    src = ref Unsafe.Add(ref src, 256);
+                    len -= 256;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated)
+            {
+                while (len > 128)
+                {
+                    Memmove(ref dest, ref src, 128);
+                    dest = ref Unsafe.Add(ref dest, 128);
+                    src = ref Unsafe.Add(ref src, 128);
+                    len -= 128;
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -27,26 +27,15 @@ namespace System
         private const nuint ZeroMemoryNativeThreshold = 1024;
 
 #if (TARGET_AMD64 || TARGET_ARM64) && !MONO
-        // Blocks are copied with a constant-length Memmove, which the JIT expands into "load the whole
-        // block into registers, then store it" - correct for any overlap. 64 bytes fits its unrolling
-        // budget on every target here, and bounds re-entry: a block-sized call skips the loops below and
-        // is finished by the tail, which never calls Memmove back.
+        // Blocks are copied with a constant-length Memmove, which the JIT unrolls into "load the whole
+        // block into registers, then store it" - which is what makes a block correct under any overlap.
         private const nuint OverlappedBlockSize = 64;
 
-        // Aligning the destination only pays for the extra leading block on larger copies.
-        private const nuint OverlappedAlignThreshold = 2048;
-
-        // Past this the platform memmove's backward loop beats a managed descending one.
-        private const nuint OverlappedBackwardThreshold = 256;
-
 #if TARGET_ARM64
-        // What makes the platform memmove worth replacing for long forward copies is 'rep movsb', which
-        // is x86-only: arm64 uses a plain vector loop that has no such cliff and is well tuned, so past
-        // this size it wins. Below it the P/Invoke is still the dominant cost and we come out ahead.
+        // arm64 has no 'rep movsb' cliff and its platform memmove is well tuned, so past this it wins.
         private const nuint OverlappedForwardThreshold = 1024;
 #else
-        // ulong rather than nuint because nuint.MaxValue is not a compile-time constant, same as
-        // MemmoveNativeThreshold above. The comparison widens to ulong and folds away.
+        // ulong because nuint.MaxValue is not a compile-time constant; the comparison folds away.
         private const ulong OverlappedForwardThreshold = ulong.MaxValue;
 #endif
 #endif
@@ -262,33 +251,13 @@ namespace System
             }
 
 #if (TARGET_AMD64 || TARGET_ARM64) && !MONO
-            // We're better off here than calling the platform memmove: for short copies the P/Invoke alone
-            // costs more than the copy, and its forward loop is tuned for disjoint buffers - 'rep movsb'
-            // collapses when the buffers are less than a cache line apart, and the non-temporal stores it
-            // uses for large copies evict the lines the rest of the copy reads back. Its backward loop has
-            // neither problem, so long right shifts are left to it.
-            //
-            // Gated on SIMD being available, which is what the blocks below are expanded into. It folds
-            // away under the JIT, R2R and AOT; it is only false in the interpreter-only mode, where the
-            // blocks would each cost a call and the platform memmove is the better deal.
-            if (Vector128.IsHardwareAccelerated)
+            // Handle left shifts in managed code under the threshold. 
+            // Right shifts had no issues on all tested platforms with the platform memmove.
+            if (Vector128.IsHardwareAccelerated &&
+                len <= OverlappedForwardThreshold && (nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
             {
-                if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
-                {
-                    // dest is below src, so copying upwards never overwrites a byte we still have to read.
-                    // Note the 'else': once we know the buffers overlap this way, a length over the
-                    // threshold has to fall through to the platform memmove, not to the backward copy.
-                    if (len <= OverlappedForwardThreshold)
-                    {
-                        CopyOverlappedForward(ref dest, ref src, len);
-                        return;
-                    }
-                }
-                else if (len <= OverlappedBackwardThreshold)
-                {
-                    CopyOverlappedBackward(ref dest, ref src, len);
-                    return;
-                }
+                CopyOverlappedForward(ref dest, ref src, len);
+                return;
             }
 #endif
 
@@ -297,23 +266,30 @@ namespace System
             Debug.Assert(len > 0);
             _ = Unsafe.ReadUnaligned<byte>(ref dest);
             _ = Unsafe.ReadUnaligned<byte>(ref src);
+#if !MONO
+            // The GC transition costs more than a copy this size. Bounded by the same chunk
+            // BulkMoveWithWriteBarrier uses: that is how long the GC can be held off waiting for us.
+            if (len <= Buffer.BulkMoveWithWriteBarrierChunk)
+            {
+                MemmoveNativeNoGCTransition(ref dest, ref src, len);
+                return;
+            }
+#endif
             MemmoveNative(ref dest, ref src, len);
         }
 
 #if (TARGET_AMD64 || TARGET_ARM64) && !MONO
-        // Every step below either is a constant-length Memmove, which the JIT expands so that the whole
-        // block is loaded before any of it is stored, or a single load feeding a single store, where the
-        // data dependency does the same for one register's worth. Steps then run in strictly ascending,
-        // non-overlapping order, so a store can never reach a source byte a later step has to read. That
-        // also rules out the trailing "block anchored at the end of the buffer" shortcut the
-        // non-overlapping paths use - those bytes may already have been rewritten.
+        // Each step loads everything it writes before it writes any of it - either a constant-length
+        // Memmove the JIT unrolls, or a single load feeding a single store. Steps then run in ascending,
+        // non-overlapping order, so a store never reaches a source byte a later step still has to read.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CopyOverlappedForward(ref byte dest, ref byte src, nuint len)
         {
             Debug.Assert(len > 0);
 
-            // Only one of the two can be aligned, and an unaligned store costs more than an unaligned load.
-            if (len >= OverlappedAlignThreshold)
+            // Align the destination - only one side can be, and stores suffer more than loads. Worth the
+            // extra leading block only on larger copies.
+            if (len >= 2048)
             {
                 nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);
                 if (head != 64)
@@ -325,10 +301,10 @@ namespace System
                 }
             }
 
-            // Take the widest block the JIT will still expand: its budget is four vector registers, so
-            // 256 bytes under AVX512 and 128 under AVX2. Wider blocks mean fewer loop iterations, and
-            // fewer boundaries where one block's store and the next block's load share a cache line,
-            // which is what a tight overlap is sensitive to. arm64 tops out at the 64-byte loop below.
+            // The widest block the JIT still unrolls: its budget is four vector registers, so 256 bytes
+            // under AVX512 and 128 under AVX2. Wider blocks mean fewer boundaries where one block's
+            // store and the next one's load share a cache line, which a tight overlap is sensitive to.
+            // arm64 tops out at the 64-byte loop below.
             if (Vector512.IsHardwareAccelerated)
             {
                 while (len > 256)
@@ -361,24 +337,9 @@ namespace System
             CopyOverlappedForwardTail(ref dest, ref src, len);
         }
 
-        // Mirror image: steps run in strictly descending order, walking down from the end.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void CopyOverlappedBackward(ref byte dest, ref byte src, nuint len)
-        {
-            Debug.Assert(len > 0);
-
-            while (len > OverlappedBlockSize)
-            {
-                len -= OverlappedBlockSize;
-                Memmove(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len), OverlappedBlockSize);
-            }
-
-            CopyOverlappedBackwardTail(ref dest, ref src, len);
-        }
-
-        // Finishes at most OverlappedBlockSize bytes, ascending. Deliberately doesn't call Memmove - this
-        // is where a block the JIT didn't expand comes back around, so calling it again is what recursion
-        // would look like. One step per set bit of len, so the steps tile the range without overlapping.
+        // Finishes at most OverlappedBlockSize bytes, ascending. Must not call Memmove: a block the JIT
+        // didn't unroll lands back here, so calling it again is what recursion would look like. One step
+        // per set bit of len, so the steps tile the range without overlapping.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void CopyOverlappedForwardTail(ref byte dest, ref byte src, nuint len)
         {
@@ -414,38 +375,6 @@ namespace System
                 dest = src;
             }
         }
-
-        // Mirror image: the steps tile the range from the end downwards.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void CopyOverlappedBackwardTail(ref byte dest, ref byte src, nuint len)
-        {
-            Debug.Assert(len <= OverlappedBlockSize);
-
-            while (len >= 16)
-            {
-                len -= 16;
-                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<Block16>(ref Unsafe.Add(ref src, len)));
-            }
-            if ((len & 8) != 0)
-            {
-                len -= 8;
-                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref src, len)));
-            }
-            if ((len & 4) != 0)
-            {
-                len -= 4;
-                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref src, len)));
-            }
-            if ((len & 2) != 0)
-            {
-                len -= 2;
-                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, len)));
-            }
-            if ((len & 1) != 0)
-            {
-                dest = src;
-            }
-        }
 #endif
 
         // Non-inlinable wrapper around the QCall that avoids polluting the fast path
@@ -460,6 +389,19 @@ namespace System
             }
         }
 
+#if !MONO
+        // Inlinable: a SuppressGCTransition call sets up no P/Invoke frame, and the JIT emits the GC poll.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void MemmoveNativeNoGCTransition(ref byte dest, ref byte src, nuint len)
+        {
+            fixed (byte* pDest = &dest)
+            fixed (byte* pSrc = &src)
+            {
+                memmoveNoGCTransition(pDest, pSrc, len);
+            }
+        }
+#endif
+
 #if MONO
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern unsafe void memmove(void* dest, void* src, nuint len);
@@ -468,6 +410,12 @@ namespace System
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "memmove")]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
         private static unsafe partial void* memmove(void* dest, void* src, nuint len);
+
+        // Same entry point; the attribute can only be applied per declaration.
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "memmove")]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        [SuppressGCTransition]
+        private static unsafe partial void* memmoveNoGCTransition(void* dest, void* src, nuint len);
 #pragma warning restore CS3016
 #endif
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -26,9 +26,16 @@ namespace System
 #endif
         private const nuint ZeroMemoryNativeThreshold = 1024;
 
-        // Copy size at which aligning the destination of an overlapping copy starts to pay for the extra
-        // leading block. Below it the alignment prologue costs more than the misaligned stores it avoids.
+        // Copy size at which aligning the destination of an overlapping forward copy starts to pay for the
+        // extra leading block. Below it the alignment prologue costs more than the misaligned stores it
+        // avoids.
         private const nuint MemmoveOverlappedAlignThreshold = 2048;
+
+        // The platform memmove's backward copy loop stays about twice as fast as a managed descending one:
+        // a descending stream defeats the hardware prefetcher, and unlike the forward direction, aligning
+        // the destination doesn't recover it. So a copy towards the end of the buffer is only done here
+        // while it is short enough for the QCall itself to dominate.
+        private const nuint MemmoveOverlappedBackwardThreshold = 256;
 
 #if HAS_CUSTOM_BLOCKS
         [StructLayout(LayoutKind.Sequential, Size = 16)]
@@ -239,18 +246,28 @@ namespace System
                 return;
             }
 
-            // 'dest' below 'src' means the data is shifted towards the start of the buffer, which is by
-            // far the most common overlapping shape (List<T>.RemoveAt/RemoveRange, Queue<T>, overlapping
-            // Span<T>.CopyTo, ...). Such a copy can run in strictly ascending order, so we do it ourselves
-            // rather than handing it to the platform's memmove, whose forward copy loop is tuned for
-            // disjoint buffers: 'rep movsb' collapses when the two buffers are less than a cache line
-            // apart, and the non-temporal stores it switches to for large copies push out exactly the
-            // lines the rest of the copy is about to read back. Shifts towards the end of the buffer keep
-            // using memmove, whose backward copy loop doesn't have either problem.
-            if (Vector128.IsHardwareAccelerated && (nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
+            if (Vector128.IsHardwareAccelerated)
             {
-                CopyForwardVectorized(ref dest, ref src, len);
-                return;
+                // 'dest' below 'src' means the data is shifted towards the start of the buffer, which is by
+                // far the most common overlapping shape (List<T>.RemoveAt/RemoveRange, Queue<T>, overlapping
+                // Span<T>.CopyTo, ...). Those are always copied here: the platform memmove's forward loop is
+                // tuned for disjoint buffers and both of the tricks it uses backfire on an in-place shift.
+                // 'rep movsb' collapses when the two buffers are less than a cache line apart, and the
+                // non-temporal stores it switches to for large copies evict the very lines the rest of the
+                // copy is about to read back.
+                if ((nuint)Unsafe.ByteOffset(ref dest, ref src) < len)
+                {
+                    CopyForwardVectorized(ref dest, ref src, len);
+                    return;
+                }
+
+                // 'dest' above 'src'. The platform memmove's backward loop has neither problem and outruns a
+                // managed descending loop, so this is only worth doing while the QCall dominates the copy.
+                if (len <= MemmoveOverlappedBackwardThreshold)
+                {
+                    CopyBackwardVectorized(ref dest, ref src, len);
+                    return;
+                }
             }
 
         PInvoke:
@@ -261,9 +278,10 @@ namespace System
             MemmoveNative(ref dest, ref src, len);
         }
 
-        // Copies 'src' to 'dest' in strictly ascending order, so a byte is always read before the copy can
-        // overwrite it. That also rules out the "copy a final block anchored at the end of the buffer"
-        // trick the non-overlapping paths use - that block may already have been rewritten by then.
+        // Copies overlapping buffers where 'dest' is at a lower address than 'src'. The blocks run in
+        // strictly ascending order, so a byte is always read before the copy can overwrite it. That also
+        // rules out the "copy a final block anchored at the end of the buffer" trick the non-overlapping
+        // paths use - by the time that block ran, the bytes it reads would already have been rewritten.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CopyForwardVectorized(ref byte dest, ref byte src, nuint len)
         {
@@ -271,39 +289,16 @@ namespace System
             Debug.Assert(Vector128.IsHardwareAccelerated);
 
             // Align the destination. An unaligned store costs more than an unaligned load, and an
-            // overlapping copy can only ever have one of the two aligned. The leading bytes have to be
-            // copied ascending as well, so unlike the non-overlapping paths this can't be done with a
-            // single oversized leading block - that block would read source bytes it just overwrote.
+            // overlapping copy can only ever have one of the two aligned.
             if (len >= MemmoveOverlappedAlignThreshold)
             {
                 nuint head = 64 - Unsafe.OpportunisticMisalignment(ref dest, 64);
                 if (head != 64)
                 {
+                    CopyBlocksForward(ref dest, ref src, head);
+                    dest = ref Unsafe.Add(ref dest, head);
+                    src = ref Unsafe.Add(ref src, head);
                     len -= head;
-
-                    while (head >= 16)
-                    {
-                        Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref src), ref dest);
-                        dest = ref Unsafe.Add(ref dest, 16);
-                        src = ref Unsafe.Add(ref src, 16);
-                        head -= 16;
-                    }
-
-                    while (head >= 4)
-                    {
-                        Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<uint>(ref src));
-                        dest = ref Unsafe.Add(ref dest, 4);
-                        src = ref Unsafe.Add(ref src, 4);
-                        head -= 4;
-                    }
-
-                    while (head != 0)
-                    {
-                        dest = src;
-                        dest = ref Unsafe.Add(ref dest, 1);
-                        src = ref Unsafe.Add(ref src, 1);
-                        head--;
-                    }
                 }
             }
 
@@ -313,73 +308,226 @@ namespace System
             {
                 while (len >= 128)
                 {
-                    // All of the blocks are loaded before any of them is stored, so a store can never
-                    // clobber source bytes that this iteration still has to read.
-                    Vector256<byte> block0 = Vector256.LoadUnsafe(ref src);
-                    Vector256<byte> block1 = Vector256.LoadUnsafe(ref src, 32);
-                    Vector256<byte> block2 = Vector256.LoadUnsafe(ref src, 64);
-                    Vector256<byte> block3 = Vector256.LoadUnsafe(ref src, 96);
-                    Vector256.StoreUnsafe(block0, ref dest);
-                    Vector256.StoreUnsafe(block1, ref dest, 32);
-                    Vector256.StoreUnsafe(block2, ref dest, 64);
-                    Vector256.StoreUnsafe(block3, ref dest, 96);
+                    CopyBlock128(ref dest, ref src);
                     dest = ref Unsafe.Add(ref dest, 128);
                     src = ref Unsafe.Add(ref src, 128);
                     len -= 128;
-                }
-
-                while (len >= 32)
-                {
-                    Vector256.StoreUnsafe(Vector256.LoadUnsafe(ref src), ref dest);
-                    dest = ref Unsafe.Add(ref dest, 32);
-                    src = ref Unsafe.Add(ref src, 32);
-                    len -= 32;
                 }
             }
             else
             {
                 while (len >= 64)
                 {
-                    Vector128<byte> block0 = Vector128.LoadUnsafe(ref src);
-                    Vector128<byte> block1 = Vector128.LoadUnsafe(ref src, 16);
-                    Vector128<byte> block2 = Vector128.LoadUnsafe(ref src, 32);
-                    Vector128<byte> block3 = Vector128.LoadUnsafe(ref src, 48);
-                    Vector128.StoreUnsafe(block0, ref dest);
-                    Vector128.StoreUnsafe(block1, ref dest, 16);
-                    Vector128.StoreUnsafe(block2, ref dest, 32);
-                    Vector128.StoreUnsafe(block3, ref dest, 48);
+                    CopyBlock64(ref dest, ref src);
                     dest = ref Unsafe.Add(ref dest, 64);
                     src = ref Unsafe.Add(ref src, 64);
                     len -= 64;
                 }
             }
 
-            // Drain the remainder with progressively smaller blocks, each one picking up exactly where the
-            // previous one ended. Every block is a single load followed by a single store, so no partial
-            // block can be written before the bytes it overlaps have been read.
-            while (len >= 16)
+            CopyBlocksForward(ref dest, ref src, len);
+        }
+
+        // Copies overlapping buffers where 'dest' is at a higher address than 'src'. Mirror image of the
+        // above: the blocks run in strictly descending order, walking down from the end of the buffer.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void CopyBackwardVectorized(ref byte dest, ref byte src, nuint len)
+        {
+            Debug.Assert(len > 0);
+            Debug.Assert(Vector128.IsHardwareAccelerated);
+
+            if (Vector256.IsHardwareAccelerated)
             {
-                Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref src), ref dest);
-                dest = ref Unsafe.Add(ref dest, 16);
-                src = ref Unsafe.Add(ref src, 16);
-                len -= 16;
+                while (len >= 128)
+                {
+                    len -= 128;
+                    CopyBlock128(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
+                }
+            }
+            else
+            {
+                while (len >= 64)
+                {
+                    len -= 64;
+                    CopyBlock64(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
+                }
             }
 
-            while (len >= 4)
+            CopyBlocksBackward(ref dest, ref src, len);
+        }
+
+        // Copies fewer than 128 bytes, largest block first, so that the blocks run in ascending order.
+        private static void CopyBlocksForward(ref byte dest, ref byte src, nuint len)
+        {
+            Debug.Assert(len < 128);
+
+            if ((len & 64) != 0)
+            {
+                CopyBlock64(ref dest, ref src);
+                dest = ref Unsafe.Add(ref dest, 64);
+                src = ref Unsafe.Add(ref src, 64);
+            }
+
+            if ((len & 32) != 0)
+            {
+                CopyBlock32(ref dest, ref src);
+                dest = ref Unsafe.Add(ref dest, 32);
+                src = ref Unsafe.Add(ref src, 32);
+            }
+
+            if ((len & 16) != 0)
+            {
+                CopyBlock16(ref dest, ref src);
+                dest = ref Unsafe.Add(ref dest, 16);
+                src = ref Unsafe.Add(ref src, 16);
+            }
+
+            if ((len & 8) != 0)
+            {
+                CopyBlock8(ref dest, ref src);
+                dest = ref Unsafe.Add(ref dest, 8);
+                src = ref Unsafe.Add(ref src, 8);
+            }
+
+            if ((len & 4) != 0)
             {
                 Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<uint>(ref src));
                 dest = ref Unsafe.Add(ref dest, 4);
                 src = ref Unsafe.Add(ref src, 4);
-                len -= 4;
             }
 
-            while (len != 0)
+            if ((len & 2) != 0)
+            {
+                Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<ushort>(ref src));
+                dest = ref Unsafe.Add(ref dest, 2);
+                src = ref Unsafe.Add(ref src, 2);
+            }
+
+            if ((len & 1) != 0)
             {
                 dest = src;
-                dest = ref Unsafe.Add(ref dest, 1);
-                src = ref Unsafe.Add(ref src, 1);
-                len--;
             }
+        }
+
+        // Copies fewer than 128 bytes, largest block first, so that the blocks run in descending order.
+        private static void CopyBlocksBackward(ref byte dest, ref byte src, nuint len)
+        {
+            Debug.Assert(len < 128);
+
+            if ((len & 64) != 0)
+            {
+                len -= 64;
+                CopyBlock64(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
+            }
+
+            if ((len & 32) != 0)
+            {
+                len -= 32;
+                CopyBlock32(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
+            }
+
+            if ((len & 16) != 0)
+            {
+                len -= 16;
+                CopyBlock16(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
+            }
+
+            if ((len & 8) != 0)
+            {
+                len -= 8;
+                CopyBlock8(ref Unsafe.Add(ref dest, len), ref Unsafe.Add(ref src, len));
+            }
+
+            if ((len & 4) != 0)
+            {
+                len -= 4;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref src, len)));
+            }
+
+            if ((len & 2) != 0)
+            {
+                len -= 2;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, len), Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref src, len)));
+            }
+
+            if ((len & 1) != 0)
+            {
+                Debug.Assert(len == 1);
+                dest = src;
+            }
+        }
+
+        // Every block below is fully loaded before any of it is stored, so it can be copied in either
+        // direction without one of its own stores clobbering source bytes it still has to read.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopyBlock128(ref byte dest, ref byte src)
+        {
+            Debug.Assert(Vector256.IsHardwareAccelerated);
+
+            Vector256<byte> block0 = Vector256.LoadUnsafe(ref src);
+            Vector256<byte> block1 = Vector256.LoadUnsafe(ref src, 32);
+            Vector256<byte> block2 = Vector256.LoadUnsafe(ref src, 64);
+            Vector256<byte> block3 = Vector256.LoadUnsafe(ref src, 96);
+            Vector256.StoreUnsafe(block0, ref dest);
+            Vector256.StoreUnsafe(block1, ref dest, 32);
+            Vector256.StoreUnsafe(block2, ref dest, 64);
+            Vector256.StoreUnsafe(block3, ref dest, 96);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopyBlock64(ref byte dest, ref byte src)
+        {
+            if (Vector256.IsHardwareAccelerated)
+            {
+                Vector256<byte> block0 = Vector256.LoadUnsafe(ref src);
+                Vector256<byte> block1 = Vector256.LoadUnsafe(ref src, 32);
+                Vector256.StoreUnsafe(block0, ref dest);
+                Vector256.StoreUnsafe(block1, ref dest, 32);
+            }
+            else
+            {
+                Vector128<byte> block0 = Vector128.LoadUnsafe(ref src);
+                Vector128<byte> block1 = Vector128.LoadUnsafe(ref src, 16);
+                Vector128<byte> block2 = Vector128.LoadUnsafe(ref src, 32);
+                Vector128<byte> block3 = Vector128.LoadUnsafe(ref src, 48);
+                Vector128.StoreUnsafe(block0, ref dest);
+                Vector128.StoreUnsafe(block1, ref dest, 16);
+                Vector128.StoreUnsafe(block2, ref dest, 32);
+                Vector128.StoreUnsafe(block3, ref dest, 48);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopyBlock32(ref byte dest, ref byte src)
+        {
+            if (Vector256.IsHardwareAccelerated)
+            {
+                Vector256.StoreUnsafe(Vector256.LoadUnsafe(ref src), ref dest);
+            }
+            else
+            {
+                Vector128<byte> block0 = Vector128.LoadUnsafe(ref src);
+                Vector128<byte> block1 = Vector128.LoadUnsafe(ref src, 16);
+                Vector128.StoreUnsafe(block0, ref dest);
+                Vector128.StoreUnsafe(block1, ref dest, 16);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopyBlock16(ref byte dest, ref byte src) =>
+            Vector128.StoreUnsafe(Vector128.LoadUnsafe(ref src), ref dest);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopyBlock8(ref byte dest, ref byte src)
+        {
+#if TARGET_64BIT
+            Unsafe.WriteUnaligned(ref dest, Unsafe.ReadUnaligned<ulong>(ref src));
+#else
+            uint block0 = Unsafe.ReadUnaligned<uint>(ref src);
+            uint block1 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref src, 4));
+            Unsafe.WriteUnaligned(ref dest, block0);
+            Unsafe.WriteUnaligned(ref Unsafe.Add(ref dest, 4), block1);
+#endif
         }
 
         // Non-inlinable wrapper around the QCall that avoids polluting the fast path


### PR DESCRIPTION
## Problem

We used to just call native `memmove` on any sign of aliased pointers in `SpanHelpers.Memmove`. It turns out it's not a rare event: when we delete an item in an array/List we end up shifting the entire content left so it's always overlapped. Same happens when we insert an element (although, this one is less common because we often need to re-allocate anyway when we add a new item). 
It seems like Windows UCRT has a performance issue for the most common case - shifting left due to `rep movsb` (see #132690) making it up to **50 times slower** than it should be. While it might be eventually fixed on their side, we probably still want to have fully managed impl for small inputs.

## Implementation

- I decided to only keep the shift left impl for now (aka List.Remove), shift right (aka List.Insert) was optimal on all platforms as is (and it's less common).
- I introduced a copy of `memmove` pinvoke but with `[SuppressGCTransition]` so under certain threshold we don't pay the price of GC transition - `Buffer.BulkMoveWithWriteBarrier` uses the same trick.
- It's quite difficult to implement a proper Memmove semantics in C# code, because if we do something like this:
```cs
var v1 = Vector.Load(x + 0);
var v2 = Vector.Load(x + 16);
var v3 = Vector.Load(x + 32);
var v4 = Vector.Load(x + 48);
v1.Store(y + 0)
v2.Store(y + 16)
v3.Store(y + 32)
v4.Store(y + 48)
```
nothing guarantees us that we'll see the desired codegen when we load data into multiple regs first, then store them (unless we use `Volatile` but that comes with an extra cost on weak memory models). That's why I ended up calling `Memmove` itself with a constant length (e.g. 64) which JIT knows how to unroll correctly. But even if it doesn't unroll it - it shouldn't lead to endless recursions.
- I did some tunning on multiple machines to come up with the various thresholds used in the PR.

### Benchmark (emulating List.Remove/List.Insert)

```cs
using System;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Bench<>).Assembly).Run(args);

[GenericTypeArguments(typeof(byte))]
[GenericTypeArguments(typeof(int))]
[GenericTypeArguments(typeof(long))]
public class Bench<T> {
    private T[] _array;

    [Params(4, 8, 10, 16, 50, 100, 1000, 2000, 10000, 100000)]
    public int Count;

    [GlobalSetup]
    public void Setup() => _array = new T[Count];

    [Benchmark]
    public void ShiftLeft() {
        Span<T> span = _array;
        span.Slice(1).CopyTo(span);
    }

    [Benchmark]
    public void ShiftRight() {
        Span<T> span = _array;
        span.Slice(0, span.Length - 1).CopyTo(span.Slice(1));
    }
}
```

Median ratio vs `main`, by copy size in bytes:

| target | left ≤1KB | left >1KB | right ≤1KB | right >1KB |
|---|---|---|---|---|
| macOS M2 | 1.87x | 1.00x | 1.12x | 1.00x |
| ubuntu Turin (Zen5) | 1.80x | **2.20x** | 1.48x | 1.02x |
| ubuntu Cobalt 100 | 1.94x | 1.00x | 1.51x | 1.01x |
| windows Emerald Rapids | 1.33x | **16.09x** | 0.99x | 1.01x |
| windows Cobalt 100 | 1.88x | 1.00x | 1.28x | 1.07x |

Best cases, all left shifts on Emerald Rapids, where `main` is pinned at 3.2 GB/s for every size ≥10KB:

| size | before | after | |
|---|---|---|---|
| 40 KB | 12653 ns | 253 ns | **50.0x** |
| 16 KB | 4960 ns | 105 ns | **47.4x** |
| 10 KB | 3134 ns | 67 ns | **46.6x** |
| 400 KB | 123953 ns | 7666 ns | **16.2x** |
| 80 KB | 24973 ns | 1551 ns | **16.1x** |

Right shifts on the same box reach 95 GB/s on `main`, which is why they are left alone. Turin shows a milder version of the same cliff, peaking at 3.59x for an 8 KB copy.

Raw results for all five targets: https://github.com/EgorBot/Benchmarks/issues/544
