### PR TITLE
Improve ILLink test parallelism

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,7 +12,10 @@ namespace Mono.Linker.Tests.TestCases
 {
     public static class TestDatabase
     {
-        private static TestCase[] _cachedAllCases;
+        private static readonly Lazy<TestCase[]> s_allCases = new(() => CreateCollector()
+            .Collect()
+            .OrderBy(c => c.DisplayName)
+            .ToArray());
 
         public static IEnumerable<object[]> AdvancedTests()
         {
@@ -283,12 +287,7 @@ namespace Mono.Linker.Tests.TestCases
 
         static IEnumerable<TestCase> AllCases()
         {
-            _cachedAllCases ??= CreateCollector()
-                    .Collect()
-                    .OrderBy(c => c.DisplayName)
-                    .ToArray();
-
-            return _cachedAllCases;
+            return s_allCases.Value;
         }
 
         static IEnumerable<object[]> TestCasesBySuiteName(string suiteName)

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -28,6 +28,12 @@ namespace Mono.Linker.Tests.TestCases
             return TestCasesBySuiteName("Attributes");
         }
 
+        public static IEnumerable<object[]> AttributeTestsShard(int shardIndex, int shardCount)
+        {
+            return TestCasesBySuiteName("Attributes")
+                .Where((_, index) => index % shardCount == shardIndex);
+        }
+
         public static IEnumerable<object[]> AttributesStructLayoutTests()
         {
             return TestCasesBySuiteName("Attributes.StructLayout");
@@ -73,6 +79,12 @@ namespace Mono.Linker.Tests.TestCases
             return TestCasesBySuiteName("DataFlow");
         }
 
+        public static IEnumerable<object[]> DataFlowTestsShard(int shardIndex, int shardCount)
+        {
+            return TestCasesBySuiteName("DataFlow")
+                .Where((_, index) => index % shardCount == shardIndex);
+        }
+
         public static IEnumerable<object[]> DynamicDependenciesTests()
         {
             return TestCasesBySuiteName("DynamicDependencies");
@@ -111,6 +123,12 @@ namespace Mono.Linker.Tests.TestCases
         public static IEnumerable<object[]> InheritanceInterfaceTests()
         {
             return TestCasesBySuiteName("Inheritance.Interfaces");
+        }
+
+        public static IEnumerable<object[]> InheritanceInterfaceTestsShard(int shardIndex, int shardCount)
+        {
+            return TestCasesBySuiteName("Inheritance.Interfaces")
+                .Where((_, index) => index % shardCount == shardIndex);
         }
 
         public static IEnumerable<object[]> InheritanceVirtualMethodsTests()

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -69,7 +69,7 @@ namespace Mono.Linker.Tests.TestCases
 
         [ConditionalTheory]
         [MemberData(nameof(TestDatabase.FunctionPointersTests), MemberType = typeof(TestDatabase))]
-        public void FunctionPointerTests(TestCase testCase)
+        public void FunctionPointersTests(TestCase testCase)
         {
             Run(testCase);
         }

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -7,18 +7,11 @@ using Xunit;
 
 namespace Mono.Linker.Tests.TestCases
 {
-    public class All
+    public class All : LinkerTestSuite
     {
         [ConditionalTheory]
         [MemberData(nameof(TestDatabase.AdvancedTests), MemberType = typeof(TestDatabase))]
         public void AdvancedTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.AttributeDebuggerTests), MemberType = typeof(TestDatabase))]
-        public void AttributesDebuggerTests(TestCase testCase)
         {
             Run(testCase);
         }
@@ -31,22 +24,8 @@ namespace Mono.Linker.Tests.TestCases
         }
 
         [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.AttributeTests), MemberType = typeof(TestDatabase))]
-        public void AttributesTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
         [MemberData(nameof(TestDatabase.BCLFeaturesTests), MemberType = typeof(TestDatabase))]
         public void BCLFeaturesTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.BasicTests), MemberType = typeof(TestDatabase))]
-        public void BasicTests(TestCase testCase)
         {
             Run(testCase);
         }
@@ -75,36 +54,8 @@ namespace Mono.Linker.Tests.TestCases
         }
 
         [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.CoreLinkTests), MemberType = typeof(TestDatabase))]
-        public void CoreLinkTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
         [MemberData(nameof(TestDatabase.CppCLITests), MemberType = typeof(TestDatabase))]
         public void CppCLITests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.DataFlowTests), MemberType = typeof(TestDatabase))]
-        public void DataFlowTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.DynamicDependenciesTests), MemberType = typeof(TestDatabase))]
-        public void DynamicDependenciesTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.ExtensibilityTests), MemberType = typeof(TestDatabase))]
-        public void ExtensibilityTests(TestCase testCase)
         {
             Run(testCase);
         }
@@ -124,29 +75,8 @@ namespace Mono.Linker.Tests.TestCases
         }
 
         [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.GenericsTests), MemberType = typeof(TestDatabase))]
-        public void GenericsTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.InheritanceAbstractClassTests), MemberType = typeof(TestDatabase))]
-        public void InheritanceAbstractClassTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
         [MemberData(nameof(TestDatabase.InheritanceComplexTests), MemberType = typeof(TestDatabase))]
         public void InheritanceComplexTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.InheritanceInterfaceTests), MemberType = typeof(TestDatabase))]
-        public void InheritanceInterfaceTests(TestCase testCase)
         {
             Run(testCase);
         }
@@ -161,13 +91,6 @@ namespace Mono.Linker.Tests.TestCases
         [ConditionalTheory]
         [MemberData(nameof(TestDatabase.InlineArrayTests), MemberType = typeof(TestDatabase))]
         public void InlineArrayTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.InteropTests), MemberType = typeof(TestDatabase))]
-        public void InteropTests(TestCase testCase)
         {
             Run(testCase);
         }
@@ -203,20 +126,6 @@ namespace Mono.Linker.Tests.TestCases
         [ConditionalTheory]
         [MemberData(nameof(TestDatabase.ReferencesTests), MemberType = typeof(TestDatabase))]
         public void ReferencesTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.ReflectionTests), MemberType = typeof(TestDatabase))]
-        public void ReflectionTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.RequiresCapabilityTests), MemberType = typeof(TestDatabase))]
-        public void RequiresCapabilityTests(TestCase testCase)
         {
             Run(testCase);
         }
@@ -264,20 +173,6 @@ namespace Mono.Linker.Tests.TestCases
         }
 
         [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.SymbolsTests), MemberType = typeof(TestDatabase))]
-        public void SymbolsTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.TestFrameworkTests), MemberType = typeof(TestDatabase))]
-        public void TestFrameworkTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
         [MemberData(nameof(TestDatabase.TopLevelStatementsTests), MemberType = typeof(TestDatabase))]
         public void TopLevelStatementsTests(TestCase testCase)
         {
@@ -287,41 +182,6 @@ namespace Mono.Linker.Tests.TestCases
         [ConditionalTheory]
         [MemberData(nameof(TestDatabase.TracingTests), MemberType = typeof(TestDatabase))]
         public void TracingTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.TypeForwardingTests), MemberType = typeof(TestDatabase))]
-        public void TypeForwardingTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.UnreachableBlockTests), MemberType = typeof(TestDatabase))]
-        public void UnreachableBlockTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.UnreachableBodyTests), MemberType = typeof(TestDatabase))]
-        public void UnreachableBodyTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.WarningsTests), MemberType = typeof(TestDatabase))]
-        public void WarningsTests(TestCase testCase)
-        {
-            Run(testCase);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(TestDatabase.XmlTests), MemberType = typeof(TestDatabase))]
-        public void XmlTests(TestCase testCase)
         {
             Run(testCase);
         }
@@ -340,6 +200,240 @@ namespace Mono.Linker.Tests.TestCases
             Run(testCase);
         }
 
+    }
+
+    public class Basic : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.BasicTests), MemberType = typeof(TestDatabase))]
+        public void BasicTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class CoreLink : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.CoreLinkTests), MemberType = typeof(TestDatabase))]
+        public void CoreLinkTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class DynamicDependencies : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.DynamicDependenciesTests), MemberType = typeof(TestDatabase))]
+        public void DynamicDependenciesTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class Extensibility : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.ExtensibilityTests), MemberType = typeof(TestDatabase))]
+        public void ExtensibilityTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class Generics : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.GenericsTests), MemberType = typeof(TestDatabase))]
+        public void GenericsTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class InheritanceAbstractClasses : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.InheritanceAbstractClassTests), MemberType = typeof(TestDatabase))]
+        public void InheritanceAbstractClassTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class Interop : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.InteropTests), MemberType = typeof(TestDatabase))]
+        public void InteropTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class RequiresCapability : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.RequiresCapabilityTests), MemberType = typeof(TestDatabase))]
+        public void RequiresCapabilityTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class Symbols : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.SymbolsTests), MemberType = typeof(TestDatabase))]
+        public void SymbolsTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class TestFramework : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.TestFrameworkTests), MemberType = typeof(TestDatabase))]
+        public void TestFrameworkTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class UnreachableBlock : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.UnreachableBlockTests), MemberType = typeof(TestDatabase))]
+        public void UnreachableBlockTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class UnreachableBody : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.UnreachableBodyTests), MemberType = typeof(TestDatabase))]
+        public void UnreachableBodyTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class AttributesDebugger : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.AttributeDebuggerTests), MemberType = typeof(TestDatabase))]
+        public void AttributesDebuggerTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class Attributes0 : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.AttributeTestsShard), 0, 2, MemberType = typeof(TestDatabase))]
+        public void AttributesTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class Attributes1 : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.AttributeTestsShard), 1, 2, MemberType = typeof(TestDatabase))]
+        public void AttributesTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class DataFlow0 : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.DataFlowTestsShard), 0, 2, MemberType = typeof(TestDatabase))]
+        public void DataFlowTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class DataFlow1 : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.DataFlowTestsShard), 1, 2, MemberType = typeof(TestDatabase))]
+        public void DataFlowTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class InheritanceInterfaces0 : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.InheritanceInterfaceTestsShard), 0, 2, MemberType = typeof(TestDatabase))]
+        public void InheritanceInterfaceTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class InheritanceInterfaces1 : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.InheritanceInterfaceTestsShard), 1, 2, MemberType = typeof(TestDatabase))]
+        public void InheritanceInterfaceTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class Reflection : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.ReflectionTests), MemberType = typeof(TestDatabase))]
+        public void ReflectionTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class TypeForwarding : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.TypeForwardingTests), MemberType = typeof(TestDatabase))]
+        public void TypeForwardingTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class Warnings : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.WarningsTests), MemberType = typeof(TestDatabase))]
+        public void WarningsTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public class Xml : LinkerTestSuite
+    {
+        [ConditionalTheory]
+        [MemberData(nameof(TestDatabase.XmlTests), MemberType = typeof(TestDatabase))]
+        public void XmlTests(TestCase testCase)
+        {
+            Run(testCase);
+        }
+    }
+
+    public abstract class LinkerTestSuite
+    {
         protected virtual void Run(TestCase testCase)
         {
             var runner = new TestRunner(new ObjectFactory());


### PR DESCRIPTION
Split the longest linker test suites into independent xUnit collections and shard the largest theories.

On my machine, this cut about 4 minutes off the execution time, which was about 10.5 minutes before this change.

> [!NOTE]
> This pull request was created with assistance from GitHub Copilot.