### PR TITLE
APX - Improve NDD on latest Intel Hardware

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1065,8 +1065,7 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
     else
     {
         // when reg3 != reg1 && reg3 != reg2, and NDD is available, we can use APX-EVEX.ND to optimize the codegen.
-        // On the latest Intel processors with APX, the memory form of NDD instructions has to be turned off by
-        // default for optimal hardware performance, so keep NDD only for register and immediate sources.
+        // For performance, avoid the memory-source form of EVEX.ND; keep NDD only for register and immediate sources.
         eligibleForNDD = emit->DoJitUseApxNDD(ins) && !op2->isUsedFromMemory();
         if (!eligibleForNDD)
         {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1065,7 +1065,9 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
     else
     {
         // when reg3 != reg1 && reg3 != reg2, and NDD is available, we can use APX-EVEX.ND to optimize the codegen.
-        eligibleForNDD = emit->DoJitUseApxNDD(ins);
+        // On the latest Intel processors with APX, the memory form of NDD instructions has to be turned off by
+        // default for optimal hardware performance, so keep NDD only for register and immediate sources.
+        eligibleForNDD = emit->DoJitUseApxNDD(ins) && !op2->isUsedFromMemory();
         if (!eligibleForNDD)
         {
             var_types op1Type = op1->TypeGet();

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -10468,8 +10468,8 @@ regNumber emitter::emitIns_BASE_R_R_RM(
     regNumber r                     = REG_NA;
     assert(regOp->isUsedFromReg());
 
-    // On the latest Intel processors with APX, the memory form of NDD instructions has to be turned off by default
-    // for optimal hardware performance, so fall back to the mov+op sequence when the RM source is in memory.
+    // Disable the memory-source form of NDD (EVEX.ND) instructions for performance reasons; fall back to the
+    // mov+op sequence when the RM source is in memory.
     bool useApxNdd = DoJitUseApxNDD(ins) && !rmOp->isUsedFromMemory();
 
     if (emitIns_Mov(INS_mov, attr, targetReg, regOp->GetRegNum(), true, useApxNdd) && useApxNdd)

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -10468,7 +10468,9 @@ regNumber emitter::emitIns_BASE_R_R_RM(
     regNumber r                     = REG_NA;
     assert(regOp->isUsedFromReg());
 
-    bool useApxNdd = DoJitUseApxNDD(ins);
+    // On the latest Intel processors with APX, the memory form of NDD instructions has to be turned off by default
+    // for optimal hardware performance, so fall back to the mov+op sequence when the RM source is in memory.
+    bool useApxNdd = DoJitUseApxNDD(ins) && !rmOp->isUsedFromMemory();
 
     if (emitIns_Mov(INS_mov, attr, targetReg, regOp->GetRegNum(), true, useApxNdd) && useApxNdd)
     {


### PR DESCRIPTION
This pull request disables memory forms of NDD instructions for optimal performance on Intel CPUs with APX support.

Instruction selection and code generation improvements:

* [`src/coreclr/jit/codegenxarch.cpp`](diffhunk://#diff-63dc452244e1b3fea66bfdc746d83c26f866ef153966fd708585df5428e49093L1068-R1070): Updated the eligibility check for NDD instructions in `genCodeForBinary` to exclude cases where the second operand is sourced from memory, ensuring NDD is used only for register and immediate sources.
* [`src/coreclr/jit/emitxarch.cpp`](diffhunk://#diff-6b4e0f32449f2f144e05699f59f74415a564693637f643084a896dfbd081830dL10471-R10473): Modified `emitIns_BASE_R_R_RM` to disable NDD instructions when the RM source operand is in memory, defaulting to a `mov+op` sequence instead.