### PR TITLE
Add custom error handling to LibraryImport source generation

### DIFF
--- a/docs/design/libraries/LibraryImportGenerator/Pipeline.md
+++ b/docs/design/libraries/LibraryImportGenerator/Pipeline.md
@@ -87,6 +87,7 @@ The stub code generator itself will handle some initial setup and variable decla
     - Call `Generate` for the `UnmarshalCapture` and `Unmarshal` stages only on marshallers marked as error-handling positions.
     - For a managed-to-unmanaged stub, run after `NotifyForSuccessfulInvoke` and before ordinary unmarshalling so an error marshaller can throw without reading potentially invalid outputs.
     - For an unmanaged-to-managed stub, run before ordinary input unmarshalling and before invoking the managed target.
+    - If error conversion throws, `CleanupCallerAllocated` still runs from the surrounding `finally`. The invocation is not marked successful, so `CleanupCalleeAllocated` is skipped rather than freeing potentially uninitialized return or `out` values.
 1. `UnmarshalCapture`: capture any native out parameters to avoid memory leaks if exceptions are thrown during `Unmarshal`.
     - If the method has a non-void return, call `Generate` on the marshalling generator for the return
     - Call `Generate` on the marshalling generator for every parameter
@@ -98,7 +99,7 @@ The stub code generator itself will handle some initial setup and variable decla
     - If this stage has any statements, put them in an if statement where the condition represents whether the call succeeded
 1. `CleanupCallerAllocated`: free any resources allocated by the caller
     - Call `Generate` on the marshalling generator for every parameter
-1. `CleanupCalleeAllocated`: if the native method succeeded, free any resources allocated by the callee (`out` parameters and return values)
+1. `CleanupCalleeAllocated`: if the native invocation and error unmarshalling succeeded, free any resources allocated by the callee (`out` parameters and return values)
     - Call `Generate` on the marshalling generator for every parameter
     - If this stage has any statements, put them in an if statement where the condition represents whether the call succeeded
 

--- a/docs/design/libraries/LibraryImportGenerator/Pipeline.md
+++ b/docs/design/libraries/LibraryImportGenerator/Pipeline.md
@@ -161,22 +161,23 @@ To help enable developers to use the full model described in the [Struct Marshal
 
 ### `SetLastError=true`
 
-The stub code generation also handles [`SetLastError=true`][SetLastError] behaviour. This configuration indicates that system error code ([`errno`](https://en.wikipedia.org/wiki/Errno.h) on Unix, [`GetLastError`](https://learn.microsoft.com/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror) on Windows) should be stored after the native invocation, such that it can be retrieved using [`Marshal.GetLastWin32Error`](https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getlastwin32error).
+The stub code generation also handles [`SetLastError=true`][SetLastError] behaviour. This configuration indicates that the system error code ([`errno`](https://en.wikipedia.org/wiki/Errno.h) on Unix, [`GetLastError`](https://learn.microsoft.com/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror) on Windows) should be captured after the native invocation and published through [`Marshal.GetLastPInvokeError`](https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getlastpinvokeerror).
 
 This means that, rather than simply invoke the native method, the generated stub will:
 
-1. Clear the system error by setting it to 0
-2. Invoke the native method
-3. Get the system error
-4. Set the stored error for the P/Invoke (accessible via `Marshal.GetLastWin32Error`)
+1. Clear the system error by setting it to 0.
+2. Invoke the native method.
+3. Capture the system error immediately after the invocation.
+4. If an error marshaller emits either `UnmarshalCapture` or `Unmarshal` statements, publish the captured value once through `Marshal.SetLastPInvokeError` before the error-unmarshal sequence begins. Error capture and conversion can therefore observe the native call's error through `Marshal.GetLastPInvokeError`. Either stage can also overwrite that stored value, in which case later error-marshalling stages and error-owned cleanup observe the changed value.
+5. If the stub completes successfully, publish the captured value again after unmarshalling and cleanup so the caller observes the native call's error instead of changes made by marshalling code.
 
-When an error marshaller is present, the stored P/Invoke error is restored before
-`ErrorUnmarshal` runs so custom error conversion cannot overwrite the value observed through
-`Marshal.GetLastPInvokeError`.
+If error conversion, ordinary unmarshalling, or cleanup throws, the final publication in step 5
+does not run. The stub therefore does not guarantee the value of `Marshal.GetLastPInvokeError`
+after an exception escapes.
 
 A core requirement of this functionality is that the P/Invoke called in (2) is blittable (the purpose of the P/Invoke source generator), such that there will be no additional operations (e.g unmarshalling) after the invocation that could change the system error that is retrieved in (3). Similarly, (3) must not involve any operations before getting the system error that could change the system error. This also relies on the runtime itself handling preserving the last error (see `BEGIN/END_PRESERVE_LAST_ERROR` macros) during JIT and P/Invoke resolution.
 
-Clearing the system error (1) is necessary because the native method may not set the error at all on success and the system error would retain its value from a previous operation. The developer should be able to check `Marshal.GetLastWin32Error` after a P/Inovke to determine success or failure, so the stub explicitly clears the error before the native invocation, such that the last error will indicate success if the native call does not change it.
+Clearing the system error in step 1 is necessary because the native method may not set the error at all on success and the system error would retain its value from a previous operation. The developer should be able to check `Marshal.GetLastPInvokeError` after a successful P/Invoke to determine success or failure, so the stub explicitly clears the error before the native invocation. The last error therefore indicates success if the native call does not change it.
 
 ## P/Invoke
 

--- a/docs/design/libraries/LibraryImportGenerator/Pipeline.md
+++ b/docs/design/libraries/LibraryImportGenerator/Pipeline.md
@@ -83,6 +83,10 @@ The stub code generator itself will handle some initial setup and variable decla
 1. `NotifyForSuccessfulInvoke`: Notify a marshaller that all stages through the "Invoke" stage were successful.
     - Used to keep alive any objects who's native representation won't keep them alive across the call.
     - Call `Generate` on the marshalling generator for every parameter.
+1. `ErrorUnmarshal`: capture and convert native error values before ordinary output values.
+    - Call `Generate` for the `UnmarshalCapture` and `Unmarshal` stages only on marshallers marked as error-handling positions.
+    - For a managed-to-unmanaged stub, run after `NotifyForSuccessfulInvoke` and before ordinary unmarshalling so an error marshaller can throw without reading potentially invalid outputs.
+    - For an unmanaged-to-managed stub, run before ordinary input unmarshalling and before invoking the managed target.
 1. `UnmarshalCapture`: capture any native out parameters to avoid memory leaks if exceptions are thrown during `Unmarshal`.
     - If the method has a non-void return, call `Generate` on the marshalling generator for the return
     - Call `Generate` on the marshalling generator for every parameter
@@ -111,6 +115,7 @@ try
         << Invoke >>
     }
     << Notify For Successful Invoke >>
+    << Error Unmarshal >>
     << Unmarshal Capture >>
     << Unmarshal >>
 }
@@ -162,6 +167,10 @@ This means that, rather than simply invoke the native method, the generated stub
 2. Invoke the native method
 3. Get the system error
 4. Set the stored error for the P/Invoke (accessible via `Marshal.GetLastWin32Error`)
+
+When an error marshaller is present, the stored P/Invoke error is restored before
+`ErrorUnmarshal` runs so custom error conversion cannot overwrite the value observed through
+`Marshal.GetLastPInvokeError`.
 
 A core requirement of this functionality is that the P/Invoke called in (2) is blittable (the purpose of the P/Invoke source generator), such that there will be no additional operations (e.g unmarshalling) after the invocation that could change the system error that is retrieved in (3). Similarly, (3) must not involve any operations before getting the system error that could change the system error. This also relies on the runtime itself handling preserving the last error (see `BEGIN/END_PRESERVE_LAST_ERROR` macros) during JIT and P/Invoke resolution.
 

--- a/docs/design/libraries/LibraryImportGenerator/Pipeline.md
+++ b/docs/design/libraries/LibraryImportGenerator/Pipeline.md
@@ -87,7 +87,8 @@ The stub code generator itself will handle some initial setup and variable decla
     - Call `Generate` for the `UnmarshalCapture` and `Unmarshal` stages only on marshallers marked as error-handling positions.
     - For a managed-to-unmanaged stub, run after `NotifyForSuccessfulInvoke` and before ordinary unmarshalling so an error marshaller can throw without reading potentially invalid outputs.
     - For an unmanaged-to-managed stub, run before ordinary input unmarshalling and before invoking the managed target.
-    - If error conversion throws, `CleanupCallerAllocated` still runs from the surrounding `finally`. The invocation is not marked successful, so `CleanupCalleeAllocated` is skipped rather than freeing potentially uninitialized return or `out` values.
+    - After the error value is captured, cleanup for callee-allocated resources owned by the error marshaller runs even if error conversion throws. `CleanupCallerAllocated` also runs from the surrounding `finally`.
+    - If error conversion throws, the invocation is not marked successful, so cleanup for ordinary callee-allocated return and `out` values is skipped rather than freeing potentially uninitialized outputs.
 1. `UnmarshalCapture`: capture any native out parameters to avoid memory leaks if exceptions are thrown during `Unmarshal`.
     - If the method has a non-void return, call `Generate` on the marshalling generator for the return
     - Call `Generate` on the marshalling generator for every parameter

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
@@ -310,7 +310,6 @@ namespace Microsoft.Interop.JavaScript
                     ManagedIndex = TypePositionInfo.ExceptionIndex,
                     NativeIndex = signatureElements.Length, // Insert at the end of the argument list
                     RefKind = RefKind.Out, // We'll treat it as a separate out parameter.
-                    IsManagedExceptionPosition = true,
                     IsErrorHandlingPosition = true,
                 });
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
@@ -310,6 +310,8 @@ namespace Microsoft.Interop.JavaScript
                     ManagedIndex = TypePositionInfo.ExceptionIndex,
                     NativeIndex = signatureElements.Length, // Insert at the end of the argument list
                     RefKind = RefKind.Out, // We'll treat it as a separate out parameter.
+                    IsManagedExceptionPosition = true,
+                    IsErrorHandlingPosition = true,
                 });
 
             for (int i = 0; i < allElements.Length; i++)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSGeneratorFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Interop.JavaScript
         public ResolvedGenerator Create(TypePositionInfo info, StubCodeContext context)
         {
             Debug.Assert(context != null);
-            if (!info.IsManagedExceptionPosition && !info.IsManagedReturnPosition && (info.IsByRef || info.ByValueContentsMarshalKind != ByValueContentsMarshalKind.Default))
+            if (!info.IsErrorHandlingPosition && !info.IsManagedReturnPosition && (info.IsByRef || info.ByValueContentsMarshalKind != ByValueContentsMarshalKind.Default))
             {
                 // out of scope for Net7.0
                 return ResolvedGenerator.NotSupported(info, context, new(info)

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -217,6 +217,14 @@ namespace Microsoft.Interop
             GeneratedComInterfaceCompilationData.TryGetGeneratedComInterfaceAttributeFromInterface(symbol.ContainingType, out var generatedComAttribute);
             var generatedComInterfaceAttributeData = GeneratedComInterfaceCompilationData.GetDataFromAttribute(generatedComAttribute);
 
+            bool preserveSig = symbol.MethodImplementationFlags.HasFlag(MethodImplAttributes.PreserveSig);
+            ErrorHandlingInfo? errorHandlingInfo = preserveSig
+                ? null
+                : new ErrorHandlingInfo(
+                    SpecialTypeInfo.Int32,
+                    new ManagedHResultExceptionMarshallingInfo(owningInterfaceInfo.InterfaceId),
+                    ErrorHandlingLocation.HiddenReturnValue);
+
             // Create the stub.
             var signatureContext = SignatureContext.Create(
                 symbol,
@@ -228,55 +236,19 @@ namespace Microsoft.Interop
                     generatedComAttribute),
                 environment,
                 new CodeEmitOptions(SkipInit: true),
-                typeof(ComInterfaceGenerator).Assembly);
+                typeof(ComInterfaceGenerator).Assembly,
+                errorHandlingInfo);
 
-            if (!symbol.MethodImplementationFlags.HasFlag(MethodImplAttributes.PreserveSig))
+            if (!preserveSig)
             {
-                // Search for the element information for the managed return value.
-                // We need to transform it such that any return type is converted to an out parameter at the end of the parameter list.
-                ImmutableArray<TypePositionInfo> returnSwappedSignatureElements = signatureContext.ElementTypeInformation;
-                for (int i = 0; i < returnSwappedSignatureElements.Length; ++i)
+                TypePositionInfo? managedReturnInfo = signatureContext.ElementTypeInformation.FirstOrDefault(e => e.IsManagedReturnPosition);
+                if (managedReturnInfo is not null
+                    && ((managedReturnInfo.ManagedType is SpecialTypeInfo { SpecialType: SpecialType.System_Int32 or SpecialType.System_Enum } or EnumTypeInfo
+                            && managedReturnInfo.MarshallingAttributeInfo.Equals(NoMarshallingInfo.Instance))
+                        || IsHResultLikeType(managedReturnInfo.ManagedType)))
                 {
-                    if (returnSwappedSignatureElements[i].IsManagedReturnPosition)
-                    {
-                        if (returnSwappedSignatureElements[i].ManagedType == SpecialTypeInfo.Void)
-                        {
-                            // Return type is void, just remove the element from the signature list.
-                            // We don't introduce an out parameter.
-                            returnSwappedSignatureElements = returnSwappedSignatureElements.RemoveAt(i);
-                        }
-                        else
-                        {
-                            if ((returnSwappedSignatureElements[i].ManagedType is SpecialTypeInfo { SpecialType: SpecialType.System_Int32 or SpecialType.System_Enum } or EnumTypeInfo
-                                    && returnSwappedSignatureElements[i].MarshallingAttributeInfo.Equals(NoMarshallingInfo.Instance))
-                                || (IsHResultLikeType(returnSwappedSignatureElements[i].ManagedType)))
-                            {
-                                generatorDiagnostics.ReportDiagnostic(DiagnosticInfo.Create(GeneratorDiagnostics.ComMethodManagedReturnWillBeOutVariable, symbol.Locations[0]));
-                            }
-                            // Convert the current element into an out parameter on the native signature
-                            // while keeping it at the return position in the managed signature.
-                            var managedSignatureAsNativeOut = returnSwappedSignatureElements[i] with
-                            {
-                                RefKind = RefKind.Out,
-                                ManagedIndex = TypePositionInfo.ReturnIndex,
-                                NativeIndex = symbol.Parameters.Length
-                            };
-                            returnSwappedSignatureElements = returnSwappedSignatureElements.SetItem(i, managedSignatureAsNativeOut);
-                        }
-                        break;
-                    }
+                    generatorDiagnostics.ReportDiagnostic(DiagnosticInfo.Create(GeneratorDiagnostics.ComMethodManagedReturnWillBeOutVariable, symbol.Locations[0]));
                 }
-
-                signatureContext = signatureContext with
-                {
-                    // Add the HRESULT return value in the native signature.
-                    // This element does not have any influence on the managed signature, so don't assign a managed index.
-                    ElementTypeInformation = returnSwappedSignatureElements.Add(
-                        new TypePositionInfo(SpecialTypeInfo.Int32, new ManagedHResultExceptionMarshallingInfo(owningInterfaceInfo.InterfaceId))
-                        {
-                            NativeIndex = TypePositionInfo.ReturnIndex
-                        })
-                };
             }
             else
             {

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ManagedHResultExceptionGeneratorResolver.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Marshallers/ManagedHResultExceptionGeneratorResolver.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Interop
             {
                 ManagedHResultExceptionMarshallingInfo marshallingInfo = (ManagedHResultExceptionMarshallingInfo)info.MarshallingAttributeInfo;
 
-                if (context.CurrentStage != StubIdentifierContext.Stage.NotifyForSuccessfulInvoke)
+                if (context.CurrentStage != StubIdentifierContext.Stage.Unmarshal)
                 {
                     yield break;
                 }
@@ -74,7 +74,7 @@ namespace Microsoft.Interop
             {
                 Debug.Assert(info.MarshallingAttributeInfo is ManagedHResultExceptionMarshallingInfo);
 
-                if (context.CurrentStage != StubIdentifierContext.Stage.NotifyForSuccessfulInvoke)
+                if (context.CurrentStage != StubIdentifierContext.Stage.Unmarshal)
                 {
                     yield break;
                 }

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
@@ -302,9 +302,20 @@ namespace Microsoft.Interop
             });
             foreach (TypePositionInfo element in originalElements)
             {
-                elements.Add(element with
+                TypePositionInfo unmanagedToManagedElement = element;
+                if (unmanagedToManagedElement is { IsErrorHandlingPosition: true, IsManagedExceptionPosition: false })
                 {
-                    NativeIndex = TypePositionInfo.IncrementIndex(element.NativeIndex)
+                    unmanagedToManagedElement = unmanagedToManagedElement with
+                    {
+                        IsErrorHandlingPosition = false,
+                        IsManagedIdentifierSynthetic = false,
+                        IsNativePositionOverlapping = false,
+                    };
+                }
+
+                elements.Add(unmanagedToManagedElement with
+                {
+                    NativeIndex = TypePositionInfo.IncrementIndex(unmanagedToManagedElement.NativeIndex)
                 });
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
@@ -317,7 +317,9 @@ namespace Microsoft.Interop
                     {
                         InstanceIdentifier = "__exception",
                         ManagedIndex = TypePositionInfo.ExceptionIndex,
-                        NativeIndex = TypePositionInfo.ReturnIndex
+                        NativeIndex = TypePositionInfo.ReturnIndex,
+                        IsManagedExceptionPosition = true,
+                        IsErrorHandlingPosition = true,
                     });
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodPointerStubGenerator.cs
@@ -303,13 +303,11 @@ namespace Microsoft.Interop
             foreach (TypePositionInfo element in originalElements)
             {
                 TypePositionInfo unmanagedToManagedElement = element;
-                if (unmanagedToManagedElement is { IsErrorHandlingPosition: true, IsManagedExceptionPosition: false })
+                if (unmanagedToManagedElement.IsErrorHandlingPosition)
                 {
                     unmanagedToManagedElement = unmanagedToManagedElement with
                     {
                         IsErrorHandlingPosition = false,
-                        IsManagedIdentifierSynthetic = false,
-                        IsNativePositionOverlapping = false,
                     };
                 }
 
@@ -329,7 +327,6 @@ namespace Microsoft.Interop
                         InstanceIdentifier = "__exception",
                         ManagedIndex = TypePositionInfo.ExceptionIndex,
                         NativeIndex = TypePositionInfo.ReturnIndex,
-                        IsManagedExceptionPosition = true,
                         IsErrorHandlingPosition = true,
                     });
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/LibraryImportDiagnosticsAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/LibraryImportDiagnosticsAnalyzer.cs
@@ -286,13 +286,16 @@ namespace Microsoft.Interop.Analyzers
                 }
             }
 
+            ErrorHandlingInfo? errorHandlingInfo = ErrorHandlingInfoParser.Parse(symbol, environment, generatorDiagnostics);
+
             // Create the signature context to collect marshalling-related diagnostics
             var signatureContext = SignatureContext.Create(
                 symbol,
                 DefaultMarshallingInfoParser.Create(environment, generatorDiagnostics, symbol, libraryImportData, libraryImportAttr),
                 environment,
                 new CodeEmitOptions(SkipInit: true),
-                typeof(LibraryImportGenerator).Assembly);
+                typeof(LibraryImportGenerator).Assembly,
+                errorHandlingInfo);
 
             // If forwarders are not being generated, we need to run stub generation logic to get those diagnostics too
             if (!options.GenerateForwarders)

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ErrorHandlingInfoParser.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ErrorHandlingInfoParser.cs
@@ -17,8 +17,13 @@ namespace Microsoft.Interop
             {
                 if (candidate.AttributeClass?.ToDisplayString() == TypeNames.ErrorHandlerAttribute)
                 {
+                    if (attribute is not null)
+                    {
+                        diagnostics.ReportConfigurationNotSupported(candidate, nameof(TypeNames.ErrorHandlerAttribute));
+                        return null;
+                    }
+
                     attribute = candidate;
-                    break;
                 }
             }
 
@@ -33,6 +38,7 @@ namespace Microsoft.Interop
                 || attribute.ConstructorArguments[1].Value is not int locationValue
                 || locationValue is < (int)ErrorHandlingLocation.ReturnValue or > (int)ErrorHandlingLocation.HiddenReturnValue)
             {
+                diagnostics.ReportConfigurationNotSupported(attribute, nameof(TypeNames.ErrorHandlerAttribute));
                 return null;
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ErrorHandlingInfoParser.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ErrorHandlingInfoParser.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Interop
                 || attribute.ConstructorArguments.Length != 2
                 || attribute.ConstructorArguments[0].Value is not INamedTypeSymbol marshallerType
                 || attribute.ConstructorArguments[1].Value is not int locationValue
-                || locationValue is < (int)ErrorHandlingLocation.ReturnValue or > (int)ErrorHandlingLocation.HiddenReturnValue)
+                || locationValue is < (int)ErrorHandlingLocation.ReturnValue or > (int)ErrorHandlingLocation.HiddenLastParameter)
             {
                 diagnostics.ReportConfigurationNotSupported(attribute, nameof(TypeNames.ErrorHandlerAttribute));
                 return null;
@@ -53,7 +53,16 @@ namespace Microsoft.Interop
                 && method.ReturnType.SpecialType != SpecialType.System_Void
                 && !SymbolEqualityComparer.Default.Equals(method.ReturnType, managedType))
             {
-                diagnostics.ReportConfigurationNotSupported(attribute, nameof(ErrorHandlingLocation.ReturnValue));
+                diagnostics.ReportConfigurationNotSupported(attribute, nameof(TypeNames.ErrorHandlerAttribute));
+                return null;
+            }
+
+            if (location == ErrorHandlingLocation.LastParameter
+                && (method.Parameters.Length == 0
+                    || method.Parameters[method.Parameters.Length - 1] is not { RefKind: RefKind.Out or RefKind.Ref } lastParameter
+                    || !SymbolEqualityComparer.Default.Equals(lastParameter.Type, managedType)))
+            {
+                diagnostics.ReportConfigurationNotSupported(attribute, nameof(TypeNames.ErrorHandlerAttribute));
                 return null;
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ErrorHandlingInfoParser.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ErrorHandlingInfoParser.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Interop
+{
+    internal static class ErrorHandlingInfoParser
+    {
+        public static ErrorHandlingInfo? Parse(
+            IMethodSymbol method,
+            StubEnvironment environment,
+            GeneratorDiagnosticsBag diagnostics)
+        {
+            AttributeData? attribute = null;
+            foreach (AttributeData candidate in method.GetAttributes())
+            {
+                if (candidate.AttributeClass?.ToDisplayString() == TypeNames.ErrorHandlerAttribute)
+                {
+                    attribute = candidate;
+                    break;
+                }
+            }
+
+            if (attribute is null)
+            {
+                return null;
+            }
+
+            if (attribute.AttributeConstructor is null
+                || attribute.ConstructorArguments.Length != 2
+                || attribute.ConstructorArguments[0].Value is not INamedTypeSymbol marshallerType
+                || attribute.ConstructorArguments[1].Value is not int locationValue
+                || locationValue is < (int)ErrorHandlingLocation.ReturnValue or > (int)ErrorHandlingLocation.SystemError)
+            {
+                return null;
+            }
+
+            if (!ManualTypeMarshallingHelper.TryGetManagedTypeFromEntryType(marshallerType, environment.Compilation, out ITypeSymbol? managedType))
+            {
+                diagnostics.ReportConfigurationNotSupported(attribute, nameof(TypeNames.ErrorHandlerAttribute));
+                return null;
+            }
+
+            ErrorHandlingLocation location = (ErrorHandlingLocation)locationValue;
+            if (location == ErrorHandlingLocation.ReturnValue
+                && method.ReturnType.SpecialType != SpecialType.System_Void
+                && !SymbolEqualityComparer.Default.Equals(method.ReturnType, managedType))
+            {
+                diagnostics.ReportConfigurationNotSupported(attribute, nameof(ErrorHandlingLocation.ReturnValue));
+                return null;
+            }
+
+            MarshallingInfo marshallingInfo = CustomMarshallingInfoHelper.CreateNativeMarshallingInfoForNonSignatureElement(
+                managedType,
+                marshallerType,
+                attribute,
+                environment.Compilation,
+                diagnostics);
+
+            if (marshallingInfo == NoMarshallingInfo.Instance)
+            {
+                diagnostics.ReportConfigurationNotSupported(attribute, nameof(TypeNames.ErrorHandlerAttribute));
+                return null;
+            }
+
+            return new ErrorHandlingInfo(
+                ManagedTypeInfo.CreateTypeInfoForTypeSymbol(managedType),
+                marshallingInfo,
+                location);
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ErrorHandlingInfoParser.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/ErrorHandlingInfoParser.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Interop
                 || attribute.ConstructorArguments.Length != 2
                 || attribute.ConstructorArguments[0].Value is not INamedTypeSymbol marshallerType
                 || attribute.ConstructorArguments[1].Value is not int locationValue
-                || locationValue is < (int)ErrorHandlingLocation.ReturnValue or > (int)ErrorHandlingLocation.SystemError)
+                || locationValue is < (int)ErrorHandlingLocation.ReturnValue or > (int)ErrorHandlingLocation.HiddenReturnValue)
             {
                 return null;
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -267,6 +267,7 @@ namespace Microsoft.Interop
             // Create a diagnostics bag that discards all diagnostics.
             // Diagnostics are now reported by the analyzer, not the generator.
             var discardedDiagnostics = new GeneratorDiagnosticsBag(new DiagnosticDescriptorProvider(), locations, SR.ResourceManager, typeof(FxResources.Microsoft.Interop.LibraryImportGenerator.SR));
+            ErrorHandlingInfo? errorHandlingInfo = ErrorHandlingInfoParser.Parse(symbol, environment, discardedDiagnostics);
 
             // Create the stub.
             var signatureContext = SignatureContext.Create(
@@ -274,7 +275,8 @@ namespace Microsoft.Interop
                 DefaultMarshallingInfoParser.Create(environment, discardedDiagnostics, symbol, libraryImportData, generatedDllImportAttr),
                 environment,
                 new CodeEmitOptions(SkipInit: true),
-                typeof(LibraryImportGenerator).Assembly);
+                typeof(LibraryImportGenerator).Assembly,
+                errorHandlingInfo);
 
             var containingTypeContext = new ContainingSyntaxContext(originalSyntax);
 
@@ -290,6 +292,7 @@ namespace Microsoft.Interop
                 LibraryImportData.From(libraryImportData),
                 options,
                 environment.EnvironmentFlags);
+
         }
 
         private static MemberDeclarationSyntax GenerateSource(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
@@ -30,26 +30,14 @@ namespace Microsoft.Interop
             IBoundMarshallingGenerator managedReturnMarshaller = defaultBoundGenerator;
             IBoundMarshallingGenerator nativeReturnMarshaller = defaultBoundGenerator;
             IBoundMarshallingGenerator managedExceptionMarshaller = defaultBoundGenerator;
-            TypePositionInfo? managedExceptionInfo = null;
             TypePositionInfo? errorHandlingInfo = null;
 
             foreach (TypePositionInfo argType in elementTypeInfo)
             {
                 if (argType.IsErrorHandlingPosition)
                 {
-                    if (context.Direction == MarshalDirection.UnmanagedToManaged)
-                    {
-                        Debug.Assert(managedExceptionInfo is null);
-                        managedExceptionInfo = argType;
-                        // The exception marshaller's selection might depend on the unmanaged type of the native return marshaller.
-                    }
-                    else
-                    {
-                        Debug.Assert(context.Direction == MarshalDirection.ManagedToUnmanaged);
-                        Debug.Assert(errorHandlingInfo is null);
-                        errorHandlingInfo = argType;
-                        // An error marshaller may overlap an ordinary marshaller in the native position.
-                    }
+                    Debug.Assert(errorHandlingInfo is null);
+                    errorHandlingInfo = argType;
                     // Delay binding until all ordinary signature marshallers have been processed.
                     continue;
                 }
@@ -77,7 +65,7 @@ namespace Microsoft.Interop
                 }
             }
 
-            if (errorHandlingInfo is not null)
+            if (errorHandlingInfo is not null && context.Direction == MarshalDirection.ManagedToUnmanaged)
             {
                 IBoundMarshallingGenerator? overlappedMarshaller = FindOverlappedMarshaller(errorHandlingInfo);
                 IMarshallingGeneratorResolver errorHandlerFactory = generatorResolver;
@@ -105,30 +93,30 @@ namespace Microsoft.Interop
 
             // Now that we've processed all of the signature marshallers,
             // we'll handle the special ones that might depend on them, like the exception marshaller.
-            if (managedExceptionInfo is not null)
+            if (errorHandlingInfo is not null && context.Direction == MarshalDirection.UnmanagedToManaged)
             {
                 // The managed exception marshaller may overlap with another marshaller in the native position.
                 // In that case, we need to validate some additional invariants.
                 // Also, some cases may require an overlap, such as when using the "COM" exception marshalling.
                 IBoundMarshallingGenerator? overlappedMarshaller = null;
-                if (managedExceptionInfo.IsNativeReturnPosition)
+                if (errorHandlingInfo.IsNativeReturnPosition)
                 {
                     overlappedMarshaller = nativeReturnMarshaller;
                 }
-                else if (managedExceptionInfo.NativeIndex is not (TypePositionInfo.UnsetIndex or TypePositionInfo.ExceptionIndex))
+                else if (errorHandlingInfo.NativeIndex is not (TypePositionInfo.UnsetIndex or TypePositionInfo.ExceptionIndex))
                 {
-                    overlappedMarshaller = nativeParamMarshallers.FirstOrDefault(e => e.TypeInfo.NativeIndex == managedExceptionInfo.NativeIndex);
+                    overlappedMarshaller = nativeParamMarshallers.FirstOrDefault(e => e.TypeInfo.NativeIndex == errorHandlingInfo.NativeIndex);
                 }
 
-                if (managedExceptionInfo.MarshallingAttributeInfo is ComExceptionMarshalling)
+                if (errorHandlingInfo.MarshallingAttributeInfo is ComExceptionMarshalling)
                 {
                     if (overlappedMarshaller is null)
                     {
-                        generatorDiagnostics.Add(new GeneratorDiagnostic.NotSupported(managedExceptionInfo));
+                        generatorDiagnostics.Add(new GeneratorDiagnostic.NotSupported(errorHandlingInfo));
                     }
                     else
                     {
-                        managedExceptionInfo = managedExceptionInfo with
+                        errorHandlingInfo = errorHandlingInfo with
                         {
                             MarshallingAttributeInfo = ComExceptionMarshalling.CreateSpecificMarshallingInfo(overlappedMarshaller.NativeType)
                         };
@@ -142,9 +130,9 @@ namespace Microsoft.Interop
                     exceptionHandlerFactory = new MatchingNativeTypeValidator(overlappedMarshaller.NativeType, exceptionHandlerFactory);
                 }
 
-                managedExceptionMarshaller = CreateGenerator(managedExceptionInfo, exceptionHandlerFactory);
+                managedExceptionMarshaller = CreateGenerator(errorHandlingInfo, exceptionHandlerFactory);
 
-                if (overlappedMarshaller is null && !TypePositionInfo.IsSpecialIndex(managedExceptionInfo.NativeIndex))
+                if (overlappedMarshaller is null && !TypePositionInfo.IsSpecialIndex(errorHandlingInfo.NativeIndex))
                 {
                     // If the exception marshaller doesn't overlap with another marshaller but has a native index,
                     // we need to add it to the list of native parameter marshallers.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
@@ -65,6 +65,9 @@ namespace Microsoft.Interop
                 }
             }
 
+            // Now that we've processed all of the signature marshallers, handle the error marshaller,
+            // which may depend on or overlap with another marshaller in the native position.
+            // Some cases may require an overlap, such as when using COM exception marshalling.
             if (errorHandlingInfo is not null && context.Direction == MarshalDirection.ManagedToUnmanaged)
             {
                 IBoundMarshallingGenerator? overlappedMarshaller = FindOverlappedMarshaller(errorHandlingInfo);
@@ -91,13 +94,8 @@ namespace Microsoft.Interop
                 }
             }
 
-            // Now that we've processed all of the signature marshallers,
-            // we'll handle the special ones that might depend on them, like the exception marshaller.
             if (errorHandlingInfo is not null && context.Direction == MarshalDirection.UnmanagedToManaged)
             {
-                // The managed exception marshaller may overlap with another marshaller in the native position.
-                // In that case, we need to validate some additional invariants.
-                // Also, some cases may require an overlap, such as when using the "COM" exception marshalling.
                 IBoundMarshallingGenerator? overlappedMarshaller = null;
                 if (errorHandlingInfo.IsNativeReturnPosition)
                 {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
@@ -35,20 +35,21 @@ namespace Microsoft.Interop
 
             foreach (TypePositionInfo argType in elementTypeInfo)
             {
-                if (argType.IsManagedExceptionPosition)
+                if (argType.IsErrorHandlingPosition)
                 {
-                    Debug.Assert(managedExceptionInfo == null);
-                    managedExceptionInfo = argType;
-                    // The exception marshaller's selection might depend on the unmanaged type of the native return marshaller.
-                    // Delay binding the generator until we've processed the native return marshaller.
-                    continue;
-                }
-
-                if (argType is { IsErrorHandlingPosition: true, ManagedIndex: TypePositionInfo.ErrorIndex })
-                {
-                    Debug.Assert(errorHandlingInfo is null);
-                    errorHandlingInfo = argType;
-                    // An error marshaller may overlap an ordinary marshaller in the native position.
+                    if (context.Direction == MarshalDirection.UnmanagedToManaged)
+                    {
+                        Debug.Assert(managedExceptionInfo is null);
+                        managedExceptionInfo = argType;
+                        // The exception marshaller's selection might depend on the unmanaged type of the native return marshaller.
+                    }
+                    else
+                    {
+                        Debug.Assert(context.Direction == MarshalDirection.ManagedToUnmanaged);
+                        Debug.Assert(errorHandlingInfo is null);
+                        errorHandlingInfo = argType;
+                        // An error marshaller may overlap an ordinary marshaller in the native position.
+                    }
                     // Delay binding until all ordinary signature marshallers have been processed.
                     continue;
                 }
@@ -206,7 +207,7 @@ namespace Microsoft.Interop
 
             static (bool IsManagedIndex, int Index) GetInfoIndex(TypePositionInfo info)
             {
-                if (info is { IsErrorHandlingPosition: true, IsManagedExceptionPosition: false })
+                if (info.IsErrorHandlingPosition)
                 {
                     return (false, info.NativeIndex);
                 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Interop
             IBoundMarshallingGenerator managedReturnMarshaller = defaultBoundGenerator;
             IBoundMarshallingGenerator nativeReturnMarshaller = defaultBoundGenerator;
             IBoundMarshallingGenerator managedExceptionMarshaller = defaultBoundGenerator;
-            IBoundMarshallingGenerator errorHandlerMarshaller = defaultBoundGenerator;
             TypePositionInfo? managedExceptionInfo = null;
 
             foreach (TypePositionInfo argType in elementTypeInfo)
@@ -47,11 +46,6 @@ namespace Microsoft.Interop
                 IBoundMarshallingGenerator generator = CreateGenerator(argType, generatorResolver);
 
                 signatureMarshallers.Add(generator);
-                if (argType.IsErrorHandlingPosition)
-                {
-                    Debug.Assert(errorHandlerMarshaller == defaultBoundGenerator);
-                    errorHandlerMarshaller = generator;
-                }
                 if (argType.IsManagedReturnPosition)
                 {
                     Debug.Assert(managedReturnMarshaller == defaultBoundGenerator);
@@ -162,7 +156,6 @@ namespace Microsoft.Interop
                 ManagedReturnMarshaller = managedReturnMarshaller,
                 NativeReturnMarshaller = nativeReturnMarshaller,
                 ManagedExceptionMarshaller = managedExceptionMarshaller,
-                ErrorHandlerMarshaller = errorHandlerMarshaller,
             };
 
             static IEnumerable<(bool IsManagedIndex, int Index)> GetInfoDependencies(TypePositionInfo info)
@@ -192,16 +185,6 @@ namespace Microsoft.Interop
             IBoundMarshallingGenerator CreateGenerator(TypePositionInfo p, IMarshallingGeneratorResolver factory)
             {
                 ResolvedGenerator generator = factory.Create(p, context);
-                if (generator.IsResolvedWithoutErrors
-                    && p is { IsErrorHandlingPosition: true, ErrorHandlingLocation: ErrorHandlingLocation.SystemError }
-                    && generator.Generator.NativeType != SpecialTypeInfo.Int32)
-                {
-                    generator = ResolvedGenerator.NotSupported(p, context, new(p)
-                    {
-                        NotSupportedDetails = SR.MarshallerInOverlappingNativePositionMustMatchNativeType
-                    });
-                }
-
                 generatorDiagnostics.AddRange(generator.Diagnostics);
                 return generator.IsResolvedWithoutErrors ? generator.Generator : fallbackGenerator.Bind(p, context);
             }
@@ -212,8 +195,6 @@ namespace Microsoft.Interop
         public IBoundMarshallingGenerator NativeReturnMarshaller { get; private init; }
 
         public IBoundMarshallingGenerator ManagedExceptionMarshaller { get; private init; }
-
-        public IBoundMarshallingGenerator ErrorHandlerMarshaller { get; private init; }
 
         public ImmutableArray<IBoundMarshallingGenerator> SignatureMarshallers { get; private init; }
 
@@ -239,8 +220,6 @@ namespace Microsoft.Interop
         public bool IsUnmanagedVoidReturn => NativeReturnMarshaller.TypeInfo.ManagedType == SpecialTypeInfo.Void;
 
         public bool HasManagedExceptionMarshaller => !ManagedExceptionMarshaller.IsForwarder();
-
-        public bool HasErrorHandler => !ErrorHandlerMarshaller.IsForwarder();
 
         /// <summary>
         /// Validate that the resolved generator resolves to the same native type.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Interop
             IBoundMarshallingGenerator managedReturnMarshaller = defaultBoundGenerator;
             IBoundMarshallingGenerator nativeReturnMarshaller = defaultBoundGenerator;
             IBoundMarshallingGenerator managedExceptionMarshaller = defaultBoundGenerator;
+            IBoundMarshallingGenerator errorHandlerMarshaller = defaultBoundGenerator;
             TypePositionInfo? managedExceptionInfo = null;
 
             foreach (TypePositionInfo argType in elementTypeInfo)
@@ -46,6 +47,11 @@ namespace Microsoft.Interop
                 IBoundMarshallingGenerator generator = CreateGenerator(argType, generatorResolver);
 
                 signatureMarshallers.Add(generator);
+                if (argType.IsErrorHandlingPosition)
+                {
+                    Debug.Assert(errorHandlerMarshaller == defaultBoundGenerator);
+                    errorHandlerMarshaller = generator;
+                }
                 if (argType.IsManagedReturnPosition)
                 {
                     Debug.Assert(managedReturnMarshaller == defaultBoundGenerator);
@@ -156,6 +162,7 @@ namespace Microsoft.Interop
                 ManagedReturnMarshaller = managedReturnMarshaller,
                 NativeReturnMarshaller = nativeReturnMarshaller,
                 ManagedExceptionMarshaller = managedExceptionMarshaller,
+                ErrorHandlerMarshaller = errorHandlerMarshaller,
             };
 
             static IEnumerable<(bool IsManagedIndex, int Index)> GetInfoDependencies(TypePositionInfo info)
@@ -185,6 +192,16 @@ namespace Microsoft.Interop
             IBoundMarshallingGenerator CreateGenerator(TypePositionInfo p, IMarshallingGeneratorResolver factory)
             {
                 ResolvedGenerator generator = factory.Create(p, context);
+                if (generator.IsResolvedWithoutErrors
+                    && p is { IsErrorHandlingPosition: true, ErrorHandlingLocation: ErrorHandlingLocation.SystemError }
+                    && generator.Generator.NativeType != SpecialTypeInfo.Int32)
+                {
+                    generator = ResolvedGenerator.NotSupported(p, context, new(p)
+                    {
+                        NotSupportedDetails = SR.MarshallerInOverlappingNativePositionMustMatchNativeType
+                    });
+                }
+
                 generatorDiagnostics.AddRange(generator.Diagnostics);
                 return generator.IsResolvedWithoutErrors ? generator.Generator : fallbackGenerator.Bind(p, context);
             }
@@ -195,6 +212,8 @@ namespace Microsoft.Interop
         public IBoundMarshallingGenerator NativeReturnMarshaller { get; private init; }
 
         public IBoundMarshallingGenerator ManagedExceptionMarshaller { get; private init; }
+
+        public IBoundMarshallingGenerator ErrorHandlerMarshaller { get; private init; }
 
         public ImmutableArray<IBoundMarshallingGenerator> SignatureMarshallers { get; private init; }
 
@@ -220,6 +239,8 @@ namespace Microsoft.Interop
         public bool IsUnmanagedVoidReturn => NativeReturnMarshaller.TypeInfo.ManagedType == SpecialTypeInfo.Void;
 
         public bool HasManagedExceptionMarshaller => !ManagedExceptionMarshaller.IsForwarder();
+
+        public bool HasErrorHandler => !ErrorHandlerMarshaller.IsForwarder();
 
         /// <summary>
         /// Validate that the resolved generator resolves to the same native type.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/BoundGenerators.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Interop
             IBoundMarshallingGenerator nativeReturnMarshaller = defaultBoundGenerator;
             IBoundMarshallingGenerator managedExceptionMarshaller = defaultBoundGenerator;
             TypePositionInfo? managedExceptionInfo = null;
+            TypePositionInfo? errorHandlingInfo = null;
 
             foreach (TypePositionInfo argType in elementTypeInfo)
             {
@@ -40,6 +41,15 @@ namespace Microsoft.Interop
                     managedExceptionInfo = argType;
                     // The exception marshaller's selection might depend on the unmanaged type of the native return marshaller.
                     // Delay binding the generator until we've processed the native return marshaller.
+                    continue;
+                }
+
+                if (argType is { IsErrorHandlingPosition: true, ManagedIndex: TypePositionInfo.ErrorIndex })
+                {
+                    Debug.Assert(errorHandlingInfo is null);
+                    errorHandlingInfo = argType;
+                    // An error marshaller may overlap an ordinary marshaller in the native position.
+                    // Delay binding until all ordinary signature marshallers have been processed.
                     continue;
                 }
 
@@ -66,6 +76,31 @@ namespace Microsoft.Interop
                 }
             }
 
+            if (errorHandlingInfo is not null)
+            {
+                IBoundMarshallingGenerator? overlappedMarshaller = FindOverlappedMarshaller(errorHandlingInfo);
+                IMarshallingGeneratorResolver errorHandlerFactory = generatorResolver;
+                if (overlappedMarshaller is not null)
+                {
+                    errorHandlerFactory = new MatchingNativeTypeValidator(overlappedMarshaller.NativeType, errorHandlerFactory);
+                }
+
+                IBoundMarshallingGenerator errorHandlingMarshaller = CreateGenerator(errorHandlingInfo, errorHandlerFactory);
+                signatureMarshallers.Add(errorHandlingMarshaller);
+
+                if (overlappedMarshaller is null)
+                {
+                    if (errorHandlingInfo.IsNativeReturnPosition)
+                    {
+                        Debug.Assert(!nativeReturnMarshaller.TypeInfo.IsNativeReturnPosition);
+                        nativeReturnMarshaller = errorHandlingMarshaller;
+                    }
+                    else if (!TypePositionInfo.IsSpecialIndex(errorHandlingInfo.NativeIndex))
+                    {
+                        nativeParamMarshallers.Add(errorHandlingMarshaller);
+                    }
+                }
+            }
 
             // Now that we've processed all of the signature marshallers,
             // we'll handle the special ones that might depend on them, like the exception marshaller.
@@ -106,7 +141,7 @@ namespace Microsoft.Interop
                     exceptionHandlerFactory = new MatchingNativeTypeValidator(overlappedMarshaller.NativeType, exceptionHandlerFactory);
                 }
 
-                managedExceptionMarshaller = CreateGenerator(managedExceptionInfo, generatorResolver);
+                managedExceptionMarshaller = CreateGenerator(managedExceptionInfo, exceptionHandlerFactory);
 
                 if (overlappedMarshaller is null && !TypePositionInfo.IsSpecialIndex(managedExceptionInfo.NativeIndex))
                 {
@@ -171,6 +206,11 @@ namespace Microsoft.Interop
 
             static (bool IsManagedIndex, int Index) GetInfoIndex(TypePositionInfo info)
             {
+                if (info is { IsErrorHandlingPosition: true, IsManagedExceptionPosition: false })
+                {
+                    return (false, info.NativeIndex);
+                }
+
                 // A TypePositionInfo needs to have either a managed or native index.
                 // We'll prioritize representing the managed index if possible
                 // as our dependency logic depends on the managed index since the native
@@ -180,6 +220,21 @@ namespace Microsoft.Interop
                     return (true, info.ManagedIndex);
                 }
                 return (false, info.NativeIndex);
+            }
+
+            IBoundMarshallingGenerator? FindOverlappedMarshaller(TypePositionInfo info)
+            {
+                if (info.IsNativeReturnPosition)
+                {
+                    return nativeReturnMarshaller.TypeInfo.IsNativeReturnPosition
+                        ? nativeReturnMarshaller
+                        : null;
+                }
+
+                return TypePositionInfo.IsSpecialIndex(info.NativeIndex)
+                    ? null
+                    : nativeParamMarshallers.FirstOrDefault(
+                        marshaller => marshaller.TypeInfo.NativeIndex == info.NativeIndex);
             }
 
             IBoundMarshallingGenerator CreateGenerator(TypePositionInfo p, IMarshallingGeneratorResolver factory)
@@ -233,7 +288,7 @@ namespace Microsoft.Interop
                 {
                     return generator;
                 }
-                // Marshallers that share the native return position must have the same native return type.
+                // Marshallers that share a native position must have the same native type.
                 if (generator.Generator.NativeType != requiredNativeType)
                 {
                     return ResolvedGenerator.NotSupported(info, context, new(info)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/DefaultIdentifierContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/DefaultIdentifierContext.cs
@@ -25,6 +25,17 @@ namespace Microsoft.Interop
 
         public override (string managed, string native) GetIdentifiers(TypePositionInfo info)
         {
+            if (info is
+                {
+                    IsErrorHandlingPosition: true,
+                    IsManagedExceptionPosition: false,
+                    ManagedIndex: TypePositionInfo.ErrorIndex,
+                    NativeIndex: TypePositionInfo.ReturnIndex,
+                })
+            {
+                return (info.InstanceIdentifier, _nativeReturnIdentifier);
+            }
+
             // If the info is in the stub return position, then we need to generate a name to use
             // for both the managed and native values since there is no name in the signature for the return value.
             if (MarshallerHelpers.IsInStubReturnPosition(info, _direction))

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/DefaultIdentifierContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/DefaultIdentifierContext.cs
@@ -12,15 +12,18 @@ namespace Microsoft.Interop
         private readonly string _returnIdentifier;
         private readonly string _nativeReturnIdentifier;
         private readonly MarshalDirection _direction;
+        private readonly TypePositionInfo? _errorHandlingOverlappedPosition;
 
         public DefaultIdentifierContext(
             string returnIdentifier,
             string nativeReturnIdentifier,
-            MarshalDirection direction)
+            MarshalDirection direction,
+            TypePositionInfo? errorHandlingOverlappedPosition = null)
         {
             _returnIdentifier = returnIdentifier;
             _nativeReturnIdentifier = nativeReturnIdentifier;
             _direction = direction;
+            _errorHandlingOverlappedPosition = errorHandlingOverlappedPosition;
         }
 
         public override (string managed, string native) GetIdentifiers(TypePositionInfo info)
@@ -28,13 +31,12 @@ namespace Microsoft.Interop
             if (info is
                 {
                     IsErrorHandlingPosition: true,
-                    IsManagedExceptionPosition: false,
-                    IsNativePositionOverlapping: true,
                     ManagedIndex: TypePositionInfo.ErrorIndex,
-                    NativeIndex: TypePositionInfo.ReturnIndex,
-                })
+                }
+                && _direction == MarshalDirection.ManagedToUnmanaged
+                && _errorHandlingOverlappedPosition is not null)
             {
-                return (info.InstanceIdentifier, _nativeReturnIdentifier);
+                return (info.InstanceIdentifier, GetIdentifiers(_errorHandlingOverlappedPosition).native);
             }
 
             // If the info is in the stub return position, then we need to generate a name to use
@@ -45,7 +47,8 @@ namespace Microsoft.Interop
                 // then we're going to return using name of the native return identifier.
                 // We use the provided instance identifier as that represents
                 // the name of the exception variable specified in the catch clause.
-                if (info.IsManagedExceptionPosition)
+                if (info.IsErrorHandlingPosition
+                    && _direction == MarshalDirection.UnmanagedToManaged)
                 {
                     return (info.InstanceIdentifier, _nativeReturnIdentifier);
                 }
@@ -69,7 +72,8 @@ namespace Microsoft.Interop
 
         public override string GetAdditionalIdentifier(TypePositionInfo info, string name)
         {
-            return info is { IsErrorHandlingPosition: true, IsNativePositionOverlapping: true }
+            return info.IsErrorHandlingPosition
+                && _direction == MarshalDirection.ManagedToUnmanaged
                 ? $"__errorHandler{GeneratedNativeIdentifierSuffix}__{name}"
                 : base.GetAdditionalIdentifier(info, name);
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/DefaultIdentifierContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/DefaultIdentifierContext.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Interop
                 {
                     IsErrorHandlingPosition: true,
                     IsManagedExceptionPosition: false,
+                    IsNativePositionOverlapping: true,
                     ManagedIndex: TypePositionInfo.ErrorIndex,
                     NativeIndex: TypePositionInfo.ReturnIndex,
                 })

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/DefaultIdentifierContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/DefaultIdentifierContext.cs
@@ -66,5 +66,12 @@ namespace Microsoft.Interop
                 return base.GetIdentifiers(info);
             }
         }
+
+        public override string GetAdditionalIdentifier(TypePositionInfo info, string name)
+        {
+            return info is { IsErrorHandlingPosition: true, IsNativePositionOverlapping: true }
+                ? $"__errorHandler{GeneratedNativeIdentifierSuffix}__{name}"
+                : base.GetAdditionalIdentifier(info, name);
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Interop
         public ImmutableArray<FixedStatementSyntax> Pin { get; init; }
         public ImmutableArray<StatementSyntax> PinnedMarshal { get; init; }
         public StatementSyntax InvokeStatement { get; init; }
+        public ImmutableArray<StatementSyntax> ErrorUnmarshal { get; init; }
         public ImmutableArray<StatementSyntax> Unmarshal { get; init; }
         public ImmutableArray<StatementSyntax> NotifyForSuccessfulInvoke { get; init; }
         public ImmutableArray<StatementSyntax> GuaranteedUnmarshal { get; init; }
@@ -35,6 +36,8 @@ namespace Microsoft.Interop
                 Pin = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.Pin }).Cast<FixedStatementSyntax>().ToImmutableArray(),
                 PinnedMarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.PinnedMarshal }),
                 InvokeStatement = EmptyStatement(),
+                ErrorUnmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.UnmarshalCapture }, errorHandlingOnly: true)
+                            .AddRange(GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.Unmarshal }, errorHandlingOnly: true)),
                 Unmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.UnmarshalCapture })
                             .AddRange(GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.Unmarshal })),
                 NotifyForSuccessfulInvoke = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.NotifyForSuccessfulInvoke }),
@@ -90,13 +93,16 @@ namespace Microsoft.Interop
             };
         }
 
-        private static ImmutableArray<StatementSyntax> GenerateStatementsForStubContext(BoundGenerators marshallers, StubIdentifierContext context)
+        private static ImmutableArray<StatementSyntax> GenerateStatementsForStubContext(
+            BoundGenerators marshallers,
+            StubIdentifierContext context,
+            bool errorHandlingOnly = false)
         {
             ImmutableArray<StatementSyntax>.Builder statementsToUpdate = ImmutableArray.CreateBuilder<StatementSyntax>();
             foreach (IBoundMarshallingGenerator marshaller in marshallers.SignatureMarshallers)
             {
-                if (marshaller.TypeInfo.IsErrorHandlingPosition
-                    && context.CurrentStage is StubIdentifierContext.Stage.UnmarshalCapture or StubIdentifierContext.Stage.Unmarshal)
+                if (context.CurrentStage is StubIdentifierContext.Stage.UnmarshalCapture or StubIdentifierContext.Stage.Unmarshal
+                    && marshaller.TypeInfo.IsErrorHandlingPosition != errorHandlingOnly)
                 {
                     continue;
                 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
@@ -95,6 +95,12 @@ namespace Microsoft.Interop
             ImmutableArray<StatementSyntax>.Builder statementsToUpdate = ImmutableArray.CreateBuilder<StatementSyntax>();
             foreach (IBoundMarshallingGenerator marshaller in marshallers.SignatureMarshallers)
             {
+                if (marshaller.TypeInfo.IsErrorHandlingPosition
+                    && context.CurrentStage is StubIdentifierContext.Stage.UnmarshalCapture or StubIdentifierContext.Stage.Unmarshal)
+                {
+                    continue;
+                }
+
                 statementsToUpdate.AddRange(marshaller.Generate(context));
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/GeneratedStatements.cs
@@ -18,10 +18,12 @@ namespace Microsoft.Interop
         public ImmutableArray<FixedStatementSyntax> Pin { get; init; }
         public ImmutableArray<StatementSyntax> PinnedMarshal { get; init; }
         public StatementSyntax InvokeStatement { get; init; }
+        public ImmutableArray<StatementSyntax> ErrorUnmarshalCapture { get; init; }
         public ImmutableArray<StatementSyntax> ErrorUnmarshal { get; init; }
         public ImmutableArray<StatementSyntax> Unmarshal { get; init; }
         public ImmutableArray<StatementSyntax> NotifyForSuccessfulInvoke { get; init; }
         public ImmutableArray<StatementSyntax> GuaranteedUnmarshal { get; init; }
+        public ImmutableArray<StatementSyntax> ErrorCleanupCalleeAllocated { get; init; }
         public ImmutableArray<StatementSyntax> CleanupCallerAllocated { get; init; }
         public ImmutableArray<StatementSyntax> CleanupCalleeAllocated { get; init; }
 
@@ -36,12 +38,13 @@ namespace Microsoft.Interop
                 Pin = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.Pin }).Cast<FixedStatementSyntax>().ToImmutableArray(),
                 PinnedMarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.PinnedMarshal }),
                 InvokeStatement = EmptyStatement(),
-                ErrorUnmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.UnmarshalCapture }, errorHandlingOnly: true)
-                            .AddRange(GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.Unmarshal }, errorHandlingOnly: true)),
+                ErrorUnmarshalCapture = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.UnmarshalCapture }, errorHandlingOnly: true),
+                ErrorUnmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.Unmarshal }, errorHandlingOnly: true),
                 Unmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.UnmarshalCapture })
                             .AddRange(GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.Unmarshal })),
                 NotifyForSuccessfulInvoke = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.NotifyForSuccessfulInvoke }),
                 GuaranteedUnmarshal = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.GuaranteedUnmarshal }),
+                ErrorCleanupCalleeAllocated = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.CleanupCalleeAllocated }, errorHandlingOnly: true),
                 CleanupCallerAllocated = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.CleanupCallerAllocated }),
                 CleanupCalleeAllocated = GenerateStatementsForStubContext(marshallers, context with { CurrentStage = StubIdentifierContext.Stage.CleanupCalleeAllocated }),
                 ManagedExceptionCatchClauses = GenerateCatchClauseForManagedException(marshallers, context)
@@ -101,7 +104,10 @@ namespace Microsoft.Interop
             ImmutableArray<StatementSyntax>.Builder statementsToUpdate = ImmutableArray.CreateBuilder<StatementSyntax>();
             foreach (IBoundMarshallingGenerator marshaller in marshallers.SignatureMarshallers)
             {
-                if (context.CurrentStage is StubIdentifierContext.Stage.UnmarshalCapture or StubIdentifierContext.Stage.Unmarshal
+                if (context.CurrentStage is
+                        StubIdentifierContext.Stage.UnmarshalCapture
+                        or StubIdentifierContext.Stage.Unmarshal
+                        or StubIdentifierContext.Stage.CleanupCalleeAllocated
                     && marshaller.TypeInfo.IsErrorHandlingPosition != errorHandlingOnly)
                 {
                     continue;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
@@ -77,9 +77,12 @@ namespace Microsoft.Interop
             }
 
             bool noMarshallingNeeded = true;
+            bool hasErrorHandler = false;
 
             foreach (IBoundMarshallingGenerator generator in _marshallers.SignatureMarshallers)
             {
+                hasErrorHandler |= generator.TypeInfo.IsErrorHandlingPosition;
+
                 // Check if generator is either blittable or just a forwarder.
                 noMarshallingNeeded &= (generator.IsBlittable() && !generator.TypeInfo.IsByRef) || generator.IsForwarder();
 
@@ -89,7 +92,7 @@ namespace Microsoft.Interop
             }
 
             NoMarshallingRequired = !setLastError
-                && !_marshallers.HasErrorHandler
+                && !hasErrorHandler
                 && _marshallers.ManagedNativeSameReturn
                 && noMarshallingNeeded;
         }
@@ -110,14 +113,12 @@ namespace Microsoft.Interop
         public BlockSyntax GenerateStubBody(string targetIdentifier)
         {
             GeneratedStatements statements = GeneratedStatements.Create(_marshallers, StubCodeContext.DefaultManagedToNativeStub, _context, IdentifierName(targetIdentifier));
-            IBoundMarshallingGenerator? errorMarshaller = _marshallers.HasErrorHandler ? _marshallers.ErrorHandlerMarshaller : null;
-            bool capturesSystemError = errorMarshaller?.TypeInfo.ErrorHandlingLocation == ErrorHandlingLocation.SystemError;
             bool shouldInitializeVariables = !statements.GuaranteedUnmarshal.IsEmpty || !statements.CleanupCallerAllocated.IsEmpty || !statements.CleanupCalleeAllocated.IsEmpty;
             VariableDeclarations declarations = VariableDeclarations.GenerateDeclarationsForManagedToUnmanaged(_marshallers, _context, shouldInitializeVariables);
 
             List<StatementSyntax> setupStatements = [];
 
-            if (_setLastError || capturesSystemError)
+            if (_setLastError)
             {
                 // Declare variable for last error
                 setupStatements.Add(Declare(
@@ -138,7 +139,7 @@ namespace Microsoft.Interop
             List<StatementSyntax> tryStatements = [.. statements.Marshal];
 
             BlockSyntax fixedBlock = Block(statements.PinnedMarshal);
-            if (_setLastError || capturesSystemError)
+            if (_setLastError)
             {
                 StatementSyntax clearLastError = MarshallerHelpers.CreateClearLastSystemErrorStatement(SuccessErrorCode);
 
@@ -154,25 +155,12 @@ namespace Microsoft.Interop
 
             tryStatements.AddRange(statements.NotifyForSuccessfulInvoke);
 
-            if (capturesSystemError)
-            {
-                tryStatements.Add(ExpressionStatement(
-                    AssignmentExpression(
-                        SyntaxKind.SimpleAssignmentExpression,
-                        IdentifierName(_context.GetIdentifiers(errorMarshaller!.TypeInfo).native),
-                        IdentifierName(LastErrorIdentifier))));
-            }
-
-            if (_setLastError && errorMarshaller is not null)
+            if (_setLastError && !statements.ErrorUnmarshal.IsEmpty)
             {
                 tryStatements.Add(MarshallerHelpers.CreateSetLastPInvokeErrorStatement(LastErrorIdentifier));
             }
 
-            if (errorMarshaller is not null)
-            {
-                tryStatements.AddRange(errorMarshaller.Generate(_context with { CurrentStage = StubIdentifierContext.Stage.UnmarshalCapture }));
-                tryStatements.AddRange(errorMarshaller.Generate(_context with { CurrentStage = StubIdentifierContext.Stage.Unmarshal }));
-            }
+            tryStatements.AddRange(statements.ErrorUnmarshal);
 
             // <invokeSucceeded> = true;
             if (!(statements.GuaranteedUnmarshal.IsEmpty && statements.CleanupCalleeAllocated.IsEmpty))

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Interop
             }
 
             NoMarshallingRequired = !setLastError
+                && !_marshallers.HasErrorHandler
                 && _marshallers.ManagedNativeSameReturn
                 && noMarshallingNeeded;
         }
@@ -109,12 +110,14 @@ namespace Microsoft.Interop
         public BlockSyntax GenerateStubBody(string targetIdentifier)
         {
             GeneratedStatements statements = GeneratedStatements.Create(_marshallers, StubCodeContext.DefaultManagedToNativeStub, _context, IdentifierName(targetIdentifier));
+            IBoundMarshallingGenerator? errorMarshaller = _marshallers.HasErrorHandler ? _marshallers.ErrorHandlerMarshaller : null;
+            bool capturesSystemError = errorMarshaller?.TypeInfo.ErrorHandlingLocation == ErrorHandlingLocation.SystemError;
             bool shouldInitializeVariables = !statements.GuaranteedUnmarshal.IsEmpty || !statements.CleanupCallerAllocated.IsEmpty || !statements.CleanupCalleeAllocated.IsEmpty;
             VariableDeclarations declarations = VariableDeclarations.GenerateDeclarationsForManagedToUnmanaged(_marshallers, _context, shouldInitializeVariables);
 
             List<StatementSyntax> setupStatements = [];
 
-            if (_setLastError)
+            if (_setLastError || capturesSystemError)
             {
                 // Declare variable for last error
                 setupStatements.Add(Declare(
@@ -135,7 +138,7 @@ namespace Microsoft.Interop
             List<StatementSyntax> tryStatements = [.. statements.Marshal];
 
             BlockSyntax fixedBlock = Block(statements.PinnedMarshal);
-            if (_setLastError)
+            if (_setLastError || capturesSystemError)
             {
                 StatementSyntax clearLastError = MarshallerHelpers.CreateClearLastSystemErrorStatement(SuccessErrorCode);
 
@@ -150,6 +153,26 @@ namespace Microsoft.Interop
             tryStatements.Add(statements.Pin.NestFixedStatements(fixedBlock));
 
             tryStatements.AddRange(statements.NotifyForSuccessfulInvoke);
+
+            if (capturesSystemError)
+            {
+                tryStatements.Add(ExpressionStatement(
+                    AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        IdentifierName(_context.GetIdentifiers(errorMarshaller!.TypeInfo).native),
+                        IdentifierName(LastErrorIdentifier))));
+            }
+
+            if (_setLastError && errorMarshaller is not null)
+            {
+                tryStatements.Add(MarshallerHelpers.CreateSetLastPInvokeErrorStatement(LastErrorIdentifier));
+            }
+
+            if (errorMarshaller is not null)
+            {
+                tryStatements.AddRange(errorMarshaller.Generate(_context with { CurrentStage = StubIdentifierContext.Stage.UnmarshalCapture }));
+                tryStatements.AddRange(errorMarshaller.Generate(_context with { CurrentStage = StubIdentifierContext.Stage.Unmarshal }));
+            }
 
             // <invokeSucceeded> = true;
             if (!(statements.GuaranteedUnmarshal.IsEmpty && statements.CleanupCalleeAllocated.IsEmpty))

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
@@ -161,7 +161,8 @@ namespace Microsoft.Interop
 
             tryStatements.AddRange(statements.NotifyForSuccessfulInvoke);
 
-            if (_setLastError && !statements.ErrorUnmarshal.IsEmpty)
+            if (_setLastError
+                && (!statements.ErrorUnmarshalCapture.IsEmpty || !statements.ErrorUnmarshal.IsEmpty))
             {
                 tryStatements.Add(MarshallerHelpers.CreateSetLastPInvokeErrorStatement(LastErrorIdentifier));
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Interop
         private const string ReturnIdentifier = "__retVal";
         private const string LastErrorIdentifier = "__lastError";
         private const string InvokeSucceededIdentifier = "__invokeSucceeded";
+        private const string ErrorValueCapturedIdentifier = "__errorValueCaptured";
 
         // Error code representing success. This maps to S_OK for Windows HRESULT semantics and 0 for POSIX errno semantics.
         private const int SuccessErrorCode = 0;
@@ -132,6 +133,11 @@ namespace Microsoft.Interop
                 setupStatements.Add(Declare(PredefinedType(Token(SyntaxKind.BoolKeyword)), InvokeSucceededIdentifier, initializeToDefault: true));
             }
 
+            if (!statements.ErrorCleanupCalleeAllocated.IsEmpty)
+            {
+                setupStatements.Add(Declare(PredefinedType(Token(SyntaxKind.BoolKeyword)), ErrorValueCapturedIdentifier, initializeToDefault: true));
+            }
+
             setupStatements.AddRange(declarations.Initializations);
             setupStatements.AddRange(declarations.Variables);
             setupStatements.AddRange(statements.Setup);
@@ -160,6 +166,14 @@ namespace Microsoft.Interop
                 tryStatements.Add(MarshallerHelpers.CreateSetLastPInvokeErrorStatement(LastErrorIdentifier));
             }
 
+            tryStatements.AddRange(statements.ErrorUnmarshalCapture);
+            if (!statements.ErrorCleanupCalleeAllocated.IsEmpty)
+            {
+                tryStatements.Add(ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                    IdentifierName(ErrorValueCapturedIdentifier),
+                    LiteralExpression(SyntaxKind.TrueLiteralExpression))));
+            }
+
             tryStatements.AddRange(statements.ErrorUnmarshal);
 
             // <invokeSucceeded> = true;
@@ -174,6 +188,13 @@ namespace Microsoft.Interop
 
             List<StatementSyntax> allStatements = setupStatements;
             List<StatementSyntax> finallyStatements = [];
+            if (!statements.ErrorCleanupCalleeAllocated.IsEmpty)
+            {
+                finallyStatements.Add(IfStatement(
+                    IdentifierName(ErrorValueCapturedIdentifier),
+                    Block(statements.ErrorCleanupCalleeAllocated)));
+            }
+
             if (!(statements.GuaranteedUnmarshal.IsEmpty && statements.CleanupCalleeAllocated.IsEmpty))
             {
                 finallyStatements.Add(IfStatement(IdentifierName(InvokeSucceededIdentifier), Block(statements.GuaranteedUnmarshal.Concat(statements.CleanupCalleeAllocated))));

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedToNativeStubGenerator.cs
@@ -61,17 +61,30 @@ namespace Microsoft.Interop
 
             diagnosticsBag.ReportGeneratorDiagnostics(bindingDiagnostics);
 
+            TypePositionInfo? errorHandlingInfo = argTypes.FirstOrDefault(static info => info.IsErrorHandlingPosition);
+            TypePositionInfo? errorHandlingOverlappedPosition = errorHandlingInfo is null
+                ? null
+                : argTypes.FirstOrDefault(info => !info.IsErrorHandlingPosition && info.NativeIndex == errorHandlingInfo.NativeIndex);
+
             if (_marshallers.ManagedReturnMarshaller.UsesNativeIdentifier)
             {
                 // If we need a different native return identifier, then recreate the context with the correct identifier before we generate any code.
-                _context = new DefaultIdentifierContext(ReturnIdentifier, $"{ReturnIdentifier}{StubIdentifierContext.GeneratedNativeIdentifierSuffix}", MarshalDirection.ManagedToUnmanaged)
+                _context = new DefaultIdentifierContext(
+                    ReturnIdentifier,
+                    $"{ReturnIdentifier}{StubIdentifierContext.GeneratedNativeIdentifierSuffix}",
+                    MarshalDirection.ManagedToUnmanaged,
+                    errorHandlingOverlappedPosition)
                 {
                     CodeEmitOptions = codeEmitOptions
                 };
             }
             else
             {
-                _context = new DefaultIdentifierContext(ReturnIdentifier, ReturnIdentifier, MarshalDirection.ManagedToUnmanaged)
+                _context = new DefaultIdentifierContext(
+                    ReturnIdentifier,
+                    ReturnIdentifier,
+                    MarshalDirection.ManagedToUnmanaged,
+                    errorHandlingOverlappedPosition)
                 {
                     CodeEmitOptions = codeEmitOptions
                 };

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -102,6 +102,43 @@ namespace Microsoft.Interop
             return TryGetMarshallersFromEntryType(entryPointType, managedType, isLinearCollectionMarshalling: false, compilation, getMarshallingInfoForElement: null, IgnoreArityMismatch, out marshallers);
         }
 
+        public static bool TryGetManagedTypeFromEntryType(
+            INamedTypeSymbol entryPointType,
+            Compilation compilation,
+            [NotNullWhen(true)] out ITypeSymbol? managedType)
+        {
+            managedType = null;
+
+            foreach (AttributeData attr in entryPointType.GetAttributes())
+            {
+                if (attr.AttributeClass?.ToDisplayString() != TypeNames.CustomMarshallerAttribute
+                    || attr.AttributeConstructor is null
+                    || attr.ConstructorArguments.Length != 3
+                    || attr.ConstructorArguments[0].Value is not ITypeSymbol managedTypeOnAttribute)
+                {
+                    continue;
+                }
+
+                ITypeSymbol resolvedManagedType = ReplaceGenericPlaceholderInType(managedTypeOnAttribute, entryPointType, compilation);
+                if (!TryResolveManagedType(entryPointType, resolvedManagedType, isLinearCollectionMarshalling: false, IgnoreArityMismatch, out resolvedManagedType))
+                {
+                    continue;
+                }
+
+                if (managedType is null)
+                {
+                    managedType = resolvedManagedType;
+                }
+                else if (!SymbolEqualityComparer.Default.Equals(managedType, resolvedManagedType))
+                {
+                    managedType = null;
+                    return false;
+                }
+            }
+
+            return managedType is not null;
+        }
+
         public static bool TryGetValueMarshallersFromEntryType(
             INamedTypeSymbol entryPointType,
             ITypeSymbol managedType,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -277,6 +277,13 @@ namespace Microsoft.Interop
 
             if (context.Direction == MarshalDirection.ManagedToUnmanaged)
             {
+                if (info.IsErrorHandlingPosition)
+                {
+                    return info.RefKind == RefKind.Ref
+                        ? MarshalDirection.Bidirectional
+                        : MarshalDirection.UnmanagedToManaged;
+                }
+
                 if (info.IsManagedReturnPosition)
                 {
                     return MarshalDirection.UnmanagedToManaged;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -171,15 +172,19 @@ namespace Microsoft.Interop
 
             void ApplyErrorHandlingInfo(ImmutableArray<TypePositionInfo>.Builder infos, ErrorHandlingInfo errorInfo)
             {
-                TypePositionInfo CreateInjectedErrorInfo(int nativeIndex)
+                TypePositionInfo CreateErrorInfo(
+                    int nativeIndex,
+                    string instanceIdentifier = "__error",
+                    bool isManagedIdentifierSynthetic = true)
                 {
                     return new TypePositionInfo(errorInfo.ManagedType, errorInfo.MarshallingInfo)
                     {
-                        InstanceIdentifier = "__error",
+                        InstanceIdentifier = instanceIdentifier,
                         RefKind = nativeIndex == TypePositionInfo.ReturnIndex ? RefKind.None : RefKind.Out,
                         ManagedIndex = TypePositionInfo.ErrorIndex,
                         NativeIndex = nativeIndex,
                         IsErrorHandlingPosition = true,
+                        IsManagedIdentifierSynthetic = isManagedIdentifierSynthetic,
                     };
                 }
 
@@ -192,16 +197,12 @@ namespace Microsoft.Interop
                         TypePositionInfo returnInfo = infos[returnIndex];
                         if (MatchesManagedType(returnInfo))
                         {
-                            infos[returnIndex] = returnInfo with
-                            {
-                                MarshallingAttributeInfo = errorInfo.MarshallingInfo,
-                                IsErrorHandlingPosition = true,
-                            };
+                            infos.Add(CreateErrorInfo(TypePositionInfo.ReturnIndex));
                         }
                         else if (returnInfo.ManagedType == SpecialTypeInfo.Void)
                         {
                             infos[returnIndex] = returnInfo with { NativeIndex = TypePositionInfo.UnsetIndex };
-                            infos.Add(CreateInjectedErrorInfo(TypePositionInfo.ReturnIndex));
+                            infos.Add(CreateErrorInfo(TypePositionInfo.ReturnIndex));
                         }
                         break;
 
@@ -223,27 +224,38 @@ namespace Microsoft.Interop
                             };
                         }
 
-                        infos.Add(CreateInjectedErrorInfo(TypePositionInfo.ReturnIndex));
+                        infos.Add(CreateErrorInfo(TypePositionInfo.ReturnIndex));
                         break;
 
                     case ErrorHandlingLocation.LastParameter:
-                        int lastParameterIndex = infos.Count - 2;
-                        if (infos.Count > 1
-                            && infos[lastParameterIndex] is { RefKind: RefKind.Out or RefKind.Ref } lastParameter
-                            && MatchesManagedType(lastParameter))
-                        {
-                            infos[lastParameterIndex] = lastParameter with
-                            {
-                                MarshallingAttributeInfo = errorInfo.MarshallingInfo,
-                                IsErrorHandlingPosition = true,
-                            };
-                        }
-                        else
-                        {
-                            infos.Add(CreateInjectedErrorInfo(method.Parameters.Length));
-                        }
+                        TypePositionInfo lastParameter = GetLastManagedParameter(infos);
+                        Debug.Assert(lastParameter is { RefKind: RefKind.Out or RefKind.Ref }
+                            && MatchesManagedType(lastParameter));
+                        infos.Add(CreateErrorInfo(
+                            lastParameter.NativeIndex,
+                            lastParameter.InstanceIdentifier,
+                            isManagedIdentifierSynthetic: false));
                         break;
 
+                    case ErrorHandlingLocation.HiddenLastParameter:
+                        infos.Add(CreateErrorInfo(method.Parameters.Length));
+                        break;
+
+                }
+
+                static TypePositionInfo GetLastManagedParameter(ImmutableArray<TypePositionInfo>.Builder infos)
+                {
+                    TypePositionInfo? lastParameter = null;
+                    foreach (TypePositionInfo info in infos)
+                    {
+                        if (!TypePositionInfo.IsSpecialIndex(info.ManagedIndex)
+                            && (lastParameter is null || info.ManagedIndex > lastParameter.ManagedIndex))
+                        {
+                            lastParameter = info;
+                        }
+                    }
+
+                    return lastParameter ?? throw new UnreachableException();
                 }
             }
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -173,20 +173,15 @@ namespace Microsoft.Interop
             void ApplyErrorHandlingInfo(ImmutableArray<TypePositionInfo>.Builder infos, ErrorHandlingInfo errorInfo)
             {
                 TypePositionInfo CreateErrorInfo(
-                    int nativeIndex,
-                    string instanceIdentifier = "__error",
-                    bool isManagedIdentifierSynthetic = true,
-                    bool isNativePositionOverlapping = false)
+                    int nativeIndex)
                 {
                     return new TypePositionInfo(errorInfo.ManagedType, errorInfo.MarshallingInfo)
                     {
-                        InstanceIdentifier = instanceIdentifier,
+                        InstanceIdentifier = "__error",
                         RefKind = nativeIndex == TypePositionInfo.ReturnIndex ? RefKind.None : RefKind.Out,
                         ManagedIndex = TypePositionInfo.ErrorIndex,
                         NativeIndex = nativeIndex,
                         IsErrorHandlingPosition = true,
-                        IsManagedIdentifierSynthetic = isManagedIdentifierSynthetic,
-                        IsNativePositionOverlapping = isNativePositionOverlapping,
                     };
                 }
 
@@ -199,9 +194,7 @@ namespace Microsoft.Interop
                         TypePositionInfo returnInfo = infos[returnIndex];
                         if (MatchesManagedType(returnInfo))
                         {
-                            infos.Add(CreateErrorInfo(
-                                TypePositionInfo.ReturnIndex,
-                                isNativePositionOverlapping: true));
+                            infos.Add(CreateErrorInfo(TypePositionInfo.ReturnIndex));
                         }
                         else if (returnInfo.ManagedType == SpecialTypeInfo.Void)
                         {
@@ -235,11 +228,7 @@ namespace Microsoft.Interop
                         TypePositionInfo lastParameter = GetLastManagedParameter(infos);
                         Debug.Assert(lastParameter is { RefKind: RefKind.Out or RefKind.Ref }
                             && MatchesManagedType(lastParameter));
-                        infos.Add(CreateErrorInfo(
-                            lastParameter.NativeIndex,
-                            lastParameter.InstanceIdentifier,
-                            isManagedIdentifierSynthetic: false,
-                            isNativePositionOverlapping: true));
+                        infos.Add(CreateErrorInfo(lastParameter.NativeIndex));
                         break;
 
                     case ErrorHandlingLocation.HiddenLastParameter:

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -180,7 +180,6 @@ namespace Microsoft.Interop
                         ManagedIndex = TypePositionInfo.ErrorIndex,
                         NativeIndex = nativeIndex,
                         IsErrorHandlingPosition = true,
-                        ErrorHandlingLocation = errorInfo.Location,
                     };
                 }
 
@@ -197,7 +196,6 @@ namespace Microsoft.Interop
                             {
                                 MarshallingAttributeInfo = errorInfo.MarshallingInfo,
                                 IsErrorHandlingPosition = true,
-                                ErrorHandlingLocation = errorInfo.Location,
                             };
                         }
                         else if (returnInfo.ManagedType == SpecialTypeInfo.Void)
@@ -238,7 +236,6 @@ namespace Microsoft.Interop
                             {
                                 MarshallingAttributeInfo = errorInfo.MarshallingInfo,
                                 IsErrorHandlingPosition = true,
-                                ErrorHandlingLocation = errorInfo.Location,
                             };
                         }
                         else
@@ -247,26 +244,6 @@ namespace Microsoft.Interop
                         }
                         break;
 
-                    case ErrorHandlingLocation.SystemError:
-                        int systemErrorParameterIndex = infos.Count - 2;
-                        if (errorInfo.ManagedType != SpecialTypeInfo.Int32
-                            && infos.Count > 1
-                            && infos[systemErrorParameterIndex] is { RefKind: RefKind.Out } systemErrorParameter
-                            && MatchesManagedType(systemErrorParameter))
-                        {
-                            infos[systemErrorParameterIndex] = systemErrorParameter with
-                            {
-                                NativeIndex = TypePositionInfo.UnsetIndex,
-                                MarshallingAttributeInfo = errorInfo.MarshallingInfo,
-                                IsErrorHandlingPosition = true,
-                                ErrorHandlingLocation = errorInfo.Location,
-                            };
-                        }
-                        else
-                        {
-                            infos.Add(CreateInjectedErrorInfo(TypePositionInfo.UnsetIndex));
-                        }
-                        break;
                 }
             }
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -175,7 +175,8 @@ namespace Microsoft.Interop
                 TypePositionInfo CreateErrorInfo(
                     int nativeIndex,
                     string instanceIdentifier = "__error",
-                    bool isManagedIdentifierSynthetic = true)
+                    bool isManagedIdentifierSynthetic = true,
+                    bool isNativePositionOverlapping = false)
                 {
                     return new TypePositionInfo(errorInfo.ManagedType, errorInfo.MarshallingInfo)
                     {
@@ -185,6 +186,7 @@ namespace Microsoft.Interop
                         NativeIndex = nativeIndex,
                         IsErrorHandlingPosition = true,
                         IsManagedIdentifierSynthetic = isManagedIdentifierSynthetic,
+                        IsNativePositionOverlapping = isNativePositionOverlapping,
                     };
                 }
 
@@ -197,7 +199,9 @@ namespace Microsoft.Interop
                         TypePositionInfo returnInfo = infos[returnIndex];
                         if (MatchesManagedType(returnInfo))
                         {
-                            infos.Add(CreateErrorInfo(TypePositionInfo.ReturnIndex));
+                            infos.Add(CreateErrorInfo(
+                                TypePositionInfo.ReturnIndex,
+                                isNativePositionOverlapping: true));
                         }
                         else if (returnInfo.ManagedType == SpecialTypeInfo.Void)
                         {
@@ -234,7 +238,8 @@ namespace Microsoft.Interop
                         infos.Add(CreateErrorInfo(
                             lastParameter.NativeIndex,
                             lastParameter.InstanceIdentifier,
-                            isManagedIdentifierSynthetic: false));
+                            isManagedIdentifierSynthetic: false,
+                            isNativePositionOverlapping: true));
                         break;
 
                     case ErrorHandlingLocation.HiddenLastParameter:

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -207,6 +207,27 @@ namespace Microsoft.Interop
                         }
                         break;
 
+                    case ErrorHandlingLocation.HiddenReturnValue:
+                        int hiddenReturnIndex = infos.Count - 1;
+                        TypePositionInfo hiddenReturnInfo = infos[hiddenReturnIndex];
+                        if (hiddenReturnInfo.ManagedType == SpecialTypeInfo.Void)
+                        {
+                            infos[hiddenReturnIndex] = hiddenReturnInfo with { NativeIndex = TypePositionInfo.UnsetIndex };
+                        }
+                        else
+                        {
+                            // Match the COM ABI transformation: keep the value in the managed return
+                            // position while moving it to a final out parameter in the native signature.
+                            infos[hiddenReturnIndex] = hiddenReturnInfo with
+                            {
+                                RefKind = RefKind.Out,
+                                NativeIndex = method.Parameters.Length,
+                            };
+                        }
+
+                        infos.Add(CreateInjectedErrorInfo(TypePositionInfo.ReturnIndex));
+                        break;
+
                     case ErrorHandlingLocation.LastParameter:
                         int lastParameterIndex = infos.Count - 2;
                         if (infos.Count > 1

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -39,8 +39,7 @@ namespace Microsoft.Interop
             {
                 foreach (TypePositionInfo typeInfo in ElementTypeInformation)
                 {
-                    if (typeInfo.ManagedIndex != TypePositionInfo.UnsetIndex
-                        && typeInfo.ManagedIndex != TypePositionInfo.ReturnIndex)
+                    if (!TypePositionInfo.IsSpecialIndex(typeInfo.ManagedIndex))
                     {
                         yield return Parameter(Identifier(typeInfo.InstanceIdentifier))
                             .WithType(typeInfo.ManagedType.Syntax)
@@ -59,7 +58,18 @@ namespace Microsoft.Interop
             CodeEmitOptions options,
             Assembly generatorInfoAssembly)
         {
-            ImmutableArray<TypePositionInfo> typeInfos = GenerateTypeInformation(method, marshallingInfoParser, env);
+            return Create(method, marshallingInfoParser, env, options, generatorInfoAssembly, errorHandlingInfo: null);
+        }
+
+        public static SignatureContext Create(
+            IMethodSymbol method,
+            MarshallingInfoParser marshallingInfoParser,
+            StubEnvironment env,
+            CodeEmitOptions options,
+            Assembly generatorInfoAssembly,
+            ErrorHandlingInfo? errorHandlingInfo)
+        {
+            ImmutableArray<TypePositionInfo> typeInfos = GenerateTypeInformation(method, marshallingInfoParser, env, errorHandlingInfo);
 
             ImmutableArray<AttributeListSyntax>.Builder additionalAttrs = ImmutableArray.CreateBuilder<AttributeListSyntax>();
 
@@ -101,7 +111,8 @@ namespace Microsoft.Interop
         private static ImmutableArray<TypePositionInfo> GenerateTypeInformation(
             IMethodSymbol method,
             MarshallingInfoParser marshallingInfoParser,
-            StubEnvironment env)
+            StubEnvironment env,
+            ErrorHandlingInfo? errorHandlingInfo)
         {
             // When the underlying method is a property accessor, bare attributes on the property declaration
             // (e.g. `[MarshalUsing(typeof(X))] string Prop { get; set; }`) land on the property symbol and
@@ -151,7 +162,92 @@ namespace Microsoft.Interop
 
             typeInfos.Add(retTypeInfo);
 
+            if (errorHandlingInfo is not null)
+            {
+                ApplyErrorHandlingInfo(typeInfos, errorHandlingInfo);
+            }
+
             return typeInfos.ToImmutable();
+
+            void ApplyErrorHandlingInfo(ImmutableArray<TypePositionInfo>.Builder infos, ErrorHandlingInfo errorInfo)
+            {
+                TypePositionInfo CreateInjectedErrorInfo(int nativeIndex)
+                {
+                    return new TypePositionInfo(errorInfo.ManagedType, errorInfo.MarshallingInfo)
+                    {
+                        InstanceIdentifier = "__error",
+                        RefKind = nativeIndex == TypePositionInfo.ReturnIndex ? RefKind.None : RefKind.Out,
+                        ManagedIndex = TypePositionInfo.ErrorIndex,
+                        NativeIndex = nativeIndex,
+                        IsErrorHandlingPosition = true,
+                        ErrorHandlingLocation = errorInfo.Location,
+                    };
+                }
+
+                bool MatchesManagedType(TypePositionInfo info) => info.ManagedType == errorInfo.ManagedType;
+
+                switch (errorInfo.Location)
+                {
+                    case ErrorHandlingLocation.ReturnValue:
+                        int returnIndex = infos.Count - 1;
+                        TypePositionInfo returnInfo = infos[returnIndex];
+                        if (MatchesManagedType(returnInfo))
+                        {
+                            infos[returnIndex] = returnInfo with
+                            {
+                                MarshallingAttributeInfo = errorInfo.MarshallingInfo,
+                                IsErrorHandlingPosition = true,
+                                ErrorHandlingLocation = errorInfo.Location,
+                            };
+                        }
+                        else if (returnInfo.ManagedType == SpecialTypeInfo.Void)
+                        {
+                            infos[returnIndex] = returnInfo with { NativeIndex = TypePositionInfo.UnsetIndex };
+                            infos.Add(CreateInjectedErrorInfo(TypePositionInfo.ReturnIndex));
+                        }
+                        break;
+
+                    case ErrorHandlingLocation.LastParameter:
+                        int lastParameterIndex = infos.Count - 2;
+                        if (infos.Count > 1
+                            && infos[lastParameterIndex] is { RefKind: RefKind.Out or RefKind.Ref } lastParameter
+                            && MatchesManagedType(lastParameter))
+                        {
+                            infos[lastParameterIndex] = lastParameter with
+                            {
+                                MarshallingAttributeInfo = errorInfo.MarshallingInfo,
+                                IsErrorHandlingPosition = true,
+                                ErrorHandlingLocation = errorInfo.Location,
+                            };
+                        }
+                        else
+                        {
+                            infos.Add(CreateInjectedErrorInfo(method.Parameters.Length));
+                        }
+                        break;
+
+                    case ErrorHandlingLocation.SystemError:
+                        int systemErrorParameterIndex = infos.Count - 2;
+                        if (errorInfo.ManagedType != SpecialTypeInfo.Int32
+                            && infos.Count > 1
+                            && infos[systemErrorParameterIndex] is { RefKind: RefKind.Out } systemErrorParameter
+                            && MatchesManagedType(systemErrorParameter))
+                        {
+                            infos[systemErrorParameterIndex] = systemErrorParameter with
+                            {
+                                NativeIndex = TypePositionInfo.UnsetIndex,
+                                MarshallingAttributeInfo = errorInfo.MarshallingInfo,
+                                IsErrorHandlingPosition = true,
+                                ErrorHandlingLocation = errorInfo.Location,
+                            };
+                        }
+                        else
+                        {
+                            infos.Add(CreateInjectedErrorInfo(TypePositionInfo.UnsetIndex));
+                        }
+                        break;
+                }
+            }
         }
 
         private static ImmutableArray<AttributeData> MergeAccessorAndPropertyAttributes(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Interop
         public const string GlobalAlias = "global::";
 
         public const string DllImportAttribute = "System.Runtime.InteropServices.DllImportAttribute";
+        public const string ErrorHandlerAttribute = "System.Runtime.InteropServices.ErrorHandlerAttribute";
         public const string LibraryImportAttribute = "System.Runtime.InteropServices.LibraryImportAttribute";
         public const string LibraryImportAttribute_ShortName = "LibraryImportAttribute";
         public const string StringMarshalling = "System.Runtime.InteropServices.StringMarshalling";

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -73,10 +73,8 @@ namespace Microsoft.Interop
 
         public bool IsManagedReturnPosition { get => ManagedIndex == ReturnIndex; }
         public bool IsNativeReturnPosition { get => NativeIndex == ReturnIndex; }
-        public bool IsManagedExceptionPosition { get; init; }
         public bool IsErrorHandlingPosition { get; init; }
-        public bool IsManagedIdentifierSynthetic { get; init; }
-        public bool IsNativePositionOverlapping { get; init; }
+        public bool IsManagedIdentifierSynthetic => IsSpecialIndex(ManagedIndex);
 
         public int ManagedIndex { get; init; } = UnsetIndex;
         public int NativeIndex { get; init; } = UnsetIndex;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Interop
         public bool IsManagedExceptionPosition { get; init; }
         public bool IsErrorHandlingPosition { get; init; }
         public bool IsManagedIdentifierSynthetic { get; init; }
+        public bool IsNativePositionOverlapping { get; init; }
 
         public int ManagedIndex { get; init; } = UnsetIndex;
         public int NativeIndex { get; init; } = UnsetIndex;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Interop
         ReturnValue = 0,
         LastParameter = 1,
         SystemError = 2,
+        HiddenReturnValue = 3,
     }
 
     public sealed record ErrorHandlingInfo(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -49,10 +49,11 @@ namespace Microsoft.Interop
         public const int UnsetIndex = int.MinValue;
         public const int ReturnIndex = UnsetIndex + 1;
         public const int ExceptionIndex = UnsetIndex + 2;
+        public const int ErrorIndex = UnsetIndex + 3;
 
         public static bool IsSpecialIndex(int index)
         {
-            return index is UnsetIndex or ReturnIndex or ExceptionIndex;
+            return index is UnsetIndex or ReturnIndex or ExceptionIndex or ErrorIndex;
         }
 
         public static int IncrementIndex(int index)
@@ -73,6 +74,8 @@ namespace Microsoft.Interop
         public bool IsManagedReturnPosition { get => ManagedIndex == ReturnIndex; }
         public bool IsNativeReturnPosition { get => NativeIndex == ReturnIndex; }
         public bool IsManagedExceptionPosition { get => ManagedIndex == ExceptionIndex; }
+        public bool IsErrorHandlingPosition { get; init; }
+        public ErrorHandlingLocation ErrorHandlingLocation { get; init; }
 
         public int ManagedIndex { get; init; } = UnsetIndex;
         public int NativeIndex { get; init; } = UnsetIndex;
@@ -102,7 +105,7 @@ namespace Microsoft.Interop
             if (info.ManagedIndex is UnsetIndex)
                 return Location.None;
 
-            if (info.ManagedIndex is ReturnIndex or ExceptionIndex)
+            if (info.ManagedIndex is ReturnIndex or ExceptionIndex or ErrorIndex)
                 return methodSymbol.Locations[0];
 
             return methodSymbol.Parameters[info.ManagedIndex].Locations[0];
@@ -125,9 +128,23 @@ namespace Microsoft.Interop
                 {
                     marshalKind |= ByValueContentsMarshalKind.In;
                 }
+
             }
 
             return marshalKind;
         }
     }
+
+    public enum ErrorHandlingLocation
+    {
+        None = -1,
+        ReturnValue = 0,
+        LastParameter = 1,
+        SystemError = 2,
+    }
+
+    public sealed record ErrorHandlingInfo(
+        ManagedTypeInfo ManagedType,
+        MarshallingInfo MarshallingInfo,
+        ErrorHandlingLocation Location);
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Interop
     {
         public const int UnsetIndex = int.MinValue;
         public const int ReturnIndex = UnsetIndex + 1;
-        public const int ExceptionIndex = UnsetIndex + 2;
-        public const int ErrorIndex = UnsetIndex + 3;
+        public const int ErrorIndex = UnsetIndex + 2;
+        public const int ExceptionIndex = ErrorIndex;
 
         public static bool IsSpecialIndex(int index)
         {
-            return index is UnsetIndex or ReturnIndex or ExceptionIndex or ErrorIndex;
+            return index is UnsetIndex or ReturnIndex or ErrorIndex;
         }
 
         public static int IncrementIndex(int index)
@@ -73,9 +73,8 @@ namespace Microsoft.Interop
 
         public bool IsManagedReturnPosition { get => ManagedIndex == ReturnIndex; }
         public bool IsNativeReturnPosition { get => NativeIndex == ReturnIndex; }
-        public bool IsManagedExceptionPosition { get => ManagedIndex == ExceptionIndex; }
+        public bool IsManagedExceptionPosition { get => ManagedIndex == ErrorIndex && !IsErrorHandlingPosition; }
         public bool IsErrorHandlingPosition { get; init; }
-        public ErrorHandlingLocation ErrorHandlingLocation { get; init; }
 
         public int ManagedIndex { get; init; } = UnsetIndex;
         public int NativeIndex { get; init; } = UnsetIndex;
@@ -105,7 +104,7 @@ namespace Microsoft.Interop
             if (info.ManagedIndex is UnsetIndex)
                 return Location.None;
 
-            if (info.ManagedIndex is ReturnIndex or ExceptionIndex or ErrorIndex)
+            if (info.ManagedIndex is ReturnIndex or ErrorIndex)
                 return methodSymbol.Locations[0];
 
             return methodSymbol.Parameters[info.ManagedIndex].Locations[0];
@@ -140,8 +139,7 @@ namespace Microsoft.Interop
         None = -1,
         ReturnValue = 0,
         LastParameter = 1,
-        SystemError = 2,
-        HiddenReturnValue = 3,
+        HiddenReturnValue = 2,
     }
 
     public sealed record ErrorHandlingInfo(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -73,8 +73,9 @@ namespace Microsoft.Interop
 
         public bool IsManagedReturnPosition { get => ManagedIndex == ReturnIndex; }
         public bool IsNativeReturnPosition { get => NativeIndex == ReturnIndex; }
-        public bool IsManagedExceptionPosition { get => ManagedIndex == ErrorIndex && !IsErrorHandlingPosition; }
+        public bool IsManagedExceptionPosition { get; init; }
         public bool IsErrorHandlingPosition { get; init; }
+        public bool IsManagedIdentifierSynthetic { get; init; }
 
         public int ManagedIndex { get; init; } = UnsetIndex;
         public int NativeIndex { get; init; } = UnsetIndex;
@@ -140,6 +141,7 @@ namespace Microsoft.Interop
         ReturnValue = 0,
         LastParameter = 1,
         HiddenReturnValue = 2,
+        HiddenLastParameter = 3,
     }
 
     public sealed record ErrorHandlingInfo(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/UnmanagedToManagedStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/UnmanagedToManagedStubGenerator.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Interop
 
             List<StatementSyntax> tryStatements =
             [
+                .. statements.ErrorUnmarshal,
                 .. statements.GuaranteedUnmarshal,
                 .. statements.Unmarshal,
                 statements.InvokeStatement,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/UnmanagedToManagedStubGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/UnmanagedToManagedStubGenerator.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Interop
 
             List<StatementSyntax> tryStatements =
             [
+                .. statements.ErrorUnmarshalCapture,
                 .. statements.ErrorUnmarshal,
                 .. statements.GuaranteedUnmarshal,
                 .. statements.Unmarshal,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Interop
                 if (info.IsManagedReturnPosition)
                     continue;
 
-                if (info.RefKind == RefKind.Out)
+                if (info.RefKind == RefKind.Out && info.ManagedIndex != TypePositionInfo.ErrorIndex)
                 {
                     initializations.Add(MarshallerHelpers.DefaultInit(info, context));
                 }
@@ -44,6 +44,23 @@ namespace Microsoft.Interop
             {
                 // Declare variables for invoke return value
                 AppendVariableDeclarations(variables, marshallers.NativeReturnMarshaller, context, initializeToDefault: initializeDeclarations);
+            }
+
+            if (marshallers.HasErrorHandler)
+            {
+                IBoundMarshallingGenerator errorMarshaller = marshallers.ErrorHandlerMarshaller;
+                TypePositionInfo errorInfo = errorMarshaller.TypeInfo;
+                (string managed, string native) = context.GetIdentifiers(errorInfo);
+
+                if (errorInfo.ManagedIndex == TypePositionInfo.ErrorIndex && !errorInfo.IsNativeReturnPosition)
+                {
+                    variables.Add(Declare(errorInfo.ManagedType.Syntax, managed, initializeDeclarations));
+                }
+
+                if (errorInfo.NativeIndex == TypePositionInfo.UnsetIndex && errorMarshaller.UsesNativeIdentifier)
+                {
+                    variables.Add(Declare(errorMarshaller.NativeType.Syntax, native, initializeDeclarations));
+                }
             }
 
             return new VariableDeclarations

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
@@ -49,8 +49,13 @@ namespace Microsoft.Interop
             foreach (IBoundMarshallingGenerator errorMarshaller in marshallers.SignatureMarshallers)
             {
                 TypePositionInfo errorInfo = errorMarshaller.TypeInfo;
-                if (errorInfo is { IsErrorHandlingPosition: true, ManagedIndex: TypePositionInfo.ErrorIndex }
-                    && !errorInfo.IsNativeReturnPosition)
+                if (errorInfo is
+                    {
+                        IsErrorHandlingPosition: true,
+                        IsManagedIdentifierSynthetic: true,
+                        ManagedIndex: TypePositionInfo.ErrorIndex,
+                    }
+                    && !ReferenceEquals(errorMarshaller, marshallers.NativeReturnMarshaller))
                 {
                     string managed = context.GetIdentifiers(errorInfo).managed;
                     variables.Add(Declare(errorInfo.ManagedType.Syntax, managed, initializeDeclarations));

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
@@ -46,20 +46,14 @@ namespace Microsoft.Interop
                 AppendVariableDeclarations(variables, marshallers.NativeReturnMarshaller, context, initializeToDefault: initializeDeclarations);
             }
 
-            if (marshallers.HasErrorHandler)
+            foreach (IBoundMarshallingGenerator errorMarshaller in marshallers.SignatureMarshallers)
             {
-                IBoundMarshallingGenerator errorMarshaller = marshallers.ErrorHandlerMarshaller;
                 TypePositionInfo errorInfo = errorMarshaller.TypeInfo;
-                (string managed, string native) = context.GetIdentifiers(errorInfo);
-
-                if (errorInfo.ManagedIndex == TypePositionInfo.ErrorIndex && !errorInfo.IsNativeReturnPosition)
+                if (errorInfo is { IsErrorHandlingPosition: true, ManagedIndex: TypePositionInfo.ErrorIndex }
+                    && !errorInfo.IsNativeReturnPosition)
                 {
+                    string managed = context.GetIdentifiers(errorInfo).managed;
                     variables.Add(Declare(errorInfo.ManagedType.Syntax, managed, initializeDeclarations));
-                }
-
-                if (errorInfo.NativeIndex == TypePositionInfo.UnsetIndex && errorMarshaller.UsesNativeIdentifier)
-                {
-                    variables.Add(Declare(errorMarshaller.NativeType.Syntax, native, initializeDeclarations));
                 }
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Interop
                 if (info.IsManagedReturnPosition)
                     continue;
 
-                if (info.RefKind == RefKind.Out && info.ManagedIndex != TypePositionInfo.ErrorIndex)
+                if (info.RefKind == RefKind.Out && !info.IsErrorHandlingPosition)
                 {
                     initializations.Add(MarshallerHelpers.DefaultInit(info, context));
                 }
@@ -182,7 +182,7 @@ namespace Microsoft.Interop
 
                     // Declare a separate managed identifier when a separate managed and native identifier is needed
                     // and the marshaller is not the "managed exception" marshaller (whose managed identifier is defined by the catch clause).
-                    if (boundaryBehavior != ValueBoundaryBehavior.ManagedIdentifier && !marshaller.TypeInfo.IsManagedExceptionPosition)
+                    if (boundaryBehavior != ValueBoundaryBehavior.ManagedIdentifier && !marshaller.TypeInfo.IsErrorHandlingPosition)
                     {
                         statementsToUpdate.Add(Declare(
                             marshaller.TypeInfo.ManagedType.Syntax,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
@@ -52,7 +52,6 @@ namespace Microsoft.Interop
                 if (errorInfo is
                     {
                         IsErrorHandlingPosition: true,
-                        IsManagedIdentifierSynthetic: true,
                         ManagedIndex: TypePositionInfo.ErrorIndex,
                     }
                     && !ReferenceEquals(errorMarshaller, marshallers.NativeReturnMarshaller))

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
@@ -12,8 +12,7 @@ namespace System.Runtime.InteropServices
     {
         ReturnValue = 0,
         LastParameter = 1,
-        SystemError = 2,
-        HiddenReturnValue = 3,
+        HiddenReturnValue = 2,
     }
 
     [AttributeUsage(AttributeTargets.Method)]
@@ -29,7 +28,6 @@ namespace LibraryImportGenerator.IntegrationTests
 {
     internal readonly record struct CustomError(int Value);
     internal readonly record struct CleanupInput(int Value);
-    internal readonly record struct SystemError(int Value);
     internal readonly record struct TrackedOutput(int Value);
 
     internal sealed class CustomErrorException(int error) : Exception
@@ -50,22 +48,6 @@ namespace LibraryImportGenerator.IntegrationTests
             }
 
             return new CustomError(error);
-        }
-    }
-
-    [CustomMarshaller(typeof(SystemError), MarshalMode.Default, typeof(SystemErrorMarshaller))]
-    internal static class SystemErrorMarshaller
-    {
-        public static int ConvertToUnmanaged(SystemError error) => error.Value;
-
-        public static SystemError ConvertToManaged(int error)
-        {
-            if (error < 0)
-            {
-                throw new CustomErrorException(error);
-            }
-
-            return new SystemError(error);
         }
     }
 
@@ -126,14 +108,6 @@ namespace LibraryImportGenerator.IntegrationTests
             [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
             public static partial void InjectedErrorParameter();
 
-            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error")]
-            [ErrorHandler(typeof(SystemErrorMarshaller), ErrorLocation.SystemError)]
-            public static partial void HandleSystemError(int error, byte shouldSetError);
-
-            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error")]
-            [ErrorHandler(typeof(SystemErrorMarshaller), ErrorLocation.SystemError)]
-            public static partial void ReturnSystemError(int error, byte shouldSetError, out SystemError errorValue);
-
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error_with_output")]
             [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.ReturnValue)]
             public static partial void ReturnErrorBeforeOutput(
@@ -149,12 +123,6 @@ namespace LibraryImportGenerator.IntegrationTests
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_output_and_error_out")]
             [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
             public static partial void LastParameterErrorBeforeOutput(
-                int error,
-                [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
-
-            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error_with_output")]
-            [ErrorHandler(typeof(SystemErrorMarshaller), ErrorLocation.SystemError)]
-            public static partial void SystemErrorBeforeOutput(
                 int error,
                 [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
 
@@ -207,26 +175,9 @@ namespace LibraryImportGenerator.IntegrationTests
             NativeExportsNE.ErrorHandling.InjectedErrorParameter();
         }
 
-        [Fact]
-        public void SystemErrorCanBeHandledWithoutManagedOutput()
-        {
-            NativeExportsNE.ErrorHandling.HandleSystemError(0, shouldSetError: 1);
-            CustomErrorException exception = Assert.Throws<CustomErrorException>(
-                () => NativeExportsNE.ErrorHandling.HandleSystemError(-2, shouldSetError: 1));
-            Assert.Equal(-2, exception.Error);
-        }
-
-        [Fact]
-        public void SystemErrorCanBeObservedThroughLastOutParameter()
-        {
-            NativeExportsNE.ErrorHandling.ReturnSystemError(42, shouldSetError: 1, out SystemError error);
-            Assert.Equal(new SystemError(42), error);
-        }
-
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
-        [InlineData(2)]
         public void ErrorHandlingPrecedesOtherOutMarshalling(int location)
         {
             TrackedOutputMarshaller.ConvertToManagedCalled = false;
@@ -237,8 +188,6 @@ namespace LibraryImportGenerator.IntegrationTests
                     () => NativeExportsNE.ErrorHandling.ReturnErrorBeforeOutput(-3, out _)),
                 1 => Assert.Throws<CustomErrorException>(
                     () => NativeExportsNE.ErrorHandling.LastParameterErrorBeforeOutput(-3, out _)),
-                2 => Assert.Throws<CustomErrorException>(
-                    () => NativeExportsNE.ErrorHandling.SystemErrorBeforeOutput(-3, out _)),
                 _ => throw new ArgumentOutOfRangeException(nameof(location)),
             };
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
@@ -75,6 +75,7 @@ namespace LibraryImportGenerator.IntegrationTests
 
             public static bool FromUnmanagedCalled { get; set; }
             public static bool ToManagedCalled { get; set; }
+            public static bool FreeCalled { get; set; }
 
             public void FromUnmanaged(int error)
             {
@@ -95,6 +96,37 @@ namespace LibraryImportGenerator.IntegrationTests
 
             public void Free()
             {
+                FreeCalled = true;
+            }
+        }
+    }
+
+    [CustomMarshaller(typeof(CustomError), MarshalMode.ManagedToUnmanagedOut, typeof(StatefulResultMarshaller.Marshaller))]
+    internal static class StatefulResultMarshaller
+    {
+        public struct Marshaller
+        {
+            private int _error;
+
+            public static bool FromUnmanagedCalled { get; set; }
+            public static bool ToManagedCalled { get; set; }
+            public static bool FreeCalled { get; set; }
+
+            public void FromUnmanaged(int error)
+            {
+                FromUnmanagedCalled = true;
+                _error = error;
+            }
+
+            public CustomError ToManaged()
+            {
+                ToManagedCalled = true;
+                return new CustomError(_error);
+            }
+
+            public void Free()
+            {
+                FreeCalled = true;
             }
         }
     }
@@ -169,7 +201,7 @@ namespace LibraryImportGenerator.IntegrationTests
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error_with_output")]
             [ErrorHandler(typeof(StatefulErrorMarshaller), ErrorLocation.ReturnValue)]
-            [return: MarshalUsing(typeof(CustomErrorMarshaller))]
+            [return: MarshalUsing(typeof(StatefulResultMarshaller))]
             public static partial CustomError StatefulReturnErrorBeforeOutput(
                 int error,
                 [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
@@ -185,6 +217,12 @@ namespace LibraryImportGenerator.IntegrationTests
             public static partial void HiddenLastParameterErrorBeforeOutput(
                 int error,
                 [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error_out")]
+            [ErrorHandler(typeof(StatefulErrorMarshaller), ErrorLocation.LastParameter)]
+            public static partial void StatefulLastParameterError(
+                int error,
+                [MarshalUsing(typeof(StatefulResultMarshaller))] out CustomError errorValue);
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error")]
             [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.HiddenReturnValue)]
@@ -301,6 +339,10 @@ namespace LibraryImportGenerator.IntegrationTests
         {
             StatefulErrorMarshaller.Marshaller.FromUnmanagedCalled = false;
             StatefulErrorMarshaller.Marshaller.ToManagedCalled = false;
+            StatefulErrorMarshaller.Marshaller.FreeCalled = false;
+            StatefulResultMarshaller.Marshaller.FromUnmanagedCalled = false;
+            StatefulResultMarshaller.Marshaller.ToManagedCalled = false;
+            StatefulResultMarshaller.Marshaller.FreeCalled = false;
             TrackedOutputMarshaller.ConvertToManagedCalled = false;
 
             CustomErrorException exception = Assert.Throws<CustomErrorException>(
@@ -309,7 +351,33 @@ namespace LibraryImportGenerator.IntegrationTests
             Assert.Equal(-5, exception.Error);
             Assert.True(StatefulErrorMarshaller.Marshaller.FromUnmanagedCalled);
             Assert.True(StatefulErrorMarshaller.Marshaller.ToManagedCalled);
+            Assert.True(StatefulErrorMarshaller.Marshaller.FreeCalled);
+            Assert.False(StatefulResultMarshaller.Marshaller.FromUnmanagedCalled);
+            Assert.False(StatefulResultMarshaller.Marshaller.ToManagedCalled);
+            Assert.False(StatefulResultMarshaller.Marshaller.FreeCalled);
             Assert.False(TrackedOutputMarshaller.ConvertToManagedCalled);
+        }
+
+        [Fact]
+        public void StatefulLastParameterErrorCleanupRunsWhenConversionThrows()
+        {
+            StatefulErrorMarshaller.Marshaller.FromUnmanagedCalled = false;
+            StatefulErrorMarshaller.Marshaller.ToManagedCalled = false;
+            StatefulErrorMarshaller.Marshaller.FreeCalled = false;
+            StatefulResultMarshaller.Marshaller.FromUnmanagedCalled = false;
+            StatefulResultMarshaller.Marshaller.ToManagedCalled = false;
+            StatefulResultMarshaller.Marshaller.FreeCalled = false;
+
+            CustomErrorException exception = Assert.Throws<CustomErrorException>(
+                () => NativeExportsNE.ErrorHandling.StatefulLastParameterError(-6, out _));
+
+            Assert.Equal(-6, exception.Error);
+            Assert.True(StatefulErrorMarshaller.Marshaller.FromUnmanagedCalled);
+            Assert.True(StatefulErrorMarshaller.Marshaller.ToManagedCalled);
+            Assert.True(StatefulErrorMarshaller.Marshaller.FreeCalled);
+            Assert.False(StatefulResultMarshaller.Marshaller.FromUnmanagedCalled);
+            Assert.False(StatefulResultMarshaller.Marshaller.ToManagedCalled);
+            Assert.False(StatefulResultMarshaller.Marshaller.FreeCalled);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
@@ -1,0 +1,251 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Xunit;
+
+namespace System.Runtime.InteropServices
+{
+    internal enum ErrorLocation
+    {
+        ReturnValue = 0,
+        LastParameter = 1,
+        SystemError = 2,
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class ErrorHandlerAttribute : Attribute
+    {
+        public ErrorHandlerAttribute(Type marshallerType, ErrorLocation errorLocation)
+        {
+        }
+    }
+}
+
+namespace LibraryImportGenerator.IntegrationTests
+{
+    internal readonly record struct CustomError(int Value);
+    internal readonly record struct CleanupInput(int Value);
+    internal readonly record struct SystemError(int Value);
+    internal readonly record struct TrackedOutput(int Value);
+
+    internal sealed class CustomErrorException(int error) : Exception
+    {
+        public int Error { get; } = error;
+    }
+
+    [CustomMarshaller(typeof(CustomError), MarshalMode.Default, typeof(CustomErrorMarshaller))]
+    internal static class CustomErrorMarshaller
+    {
+        public static int ConvertToUnmanaged(CustomError error) => error.Value;
+
+        public static CustomError ConvertToManaged(int error)
+        {
+            if (error < 0)
+            {
+                throw new CustomErrorException(error);
+            }
+
+            return new CustomError(error);
+        }
+    }
+
+    [CustomMarshaller(typeof(SystemError), MarshalMode.Default, typeof(SystemErrorMarshaller))]
+    internal static class SystemErrorMarshaller
+    {
+        public static int ConvertToUnmanaged(SystemError error) => error.Value;
+
+        public static SystemError ConvertToManaged(int error)
+        {
+            if (error < 0)
+            {
+                throw new CustomErrorException(error);
+            }
+
+            return new SystemError(error);
+        }
+    }
+
+    [CustomMarshaller(typeof(CleanupInput), MarshalMode.ManagedToUnmanagedIn, typeof(CleanupInputMarshaller))]
+    internal static class CleanupInputMarshaller
+    {
+        public static bool FreeCalled { get; set; }
+
+        public static nint ConvertToUnmanaged(CleanupInput input)
+        {
+            nint value = Marshal.AllocCoTaskMem(sizeof(int));
+            Marshal.WriteInt32(value, input.Value);
+            return value;
+        }
+
+        public static void Free(nint value)
+        {
+            FreeCalled = true;
+            Marshal.FreeCoTaskMem(value);
+        }
+    }
+
+    [CustomMarshaller(typeof(TrackedOutput), MarshalMode.Default, typeof(TrackedOutputMarshaller))]
+    internal static class TrackedOutputMarshaller
+    {
+        public static bool ConvertToManagedCalled { get; set; }
+
+        public static int ConvertToUnmanaged(TrackedOutput value) => value.Value;
+
+        public static TrackedOutput ConvertToManaged(int value)
+        {
+            ConvertToManagedCalled = true;
+            return new TrackedOutput(value);
+        }
+    }
+
+    partial class NativeExportsNE
+    {
+        internal static partial class ErrorHandling
+        {
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.ReturnValue)]
+            public static partial CustomError ReturnError(int error);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.ReturnValue)]
+            public static partial void HandleReturnError(int error);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error_out")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
+            public static partial void ErrorInOutParameter(int error, out CustomError errorValue);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error_ref")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
+            public static partial void ErrorInRefParameter(int error, ref CustomError errorValue);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_constant_error_out")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
+            public static partial void InjectedErrorParameter();
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error")]
+            [ErrorHandler(typeof(SystemErrorMarshaller), ErrorLocation.SystemError)]
+            public static partial void HandleSystemError(int error, byte shouldSetError);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error")]
+            [ErrorHandler(typeof(SystemErrorMarshaller), ErrorLocation.SystemError)]
+            public static partial void ReturnSystemError(int error, byte shouldSetError, out SystemError errorValue);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error_with_output")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.ReturnValue)]
+            public static partial void ReturnErrorBeforeOutput(
+                int error,
+                [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error_with_input")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.ReturnValue)]
+            public static partial void ReturnErrorWithAllocatedInput(
+                int error,
+                [MarshalUsing(typeof(CleanupInputMarshaller))] CleanupInput input);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_output_and_error_out")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
+            public static partial void LastParameterErrorBeforeOutput(
+                int error,
+                [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error_with_output")]
+            [ErrorHandler(typeof(SystemErrorMarshaller), ErrorLocation.SystemError)]
+            public static partial void SystemErrorBeforeOutput(
+                int error,
+                [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
+        }
+    }
+
+    public class ErrorHandlingTests
+    {
+        [Fact]
+        public void ReturnValueCanBeObserved()
+        {
+            Assert.Equal(new CustomError(42), NativeExportsNE.ErrorHandling.ReturnError(42));
+        }
+
+        [Fact]
+        public void ReturnValueCanBeHandledWithoutManagedReturn()
+        {
+            NativeExportsNE.ErrorHandling.HandleReturnError(0);
+            CustomErrorException exception = Assert.Throws<CustomErrorException>(
+                () => NativeExportsNE.ErrorHandling.HandleReturnError(-1));
+            Assert.Equal(-1, exception.Error);
+        }
+
+        [Fact]
+        public void LastOutParameterCanBeObserved()
+        {
+            NativeExportsNE.ErrorHandling.ErrorInOutParameter(42, out CustomError error);
+            Assert.Equal(new CustomError(42), error);
+        }
+
+        [Fact]
+        public void LastRefParameterCanBeObserved()
+        {
+            CustomError error = new(1);
+            NativeExportsNE.ErrorHandling.ErrorInRefParameter(42, ref error);
+            Assert.Equal(new CustomError(43), error);
+        }
+
+        [Fact]
+        public void LastParameterIsInjectedWhenMissing()
+        {
+            NativeExportsNE.ErrorHandling.InjectedErrorParameter();
+        }
+
+        [Fact]
+        public void SystemErrorCanBeHandledWithoutManagedOutput()
+        {
+            NativeExportsNE.ErrorHandling.HandleSystemError(0, shouldSetError: 1);
+            CustomErrorException exception = Assert.Throws<CustomErrorException>(
+                () => NativeExportsNE.ErrorHandling.HandleSystemError(-2, shouldSetError: 1));
+            Assert.Equal(-2, exception.Error);
+        }
+
+        [Fact]
+        public void SystemErrorCanBeObservedThroughLastOutParameter()
+        {
+            NativeExportsNE.ErrorHandling.ReturnSystemError(42, shouldSetError: 1, out SystemError error);
+            Assert.Equal(new SystemError(42), error);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void ErrorHandlingPrecedesOtherOutMarshalling(int location)
+        {
+            TrackedOutputMarshaller.ConvertToManagedCalled = false;
+
+            CustomErrorException exception = location switch
+            {
+                0 => Assert.Throws<CustomErrorException>(
+                    () => NativeExportsNE.ErrorHandling.ReturnErrorBeforeOutput(-3, out _)),
+                1 => Assert.Throws<CustomErrorException>(
+                    () => NativeExportsNE.ErrorHandling.LastParameterErrorBeforeOutput(-3, out _)),
+                2 => Assert.Throws<CustomErrorException>(
+                    () => NativeExportsNE.ErrorHandling.SystemErrorBeforeOutput(-3, out _)),
+                _ => throw new ArgumentOutOfRangeException(nameof(location)),
+            };
+
+            Assert.Equal(-3, exception.Error);
+            Assert.False(TrackedOutputMarshaller.ConvertToManagedCalled);
+        }
+
+        [Fact]
+        public void ErrorHandlingExceptionCleansUpCallerAllocatedMemory()
+        {
+            CleanupInputMarshaller.FreeCalled = false;
+
+            CustomErrorException exception = Assert.Throws<CustomErrorException>(
+                () => NativeExportsNE.ErrorHandling.ReturnErrorWithAllocatedInput(-4, new CleanupInput(42)));
+
+            Assert.Equal(-4, exception.Error);
+            Assert.True(CleanupInputMarshaller.FreeCalled);
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
@@ -13,6 +13,7 @@ namespace System.Runtime.InteropServices
         ReturnValue = 0,
         LastParameter = 1,
         HiddenReturnValue = 2,
+        HiddenLastParameter = 3,
     }
 
     [AttributeUsage(AttributeTargets.Method)]
@@ -48,6 +49,20 @@ namespace LibraryImportGenerator.IntegrationTests
             }
 
             return new CustomError(error);
+        }
+    }
+
+    [CustomMarshaller(typeof(CustomError), MarshalMode.Default, typeof(ObservedCustomErrorMarshaller))]
+    internal static class ObservedCustomErrorMarshaller
+    {
+        public static bool ConvertToManagedCalled { get; set; }
+
+        public static int ConvertToUnmanaged(CustomError error) => error.Value;
+
+        public static CustomError ConvertToManaged(int error)
+        {
+            ConvertToManagedCalled = true;
+            return new CustomError(error + 1000);
         }
     }
 
@@ -123,6 +138,7 @@ namespace LibraryImportGenerator.IntegrationTests
         {
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error")]
             [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.ReturnValue)]
+            [return: MarshalUsing(typeof(ObservedCustomErrorMarshaller))]
             public static partial CustomError ReturnError(int error);
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error")]
@@ -131,14 +147,18 @@ namespace LibraryImportGenerator.IntegrationTests
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error_out")]
             [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
-            public static partial void ErrorInOutParameter(int error, out CustomError errorValue);
+            public static partial void ErrorInOutParameter(
+                int error,
+                [MarshalUsing(typeof(ObservedCustomErrorMarshaller))] out CustomError errorValue);
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error_ref")]
             [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
-            public static partial void ErrorInRefParameter(int error, ref CustomError errorValue);
+            public static partial void ErrorInRefParameter(
+                int error,
+                [MarshalUsing(typeof(ObservedCustomErrorMarshaller))] ref CustomError errorValue);
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_constant_error_out")]
-            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.HiddenLastParameter)]
             public static partial void InjectedErrorParameter();
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error_with_output")]
@@ -160,8 +180,8 @@ namespace LibraryImportGenerator.IntegrationTests
                 [MarshalUsing(typeof(CleanupInputMarshaller))] CleanupInput input);
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_output_and_error_out")]
-            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.LastParameter)]
-            public static partial void LastParameterErrorBeforeOutput(
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.HiddenLastParameter)]
+            public static partial void HiddenLastParameterErrorBeforeOutput(
                 int error,
                 [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
 
@@ -181,7 +201,10 @@ namespace LibraryImportGenerator.IntegrationTests
         [Fact]
         public void ReturnValueCanBeObserved()
         {
-            Assert.Equal(new CustomError(42), NativeExportsNE.ErrorHandling.ReturnError(42));
+            ObservedCustomErrorMarshaller.ConvertToManagedCalled = false;
+
+            Assert.Equal(new CustomError(1042), NativeExportsNE.ErrorHandling.ReturnError(42));
+            Assert.True(ObservedCustomErrorMarshaller.ConvertToManagedCalled);
         }
 
         [Fact]
@@ -196,20 +219,46 @@ namespace LibraryImportGenerator.IntegrationTests
         [Fact]
         public void LastOutParameterCanBeObserved()
         {
+            ObservedCustomErrorMarshaller.ConvertToManagedCalled = false;
+
             NativeExportsNE.ErrorHandling.ErrorInOutParameter(42, out CustomError error);
-            Assert.Equal(new CustomError(42), error);
+            Assert.Equal(new CustomError(1042), error);
+            Assert.True(ObservedCustomErrorMarshaller.ConvertToManagedCalled);
         }
 
         [Fact]
         public void LastRefParameterCanBeObserved()
         {
+            ObservedCustomErrorMarshaller.ConvertToManagedCalled = false;
+
             CustomError error = new(1);
             NativeExportsNE.ErrorHandling.ErrorInRefParameter(42, ref error);
-            Assert.Equal(new CustomError(43), error);
+            Assert.Equal(new CustomError(1043), error);
+            Assert.True(ObservedCustomErrorMarshaller.ConvertToManagedCalled);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ErrorHandlingPrecedesOverlappingValueMarshalling(int location)
+        {
+            ObservedCustomErrorMarshaller.ConvertToManagedCalled = false;
+
+            CustomErrorException exception = location switch
+            {
+                0 => Assert.Throws<CustomErrorException>(
+                    () => NativeExportsNE.ErrorHandling.ReturnError(-2)),
+                1 => Assert.Throws<CustomErrorException>(
+                    () => NativeExportsNE.ErrorHandling.ErrorInOutParameter(-2, out _)),
+                _ => throw new ArgumentOutOfRangeException(nameof(location)),
+            };
+
+            Assert.Equal(-2, exception.Error);
+            Assert.False(ObservedCustomErrorMarshaller.ConvertToManagedCalled);
         }
 
         [Fact]
-        public void LastParameterIsInjectedWhenMissing()
+        public void HiddenLastParameterIsInjected()
         {
             NativeExportsNE.ErrorHandling.InjectedErrorParameter();
         }
@@ -226,7 +275,7 @@ namespace LibraryImportGenerator.IntegrationTests
                 0 => Assert.Throws<CustomErrorException>(
                     () => NativeExportsNE.ErrorHandling.ReturnErrorBeforeOutput(-3, out _)),
                 1 => Assert.Throws<CustomErrorException>(
-                    () => NativeExportsNE.ErrorHandling.LastParameterErrorBeforeOutput(-3, out _)),
+                    () => NativeExportsNE.ErrorHandling.HiddenLastParameterErrorBeforeOutput(-3, out _)),
                 _ => throw new ArgumentOutOfRangeException(nameof(location)),
             };
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
@@ -13,6 +13,7 @@ namespace System.Runtime.InteropServices
         ReturnValue = 0,
         LastParameter = 1,
         SystemError = 2,
+        HiddenReturnValue = 3,
     }
 
     [AttributeUsage(AttributeTargets.Method)]
@@ -156,6 +157,15 @@ namespace LibraryImportGenerator.IntegrationTests
             public static partial void SystemErrorBeforeOutput(
                 int error,
                 [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.HiddenReturnValue)]
+            public static partial void HandleHiddenReturnError(int error);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error_with_hidden_return")]
+            [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.HiddenReturnValue)]
+            [return: MarshalUsing(typeof(TrackedOutputMarshaller))]
+            public static partial TrackedOutput HiddenReturnValue(int error);
         }
     }
 
@@ -246,6 +256,29 @@ namespace LibraryImportGenerator.IntegrationTests
 
             Assert.Equal(-4, exception.Error);
             Assert.True(CleanupInputMarshaller.FreeCalled);
+        }
+
+        [Fact]
+        public void HiddenReturnValueWithVoidManagedReturnHandlesNativeReturnError()
+        {
+            NativeExportsNE.ErrorHandling.HandleHiddenReturnError(0);
+            CustomErrorException exception = Assert.Throws<CustomErrorException>(
+                () => NativeExportsNE.ErrorHandling.HandleHiddenReturnError(-5));
+            Assert.Equal(-5, exception.Error);
+        }
+
+        [Fact]
+        public void HiddenReturnValueMovesManagedReturnToNativeOutParameter()
+        {
+            TrackedOutputMarshaller.ConvertToManagedCalled = false;
+            Assert.Equal(new TrackedOutput(42), NativeExportsNE.ErrorHandling.HiddenReturnValue(0));
+            Assert.True(TrackedOutputMarshaller.ConvertToManagedCalled);
+
+            TrackedOutputMarshaller.ConvertToManagedCalled = false;
+            CustomErrorException exception = Assert.Throws<CustomErrorException>(
+                () => NativeExportsNE.ErrorHandling.HiddenReturnValue(-5));
+            Assert.Equal(-5, exception.Error);
+            Assert.False(TrackedOutputMarshaller.ConvertToManagedCalled);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
@@ -51,6 +51,39 @@ namespace LibraryImportGenerator.IntegrationTests
         }
     }
 
+    [CustomMarshaller(typeof(CustomError), MarshalMode.ManagedToUnmanagedOut, typeof(StatefulErrorMarshaller.Marshaller))]
+    internal static class StatefulErrorMarshaller
+    {
+        public struct Marshaller
+        {
+            private int _error;
+
+            public static bool FromUnmanagedCalled { get; set; }
+            public static bool ToManagedCalled { get; set; }
+
+            public void FromUnmanaged(int error)
+            {
+                FromUnmanagedCalled = true;
+                _error = error;
+            }
+
+            public CustomError ToManaged()
+            {
+                ToManagedCalled = true;
+                if (_error < 0)
+                {
+                    throw new CustomErrorException(_error);
+                }
+
+                return new CustomError(_error);
+            }
+
+            public void Free()
+            {
+            }
+        }
+    }
+
     [CustomMarshaller(typeof(CleanupInput), MarshalMode.ManagedToUnmanagedIn, typeof(CleanupInputMarshaller))]
     internal static class CleanupInputMarshaller
     {
@@ -111,6 +144,12 @@ namespace LibraryImportGenerator.IntegrationTests
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error_with_output")]
             [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.ReturnValue)]
             public static partial void ReturnErrorBeforeOutput(
+                int error,
+                [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error_with_output")]
+            [ErrorHandler(typeof(StatefulErrorMarshaller), ErrorLocation.ReturnValue)]
+            public static partial CustomError StatefulReturnErrorBeforeOutput(
                 int error,
                 [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);
 
@@ -205,6 +244,22 @@ namespace LibraryImportGenerator.IntegrationTests
 
             Assert.Equal(-4, exception.Error);
             Assert.True(CleanupInputMarshaller.FreeCalled);
+        }
+
+        [Fact]
+        public void ErrorUnmarshalStagesRunBeforeOtherOutMarshalling()
+        {
+            StatefulErrorMarshaller.Marshaller.FromUnmanagedCalled = false;
+            StatefulErrorMarshaller.Marshaller.ToManagedCalled = false;
+            TrackedOutputMarshaller.ConvertToManagedCalled = false;
+
+            CustomErrorException exception = Assert.Throws<CustomErrorException>(
+                () => NativeExportsNE.ErrorHandling.StatefulReturnErrorBeforeOutput(-5, out _));
+
+            Assert.Equal(-5, exception.Error);
+            Assert.True(StatefulErrorMarshaller.Marshaller.FromUnmanagedCalled);
+            Assert.True(StatefulErrorMarshaller.Marshaller.ToManagedCalled);
+            Assert.False(TrackedOutputMarshaller.ConvertToManagedCalled);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
@@ -131,6 +131,65 @@ namespace LibraryImportGenerator.IntegrationTests
         }
     }
 
+    [CustomMarshaller(typeof(CustomError), MarshalMode.ManagedToUnmanagedOut, typeof(CaptureOnlyErrorMarshaller.Marshaller))]
+    internal static class CaptureOnlyErrorMarshaller
+    {
+        public struct Marshaller
+        {
+            private int _error;
+
+            public static int LastPInvokeErrorDuringCapture { get; set; }
+
+            public void FromUnmanaged(int error)
+            {
+                _error = error;
+                LastPInvokeErrorDuringCapture = Marshal.GetLastPInvokeError();
+            }
+
+            public CustomError ToManagedFinally() => new(_error);
+
+            public void Free()
+            {
+            }
+        }
+    }
+
+    [CustomMarshaller(typeof(CustomError), MarshalMode.ManagedToUnmanagedOut, typeof(SetLastErrorObservingErrorMarshaller.Marshaller))]
+    internal static class SetLastErrorObservingErrorMarshaller
+    {
+        public struct Marshaller
+        {
+            private int _error;
+
+            public static int LastPInvokeErrorDuringCapture { get; set; }
+            public static int LastPInvokeErrorDuringConversion { get; set; }
+            public static int LastPInvokeErrorDuringFree { get; set; }
+
+            public void FromUnmanaged(int error)
+            {
+                _error = error;
+                LastPInvokeErrorDuringCapture = Marshal.GetLastPInvokeError();
+            }
+
+            public CustomError ToManaged()
+            {
+                LastPInvokeErrorDuringConversion = Marshal.GetLastPInvokeError();
+                if (_error < 0)
+                {
+                    throw new CustomErrorException(_error);
+                }
+
+                Marshal.SetLastPInvokeError(_error + 1000);
+                return new CustomError(_error);
+            }
+
+            public void Free()
+            {
+                LastPInvokeErrorDuringFree = Marshal.GetLastPInvokeError();
+            }
+        }
+    }
+
     [CustomMarshaller(typeof(CleanupInput), MarshalMode.ManagedToUnmanagedIn, typeof(CleanupInputMarshaller))]
     internal static class CleanupInputMarshaller
     {
@@ -223,6 +282,14 @@ namespace LibraryImportGenerator.IntegrationTests
             public static partial void StatefulLastParameterError(
                 int error,
                 [MarshalUsing(typeof(StatefulResultMarshaller))] out CustomError errorValue);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error", SetLastError = true)]
+            [ErrorHandler(typeof(CaptureOnlyErrorMarshaller), ErrorLocation.ReturnValue)]
+            public static partial void CaptureOnlyErrorObservesLastPInvokeError(int error, byte shouldSetError);
+
+            [LibraryImport(NativeExportsNE_Binary, EntryPoint = "set_error", SetLastError = true)]
+            [ErrorHandler(typeof(SetLastErrorObservingErrorMarshaller), ErrorLocation.ReturnValue)]
+            public static partial void ErrorLifecycleObservesLastPInvokeError(int error, byte shouldSetError);
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error")]
             [ErrorHandler(typeof(CustomErrorMarshaller), ErrorLocation.HiddenReturnValue)]
@@ -381,6 +448,51 @@ namespace LibraryImportGenerator.IntegrationTests
         }
 
         [Fact]
+        public void CaptureOnlyErrorMarshallerObservesLastPInvokeError()
+        {
+            const int Error = 123;
+            CaptureOnlyErrorMarshaller.Marshaller.LastPInvokeErrorDuringCapture = 0;
+
+            NativeExportsNE.ErrorHandling.CaptureOnlyErrorObservesLastPInvokeError(Error, shouldSetError: 1);
+
+            Assert.Equal(Error, CaptureOnlyErrorMarshaller.Marshaller.LastPInvokeErrorDuringCapture);
+            Assert.Equal(Error, Marshal.GetLastPInvokeError());
+        }
+
+        [Theory]
+        [InlineData(1, 123)]
+        [InlineData(0, 0)]
+        public void ErrorMarshallerLifecycleAndCallerObserveExpectedLastPInvokeError(
+            byte shouldSetError,
+            int expectedLastPInvokeError)
+        {
+            const int Error = 123;
+            ResetSetLastErrorObservations();
+
+            NativeExportsNE.ErrorHandling.ErrorLifecycleObservesLastPInvokeError(Error, shouldSetError);
+
+            Assert.Equal(expectedLastPInvokeError, SetLastErrorObservingErrorMarshaller.Marshaller.LastPInvokeErrorDuringCapture);
+            Assert.Equal(expectedLastPInvokeError, SetLastErrorObservingErrorMarshaller.Marshaller.LastPInvokeErrorDuringConversion);
+            Assert.Equal(Error + 1000, SetLastErrorObservingErrorMarshaller.Marshaller.LastPInvokeErrorDuringFree);
+            Assert.Equal(expectedLastPInvokeError, Marshal.GetLastPInvokeError());
+        }
+
+        [Fact]
+        public void ThrowingErrorMarshallerObservesLastPInvokeErrorAndRunsCleanup()
+        {
+            const int Error = -123;
+            ResetSetLastErrorObservations();
+
+            CustomErrorException exception = Assert.Throws<CustomErrorException>(
+                () => NativeExportsNE.ErrorHandling.ErrorLifecycleObservesLastPInvokeError(Error, shouldSetError: 1));
+
+            Assert.Equal(Error, exception.Error);
+            Assert.Equal(Error, SetLastErrorObservingErrorMarshaller.Marshaller.LastPInvokeErrorDuringCapture);
+            Assert.Equal(Error, SetLastErrorObservingErrorMarshaller.Marshaller.LastPInvokeErrorDuringConversion);
+            Assert.Equal(Error, SetLastErrorObservingErrorMarshaller.Marshaller.LastPInvokeErrorDuringFree);
+        }
+
+        [Fact]
         public void HiddenReturnValueWithVoidManagedReturnHandlesNativeReturnError()
         {
             NativeExportsNE.ErrorHandling.HandleHiddenReturnError(0);
@@ -401,6 +513,13 @@ namespace LibraryImportGenerator.IntegrationTests
                 () => NativeExportsNE.ErrorHandling.HiddenReturnValue(-5));
             Assert.Equal(-5, exception.Error);
             Assert.False(TrackedOutputMarshaller.ConvertToManagedCalled);
+        }
+
+        private static void ResetSetLastErrorObservations()
+        {
+            SetLastErrorObservingErrorMarshaller.Marshaller.LastPInvokeErrorDuringCapture = 0;
+            SetLastErrorObservingErrorMarshaller.Marshaller.LastPInvokeErrorDuringConversion = 0;
+            SetLastErrorObservingErrorMarshaller.Marshaller.LastPInvokeErrorDuringFree = 0;
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/ErrorHandlingTests.cs
@@ -169,6 +169,7 @@ namespace LibraryImportGenerator.IntegrationTests
 
             [LibraryImport(NativeExportsNE_Binary, EntryPoint = "return_error_with_output")]
             [ErrorHandler(typeof(StatefulErrorMarshaller), ErrorLocation.ReturnValue)]
+            [return: MarshalUsing(typeof(CustomErrorMarshaller))]
             public static partial CustomError StatefulReturnErrorBeforeOutput(
                 int error,
                 [MarshalUsing(typeof(TrackedOutputMarshaller))] out TrackedOutput output);

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
@@ -168,6 +168,7 @@ namespace LibraryImportGenerator.UnitTests
                     [return: MarshalAs(UnmanagedType.FunctionPtr)]
                     public static partial bool {|#1:Method2|}(int i);
                 }
+
                 """;
 
             await VerifyCS.VerifyAnalyzerAsync(source,
@@ -177,6 +178,58 @@ namespace LibraryImportGenerator.UnitTests
                 VerifyCS.Diagnostic(GeneratorDiagnostics.MarshalAsReturnConfigurationNotSupported)
                     .WithLocation(1)
                     .WithArguments(nameof(MarshalAsAttribute), "Method2"));
+        }
+
+        [Fact]
+        public async Task InvalidErrorHandlerAttribute_ReportsDiagnostic()
+        {
+            string source = """
+
+                using System;
+                using System.Runtime.InteropServices;
+
+                namespace System.Runtime.InteropServices
+                {
+                    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+                    internal sealed class ErrorHandlerAttribute : Attribute
+                    {
+                        public ErrorHandlerAttribute(Type marshallerType)
+                        {
+                        }
+
+                        public ErrorHandlerAttribute(Type marshallerType, int location)
+                        {
+                        }
+                    }
+                }
+
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    [{|#0:ErrorHandler(typeof(int))|}]
+                    public static partial void Method1();
+
+                    [LibraryImport("DoesNotExist")]
+                    [{|#1:ErrorHandler(typeof(int), 3)|}]
+                    public static partial void Method2();
+
+                    [LibraryImport("DoesNotExist")]
+                    [ErrorHandler(typeof(int), 0)]
+                    [{|#2:ErrorHandler(typeof(int), 1)|}]
+                    public static partial void Method3();
+                }
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(source,
+                VerifyCS.Diagnostic(GeneratorDiagnostics.ConfigurationNotSupported)
+                    .WithLocation(0)
+                    .WithArguments("ErrorHandlerAttribute"),
+                VerifyCS.Diagnostic(GeneratorDiagnostics.ConfigurationNotSupported)
+                    .WithLocation(1)
+                    .WithArguments("ErrorHandlerAttribute"),
+                VerifyCS.Diagnostic(GeneratorDiagnostics.ConfigurationNotSupported)
+                    .WithLocation(2)
+                    .WithArguments("ErrorHandlerAttribute"));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Diagnostics.cs
@@ -210,7 +210,7 @@ namespace LibraryImportGenerator.UnitTests
                     public static partial void Method1();
 
                     [LibraryImport("DoesNotExist")]
-                    [{|#1:ErrorHandler(typeof(int), 3)|}]
+                    [{|#1:ErrorHandler(typeof(int), 4)|}]
                     public static partial void Method2();
 
                     [LibraryImport("DoesNotExist")]
@@ -229,6 +229,58 @@ namespace LibraryImportGenerator.UnitTests
                     .WithArguments("ErrorHandlerAttribute"),
                 VerifyCS.Diagnostic(GeneratorDiagnostics.ConfigurationNotSupported)
                     .WithLocation(2)
+                    .WithArguments("ErrorHandlerAttribute"));
+        }
+
+        [Fact]
+        public async Task ErrorHandlerWithMismatchedManagedType_ReportsDiagnostic()
+        {
+            string source = """
+
+                using System;
+                using System.Runtime.InteropServices;
+                using System.Runtime.InteropServices.Marshalling;
+
+                namespace System.Runtime.InteropServices
+                {
+                    [AttributeUsage(AttributeTargets.Method)]
+                    internal sealed class ErrorHandlerAttribute : Attribute
+                    {
+                        public ErrorHandlerAttribute(Type marshallerType, int location)
+                        {
+                        }
+                    }
+                }
+
+                struct CustomError
+                {
+                }
+
+                [CustomMarshaller(typeof(CustomError), MarshalMode.Default, typeof(CustomErrorMarshaller))]
+                static class CustomErrorMarshaller
+                {
+                    public static int ConvertToUnmanaged(CustomError error) => 0;
+                    public static CustomError ConvertToManaged(int error) => default;
+                }
+
+                partial class Test
+                {
+                    [LibraryImport("DoesNotExist")]
+                    [{|#0:ErrorHandler(typeof(CustomErrorMarshaller), 0)|}]
+                    public static partial int Method1();
+
+                    [LibraryImport("DoesNotExist")]
+                    [{|#1:ErrorHandler(typeof(CustomErrorMarshaller), 1)|}]
+                    public static partial void Method2(out int error);
+                }
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(source,
+                VerifyCS.Diagnostic(GeneratorDiagnostics.ConfigurationNotSupported)
+                    .WithLocation(0)
+                    .WithArguments("ErrorHandlerAttribute"),
+                VerifyCS.Diagnostic(GeneratorDiagnostics.ConfigurationNotSupported)
+                    .WithLocation(1)
                     .WithArguments("ErrorHandlerAttribute"));
         }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Error.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Error.cs
@@ -83,13 +83,6 @@ namespace NativeExports
             *errorValue = error;
         }
 
-        [UnmanagedCallersOnly(EntryPoint = "set_error_with_output")]
-        public static void SetErrorWithOutput(int error, int* output)
-        {
-            *output = 42;
-            SetLastError(error);
-        }
-
         [UnmanagedCallersOnly(EntryPoint = "set_error_return_string")]
         public static ushort* SetErrorReturnString(int error, byte shouldSetError, ushort* errorString)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Error.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Error.cs
@@ -35,6 +35,54 @@ namespace NativeExports
             return error;
         }
 
+        [UnmanagedCallersOnly(EntryPoint = "return_error")]
+        public static int ReturnError(int error) => error;
+
+        [UnmanagedCallersOnly(EntryPoint = "set_error_out")]
+        public static void SetErrorOut(int error, int* errorValue)
+        {
+            *errorValue = error;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "set_error_ref")]
+        public static void SetErrorRef(int error, int* errorValue)
+        {
+            *errorValue += error;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "set_constant_error_out")]
+        public static void SetConstantErrorOut(int* errorValue)
+        {
+            *errorValue = 0;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "return_error_with_output")]
+        public static int ReturnErrorWithOutput(int error, int* output)
+        {
+            *output = 42;
+            return error;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "return_error_with_input")]
+        public static int ReturnErrorWithInput(int error, int* input)
+        {
+            return *input == 42 ? error : -1;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "set_output_and_error_out")]
+        public static void SetOutputAndErrorOut(int error, int* output, int* errorValue)
+        {
+            *output = 42;
+            *errorValue = error;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "set_error_with_output")]
+        public static void SetErrorWithOutput(int error, int* output)
+        {
+            *output = 42;
+            SetLastError(error);
+        }
+
         [UnmanagedCallersOnly(EntryPoint = "set_error_return_string")]
         public static ushort* SetErrorReturnString(int error, byte shouldSetError, ushort* errorString)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Error.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Error.cs
@@ -69,6 +69,13 @@ namespace NativeExports
             return *input == 42 ? error : -1;
         }
 
+        [UnmanagedCallersOnly(EntryPoint = "return_error_with_hidden_return")]
+        public static int ReturnErrorWithHiddenReturn(int error, int* value)
+        {
+            *value = 42;
+            return error;
+        }
+
         [UnmanagedCallersOnly(EntryPoint = "set_output_and_error_out")]
         public static void SetOutputAndErrorOut(int error, int* output, int* errorValue)
         {


### PR DESCRIPTION
## Summary

Add custom error handling to the `LibraryImport` source generator. A
method-level `ErrorHandlerAttribute` identifies a custom marshaller and the
location of the native error value.

The generator supports errors returned through:

- The native return value.
- A declared final managed `out` or `ref` parameter that maps to the final native
  parameter.
- A hidden final native parameter that is not present in the managed signature.
- The native return value when the logical managed return is supplied through a
  hidden final native out parameter.

Error conversion runs before logical-return and ordinary out conversion. This
allows the error marshaller to throw before potentially invalid native outputs
are read. Notification and keep-alive behavior occurs before error conversion.
With `SetLastError=true`, the native system error is captured immediately after
the call, made observable to error marshalling, and restored after successful
stub completion. `ref` error inputs remain bidirectional, and unmanaged input
cleanup still runs when error conversion throws.

The feature is intentionally recognized by metadata name. This change does not
add `ErrorHandlerAttribute` or `ErrorLocation` to the framework reference
assemblies.

## Testing

- `LibraryImportGenerator.Tests`: 306 passed.
- `LibraryImportGenerator.Unit.Tests`: 735 passed, 1 skipped.
- `ComInterfaceGenerator.Tests`: 194 passed.
- `ComInterfaceGenerator.Unit.Tests`: 899 passed.
- `JSImportGenerator.Unit.Tests`: 22 passed.
- Coverage includes every error location, exposed and hidden error values,
  explicit `out` and `ref` final parameters, hidden final native parameters, void
  and non-void hidden returns, exception ordering relative to output conversion,
  caller- and error-marshaller-allocated cleanup, `SetLastError` interactions across
  capture, conversion, mutation, cleanup, and exceptions, and invalid or duplicate
  handler attributes.

## Documentation: Handle native errors with custom marshalling

Apply `ErrorHandlerAttribute` to a `LibraryImport` method to identify a custom
marshaller for the native error value and the location from which that value is
obtained. The marshaller is defined with `CustomMarshallerAttribute` in the same
way as other source-generated custom marshallers.

Only one `ErrorHandlerAttribute` can be applied to a method. If multiple
matching attributes are present, the generator reports an unsupported
configuration instead of selecting one based on attribute order.

`ErrorLocation` supports the following values:

- `ReturnValue`: The native function returns the error value. If the managed
  method returns the marshaller's managed type, callers receive the converted
  value. If the managed method returns `void`, the converted value is used only
  for error handling and is discarded when conversion succeeds.
- `LastParameter`: The native function writes the error value through its final
  parameter. The managed signature must declare a matching final `out` or `ref`
  parameter, which receives the converted value. A missing, non-by-ref, or
  mismatched final parameter is reported as an unsupported configuration.
- `HiddenLastParameter`: The native function writes the error value through its
  final parameter, which the generator adds only to the native signature. The
  managed signature does not declare the error parameter.
- `HiddenReturnValue`: The native function returns the error value. For a
  non-void managed method, the logical return value is supplied by the native
  function through an additional final `out` parameter. For a `void` managed
  method, this behaves like `ReturnValue` and no additional native parameter is
  added.

For example, define an error marshaller that converts the native error value and
throws for failures:

```csharp
using System.Runtime.InteropServices;
using System.Runtime.InteropServices.Marshalling;

[CustomMarshaller(typeof(NativeError), MarshalMode.Default,
    typeof(NativeErrorMarshaller))]
static class NativeErrorMarshaller
{
    public static int ConvertToUnmanaged(NativeError error) => error.Value;

    public static NativeError ConvertToManaged(int error)
    {
        if (error < 0)
        {
            throw new NativeErrorException(error);
        }

        return new NativeError(error);
    }
}

[LibraryImport("NativeLibrary")]
[ErrorHandler(typeof(NativeErrorMarshaller), ErrorLocation.ReturnValue)]
static partial NativeError Invoke();
```

The managed declaration can omit an error value when only throwing behavior is
needed:

```csharp
[LibraryImport("NativeLibrary")]
[ErrorHandler(typeof(NativeErrorMarshaller), ErrorLocation.ReturnValue)]
static partial void Invoke();
```

For an error written through the final native parameter, use `LastParameter` with
a matching final `out` or `ref` managed parameter. Use `HiddenLastParameter` only
when the error parameter must be added to the native call without appearing in
the managed signature:

```csharp
[LibraryImport("NativeLibrary")]
[ErrorHandler(typeof(NativeErrorMarshaller), ErrorLocation.LastParameter)]
static partial void Invoke(out NativeError error);

[LibraryImport("NativeLibrary")]
[ErrorHandler(typeof(NativeErrorMarshaller), ErrorLocation.HiddenLastParameter)]
static partial void InvokeWithoutExposingError();
```

Use `HiddenReturnValue` when the native ABI returns an error code and writes the
logical result through its final parameter. For example, this managed
declaration:

```csharp
[LibraryImport("NativeLibrary")]
[ErrorHandler(typeof(NativeErrorMarshaller), ErrorLocation.HiddenReturnValue)]
static partial Widget CreateWidget();
```

maps to a native signature equivalent to:

```c
int create_widget(Widget* result);
```

The generator converts the native return value with
`NativeErrorMarshaller.ConvertToManaged` and, if error conversion succeeds,
converts the final native out parameter into the managed return value. If error
conversion throws, logical-return conversion does not run.

For a managed `void` return, `HiddenReturnValue` does not add a native out
parameter. The native return value is handled as the error:

```csharp
[LibraryImport("NativeLibrary")]
[ErrorHandler(typeof(NativeErrorMarshaller), ErrorLocation.HiddenReturnValue)]
static partial void PerformOperation();
```

Error marshalling is performed before the logical return value and other out
values are marshalled. If the error marshaller throws, ordinary out conversion
does not run, so native APIs do not need to initialize their output values on
failure. Cleanup for unmanaged resources allocated while marshalling inputs
still runs when error marshalling throws. After the error value is captured, cleanup
for callee-allocated resources owned by the error marshaller also runs if conversion
throws. Error conversion occurs before the invocation is marked successful, so
cleanup for ordinary callee-allocated return and out values is skipped rather than
freeing potentially uninitialized outputs. Native APIs that return other owned
resources together with an error require an explicit ownership contract.

For a managed-to-native `LibraryImport` call, the error marshaller's
unmanaged-to-managed capture and conversion stages run immediately after the
native invocation and successful-invocation notifications, before logical
return and ordinary out conversion. If the shared marshalling pipeline is used
for an unmanaged-to-managed stub, those error-unmarshal stages run before
guaranteed and ordinary input unmarshalling and before the managed target is
invoked.

With `SetLastError=true`, the stub clears the system error before the native call
and captures it immediately afterward. If the error marshaller has a capture or
conversion stage, the stub publishes the captured value once through
`Marshal.SetLastPInvokeError` before error unmarshalling starts. Error capture,
conversion, and error-owned cleanup can observe that value; if capture or
conversion changes it, later stages observe the changed value. After successful
unmarshalling and cleanup, the stub publishes the native call's captured value
again so the caller observes it. If conversion, ordinary unmarshalling, or
cleanup throws, that final publication does not run, and no post-exception last
error value is guaranteed.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
