### PR TITLE
Fix ComWrappers ICustomQueryInterface exception handling

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.CoreCLR.cs
@@ -76,7 +76,7 @@ namespace System.Runtime.InteropServices
             catch (Exception ex)
             {
                 *pException = ex;
-                return default;
+                return -1; // See TryInvokeICustomQueryInterfaceResult.FailedToInvoke
             }
         }
 


### PR DESCRIPTION
## Description

When a user's `ICustomQueryInterface.GetInterface` implementation throws an exception, the native `QueryInterface` path in `comwrappers.cpp` asserts and crashes the process (`Assertion failed: ((*ppvObject != nullptr))`).

The root cause is in the `[UnmanagedCallersOnly]` `CallICustomQueryInterface` wrapper in `ComWrappers.CoreCLR.cs`. It catches the exception but returns `default` (`0`) from the catch block. `0` happens to be the numeric value of `TryInvokeICustomQueryInterfaceResult.Handled`, so native code is told the call succeeded and that `*ppvObject` was set - but it's still `null`, tripping the assert.

The fix returns `-1` (`TryInvokeICustomQueryInterfaceResult.FailedToInvoke`) from the catch block instead, so native code correctly treats the call as failed and falls back rather than asserting on a null pointer.

Fixes the CI failure reported in #132677, reproduced locally by `Regressions/coreclr/GitHub_117393/test117393`.

## Verification

- Built checked `clr+libs`, built `test117393`, generated `Core_Root` - test passes with the fix applied.
- Reverted the fix, rebuilt `System.Private.CoreLib` only, reran the test - reproduced the exact native assertion crash from the issue.
- Reapplied the fix, rebuilt, reran - test passes again.

Closes #132677

> [!NOTE]
> This description was generated with AI assistance.