### PR TITLE
Reduce cDAC contract descriptor parser size

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorParser.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorParser.cs
@@ -19,39 +19,33 @@ public partial class ContractDescriptorParser
     // data_descriptor.md uses a distinguished property name to indicate the size of a type
     public const string TypeDescriptorSizeSigil = "!";
 
+    private static readonly JsonReaderOptions s_readerOptions = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip,
+    };
+
+    private delegate TValue ReadValue<TValue>(ref Utf8JsonReader reader);
+
     /// <summary>
     ///  Parses the "compact" representation of a contract descriptor.
     /// </summary>
     public static ContractDescriptor? ParseCompact(ReadOnlySpan<byte> json)
     {
-        try
-        {
-            return ParseCompactCore(json);
-        }
-        catch (JsonException ex) when (ex.GetType() != typeof(JsonException))
-        {
-            throw new JsonException(ex.Message, ex);
-        }
-    }
-
-    private static ContractDescriptor? ParseCompactCore(ReadOnlySpan<byte> json)
-    {
-        var reader = new Utf8JsonReader(
-            json,
-            new JsonReaderOptions
-            {
-                AllowTrailingCommas = true,
-                CommentHandling = JsonCommentHandling.Skip,
-            });
+        Utf8JsonReader reader = new(json, s_readerOptions);
 
         if (!reader.Read())
             throw new JsonException();
         if (reader.TokenType == JsonTokenType.Null)
+        {
+            if (reader.Read())
+                throw new JsonException();
             return null;
+        }
         if (reader.TokenType != JsonTokenType.StartObject)
             throw new JsonException();
 
-        var descriptor = new ContractDescriptor();
+        ContractDescriptor descriptor = new();
         while (reader.Read())
         {
             if (reader.TokenType == JsonTokenType.EndObject)
@@ -74,16 +68,16 @@ public partial class ContractDescriptorParser
                     descriptor.Baseline = ReadNullableString(ref reader);
                     break;
                 case "contracts":
-                    descriptor.Contracts = ReadStringDictionary(ref reader);
+                    descriptor.Contracts = ReadDictionary(ref reader, ReadString);
                     break;
                 case "types":
-                    descriptor.Types = ReadTypeDictionary(ref reader);
+                    descriptor.Types = ReadDictionary(ref reader, ReadTypeDescriptor);
                     break;
                 case "globals":
-                    descriptor.Globals = ReadGlobalDictionary(ref reader);
+                    descriptor.Globals = ReadDictionary(ref reader, ReadGlobalDescriptor);
                     break;
                 case "subDescriptors":
-                    descriptor.SubDescriptors = ReadGlobalDictionary(ref reader);
+                    descriptor.SubDescriptors = ReadDictionary(ref reader, ReadGlobalDescriptor);
                     break;
                 default:
                     reader.Skip();
@@ -136,52 +130,10 @@ public partial class ContractDescriptorParser
         public string? StringValue { get; set; }
     }
 
-    private static Dictionary<string, string>? ReadStringDictionary(ref Utf8JsonReader reader)
+    private static string ReadString(ref Utf8JsonReader reader)
     {
-        if (reader.TokenType == JsonTokenType.Null)
-            return null;
-        if (reader.TokenType != JsonTokenType.StartObject)
-            throw new JsonException();
-
-        var values = new Dictionary<string, string>();
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-                return values;
-            if (reader.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException();
-
-            string name = reader.GetString() ?? throw new JsonException();
-            ReadNext(ref reader);
-            string value = reader.TokenType == JsonTokenType.String
-                ? reader.GetString() ?? throw new JsonException()
-                : throw new JsonException();
-            values[name] = value;
-        }
-
-        throw new JsonException();
-    }
-
-    private static Dictionary<string, TypeDescriptor>? ReadTypeDictionary(ref Utf8JsonReader reader)
-    {
-        if (reader.TokenType == JsonTokenType.Null)
-            return null;
-        if (reader.TokenType != JsonTokenType.StartObject)
-            throw new JsonException();
-
-        var types = new Dictionary<string, TypeDescriptor>();
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-                return types;
-            if (reader.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException();
-
-            string name = reader.GetString() ?? throw new JsonException();
-            ReadNext(ref reader);
-            types[name] = ReadTypeDescriptor(ref reader);
-        }
-
+        if (reader.TokenType == JsonTokenType.String)
+            return reader.GetString() ?? throw new JsonException();
         throw new JsonException();
     }
 
@@ -194,7 +146,7 @@ public partial class ContractDescriptorParser
             throw new JsonException();
 
         uint? size = null;
-        var fields = new Dictionary<string, FieldDescriptor>();
+        Dictionary<string, FieldDescriptor> fields = new();
         while (reader.Read())
         {
             if (reader.TokenType == JsonTokenType.EndObject)
@@ -243,24 +195,26 @@ public partial class ContractDescriptorParser
         return new FieldDescriptor { Type = type, Offset = offset };
     }
 
-    private static Dictionary<string, GlobalDescriptor>? ReadGlobalDictionary(ref Utf8JsonReader reader)
+    private static Dictionary<string, TValue>? ReadDictionary<TValue>(
+        ref Utf8JsonReader reader,
+        ReadValue<TValue> readValue)
     {
         if (reader.TokenType == JsonTokenType.Null)
             return null;
         if (reader.TokenType != JsonTokenType.StartObject)
             throw new JsonException();
 
-        var globals = new Dictionary<string, GlobalDescriptor>();
+        Dictionary<string, TValue> values = [];
         while (reader.Read())
         {
             if (reader.TokenType == JsonTokenType.EndObject)
-                return globals;
+                return values;
             if (reader.TokenType != JsonTokenType.PropertyName)
                 throw new JsonException();
 
             string name = reader.GetString() ?? throw new JsonException();
             ReadNext(ref reader);
-            globals[name] = ReadGlobalDescriptor(ref reader);
+            values[name] = readValue(ref reader);
         }
 
         throw new JsonException();
@@ -401,7 +355,7 @@ public partial class ContractDescriptorParser
         }
         if (reader.TokenType == JsonTokenType.String)
         {
-            var s = reader.GetString();
+            string? s = reader.GetString();
             if (s == null)
             {
                 value = 0u;
@@ -440,7 +394,7 @@ public partial class ContractDescriptorParser
         }
         if (reader.TokenType == JsonTokenType.String)
         {
-            var s = reader.GetString();
+            string? s = reader.GetString();
             if (s == null)
             {
                 value = 0;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorParser.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorParser.cs
@@ -86,11 +86,7 @@ public partial class ContractDescriptorParser
                     descriptor.SubDescriptors = ReadGlobalDictionary(ref reader);
                     break;
                 default:
-                    descriptor.Extras ??= [];
-                    using (JsonDocument extra = JsonDocument.ParseValue(ref reader))
-                    {
-                        descriptor.Extras[propertyName] = extra.RootElement.Clone();
-                    }
+                    reader.Skip();
                     break;
             }
         }
@@ -109,8 +105,6 @@ public partial class ContractDescriptorParser
         public Dictionary<string, GlobalDescriptor>? Globals { get; set; }
 
         public Dictionary<string, GlobalDescriptor>? SubDescriptors { get; set; }
-
-        public Dictionary<string, JsonElement>? Extras { get; set; }
 
         public override string ToString()
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorParser.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorParser.cs
@@ -3,11 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Text.Unicode;
 
 namespace Microsoft.Diagnostics.DataContractReader;
 
@@ -25,36 +22,80 @@ public partial class ContractDescriptorParser
     /// <summary>
     ///  Parses the "compact" representation of a contract descriptor.
     /// </summary>
-    // Workaround for https://github.com/dotnet/runtime/issues/101205
-    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Root))]
     public static ContractDescriptor? ParseCompact(ReadOnlySpan<byte> json)
     {
-        return JsonSerializer.Deserialize(json, ContractDescriptorContext.Default.ContractDescriptor);
+        try
+        {
+            return ParseCompactCore(json);
+        }
+        catch (JsonException ex) when (ex.GetType() != typeof(JsonException))
+        {
+            throw new JsonException(ex.Message, ex);
+        }
     }
 
-    [JsonSerializable(typeof(ContractDescriptor))]
-    [JsonSerializable(typeof(int?))]
-    [JsonSerializable(typeof(string))]
-    [JsonSerializable(typeof(Dictionary<string, string>))]
-    [JsonSerializable(typeof(Dictionary<string, TypeDescriptor>))]
-    [JsonSerializable(typeof(Dictionary<string, FieldDescriptor>))]
-    [JsonSerializable(typeof(Dictionary<string, GlobalDescriptor>))]
-    [JsonSerializable(typeof(TypeDescriptor))]
-    [JsonSerializable(typeof(FieldDescriptor))]
-    [JsonSerializable(typeof(GlobalDescriptor))]
-    [JsonSerializable(typeof(Dictionary<string, JsonElement>))]
-    [JsonSourceGenerationOptions(AllowTrailingCommas = true,
-                                DictionaryKeyPolicy = JsonKnownNamingPolicy.Unspecified, // contracts, types and globals are case sensitive
-                                PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
-                                NumberHandling = JsonNumberHandling.AllowReadingFromString,
-                                ReadCommentHandling = JsonCommentHandling.Skip,
-                                UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
-                                UnknownTypeHandling = JsonUnknownTypeHandling.JsonElement,
-                                Converters = [typeof(TypeDescriptorConverter),
-                                            typeof(FieldDescriptorConverter),
-                                            typeof(GlobalDescriptorConverter)])]
-    internal sealed partial class ContractDescriptorContext : JsonSerializerContext
+    private static ContractDescriptor? ParseCompactCore(ReadOnlySpan<byte> json)
     {
+        var reader = new Utf8JsonReader(
+            json,
+            new JsonReaderOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip,
+            });
+
+        if (!reader.Read())
+            throw new JsonException();
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException();
+
+        var descriptor = new ContractDescriptor();
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                if (reader.Read())
+                    throw new JsonException();
+                return descriptor;
+            }
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException();
+
+            string propertyName = reader.GetString() ?? throw new JsonException();
+            ReadNext(ref reader);
+            switch (propertyName)
+            {
+                case "version":
+                    descriptor.Version = ReadNullableInt32(ref reader);
+                    break;
+                case "baseline":
+                    descriptor.Baseline = ReadNullableString(ref reader);
+                    break;
+                case "contracts":
+                    descriptor.Contracts = ReadStringDictionary(ref reader);
+                    break;
+                case "types":
+                    descriptor.Types = ReadTypeDictionary(ref reader);
+                    break;
+                case "globals":
+                    descriptor.Globals = ReadGlobalDictionary(ref reader);
+                    break;
+                case "subDescriptors":
+                    descriptor.SubDescriptors = ReadGlobalDictionary(ref reader);
+                    break;
+                default:
+                    descriptor.Extras ??= [];
+                    using (JsonDocument extra = JsonDocument.ParseValue(ref reader))
+                    {
+                        descriptor.Extras[propertyName] = extra.RootElement.Clone();
+                    }
+                    break;
+            }
+        }
+
+        throw new JsonException();
     }
 
     public class ContractDescriptor
@@ -69,7 +110,6 @@ public partial class ContractDescriptorParser
 
         public Dictionary<string, GlobalDescriptor>? SubDescriptors { get; set; }
 
-        [JsonExtensionData]
         public Dictionary<string, JsonElement>? Extras { get; set; }
 
         public override string ToString()
@@ -79,21 +119,18 @@ public partial class ContractDescriptorParser
 
     }
 
-    [JsonConverter(typeof(TypeDescriptorConverter))]
     public class TypeDescriptor
     {
         public uint? Size { get; set; }
         public Dictionary<string, FieldDescriptor>? Fields { get; set; }
     }
 
-    [JsonConverter(typeof(FieldDescriptorConverter))]
     public class FieldDescriptor
     {
         public string? Type { get; set; }
         public int Offset { get; set; }
     }
 
-    [JsonConverter(typeof(GlobalDescriptorConverter))]
     public class GlobalDescriptor
     {
         [MemberNotNullWhen(true, nameof(NumericValue))]
@@ -105,171 +142,219 @@ public partial class ContractDescriptorParser
         public string? StringValue { get; set; }
     }
 
-    internal sealed class TypeDescriptorConverter : JsonConverter<TypeDescriptor>
+    private static Dictionary<string, string>? ReadStringDictionary(ref Utf8JsonReader reader)
     {
-        // Almost a normal dictionary converter except:
-        //  1. looks for a special key "!" to set the Size property
-        //  2. field names are property names, but treated case-sensitively
-        public override TypeDescriptor Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            if (reader.TokenType != JsonTokenType.StartObject)
-                throw new JsonException();
-            uint? size = null;
-            Dictionary<string, FieldDescriptor>? fields = new();
-            while (reader.Read())
-            {
-                switch (reader.TokenType)
-                {
-                    case JsonTokenType.EndObject:
-                        return new TypeDescriptor { Size = size, Fields = fields };
-                    case JsonTokenType.PropertyName:
-                        string? fieldNameOrSizeSigil = reader.GetString();
-                        reader.Read(); // read the next value: either a number or a field descriptor
-                        if (fieldNameOrSizeSigil == TypeDescriptorSizeSigil)
-                        {
-                            uint newSize = reader.GetUInt32();
-                            if (size is not null)
-                            {
-                                throw new JsonException($"Size specified multiple times: {size} and {newSize}");
-                            }
-                            size = newSize;
-                        }
-                        else
-                        {
-                            string? fieldName = fieldNameOrSizeSigil;
-                            var field = JsonSerializer.Deserialize(ref reader, ContractDescriptorContext.Default.FieldDescriptor);
-                            if (fieldName is null || field is null)
-                                throw new JsonException();
-                            if (!fields.TryAdd(fieldName, field))
-                            {
-                                throw new JsonException($"Duplicate field name: {fieldName}");
-                            }
-                        }
-                        break;
-                    case JsonTokenType.Comment:
-                        // unexpected - we specified to skip comments.  but let's ignore anyway
-                        break;
-                    default:
-                        throw new JsonException();
-                }
-            }
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+        if (reader.TokenType != JsonTokenType.StartObject)
             throw new JsonException();
+
+        var values = new Dictionary<string, string>();
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                return values;
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException();
+
+            string name = reader.GetString() ?? throw new JsonException();
+            ReadNext(ref reader);
+            string value = reader.TokenType == JsonTokenType.String
+                ? reader.GetString() ?? throw new JsonException()
+                : throw new JsonException();
+            values[name] = value;
         }
 
-        public override void Write(Utf8JsonWriter writer, TypeDescriptor value, JsonSerializerOptions options)
-        {
-            throw new NotImplementedException();
-        }
+        throw new JsonException();
     }
 
-    internal sealed class FieldDescriptorConverter : JsonConverter<FieldDescriptor>
+    private static Dictionary<string, TypeDescriptor>? ReadTypeDictionary(ref Utf8JsonReader reader)
     {
-        // Compact Field descriptors are either a number or a two element array
-        // 1. number - no type, offset is given as the number
-        // 2. [number, string] - offset is given as the number, type name is given as the string
-        public override FieldDescriptor Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException();
+
+        var types = new Dictionary<string, TypeDescriptor>();
+        while (reader.Read())
         {
-            if (TryGetInt32FromToken(ref reader, out int offset))
-                return new FieldDescriptor { Offset = offset };
-            if (reader.TokenType != JsonTokenType.StartArray)
+            if (reader.TokenType == JsonTokenType.EndObject)
+                return types;
+            if (reader.TokenType != JsonTokenType.PropertyName)
                 throw new JsonException();
-            reader.Read();
-            //   [number, string]
-            //    ^ we're here
-            if (!TryGetInt32FromToken(ref reader, out offset))
+
+            string name = reader.GetString() ?? throw new JsonException();
+            ReadNext(ref reader);
+            types[name] = ReadTypeDescriptor(ref reader);
+        }
+
+        throw new JsonException();
+    }
+
+    private static TypeDescriptor ReadTypeDescriptor(ref Utf8JsonReader reader)
+    {
+        // Almost a normal dictionary except:
+        //  1. "!" specifies the type size.
+        //  2. All other property names are case-sensitive field names.
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException();
+
+        uint? size = null;
+        var fields = new Dictionary<string, FieldDescriptor>();
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                return new TypeDescriptor { Size = size, Fields = fields };
+            if (reader.TokenType != JsonTokenType.PropertyName)
                 throw new JsonException();
-            reader.Read(); // string
+
+            string fieldName = reader.GetString() ?? throw new JsonException();
+            ReadNext(ref reader);
+            if (fieldName == TypeDescriptorSizeSigil)
+            {
+                uint newSize = reader.GetUInt32();
+                if (size is not null)
+                    throw new JsonException($"Size specified multiple times: {size} and {newSize}");
+                size = newSize;
+            }
+            else if (!fields.TryAdd(fieldName, ReadFieldDescriptor(ref reader)))
+            {
+                throw new JsonException($"Duplicate field name: {fieldName}");
+            }
+        }
+
+        throw new JsonException();
+    }
+
+    private static FieldDescriptor ReadFieldDescriptor(ref Utf8JsonReader reader)
+    {
+        // Compact field descriptors are either:
+        //  1. number - no type, offset is given as the number.
+        //  2. [number, string] - offset is the number and type name is the string.
+        if (TryGetInt32FromToken(ref reader, out int offset))
+            return new FieldDescriptor { Offset = offset };
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new JsonException();
+
+        ReadNext(ref reader);
+        if (!TryGetInt32FromToken(ref reader, out offset))
+            throw new JsonException();
+        ReadNext(ref reader);
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException();
+        string type = reader.GetString() ?? throw new JsonException();
+        ReadNext(ref reader);
+        if (reader.TokenType != JsonTokenType.EndArray)
+            throw new JsonException();
+        return new FieldDescriptor { Type = type, Offset = offset };
+    }
+
+    private static Dictionary<string, GlobalDescriptor>? ReadGlobalDictionary(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException();
+
+        var globals = new Dictionary<string, GlobalDescriptor>();
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                return globals;
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException();
+
+            string name = reader.GetString() ?? throw new JsonException();
+            ReadNext(ref reader);
+            globals[name] = ReadGlobalDescriptor(ref reader);
+        }
+
+        throw new JsonException();
+    }
+
+    private static GlobalDescriptor ReadGlobalDescriptor(ref Utf8JsonReader reader)
+    {
+        // Compact global descriptors have four forms:
+        //  1. value - no type, direct value.
+        //  2. [value] - no type, indirect value.
+        //  3. [value, string] - typed direct value.
+        //  4. [[value], string] - typed indirect value.
+        // A value can be a string or number. Numeric strings are retained as strings and parsed as numbers.
+        if (TryGetGlobalValueFromToken(ref reader, out GlobalValue directValue))
+            return CreateGlobalDescriptor(directValue, indirect: false, type: null);
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new JsonException();
+
+        ReadNext(ref reader);
+        if (TryGetGlobalValueFromToken(ref reader, out GlobalValue value))
+        {
+            ReadNext(ref reader);
+            if (reader.TokenType == JsonTokenType.EndArray)
+                return CreateGlobalDescriptor(value, indirect: true, type: null);
             if (reader.TokenType != JsonTokenType.String)
                 throw new JsonException();
-            string? type = reader.GetString();
-            reader.Read(); // end of array
+
+            string type = reader.GetString() ?? throw new JsonException();
+            ReadNext(ref reader);
             if (reader.TokenType != JsonTokenType.EndArray)
                 throw new JsonException();
-            return new FieldDescriptor { Type = type, Offset = offset };
+            return CreateGlobalDescriptor(value, indirect: false, type);
         }
 
-        public override void Write(Utf8JsonWriter writer, FieldDescriptor value, JsonSerializerOptions options)
-        {
+        if (reader.TokenType != JsonTokenType.StartArray)
             throw new JsonException();
-        }
+        ReadNext(ref reader);
+        if (!TryGetGlobalValueFromToken(ref reader, out value))
+            throw new JsonException();
+        ReadNext(ref reader);
+        if (reader.TokenType != JsonTokenType.EndArray)
+            throw new JsonException();
+        ReadNext(ref reader);
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException();
+        string indirectType = reader.GetString() ?? throw new JsonException();
+        ReadNext(ref reader);
+        if (reader.TokenType != JsonTokenType.EndArray)
+            throw new JsonException();
+        return CreateGlobalDescriptor(value, indirect: true, indirectType);
     }
 
-    internal sealed class GlobalDescriptorConverter : JsonConverter<GlobalDescriptor>
+    private static GlobalDescriptor CreateGlobalDescriptor(GlobalValue value, bool indirect, string? type)
     {
-        public override GlobalDescriptor Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            // four cases:
-            // 1. value - no type, direct value, given value
-            // 2. [number] - no type, indirect value, given aux data ptr
-            // 3. [value, string] - type, direct value, given value
-            // 4. [[number], string] - type, indirect value, given aux data ptr
-            // value can either be a string or a number. if a string is able to be parsed as a number, it is read as both
+        if (indirect && value.NumericValue is null)
+            throw new JsonException("Indirect global value could not be converted to a number.");
 
-            // Case 1: value
-            if (TryGetGlobalValueFromToken(ref reader, out GlobalValue valueCase1))
-                return new GlobalDescriptor { NumericValue = valueCase1.NumericValue, StringValue = valueCase1.StringValue, Indirect = false };
-            if (reader.TokenType != JsonTokenType.StartArray)
-                throw new JsonException();
-            reader.Read();
-            // we're in case 2, 3, or 4:
-            // case 2: [number]
-            //          ^ we're here
-            // case 3: [value, string]
-            //          ^ we're here
-            // case 4: [[number], string]
-            //          ^ we're here
-            if (TryGetGlobalValueFromToken(ref reader, out GlobalValue valueCase2or3))
-            {
-                // case 2 or 3
-                // case 2: [number]
-                //          ^ we're here
-                // case 3: [value, string]
-                //          ^ we're here
-                reader.Read(); // end of array (case 2) or string (case 3)
-                if (reader.TokenType == JsonTokenType.EndArray) // it was case 2
-                {
-                    if (valueCase2or3.NumericValue is null)
-                        throw new JsonException("Indirect global value could not be converted to a number.");
-                    return new GlobalDescriptor { NumericValue = valueCase2or3.NumericValue, StringValue = valueCase2or3.StringValue, Indirect = true };
-                }
-                if (reader.TokenType == JsonTokenType.String) // it was case 3
-                {
-                    string? type = reader.GetString();
-                    reader.Read(); // end of array for case 3
-                    if (reader.TokenType != JsonTokenType.EndArray)
-                        throw new JsonException();
-                    return new GlobalDescriptor { Type = type, NumericValue = valueCase2or3.NumericValue, StringValue = valueCase2or3.StringValue, Indirect = false };
-                }
-                throw new JsonException();
-            }
-            if (reader.TokenType == JsonTokenType.StartArray)
-            {
-                // case 4: [[number], string]
-                //          ^ we're here
-                reader.Read(); // number
-                if (!TryGetGlobalValueFromToken(ref reader, out GlobalValue valueCase4))
-                    throw new JsonException();
-                reader.Read(); // end of inner array
-                if (reader.TokenType != JsonTokenType.EndArray)
-                    throw new JsonException();
-                reader.Read(); // string
-                if (reader.TokenType != JsonTokenType.String)
-                    throw new JsonException();
-                string? type = reader.GetString();
-                reader.Read(); // end of outer array
-                if (reader.TokenType != JsonTokenType.EndArray)
-                    throw new JsonException();
-                if (valueCase4.NumericValue is null)
-                    throw new JsonException("Indirect global value could not be converted to a number.");
-                return new GlobalDescriptor { Type = type, NumericValue = valueCase4.NumericValue, StringValue = valueCase4.StringValue, Indirect = true };
-            }
-            throw new JsonException();
-        }
-
-        public override void Write(Utf8JsonWriter writer, GlobalDescriptor value, JsonSerializerOptions options)
+        return new GlobalDescriptor
         {
+            Type = type,
+            NumericValue = value.NumericValue,
+            StringValue = value.StringValue,
+            Indirect = indirect,
+        };
+    }
+
+    private static int? ReadNullableInt32(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+        if (TryGetInt32FromToken(ref reader, out int value))
+            return value;
+        throw new JsonException();
+    }
+
+    private static string? ReadNullableString(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return null;
+        if (reader.TokenType == JsonTokenType.String)
+            return reader.GetString();
+        throw new JsonException();
+    }
+
+    private static void ReadNext(ref Utf8JsonReader reader)
+    {
+        if (!reader.Read())
             throw new JsonException();
-        }
     }
 
     private struct GlobalValue

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorParser.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorParser.cs
@@ -183,9 +183,13 @@ public partial class ContractDescriptorParser
             throw new JsonException();
 
         ReadNext(ref reader);
+        //   [number, string]
+        //    ^ we're here
         if (!TryGetInt32FromToken(ref reader, out offset))
             throw new JsonException();
         ReadNext(ref reader);
+        //   [number, string]
+        //            ^ we're here
         if (reader.TokenType != JsonTokenType.String)
             throw new JsonException();
         string type = reader.GetString() ?? throw new JsonException();
@@ -234,6 +238,14 @@ public partial class ContractDescriptorParser
             throw new JsonException();
 
         ReadNext(ref reader);
+        // Cases 2 and 3:
+        //   [value]
+        //    ^ we're here
+        //   [value, string]
+        //    ^ we're here
+        // Case 4:
+        //   [[value], string]
+        //    ^ we're here
         if (TryGetGlobalValueFromToken(ref reader, out GlobalValue value))
         {
             ReadNext(ref reader);
@@ -252,12 +264,18 @@ public partial class ContractDescriptorParser
         if (reader.TokenType != JsonTokenType.StartArray)
             throw new JsonException();
         ReadNext(ref reader);
+        //   [[value], string]
+        //     ^ we're here
         if (!TryGetGlobalValueFromToken(ref reader, out value))
             throw new JsonException();
         ReadNext(ref reader);
+        //   [[value], string]
+        //           ^ we're here
         if (reader.TokenType != JsonTokenType.EndArray)
             throw new JsonException();
         ReadNext(ref reader);
+        //   [[value], string]
+        //             ^ we're here
         if (reader.TokenType != JsonTokenType.String)
             throw new JsonException();
         string indirectType = reader.GetString() ?? throw new JsonException();

--- a/src/native/managed/cdac/tests/UnitTests/ContractDescriptor/ParserTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ContractDescriptor/ParserTests.cs
@@ -65,9 +65,14 @@ public class ParserTests
     [Fact]
     public void RejectsTrailingJson()
     {
-        byte[] json = "{}{}"u8.ToArray();
+        byte[][] invalidJson =
+        [
+            "{}{}"u8.ToArray(),
+            "null{}"u8.ToArray(),
+        ];
 
-        Assert.Throws<JsonException>(() => ContractDescriptorParser.ParseCompact(json));
+        foreach (byte[] json in invalidJson)
+            Assert.ThrowsAny<JsonException>(() => ContractDescriptorParser.ParseCompact(json));
     }
 
     [Fact]

--- a/src/native/managed/cdac/tests/UnitTests/ContractDescriptor/ParserTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ContractDescriptor/ParserTests.cs
@@ -44,6 +44,51 @@ public class ParserTests
     }
 
     [Fact]
+    public void ParsesExtensionData()
+    {
+        ReadOnlySpan<byte> json = """
+        {
+            "version": "1",
+            "unknownObject": { "value": 2 },
+            "unknownArray": [3, 4],
+            "unknownString": "value"
+        }
+        """u8;
+
+        ContractDescriptorParser.ContractDescriptor descriptor = ContractDescriptorParser.ParseCompact(json);
+
+        Assert.Equal(1, descriptor.Version);
+        Assert.Equal(2, descriptor.Extras["unknownObject"].GetProperty("value").GetInt32());
+        Assert.Equal(2, descriptor.Extras["unknownArray"].GetArrayLength());
+        Assert.Equal("value", descriptor.Extras["unknownString"].GetString());
+    }
+
+    [Fact]
+    public void RejectsTrailingJson()
+    {
+        byte[] json = "{}{}"u8.ToArray();
+
+        Assert.Throws<JsonException>(() => ContractDescriptorParser.ParseCompact(json));
+    }
+
+    [Fact]
+    public void RejectsDuplicateFieldNames()
+    {
+        byte[] json = """
+        {
+            "types": {
+                "Type": {
+                    "field": 0,
+                    "field": 8
+                }
+            }
+        }
+        """u8.ToArray();
+
+        Assert.Throws<JsonException>(() => ContractDescriptorParser.ParseCompact(json));
+    }
+
+    [Fact]
     public void ParseSizedTypes()
     {
         ReadOnlySpan<byte> json = """

--- a/src/native/managed/cdac/tests/UnitTests/ContractDescriptor/ParserTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ContractDescriptor/ParserTests.cs
@@ -20,7 +20,6 @@ public class ParserTests
         Assert.Null(descriptor.Baseline);
         Assert.Null(descriptor.Contracts);
         Assert.Null(descriptor.Types);
-        Assert.Null(descriptor.Extras);
     }
     [Fact]
     public void ParsesTrivialContract()
@@ -40,11 +39,10 @@ public class ParserTests
         Assert.Empty(descriptor.Contracts);
         Assert.Empty(descriptor.Types);
         Assert.Empty(descriptor.Globals);
-        Assert.Null(descriptor.Extras);
     }
 
     [Fact]
-    public void ParsesExtensionData()
+    public void IgnoresUnknownProperties()
     {
         ReadOnlySpan<byte> json = """
         {
@@ -58,9 +56,10 @@ public class ParserTests
         ContractDescriptorParser.ContractDescriptor descriptor = ContractDescriptorParser.ParseCompact(json);
 
         Assert.Equal(1, descriptor.Version);
-        Assert.Equal(2, descriptor.Extras["unknownObject"].GetProperty("value").GetInt32());
-        Assert.Equal(2, descriptor.Extras["unknownArray"].GetArrayLength());
-        Assert.Equal("value", descriptor.Extras["unknownString"].GetString());
+        Assert.Null(descriptor.Baseline);
+        Assert.Null(descriptor.Contracts);
+        Assert.Null(descriptor.Types);
+        Assert.Null(descriptor.Globals);
     }
 
     [Fact]

--- a/src/native/managed/cdac/tests/UnitTests/ContractDescriptor/TargetTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/ContractDescriptor/TargetTests.cs
@@ -246,7 +246,7 @@ public unsafe partial class TargetTests
         ContractDescriptorHelpers.Fill(descriptor, targetTestHelpers.Arch, descriptorJson.Length, 0xdddddddd, 0, 0xeeeeeeee);
 
         FormatException ex = Assert.Throws<FormatException>(() => builder.CreateTargetFromRawDescriptor(descriptor, descriptorJson, []));
-        Assert.IsType<System.Text.Json.JsonException>(ex.InnerException);
+        Assert.IsAssignableFrom<System.Text.Json.JsonException>(ex.InnerException);
         Assert.Equal(CdacHResults.CDAC_E_DESCRIPTOR_MALFORMED, ex.HResult);
     }
 


### PR DESCRIPTION
## Summary

- replace the source-generated `JsonSerializer` contract descriptor parser with direct `Utf8JsonReader` parsing
- preserve compact descriptor formats, comments, trailing commas, complete-input validation, and flexible numeric parsing
- ignore unknown top-level properties without retaining unused `JsonElement` extension data
- share dictionary token parsing across contracts, types, globals, and sub-descriptors
- add coverage for unknown properties, duplicate fields, and trailing JSON after object and null roots

## Size impact

Sizeoscope comparison for the Release win-x64 `mscordaccore_universal.dll`:

- before: 6,097,408 bytes
- after: 5,483,520 bytes
- reduction: 613,888 bytes (10.07%)

The accounted reduction primarily comes from `System.Text.Json`, `System.Private.CoreLib`, `System.Text.Encodings.Web`, and related collection support.

## Testing

- `Microsoft.Diagnostics.DataContractReader.Tests`: 3,097 tests passed