### PR TITLE
Include issue authors in CI scan dedup searches

### DIFF
--- a/.github/workflows/shared/create-kbe.instructions.md
+++ b/.github/workflows/shared/create-kbe.instructions.md
@@ -43,6 +43,10 @@ Search open `dotnet/runtime` issues with the `Known Build Error` label. Try
 these variations in order, scanning the first ~10 results of each. GitHub
 best-match ranking can place noisier hits above the correct one.
 
+For every `search_issues` call in this flow, include `user` in the requested
+`fields`, even when the author is not otherwise needed. The integrity gateway
+uses `user.login` to recognize trusted bots before filtering search results.
+
 1. Full `[FAIL]` line.
 2. Assertion text.
 3. Exception class + test name.


### PR DESCRIPTION
## Summary

Request the `user` field in every shared KBE issue search so the integrity gateway can recognize trusted bot authors before filtering results.

This prevents Actions-authored KBEs such as #132668 from being hidden during duplicate detection, which led to duplicate #132729.

## Validation

- `gh aw compile ci-failure-scan --no-emit --validate`

> [!NOTE]
> This pull request description was generated by GitHub Copilot.