### PR TITLE
Remove commented ActiveIssue from SslKeyLogFile test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -86,7 +86,6 @@ namespace System.Net.Security.Tests
         [PlatformSpecific(TestPlatforms.Linux)] // SSLKEYLOGFILE is only supported on Linux for SslStream
         [InlineData(true)]
         [InlineData(false)]
-        //[ActiveIssue("https://github.com/dotnet/runtime/issues/116473")]
         public async Task SslKeyLogFile_IsCreatedAndFilled(bool enabledBySwitch)
         {
             if (PlatformDetection.IsDebugLibrary(typeof(SslStream).Assembly) && !enabledBySwitch)


### PR DESCRIPTION
Since OpenSSL seems to keep the SSLKEYLOGFILE support and there is no app-level API to prevent it to enforce our policy, there is nothing for us to do other than keep the relevant test cases disabled.

Closes https://github.com/dotnet/runtime/issues/116473.