### PR TITLE
Add update-area-owners skill

### DIFF
--- a/.github/skills/update-area-owners/SKILL.md
+++ b/.github/skills/update-area-owners/SKILL.md
@@ -142,9 +142,11 @@ Produce a compact before/after table for each area. Include:
 - references that are intentionally left unchanged and why.
 
 For a new routed area, add the label to the outer list and add an inner route.
-For a label rename, change both policy occurrences and the Markdown row in one
-change. For a lead-only change, do not add the lead to policy mentionees unless
-the request also changes notifications.
+For a label rename performed externally, change both repository policy
+occurrences and the Markdown row in one change after the GitHub label has been
+renamed. This skill must not rename the GitHub label itself. For a lead-only
+change, do not add the lead to policy mentionees unless the request also
+changes notifications.
 
 For owner changes, distinguish:
 
@@ -204,7 +206,7 @@ The final report must include:
 2. areas and scenarios handled;
 3. generated script paths, when applicable;
 4. exact permissions required for the listed team operations;
-6. validation results and any unresolved external state.
+5. validation results and any unresolved external state.
 
 ## Output discipline
 

--- a/.github/skills/update-area-owners/SKILL.md
+++ b/.github/skills/update-area-owners/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: update-area-owners
+description: >
+  Update dotnet/runtime area ownership documentation and issue/PR routing. Use
+  for adding, changing, or removing area leads, owners, consultants, mentionees,
+  scoping/notes, or GitHub area team membership.
+---
+
+## Inputs
+
+Accept a request describing one or more of:
+
+- a new area label and its display row;
+- a lead change;
+- direct owner changes;
+- GitHub team membership changes;
+- consultant changes;
+- non-team mentionees;
+- removal of an area and the area into which it is being collapsed.
+
+For each affected area, resolve and show:
+
+```text
+label:       the exact existing or proposed label, preserving casing
+display row: affected area data mapped from the headers in docs/area-owners.md
+team:        zero or more dotnet/<team-slug> teams, or no team
+mentionees:  direct GitHub usernames and dotnet/<team-slug> entries in policy YAML
+target:      destination area for a collapse, when applicable
+```
+
+If the request does not identify the destination for a removal/collapse, stop
+and ask for it. Do not infer a destination.
+
+# Update area owners
+
+Keep the runtime area-owner sources synchronized. This skill is for repository
+changes. When a request includes GitHub area-team membership or team
+creation/deletion, read
+[references/github-team-management.md](references/github-team-management.md).
+It produces reviewable Bash and PowerShell handoff scripts for an authorized
+maintainer; those scripts do not make live changes unless the maintainer
+explicitly runs them.
+
+## Source files and related artifacts
+
+Read all of these before editing:
+
+1. `docs/area-owners.md`
+2. `.github/policies/resourceManagement.yml`
+3. `.github/CODEOWNERS`
+4. `docs/infra/automation.md`
+5. `.github/labeler-readme.md` and any labeler workflow/configuration found by
+   searching for the affected label
+
+Search the repository for every exact affected label, team slug, old owner, and
+new owner. Include references in workflow files, issue-management documentation,
+and other peer policy files in the impact report. Do not change unrelated
+references merely because they contain a similar string.
+
+Do not create, rename, or delete actual GitHub labels. This skill updates area
+ownership documentation and issue/PR routing only.
+
+## Current source formats
+
+### `docs/area-owners.md`
+
+Read the file's area-table header row before interpreting or editing any area.
+Use those headers to map each area's cell values. Preserve the table's existing
+alignment, exact label casing, mentions, and explanatory notes. The area table
+is followed by separate operating-system, architecture, and community-triager
+sections. Change those sections only when the request explicitly targets one of
+them, not when an area has a similar name.
+
+### `.github/policies/resourceManagement.yml`
+
+Area routing is the `eventResponderTasks` entry whose description is
+`Area-owners`. It has two coupled parts:
+
+1. An outer `or` list of `labelAdded` predicates under an open issue/PR
+   condition.
+2. A `then` list containing one `if` block per routed area. Each block has a
+   `hasLabel` predicate and a `mentionUsers` action:
+
+```yaml
+      - if:
+        - hasLabel:
+            label: area-System.Example
+        then:
+        - mentionUsers:
+            mentionees:
+            - dotnet/area-system-example
+            - consultant-username
+            replyTemplate: >-
+              Tagging subscribers to this area: ${mentionees}
+
+              See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.
+            assignMentionees: False
+```
+
+For a routed area, always update both the outer `labelAdded` predicate and the
+inner `hasLabel`/`mentionUsers` block. Keep the standard reply template and
+`assignMentionees: False`. Team values in this file are `dotnet/<team-slug>`;
+direct mentionees are GitHub usernames without `@`.
+
+The policy mentionee list is deliberately not a mechanical copy of the area's
+owners field. Existing blocks can include a lead, omit an owner, include
+consultants, or combine direct users with a team. Preserve those differences
+unless the request specifically changes notifications. An area row may also
+exist without a policy route; report that state instead of adding a route
+without instruction.
+
+`docs/infra/automation.md` confirms that this policy YAML controls area
+subscriptions. The Markdown table alone is not sufficient.
+
+## Workflow
+
+### 1. Inventory and classify the request
+
+Read the affected row and policy blocks, then search for all related references.
+Classify each requested operation as one of:
+
+- add;
+- update lead;
+- update direct owners;
+- update team membership;
+- update consultants;
+- update non-team mentionees;
+- collapse/remove.
+
+For an existing team, inspect its current slug and membership with read-only
+GitHub queries when available. If the team is absent, distinguish "create a
+new team" from "use direct mentionees" and record that decision.
+
+### 2. Plan the synchronized repository edit
+
+Produce a compact before/after table for each area. Include:
+
+- exact Markdown row changes;
+- outer policy `labelAdded` changes;
+- inner policy route changes;
+- team operation(s), if any;
+- references that are intentionally left unchanged and why.
+
+For a new routed area, add the label to the outer list and add an inner route.
+For a label rename, change both policy occurrences and the Markdown row in one
+change. For a lead-only change, do not add the lead to policy mentionees unless
+the request also changes notifications.
+
+For owner changes, distinguish:
+
+- direct owners represented in the mapped area data;
+- members of a GitHub team represented by `@dotnet/<team-slug>`;
+- policy mentionees who are neither direct owners nor team members.
+
+For consultant or non-team mentionee changes, update the mapped notes field
+and/or the policy list independently as requested. Never remove a team member
+merely because a consultant was removed from the notes.
+
+For a collapse/removal:
+
+1. require and validate the destination area;
+2. decide whether old issues/PRs retain the old label or need a label migration;
+3. remove the source row;
+4. remove the source `labelAdded` predicate and inner policy route;
+5. update the destination row, policy mentionees, and notes only as needed;
+6. emit an explicit team disposition: rename into the destination team, merge
+   membership, archive/leave the old team, or delete it;
+7. search again for stale source-label and source-team references.
+
+### 3. Apply repository edits
+
+Edit only the relevant sections of `docs/area-owners.md` and
+`.github/policies/resourceManagement.yml`. Preserve surrounding ordering,
+whitespace, and policy formatting. Update a peer file only when the inventory
+shows a concrete reference that must change, such as a path-specific
+`.github/CODEOWNERS` entry.
+
+Do not make changes to actual GitHub labels or teams directly. The repository PR
+should contain the ownership and routing changes; any generated team-management
+scripts are session-local and should not be added to the PR.
+
+### 4. Generate the session-local handoff
+
+When the inventory identifies GitHub team membership or team creation/deletion
+work, follow [the GitHub team-management handoff](references/github-team-management.md).
+The generated scripts are session-local and must not be added to the repository
+change.
+
+### 5. Validate and report
+
+Run the smallest available static checks:
+
+- parse the edited YAML with an available YAML parser, if present;
+- verify the Markdown table remains structurally valid;
+- verify every routed area has exactly one outer trigger and one inner route;
+- verify no requested old label/team reference remains except in documented
+  migration notes;
+- syntax-check both generated scripts without executing mutations;
+- verify the Bash and PowerShell operation inventories are identical.
+
+The final report must include:
+
+1. repository files changed;
+2. areas and scenarios handled;
+3. generated script paths, when applicable;
+4. exact permissions required for the listed team operations;
+6. validation results and any unresolved external state.
+
+## Output discipline
+
+Do not claim that a GitHub team changed. The skill changes repository ownership
+and routing files and, when needed, generates team-management scripts only.
+State that team operations remain pending until an authorized user reviews and
+runs the generated scripts.

--- a/.github/skills/update-area-owners/references/github-team-management.md
+++ b/.github/skills/update-area-owners/references/github-team-management.md
@@ -10,9 +10,10 @@ directory, then report both paths.
 
 The generated scripts must:
 
-- default to `dotnet/runtime` and the `dotnet` organization;
-- support `-WhatIf`/`--dry-run` and require an explicit confirmation before
-  mutating operations;
+- default repository association operations to `dotnet/runtime` in the
+  `dotnet` organization;
+- default to dry-run and require an explicit `--apply`/`-Apply` confirmation
+  before mutating operations;
 - use the authenticated `gh` CLI and never accept or print a token;
 - use `set -euo pipefail` in Bash and `$ErrorActionPreference = 'Stop'` in
   PowerShell;
@@ -55,8 +56,9 @@ slug is lower-kebab-case (`area-system-example`).
 Create a unique directory, for example:
 
 ```text
-<session-files>/update-<area>.sh
-<session-files>/update-<area>.ps1
+<session-files>/update-system-example/
+  update-system-example.sh
+  update-system-example.ps1
 ```
 
 The two scripts must contain the same operations and target values. Include:

--- a/.github/skills/update-area-owners/references/github-team-management.md
+++ b/.github/skills/update-area-owners/references/github-team-management.md
@@ -95,7 +95,9 @@ CURRENT_ROLE="$(gh api "/orgs/${ORG}/teams/${TEAM_SLUG}/memberships/${CURRENT_US
 
 run() {
   echo "+ gh $*"
-  [[ "$APPLY" == true ]] && gh "$@"
+  if [[ "$APPLY" == true ]]; then
+    gh "$@"
+  fi
 }
 
 for username in "${ADD_MEMBERS[@]}"; do
@@ -192,14 +194,15 @@ foreach ($Username in $FormerOwners) {
 if (-not $Apply) {
     Write-Output 'Dry run only. Re-run with -Apply to execute additions and removals.'
 }
-else {
+
+if ($Apply) {
     if ($CurrentRole -eq 'maintainer' -and $NewMaintainers -notcontains $CurrentUser) {
         Write-Warning 'The current user remains a maintainer. Have a new maintainer perform any requested downgrade.'
     }
-    & gh api "/orgs/$Org/teams/$TeamSlug/members" | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        throw "gh api verification failed with exit code $LASTEXITCODE"
-    }
+}
+& gh api "/orgs/$Org/teams/$TeamSlug/members" | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "gh api verification failed with exit code $LASTEXITCODE"
 }
 ```
 

--- a/.github/skills/update-area-owners/references/github-team-management.md
+++ b/.github/skills/update-area-owners/references/github-team-management.md
@@ -1,0 +1,210 @@
+# GitHub team management handoff
+
+Use this reference when an area-owner maintenance request updates GitHub area
+team membership or creates or deletes a GitHub area team. The skill must not
+call mutating GitHub APIs directly. Generate a Bash script and a PowerShell
+script in a unique directory below the session's local `files/` artifact
+directory, then report both paths.
+
+## Safety and permissions
+
+The generated scripts must:
+
+- default to `dotnet/runtime` and the `dotnet` organization;
+- support `-WhatIf`/`--dry-run` and require an explicit confirmation before
+  mutating operations;
+- use the authenticated `gh` CLI and never accept or print a token;
+- use `set -euo pipefail` in Bash and `$ErrorActionPreference = 'Stop'` in
+  PowerShell;
+- check every API response and stop on an unexpected status;
+- use the `gh` CLI for team creation, team updates, membership updates,
+  repository association, and team deletion only when the requested change
+  explicitly requires them;
+- print the planned operation and target before each mutation.
+
+Team creation, renaming, deletion, and membership changes require an
+authenticated GitHub identity with the corresponding organization permissions.
+Team creation is configurable: organization members can create teams when the
+organization allows member-created teams; otherwise an organization owner is
+required. Organization owners can delete teams, while team maintainers can
+manage membership, team details, and repository access for teams they maintain.
+The identity must also be an organization member where GitHub requires it.
+
+## Team configuration
+
+Team names use lower-kebab-case. Area teams are children of `dotnet/npt`, which
+is itself a child of `dotnet/microsoft`.
+
+When creating a new area team, declare and apply this configuration:
+
+```text
+team slug:             area-system-example
+display name:          area-system-example
+description:           Area owners for area-System.Example
+visibility:            closed
+repository permission: pull
+notifications:         notifications_enabled
+parent team:           dotnet/npt
+```
+
+The `area-System.Example` label preserves its dot and casing, while the team
+slug is lower-kebab-case (`area-system-example`).
+
+## Script contents
+
+Create a unique directory, for example:
+
+```text
+<session-files>/update-<area>.sh
+<session-files>/update-<area>.ps1
+```
+
+The two scripts must contain the same operations and target values. Include:
+
+- a header with the organization, repository, affected areas, required
+  permissions, and a warning that the script changes live GitHub state;
+- the proposed team slug, display name, description, visibility, notification
+  setting, repository permission, and parent team (`dotnet/npt`);
+- create/rename/delete team operations where requested;
+- membership additions and removals, sorted and deduplicated;
+- repository association updates when the team is intended to represent
+  `dotnet/runtime`;
+- dry-run as the default and an explicit confirmation switch for writes;
+- a final read-only verification of team membership and team/repository
+  association where the operation permits it.
+
+## Bash sample
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ORG="dotnet"
+TEAM_SLUG="area-system-example"
+ADD_MEMBERS=("new-owner" "another-owner")
+# Includes members who used to be owners and other members to remove.
+REMOVE_MEMBERS=("former-member" "former-owner")
+FORMER_OWNERS=("former-owner")
+NEW_MAINTAINERS=("new-lead")
+APPLY=false
+[[ "${1:-}" == "--apply" ]] && APPLY=true
+CURRENT_USER="$(gh api user --jq .login)"
+CURRENT_ROLE="$(gh api "/orgs/${ORG}/teams/${TEAM_SLUG}/memberships/${CURRENT_USER}" --jq .role)"
+
+run() {
+  echo "+ gh $*"
+  [[ "$APPLY" == true ]] && gh "$@"
+}
+
+for username in "${ADD_MEMBERS[@]}"; do
+  run api --method PUT \
+    "/orgs/${ORG}/teams/${TEAM_SLUG}/memberships/${username}" \
+    -f role=member
+done
+
+for username in "${NEW_MAINTAINERS[@]}"; do
+  run api --method PUT \
+    "/orgs/${ORG}/teams/${TEAM_SLUG}/memberships/${username}" \
+    -f role=maintainer
+done
+
+for username in "${REMOVE_MEMBERS[@]}"; do
+  if [[ "$username" == "$CURRENT_USER" ]]; then
+    echo "Cannot remove the current user. Have a new maintainer remove ${username}."
+    continue
+  fi
+  run api --method DELETE \
+    "/orgs/${ORG}/teams/${TEAM_SLUG}/memberships/${username}"
+done
+
+for username in "${FORMER_OWNERS[@]}"; do
+  echo "Former owner scheduled for removal: ${username}"
+done
+
+if [[ "$APPLY" != true ]]; then
+  echo "Dry run only. Re-run with --apply to execute additions and removals."
+elif [[ "$CURRENT_ROLE" == "maintainer" && ! " ${NEW_MAINTAINERS[*]} " =~ " ${CURRENT_USER} " ]]; then
+  echo "The current user remains a maintainer. Have a new maintainer perform any requested downgrade."
+fi
+gh api "/orgs/${ORG}/teams/${TEAM_SLUG}/members" >/dev/null
+```
+
+## PowerShell sample
+
+```powershell
+param([switch]$Apply)
+
+$ErrorActionPreference = 'Stop'
+$Org = 'dotnet'
+$TeamSlug = 'area-system-example'
+$AddMembers = @('new-owner', 'another-owner')
+# Includes members who used to be owners and other members to remove.
+$RemoveMembers = @('former-member', 'former-owner')
+$FormerOwners = @('former-owner')
+$NewMaintainers = @('new-lead')
+$CurrentUser = & gh api user --jq .login
+if ($LASTEXITCODE -ne 0) {
+    throw "gh api failed to identify the current user"
+}
+$CurrentRole = & gh api "/orgs/$Org/teams/$TeamSlug/memberships/$CurrentUser" --jq .role
+if ($LASTEXITCODE -ne 0) {
+    throw "gh api failed to identify the current user's team role"
+}
+
+function Invoke-Gh {
+    param([string[]]$Arguments)
+    Write-Output "+ gh $($Arguments -join ' ')"
+    if ($Apply) {
+        & gh @Arguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "gh failed with exit code $LASTEXITCODE"
+        }
+    }
+}
+
+foreach ($Username in $AddMembers) {
+    Invoke-Gh @('api', '--method', 'PUT',
+        "/orgs/$Org/teams/$TeamSlug/memberships/$Username",
+        '-f', 'role=member')
+}
+
+foreach ($Username in $NewMaintainers) {
+    Invoke-Gh @('api', '--method', 'PUT',
+        "/orgs/$Org/teams/$TeamSlug/memberships/$Username",
+        '-f', 'role=maintainer')
+}
+
+foreach ($Username in $RemoveMembers) {
+    if ($Username -eq $CurrentUser) {
+        Write-Warning "Cannot remove the current user. Have a new maintainer remove $Username."
+        continue
+    }
+    Invoke-Gh @('api', '--method', 'DELETE',
+        "/orgs/$Org/teams/$TeamSlug/memberships/$Username")
+}
+
+foreach ($Username in $FormerOwners) {
+    Write-Output "Former owner scheduled for removal: $Username"
+}
+
+if (-not $Apply) {
+    Write-Output 'Dry run only. Re-run with -Apply to execute additions and removals.'
+}
+else {
+    if ($CurrentRole -eq 'maintainer' -and $NewMaintainers -notcontains $CurrentUser) {
+        Write-Warning 'The current user remains a maintainer. Have a new maintainer perform any requested downgrade.'
+    }
+    & gh api "/orgs/$Org/teams/$TeamSlug/members" | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh api verification failed with exit code $LASTEXITCODE"
+    }
+}
+```
+
+These samples use `gh api` as the CLI interface to GitHub. Generated scripts
+must check each command's exit status and response, never use `--silent` in a
+way that hides an error, and must not delete an old team automatically during a
+rename or collapse. Add members and new maintainer(s) before processing
+removals. Never downgrade the current user from maintainer or remove the
+current user. If either is needed, stop that operation and instruct the user
+to have a new maintainer perform the downgrade or removal.


### PR DESCRIPTION
## Summary

Adds the `/update-area-owners` skill for maintaining runtime area ownership and issue/PR routing.

The skill:

- synchronizes `docs/area-owners.md` and routing policy references;
- inventories related ownership and labeler artifacts;
- handles area leads, owners, consultants, mentionees, team membership, and area collapse workflows;
- provides reviewable Bash and PowerShell handoff scripts for GitHub team changes;
- declares the standard configuration for newly created area teams;
- explicitly excludes creating, renaming, or deleting repository labels.

The `area-Announcements` documentation change is intentionally not included and will be submitted separately.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.