### PR TITLE
[release/10.0] Fix sporadic AccessViolation in compressed single-file apps on Apple Silicon

### DIFF
--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -830,17 +830,29 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
 #endif // FEATURE_ENABLE_NO_ADDRESS_SPACE_RANDOMIZATION
 
     DWORD allocationType = MEM_RESERVE | MEM_COMMIT;
+    DWORD initialProtection = PAGE_READWRITE;
 #ifdef HOST_UNIX
     // Tell PAL to use the executable memory allocator to satisfy this request for virtual memory.
     // This is required on MacOS and otherwise will allow us to place native R2R code close to the
     // coreclr library and thus improve performance by avoiding jump stubs in managed code.
     allocationType |= MEM_RESERVE_EXECUTABLE;
 #endif
+#if defined(HOST_OSX) && defined(HOST_ARM64)
+    // On Apple Silicon, allocating the image region as plain PAGE_READWRITE and then promoting
+    // executable sections to PAGE_EXECUTE_READ via mprotect has been observed to
+    // intermittently leave pages non-executable at the kernel level. This manifests as sporadic
+    // AccessViolationException crashes.
+    //
+    // Avoid the unreliable transition - reserve the whole region as PAGE_NOACCESS first, then
+    // commit each section directly with its final protection.
+    allocationType &= ~MEM_COMMIT;
+    initialProtection = PAGE_NOACCESS;
+#endif
 
     COUNT_T allocSize = ALIGN_UP(this->GetVirtualSize(), g_SystemInfo.dwAllocationGranularity);
-    LPVOID base = ClrVirtualAlloc(preferredBase, allocSize, allocationType, PAGE_READWRITE);
+    LPVOID base = ClrVirtualAlloc(preferredBase, allocSize, allocationType, initialProtection);
     if (base == NULL && preferredBase != NULL)
-        base = ClrVirtualAlloc(NULL, allocSize, allocationType, PAGE_READWRITE);
+        base = ClrVirtualAlloc(NULL, allocSize, allocationType, initialProtection);
 
     if (base == NULL)
         ThrowLastError();
@@ -848,15 +860,62 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
     // when loading by copying we have only one part to free.
     m_imageParts[0] = AllocatedPart(base);
 
+    IMAGE_SECTION_HEADER* sectionStart = IMAGE_FIRST_SECTION(FindNTHeaders());
+    IMAGE_SECTION_HEADER* sectionEnd = sectionStart + VAL16(FindNTHeaders()->FileHeader.NumberOfSections);
+
+#if defined(HOST_OSX) && defined(HOST_ARM64)
+    _ASSERTE((allocationType & MEM_COMMIT) == 0);
+    _ASSERTE(initialProtection != PAGE_READWRITE);
+
+    DWORD sizeOfHeaders = VAL32(FindNTHeaders()->OptionalHeader.SizeOfHeaders);
+
+    // Commit and copy headers, then apply read-only protection.
+    if (ClrVirtualAlloc(base, sizeOfHeaders, MEM_COMMIT, PAGE_READWRITE) == NULL)
+        ThrowLastError();
+
+    CopyMemory(base, (void*)GetBase(), sizeOfHeaders);
+
+    DWORD oldProtection; // PAL layer doesn't properly set the previous protection, so we don't try to validate it here.
+    if (!ClrVirtualProtect((void*)base, sizeOfHeaders, PAGE_READONLY, &oldProtection))
+        ThrowLastError();
+
+    // Commit and copy each section with its desired protection.
+    for (IMAGE_SECTION_HEADER* section = sectionStart; section < sectionEnd; section++)
+    {
+        DWORD virtualSize = VAL32(section->Misc.VirtualSize);
+        if (virtualSize == 0)
+            continue;
+
+        bool isExec = (section->Characteristics & IMAGE_SCN_MEM_EXECUTE) != 0;
+        BYTE* sectionBase = (BYTE*)base + VAL32(section->VirtualAddress);
+        DWORD copySize = min(VAL32(section->SizeOfRawData), virtualSize);
+
+        if (ClrVirtualAlloc(sectionBase, virtualSize, MEM_COMMIT, isExec ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE) == NULL)
+            ThrowLastError();
+
+        if (isExec)
+            PAL_JitWriteProtect(true);
+
+        CopyMemory(sectionBase, (BYTE*)GetBase() + VAL32(section->PointerToRawData), copySize);
+
+        if (isExec)
+        {
+            PAL_JitWriteProtect(false);
+        }
+        else if ((section->Characteristics & IMAGE_SCN_MEM_WRITE) == 0)
+        {
+            DWORD oldProt;
+            if (!ClrVirtualProtect(sectionBase, virtualSize, PAGE_READONLY, &oldProt))
+                ThrowLastError();
+        }
+    }
+#else
     // We're going to copy everything first, and write protect what we need to later.
 
     // First, copy headers
     CopyMemory(base, (void*)GetBase(), VAL32(FindNTHeaders()->OptionalHeader.SizeOfHeaders));
 
     // Now, copy all sections to appropriate virtual address
-
-    IMAGE_SECTION_HEADER* sectionStart = IMAGE_FIRST_SECTION(FindNTHeaders());
-    IMAGE_SECTION_HEADER* sectionEnd = sectionStart + VAL16(FindNTHeaders()->FileHeader.NumberOfSections);
 
     IMAGE_SECTION_HEADER* section = sectionStart;
     while (section < sectionEnd)
@@ -881,13 +940,9 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
     // Finally, apply proper protection to copied sections
     for (section = sectionStart; section < sectionEnd; section++)
     {
-        DWORD executableProtection = PAGE_EXECUTE_READ;
-#if defined(__APPLE__) && defined(HOST_ARM64)
-        executableProtection = PAGE_EXECUTE_READWRITE;
-#endif
         // Add appropriate page protection.
         DWORD newProtection = section->Characteristics & IMAGE_SCN_MEM_EXECUTE ?
-            executableProtection :
+            PAGE_EXECUTE_READ :
             section->Characteristics & IMAGE_SCN_MEM_WRITE ?
             PAGE_READWRITE :
             PAGE_READONLY;
@@ -899,6 +954,7 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
             ThrowLastError();
         }
     }
+#endif // defined(HOST_OSX) && defined(HOST_ARM64)
 
     return base;
 }

--- a/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
@@ -110,6 +110,24 @@ namespace AppHost.Bundle.Tests
             }
         }
 
+        // Regression test: on macOS Apple Silicon, compressed self-contained single-file
+        // apps intermittently hit an AccessViolationException based on how we load images.
+        // This was observed via concurrent child process launches, so this test launches
+        // multiple child processes in parallel as a regression test.
+        [Fact]
+        [PlatformSpecific(TestPlatforms.OSX)]
+        public void SelfContained_Compressed_SpawnsChildren()
+        {
+            string singleFile = sharedTestState.SelfContainedApp.Bundle(BundleOptions.EnableCompression);
+
+            Command.Create(singleFile, "launch_self")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World!");
+        }
+
         [ConditionalTheory(typeof(Binaries.CetCompat), nameof(Binaries.CetCompat.IsSupported))]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/installer/tests/Assets/Projects/HelloWorld/Program.cs
+++ b/src/installer/tests/Assets/Projects/HelloWorld/Program.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Threading.Tasks;
 
 namespace HelloWorld
 {
@@ -53,6 +56,24 @@ namespace HelloWorld
                     // Disable core dumps - test is intentionally crashing
                     Utilities.CoreDump.Disable();
                     throw new Exception("Goodbye World!");
+                case "launch_self":
+                    // Launch copies of this app in parallel.
+                    // When run via dotnet <app_dll>, GetCommandLineArgs[0] is the managed
+                    // dll - forward it so the child knows what to launch.
+                    string fileName = Environment.ProcessPath!;
+                    string entry = Environment.GetCommandLineArgs()[0];
+                    bool forwardEntry = entry != Environment.ProcessPath;
+
+                    var tasks = Enumerable.Range(0, 5).Select(_ => Task.Run(() =>
+                    {
+                        var startInfo = new ProcessStartInfo { FileName = fileName };
+                        if (forwardEntry)
+                            startInfo.ArgumentList.Add(entry);
+                        using var process = Process.Start(startInfo)!;
+                        process.WaitForExit();
+                    })).ToArray();
+                    Task.WaitAll(tasks);
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
Backport of #127355 to release/10.0

/cc @dotnet/appmodel @AaronRobinsonMSFT 

## Customer Impact

- [x] Customer reported
- [ ] Found internally

When running compressed single-file applications on macOS, users would hit intermittent crashes with an access violation.

Issues: https://github.com/dotnet/runtime/issues/112167, https://github.com/dotnet/runtime/issues/123324, https://github.com/dotnet/runtime/issues/132627


On macOS, when loading compressed images from single-file, the runtime allocates the image region with `MAP_JIT` as `PAGE_READWRITE`, copies in all section bytes, then promotes executable sections to `PAGE_EXECUTE_READWRITE` via a second `mprotect`. On Apple Silicon, this `RW → RWX` transition on `MAP_JIT` memory has been observed to intermittently succeed at the API level but leave pages non-executable at the kernel level, producing the sporadic AVs.

This change (only on maOS arm64) reserve the whole image region as `PAGE_NOACCESS` up front, then commit each section directly with its final runtime protection.

## Regression

- [ ] Yes
- [x] No

## Testing

Automated test added.

## Risk

Low. Fix has been in main for 3 months. The non-Apple Silicon path is unchanged by the fix.