### PR TITLE
Publish the cDAC usage graph package

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -542,6 +542,7 @@
                              $(SharedNativeRoot)managed\cdac\Microsoft.Diagnostics.DataContractReader.Abstractions\Microsoft.Diagnostics.DataContractReader.Abstractions.csproj;
                              $(SharedNativeRoot)managed\cdac\Microsoft.Diagnostics.DataContractReader.Legacy\Microsoft.Diagnostics.DataContractReader.Legacy.csproj;
                              $(SharedNativeRoot)managed\cdac\Microsoft.Diagnostics.DataContractReader.Contracts\Microsoft.Diagnostics.DataContractReader.Contracts.csproj;
+                             $(SharedNativeRoot)managed\cdac\tools\CdacUsageGraph\src\CdacUsageGraph\CdacUsageGraph.csproj;
                              $(SharedNativeRoot)managed\cdac\tests\TestInfrastructure\Microsoft.Diagnostics.DataContractReader.TestInfrastructure.csproj" Category="tools" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 


### PR DESCRIPTION
Include the CdacUsageGraph project in the tools.cdac subset's direct packing project list. The project is packable, but official VMR builds currently only encounter it through the usage tests, so Microsoft.Diagnostics.DataContractReader.UsageGraph is absent from the publish manifest. This ensures official builds produce the non-shipping package alongside the other DataContractReader packages.