### PR TITLE
Update exception handling in SslStreamDisposeTest

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
@@ -149,7 +149,7 @@ namespace System.Net.Security.Tests
                 {
                     await task;
                 }
-                catch (InvalidOperationException ex) when (ex.StackTrace?.Contains("System.IO.StreamBuffer.WriteAsync") ?? true)
+                catch (InvalidOperationException ex) when (ex.StackTrace?.Contains("System.IO.ConnectedStreams") ?? true)
                 {
                     // Writing to a disposed ConnectedStream (test only, does not happen with NetworkStream)
                     return;


### PR DESCRIPTION
Call to `StreamBuffer.WriteAsync` may be inlined, so we check for the presence of ConnectedStreams.* instead.

Example stacktrace of a failed test:

```
    System.Net.Security.Tests.SslStreamDisposeTest.Dispose_ParallelWithHandshake_ThrowsODE [FAIL]
      System.InvalidOperationException : Operation is not valid due to the current state of the object.
      Stack Trace:
        /_/src/libraries/Common/tests/System/IO/ConnectedStreams.cs(401,0): at System.IO.ConnectedStreams.BidirectionalStreamBufferStream.WriteAsync(ReadOnlyMemory`1 buffer, CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs(380,0): at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
        /_/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs(150,0): at System.Net.Security.Tests.SslStreamDisposeTest.<Dispose_ParallelWithHandshake_ThrowsODE>g__ValidateExceptionAsync|3_1(Task task)
        /_/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs(143,0): at System.Net.Security.Tests.SslStreamDisposeTest.<>c__DisplayClass3_0.<Dispose_ParallelWithHandshake_ThrowsODE>b__0(Int32 i, CancellationToken token)
        /_/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs(301,0): at System.Threading.Tasks.Parallel.<>c__53`1.<ForEachAsync>b__53_0(Object o)
        /_/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs(115,0): at System.Net.Security.Tests.SslStreamDisposeTest.Dispose_ParallelWithHandshake_ThrowsODE()
        --- End of stack trace from previous location ---
```