### PR TITLE
Add label for area-ReadyToRun in resourceManagement

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -199,6 +199,8 @@ configuration:
         - labelAdded:
             label: area-NativeAOT-coreclr
         - labelAdded:
+            label: area-ReadyToRun
+        - labelAdded:
             label: area-Single-File
         - labelAdded:
             label: area-System.Buffers

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -794,6 +794,19 @@ configuration:
             assignMentionees: False
       - if:
         - hasLabel:
+            label: area-ReadyToRun
+        then:
+        - mentionUsers:
+            mentionees:
+            - agocke
+            - dotnet/crossgen-contrib
+            replyTemplate: >-
+              Tagging subscribers to this area: ${mentionees}
+
+              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+            assignMentionees: False
+      - if:
+        - hasLabel:
             label: area-Single-File
         then:
         - mentionUsers:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -798,7 +798,6 @@ configuration:
         then:
         - mentionUsers:
             mentionees:
-            - agocke
             - dotnet/crossgen-contrib
             replyTemplate: >-
               Tagging subscribers to this area: ${mentionees}


### PR DESCRIPTION
There is no automatic tagging for `area-ReadyToRun` like there is for other areas.

cc @dotnet/crossgen-contrib