### PR TITLE
Enable PAL test result publishing token

### DIFF
--- a/eng/pipelines/coreclr/templates/run-paltests-step.yml
+++ b/eng/pipelines/coreclr/templates/run-paltests-step.yml
@@ -20,3 +20,4 @@ steps:
       osGroup: ${{ parameters.osGroup }}
       archType: ${{ parameters.archType }}
       shouldContinueOnError: ${{ parameters.continueOnError }}
+      publishTestResults: true


### PR DESCRIPTION
The PALTests Helix leg enables the Azure Pipelines reporter in `paltests.proj`, but its send step did not request test-result publishing from the common Helix template. That left `SYSTEM_ACCESSTOKEN` unset and caused the PAL legs to fail before any Helix work items were queued.

This passes `publishTestResults: true` through the PAL send step so `send-to-helix-step.yml` injects `SYSTEM_ACCESSTOKEN: $(System.AccessToken)` the same way the normal runtime test legs do.

Fixes #132545, #132614, #132656.

> [!NOTE]
> This PR description was generated by GitHub Copilot.