### PR TITLE
Add message template formatting to DataAnnotations validation attributes

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -209,6 +209,7 @@ namespace Microsoft.Extensions.Options.Generators
             OutGeneratedCodeAttribute();
 
             string qualifiedClassName = $"{prefix}{suffix}_{className}";
+            string formatMessageOverride = GenerateFormatMessageOverride("Length");
 
             OutLn($$"""
 [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -220,7 +221,7 @@ namespace Microsoft.Extensions.Options.Generators
         public {{qualifiedClassName}}(): base(() => DefaultErrorMessageString) { Length = MaxAllowableLength; }
         public int Length { get; }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
-        public override bool IsValid(object? value)
+{{formatMessageOverride}}        public override bool IsValid(object? value)
         {
             if (Length == 0 || Length < -1)
             {
@@ -256,6 +257,7 @@ namespace Microsoft.Extensions.Options.Generators
             OutGeneratedCodeAttribute();
 
             string qualifiedClassName = $"{prefix}{suffix}_{className}";
+            string formatMessageOverride = GenerateFormatMessageOverride("Length");
 
             OutLn($$"""
 [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -293,7 +295,7 @@ namespace Microsoft.Extensions.Options.Generators
             return length >= Length;
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
-    }
+{{formatMessageOverride}}    }
 """);
         }
 
@@ -302,6 +304,7 @@ namespace Microsoft.Extensions.Options.Generators
             OutGeneratedCodeAttribute();
 
             string qualifiedClassName = $"{prefix}{suffix}_{className}";
+            string formatMessageOverride = GenerateFormatMessageOverride("MinimumLength, MaximumLength");
 
             OutLn($$"""
 [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -343,7 +346,7 @@ namespace Microsoft.Extensions.Options.Generators
             return (uint)(length - MinimumLength) <= (uint)(MaximumLength - MinimumLength);
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
-    }
+{{formatMessageOverride}}    }
 """);
         }
 
@@ -352,6 +355,7 @@ namespace Microsoft.Extensions.Options.Generators
             OutGeneratedCodeAttribute();
 
             string qualifiedClassName = $"{prefix}{suffix}_{className}";
+            string formatMessageOverride = GenerateFormatMessageOverride("OtherProperty");
 
             OutLn($$"""
 [global::System.AttributeUsage(global::System.AttributeTargets.Property, AllowMultiple = false)]
@@ -383,7 +387,7 @@ namespace Microsoft.Extensions.Options.Generators
             return null;
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, OtherProperty);
-    }
+{{formatMessageOverride}}    }
 """);
         }
 
@@ -392,6 +396,7 @@ namespace Microsoft.Extensions.Options.Generators
             OutGeneratedCodeAttribute();
 
             string qualifiedClassName = $"{prefix}{suffix}_{className}";
+            string formatMessageOverride = GenerateFormatMessageOverride("Minimum, Maximum", ensureInitialized: true);
 
             string initializationString = emitTimeSpanSupport ?
             """
@@ -462,7 +467,50 @@ namespace Microsoft.Extensions.Options.Generators
                         }
             """;
 
+            string ensureInitializedBody = $$"""
+            if (!_initialized)
+            {
+                lock (_lock)
+                {
+                    if (!_initialized)
+                    {
+                        if (Minimum is null || Maximum is null)
+                        {
+                            throw new global::System.InvalidOperationException(MinMaxError);
+                        }
+                        if (_needToConvertMinMax)
+                        {
+                            global::System.Globalization.CultureInfo culture = ParseLimitsInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
+{{initializationString}}
+                        }
+                        int cmp = ((global::System.IComparable)Minimum).CompareTo((global::System.IComparable)Maximum);
+                        if (cmp > 0)
+                        {
+                            throw new global::System.InvalidOperationException("The maximum value '{Maximum}' must be greater than or equal to the minimum value '{Minimum}'.");
+                        }
+                        else if (cmp == 0 && (MinimumIsExclusive || MaximumIsExclusive))
+                        {
+                            throw new global::System.InvalidOperationException("Cannot use exclusive bounds when the maximum value is equal to the minimum value.");
+                        }
+                        _initialized = true;
+                    }
+                }
+            }
+""";
 
+            string initializeRange = ensureInitializedBody;
+            string ensureInitializedMethod = string.Empty;
+            if (_symbolHolder.HasValidationAttributeFormatMessageMethod)
+            {
+                initializeRange = "            EnsureInitialized();";
+
+                StringBuilder sb = new();
+                sb.AppendLine("        private void EnsureInitialized()");
+                sb.AppendLine("        {");
+                sb.AppendLine(ensureInitializedBody);
+                sb.AppendLine("        }");
+                ensureInitializedMethod = sb.ToString();
+            }
 
             OutLn($$"""
 [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -496,41 +544,14 @@ namespace Microsoft.Extensions.Options.Generators
         public bool ConvertValueInInvariantCulture { get; set; }
         public override string FormatErrorMessage(string name) =>
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
-        private readonly bool _needToConvertMinMax;
+{{formatMessageOverride}}        private readonly bool _needToConvertMinMax;
         private volatile bool _initialized;
         private readonly object _lock = new();
         private const string MinMaxError = "The minimum and maximum values must be set to valid values.";
 
         public override bool IsValid(object? value)
         {
-            if (!_initialized)
-            {
-                lock (_lock)
-                {
-                    if (!_initialized)
-                    {
-                        if (Minimum is null || Maximum is null)
-                        {
-                            throw new global::System.InvalidOperationException(MinMaxError);
-                        }
-                        if (_needToConvertMinMax)
-                        {
-                            global::System.Globalization.CultureInfo culture = ParseLimitsInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
-{{initializationString}}
-                        }
-                        int cmp = ((global::System.IComparable)Minimum).CompareTo((global::System.IComparable)Maximum);
-                        if (cmp > 0)
-                        {
-                            throw new global::System.InvalidOperationException("The maximum value '{Maximum}' must be greater than or equal to the minimum value '{Minimum}'.");
-                        }
-                        else if (cmp == 0 && (MinimumIsExclusive || MaximumIsExclusive))
-                        {
-                            throw new global::System.InvalidOperationException("Cannot use exclusive bounds when the maximum value is equal to the minimum value.");
-                        }
-                        _initialized = true;
-                    }
-                }
-            }
+{{initializeRange}}
 
             if (value is null or string { Length: 0 })
             {
@@ -549,7 +570,7 @@ namespace Microsoft.Extensions.Options.Generators
                 (MinimumIsExclusive ? min.CompareTo(convertedValue) < 0 : min.CompareTo(convertedValue) <= 0) &&
                 (MaximumIsExclusive ? max.CompareTo(convertedValue) > 0 : max.CompareTo(convertedValue) >= 0);
         }
-        private string GetValidationErrorMessage()
+{{ensureInitializedMethod}}        private string GetValidationErrorMessage()
         {
             return (MinimumIsExclusive, MaximumIsExclusive) switch
             {
@@ -573,6 +594,33 @@ namespace Microsoft.Extensions.Options.Generators
         }
     }
 """);
+        }
+
+        private string GenerateFormatMessageOverride(string arguments, bool ensureInitialized = false)
+        {
+            if (!_symbolHolder.HasValidationAttributeFormatMessageMethod)
+            {
+                return string.Empty;
+            }
+
+            StringBuilder sb = new();
+            sb.AppendLine("""        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)""");
+            sb.AppendLine("        {");
+            sb.AppendLine("            if (format == null)");
+            sb.AppendLine("            {");
+            sb.AppendLine("                throw new global::System.ArgumentNullException(nameof(format));");
+            sb.AppendLine("            }");
+            sb.AppendLine();
+
+            if (ensureInitialized)
+            {
+                sb.AppendLine("            EnsureInitialized();");
+                sb.AppendLine();
+            }
+
+            sb.AppendLine($"            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, {arguments});");
+            sb.AppendLine("        }");
+            return sb.ToString();
         }
 
         private string GenerateStronglyTypedCodeForLengthAttributes(HashSet<object> data)

--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -606,11 +606,6 @@ namespace Microsoft.Extensions.Options.Generators
             StringBuilder sb = new();
             sb.AppendLine("""        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)""");
             sb.AppendLine("        {");
-            sb.AppendLine("            if (format == null)");
-            sb.AppendLine("            {");
-            sb.AppendLine("                throw new global::System.ArgumentNullException(nameof(format));");
-            sb.AppendLine("            }");
-            sb.AppendLine();
 
             if (ensureInitialized)
             {

--- a/src/libraries/Microsoft.Extensions.Options/gen/SymbolHolder.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/SymbolHolder.cs
@@ -30,5 +30,6 @@ namespace Microsoft.Extensions.Options.Generators
         INamedTypeSymbol? IAsyncValidatableObjectSymbol = null,
         bool HasTryValidateValueAsyncMethod = false,
         INamedTypeSymbol? AsyncValidateOptionsSymbol = null,
-        INamedTypeSymbol? AsyncValidationAttributeSymbol = null);
+        INamedTypeSymbol? AsyncValidationAttributeSymbol = null,
+        bool HasValidationAttributeFormatMessageMethod = false);
 }

--- a/src/libraries/Microsoft.Extensions.Options/gen/SymbolLoader.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/SymbolLoader.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Extensions.Options.Generators
@@ -95,6 +96,16 @@ namespace Microsoft.Extensions.Options.Generators
             var asyncValidationAttributeSymbol = GetSymbol(AsyncValidationAttributeType);
             var validatorSymbol = GetSymbol(ValidatorType);
             bool hasTryValidateValueAsyncMethod = validatorSymbol?.GetMembers("TryValidateValueAsync").Length > 0;
+            bool hasValidationAttributeFormatMessageMethod = validationAttributeSymbol
+                .GetMembers("FormatMessage")
+                .Any(static member =>
+                    member is IMethodSymbol method &&
+                    method.IsVirtual &&
+                    method.DeclaredAccessibility == Accessibility.Public &&
+                    method.ReturnType.SpecialType == SpecialType.System_String &&
+                    method.Parameters.Length == 2 &&
+                    method.Parameters[0].Type.SpecialType == SpecialType.System_String &&
+                    method.Parameters[1].Type.SpecialType == SpecialType.System_String);
 
             symbolHolder = new(
                 optionsValidatorSymbol,
@@ -118,7 +129,8 @@ namespace Microsoft.Extensions.Options.Generators
                 iAsyncValidatableObjectSymbol,
                 hasTryValidateValueAsyncMethod,
                 asyncValidateOptionsSymbol,
-                asyncValidationAttributeSymbol);
+                asyncValidationAttributeSymbol,
+                hasValidationAttributeFormatMessageMethod);
 
             return true;
         }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/DataAnnotationAttributesWithParams.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/DataAnnotationAttributesWithParams.g.cs
@@ -139,11 +139,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
         }
     }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/DataAnnotationAttributesWithParams.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/DataAnnotationAttributesWithParams.g.cs
@@ -137,5 +137,14 @@ namespace __OptionValidationGeneratedAttributes
             return (uint)(length - MinimumLength) <= (uint)(MaximumLength - MinimumLength);
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/EmitterWithCustomValidator.netcore.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/EmitterWithCustomValidator.netcore.g.cs
@@ -105,11 +105,6 @@ namespace __OptionValidationGeneratedAttributes
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             EnsureInitialized();
 
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/EmitterWithCustomValidator.netcore.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/EmitterWithCustomValidator.netcore.g.cs
@@ -103,12 +103,51 @@ namespace __OptionValidationGeneratedAttributes
         public bool ConvertValueInInvariantCulture { get; set; }
         public override string FormatErrorMessage(string name) =>
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            EnsureInitialized();
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);
+        }
         private readonly bool _needToConvertMinMax;
         private volatile bool _initialized;
         private readonly object _lock = new();
         private const string MinMaxError = "The minimum and maximum values must be set to valid values.";
 
         public override bool IsValid(object? value)
+        {
+            EnsureInitialized();
+
+            if (value is null or string { Length: 0 })
+            {
+                return true;
+            }
+
+            global::System.Globalization.CultureInfo formatProvider = ConvertValueInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
+            object? convertedValue;
+
+            try
+            {
+                convertedValue = ConvertValue(value, formatProvider);
+            }
+            catch (global::System.Exception e) when (e is global::System.FormatException or global::System.InvalidCastException or global::System.NotSupportedException or global::System.OverflowException)
+            {
+                return false;
+            }
+
+            var min = (global::System.IComparable)Minimum;
+            var max = (global::System.IComparable)Maximum;
+
+            return
+                (MinimumIsExclusive ? min.CompareTo(convertedValue) < 0 : min.CompareTo(convertedValue) <= 0) &&
+                (MaximumIsExclusive ? max.CompareTo(convertedValue) > 0 : max.CompareTo(convertedValue) >= 0);
+        }
+        private void EnsureInitialized()
         {
             if (!_initialized)
             {
@@ -139,30 +178,6 @@ namespace __OptionValidationGeneratedAttributes
                     }
                 }
             }
-
-            if (value is null or string { Length: 0 })
-            {
-                return true;
-            }
-
-            global::System.Globalization.CultureInfo formatProvider = ConvertValueInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
-            object? convertedValue;
-
-            try
-            {
-                convertedValue = ConvertValue(value, formatProvider);
-            }
-            catch (global::System.Exception e) when (e is global::System.FormatException or global::System.InvalidCastException or global::System.NotSupportedException or global::System.OverflowException)
-            {
-                return false;
-            }
-
-            var min = (global::System.IComparable)Minimum;
-            var max = (global::System.IComparable)Maximum;
-
-            return
-                (MinimumIsExclusive ? min.CompareTo(convertedValue) < 0 : min.CompareTo(convertedValue) <= 0) &&
-                (MaximumIsExclusive ? max.CompareTo(convertedValue) > 0 : max.CompareTo(convertedValue) >= 0);
         }
         private string GetValidationErrorMessage()
         {

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/GeneratedAttributesTest.netcore.lang10.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/GeneratedAttributesTest.netcore.lang10.g.cs
@@ -256,6 +256,15 @@ namespace __OptionValidationGeneratedAttributes
             return null;
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, OtherProperty);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, OtherProperty);
+        }
     }
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -305,6 +314,15 @@ namespace __OptionValidationGeneratedAttributes
             return (uint)(length - MinimumLength) <= (uint)(MaximumLength - MinimumLength);
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
+        }
     }
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -316,6 +334,15 @@ namespace __OptionValidationGeneratedAttributes
         public __SourceGen__2C497155_MaxLengthAttribute(): base(() => DefaultErrorMessageString) { Length = MaxAllowableLength; }
         public int Length { get; }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
+        }
         public override bool IsValid(object? value)
         {
             if (Length == 0 || Length < -1)
@@ -396,6 +423,15 @@ namespace __OptionValidationGeneratedAttributes
             return length >= Length;
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
+        }
     }
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -429,6 +465,17 @@ namespace __OptionValidationGeneratedAttributes
         public bool ConvertValueInInvariantCulture { get; set; }
         public override string FormatErrorMessage(string name) =>
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            EnsureInitialized();
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);
+        }
         private readonly bool _needToConvertMinMax;
         private volatile bool _initialized;
         private readonly object _lock = new();
@@ -436,48 +483,7 @@ namespace __OptionValidationGeneratedAttributes
 
         public override bool IsValid(object? value)
         {
-            if (!_initialized)
-            {
-                lock (_lock)
-                {
-                    if (!_initialized)
-                    {
-                        if (Minimum is null || Maximum is null)
-                        {
-                            throw new global::System.InvalidOperationException(MinMaxError);
-                        }
-                        if (_needToConvertMinMax)
-                        {
-                            global::System.Globalization.CultureInfo culture = ParseLimitsInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
-                            if (OperandType == typeof(global::System.TimeSpan))
-                            {
-                                if (!global::System.TimeSpan.TryParse((string)Minimum, culture, out global::System.TimeSpan timeSpanMinimum) ||
-                                    !global::System.TimeSpan.TryParse((string)Maximum, culture, out global::System.TimeSpan timeSpanMaximum))
-                                {
-                                    throw new global::System.InvalidOperationException(MinMaxError);
-                                }
-                                Minimum = timeSpanMinimum;
-                                Maximum = timeSpanMaximum;
-                            }
-                            else
-                            {
-                                Minimum = ConvertValue(Minimum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
-                                Maximum = ConvertValue(Maximum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
-                            }
-                        }
-                        int cmp = ((global::System.IComparable)Minimum).CompareTo((global::System.IComparable)Maximum);
-                        if (cmp > 0)
-                        {
-                            throw new global::System.InvalidOperationException("The maximum value '{Maximum}' must be greater than or equal to the minimum value '{Minimum}'.");
-                        }
-                        else if (cmp == 0 && (MinimumIsExclusive || MaximumIsExclusive))
-                        {
-                            throw new global::System.InvalidOperationException("Cannot use exclusive bounds when the maximum value is equal to the minimum value.");
-                        }
-                        _initialized = true;
-                    }
-                }
-            }
+            EnsureInitialized();
 
             if (value is null or string { Length: 0 })
             {
@@ -524,6 +530,51 @@ namespace __OptionValidationGeneratedAttributes
             return
                 (MinimumIsExclusive ? min.CompareTo(convertedValue) < 0 : min.CompareTo(convertedValue) <= 0) &&
                 (MaximumIsExclusive ? max.CompareTo(convertedValue) > 0 : max.CompareTo(convertedValue) >= 0);
+        }
+        private void EnsureInitialized()
+        {
+            if (!_initialized)
+            {
+                lock (_lock)
+                {
+                    if (!_initialized)
+                    {
+                        if (Minimum is null || Maximum is null)
+                        {
+                            throw new global::System.InvalidOperationException(MinMaxError);
+                        }
+                        if (_needToConvertMinMax)
+                        {
+                            global::System.Globalization.CultureInfo culture = ParseLimitsInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
+                            if (OperandType == typeof(global::System.TimeSpan))
+                            {
+                                if (!global::System.TimeSpan.TryParse((string)Minimum, culture, out global::System.TimeSpan timeSpanMinimum) ||
+                                    !global::System.TimeSpan.TryParse((string)Maximum, culture, out global::System.TimeSpan timeSpanMaximum))
+                                {
+                                    throw new global::System.InvalidOperationException(MinMaxError);
+                                }
+                                Minimum = timeSpanMinimum;
+                                Maximum = timeSpanMaximum;
+                            }
+                            else
+                            {
+                                Minimum = ConvertValue(Minimum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
+                                Maximum = ConvertValue(Maximum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
+                            }
+                        }
+                        int cmp = ((global::System.IComparable)Minimum).CompareTo((global::System.IComparable)Maximum);
+                        if (cmp > 0)
+                        {
+                            throw new global::System.InvalidOperationException("The maximum value '{Maximum}' must be greater than or equal to the minimum value '{Minimum}'.");
+                        }
+                        else if (cmp == 0 && (MinimumIsExclusive || MaximumIsExclusive))
+                        {
+                            throw new global::System.InvalidOperationException("Cannot use exclusive bounds when the maximum value is equal to the minimum value.");
+                        }
+                        _initialized = true;
+                    }
+                }
+            }
         }
         private string GetValidationErrorMessage()
         {

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/GeneratedAttributesTest.netcore.lang10.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/GeneratedAttributesTest.netcore.lang10.g.cs
@@ -258,11 +258,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, OtherProperty);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, OtherProperty);
         }
     }
@@ -316,11 +311,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
         }
     }
@@ -336,11 +326,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
         }
         public override bool IsValid(object? value)
@@ -425,11 +410,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
         }
     }
@@ -467,11 +447,6 @@ namespace __OptionValidationGeneratedAttributes
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             EnsureInitialized();
 
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/GeneratedAttributesTest.netcore.lang11.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/GeneratedAttributesTest.netcore.lang11.g.cs
@@ -258,11 +258,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, OtherProperty);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, OtherProperty);
         }
     }
@@ -316,11 +311,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
         }
     }
@@ -336,11 +326,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
         }
         public override bool IsValid(object? value)
@@ -425,11 +410,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
         }
     }
@@ -467,11 +447,6 @@ namespace __OptionValidationGeneratedAttributes
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             EnsureInitialized();
 
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/GeneratedAttributesTest.netcore.lang11.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/GeneratedAttributesTest.netcore.lang11.g.cs
@@ -256,6 +256,15 @@ namespace __OptionValidationGeneratedAttributes
             return null;
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, OtherProperty);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, OtherProperty);
+        }
     }
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -305,6 +314,15 @@ namespace __OptionValidationGeneratedAttributes
             return (uint)(length - MinimumLength) <= (uint)(MaximumLength - MinimumLength);
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
+        }
     }
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -316,6 +334,15 @@ namespace __OptionValidationGeneratedAttributes
         public __SourceGen__MaxLengthAttribute(): base(() => DefaultErrorMessageString) { Length = MaxAllowableLength; }
         public int Length { get; }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
+        }
         public override bool IsValid(object? value)
         {
             if (Length == 0 || Length < -1)
@@ -396,6 +423,15 @@ namespace __OptionValidationGeneratedAttributes
             return length >= Length;
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
+        }
     }
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -429,6 +465,17 @@ namespace __OptionValidationGeneratedAttributes
         public bool ConvertValueInInvariantCulture { get; set; }
         public override string FormatErrorMessage(string name) =>
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            EnsureInitialized();
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);
+        }
         private readonly bool _needToConvertMinMax;
         private volatile bool _initialized;
         private readonly object _lock = new();
@@ -436,48 +483,7 @@ namespace __OptionValidationGeneratedAttributes
 
         public override bool IsValid(object? value)
         {
-            if (!_initialized)
-            {
-                lock (_lock)
-                {
-                    if (!_initialized)
-                    {
-                        if (Minimum is null || Maximum is null)
-                        {
-                            throw new global::System.InvalidOperationException(MinMaxError);
-                        }
-                        if (_needToConvertMinMax)
-                        {
-                            global::System.Globalization.CultureInfo culture = ParseLimitsInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
-                            if (OperandType == typeof(global::System.TimeSpan))
-                            {
-                                if (!global::System.TimeSpan.TryParse((string)Minimum, culture, out global::System.TimeSpan timeSpanMinimum) ||
-                                    !global::System.TimeSpan.TryParse((string)Maximum, culture, out global::System.TimeSpan timeSpanMaximum))
-                                {
-                                    throw new global::System.InvalidOperationException(MinMaxError);
-                                }
-                                Minimum = timeSpanMinimum;
-                                Maximum = timeSpanMaximum;
-                            }
-                            else
-                            {
-                                Minimum = ConvertValue(Minimum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
-                                Maximum = ConvertValue(Maximum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
-                            }
-                        }
-                        int cmp = ((global::System.IComparable)Minimum).CompareTo((global::System.IComparable)Maximum);
-                        if (cmp > 0)
-                        {
-                            throw new global::System.InvalidOperationException("The maximum value '{Maximum}' must be greater than or equal to the minimum value '{Minimum}'.");
-                        }
-                        else if (cmp == 0 && (MinimumIsExclusive || MaximumIsExclusive))
-                        {
-                            throw new global::System.InvalidOperationException("Cannot use exclusive bounds when the maximum value is equal to the minimum value.");
-                        }
-                        _initialized = true;
-                    }
-                }
-            }
+            EnsureInitialized();
 
             if (value is null or string { Length: 0 })
             {
@@ -524,6 +530,51 @@ namespace __OptionValidationGeneratedAttributes
             return
                 (MinimumIsExclusive ? min.CompareTo(convertedValue) < 0 : min.CompareTo(convertedValue) <= 0) &&
                 (MaximumIsExclusive ? max.CompareTo(convertedValue) > 0 : max.CompareTo(convertedValue) >= 0);
+        }
+        private void EnsureInitialized()
+        {
+            if (!_initialized)
+            {
+                lock (_lock)
+                {
+                    if (!_initialized)
+                    {
+                        if (Minimum is null || Maximum is null)
+                        {
+                            throw new global::System.InvalidOperationException(MinMaxError);
+                        }
+                        if (_needToConvertMinMax)
+                        {
+                            global::System.Globalization.CultureInfo culture = ParseLimitsInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
+                            if (OperandType == typeof(global::System.TimeSpan))
+                            {
+                                if (!global::System.TimeSpan.TryParse((string)Minimum, culture, out global::System.TimeSpan timeSpanMinimum) ||
+                                    !global::System.TimeSpan.TryParse((string)Maximum, culture, out global::System.TimeSpan timeSpanMaximum))
+                                {
+                                    throw new global::System.InvalidOperationException(MinMaxError);
+                                }
+                                Minimum = timeSpanMinimum;
+                                Maximum = timeSpanMaximum;
+                            }
+                            else
+                            {
+                                Minimum = ConvertValue(Minimum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
+                                Maximum = ConvertValue(Maximum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
+                            }
+                        }
+                        int cmp = ((global::System.IComparable)Minimum).CompareTo((global::System.IComparable)Maximum);
+                        if (cmp > 0)
+                        {
+                            throw new global::System.InvalidOperationException("The maximum value '{Maximum}' must be greater than or equal to the minimum value '{Minimum}'.");
+                        }
+                        else if (cmp == 0 && (MinimumIsExclusive || MaximumIsExclusive))
+                        {
+                            throw new global::System.InvalidOperationException("Cannot use exclusive bounds when the maximum value is equal to the minimum value.");
+                        }
+                        _initialized = true;
+                    }
+                }
+            }
         }
         private string GetValidationErrorMessage()
         {

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/OptionsExtendingSystemClassTest.netcore.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/OptionsExtendingSystemClassTest.netcore.g.cs
@@ -218,11 +218,6 @@ namespace __OptionValidationGeneratedAttributes
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             EnsureInitialized();
 
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/OptionsExtendingSystemClassTest.netcore.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/OptionsExtendingSystemClassTest.netcore.g.cs
@@ -216,12 +216,51 @@ namespace __OptionValidationGeneratedAttributes
         public bool ConvertValueInInvariantCulture { get; set; }
         public override string FormatErrorMessage(string name) =>
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            EnsureInitialized();
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);
+        }
         private readonly bool _needToConvertMinMax;
         private volatile bool _initialized;
         private readonly object _lock = new();
         private const string MinMaxError = "The minimum and maximum values must be set to valid values.";
 
         public override bool IsValid(object? value)
+        {
+            EnsureInitialized();
+
+            if (value is null or string { Length: 0 })
+            {
+                return true;
+            }
+
+            global::System.Globalization.CultureInfo formatProvider = ConvertValueInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
+            object? convertedValue;
+
+            try
+            {
+                convertedValue = ConvertValue(value, formatProvider);
+            }
+            catch (global::System.Exception e) when (e is global::System.FormatException or global::System.InvalidCastException or global::System.NotSupportedException or global::System.OverflowException)
+            {
+                return false;
+            }
+
+            var min = (global::System.IComparable)Minimum;
+            var max = (global::System.IComparable)Maximum;
+
+            return
+                (MinimumIsExclusive ? min.CompareTo(convertedValue) < 0 : min.CompareTo(convertedValue) <= 0) &&
+                (MaximumIsExclusive ? max.CompareTo(convertedValue) > 0 : max.CompareTo(convertedValue) >= 0);
+        }
+        private void EnsureInitialized()
         {
             if (!_initialized)
             {
@@ -252,30 +291,6 @@ namespace __OptionValidationGeneratedAttributes
                     }
                 }
             }
-
-            if (value is null or string { Length: 0 })
-            {
-                return true;
-            }
-
-            global::System.Globalization.CultureInfo formatProvider = ConvertValueInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
-            object? convertedValue;
-
-            try
-            {
-                convertedValue = ConvertValue(value, formatProvider);
-            }
-            catch (global::System.Exception e) when (e is global::System.FormatException or global::System.InvalidCastException or global::System.NotSupportedException or global::System.OverflowException)
-            {
-                return false;
-            }
-
-            var min = (global::System.IComparable)Minimum;
-            var max = (global::System.IComparable)Maximum;
-
-            return
-                (MinimumIsExclusive ? min.CompareTo(convertedValue) < 0 : min.CompareTo(convertedValue) <= 0) &&
-                (MaximumIsExclusive ? max.CompareTo(convertedValue) > 0 : max.CompareTo(convertedValue) >= 0);
         }
         private string GetValidationErrorMessage()
         {

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/UsingInterfaceAsPropertyTypeForLengthAttributesTests.netcore.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/UsingInterfaceAsPropertyTypeForLengthAttributesTests.netcore.g.cs
@@ -163,6 +163,15 @@ namespace __OptionValidationGeneratedAttributes
             return (uint)(length - MinimumLength) <= (uint)(MaximumLength - MinimumLength);
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
+        }
     }
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -174,6 +183,15 @@ namespace __OptionValidationGeneratedAttributes
         public __SourceGen__MaxLengthAttribute(): base(() => DefaultErrorMessageString) { Length = MaxAllowableLength; }
         public int Length { get; }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
+        }
         public override bool IsValid(object? value)
         {
             if (Length == 0 || Length < -1)
@@ -254,5 +272,14 @@ namespace __OptionValidationGeneratedAttributes
             return length >= Length;
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/UsingInterfaceAsPropertyTypeForLengthAttributesTests.netcore.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Baselines/UsingInterfaceAsPropertyTypeForLengthAttributesTests.netcore.g.cs
@@ -165,11 +165,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
         }
     }
@@ -185,11 +180,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
         }
         public override bool IsValid(object? value)
@@ -274,11 +264,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
         }
     }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGeneration.Unit.Tests/Main.cs
@@ -13,6 +13,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -2362,11 +2365,75 @@ string lengthAttribute = "";
         Assert.Equal(generatedSource.Replace("\r\n", "\n"), emittedSource.Replace("\r\n", "\n"));
 
         CSharpCompilation compilation = CreateCompilationForOptionsSource(Path.GetRandomFileName(), source + emittedSource, refAssemblyPath: null, languageVersion);
-        var emitResult = compilation.Emit(new MemoryStream());
+        using MemoryStream assemblyStream = new();
+        var emitResult = compilation.Emit(assemblyStream);
 
         Assert.True(emitResult.Success);
+#if NET
+        Assembly generatedAssembly = Assembly.Load(assemblyStream.ToArray());
+        AssertGeneratedFormatMessage(
+            generatedAssembly,
+            "CompareAttribute",
+            new object[] { "P5" },
+            "external {0}:{1}",
+            "external name:P5");
+        AssertGeneratedFormatMessage(
+            generatedAssembly,
+            "LengthAttribute",
+            new object[] { 1, 3 },
+            "external {0}:{1:D2}:{2:D2}",
+            "external name:01:03");
+        AssertGeneratedFormatMessage(
+            generatedAssembly,
+            "MaxLengthAttribute",
+            new object[] { 5 },
+            "external {0}:{1:D2}",
+            "external name:05");
+        AssertGeneratedFormatMessage(
+            generatedAssembly,
+            "MinLengthAttribute",
+            new object[] { 5 },
+            "external {0}:{1:D2}",
+            "external name:05");
+        AssertGeneratedFormatMessage(
+            generatedAssembly,
+            "RangeAttribute",
+            new object[] { typeof(int), "1", "3" },
+            "external {0}:{1:D2}:{2:D2}",
+            "external name:01:03");
+#endif
         // Console.WriteLine(emittedSource);
     }
+
+#if NET
+    private static void AssertGeneratedFormatMessage(
+        Assembly generatedAssembly,
+        string attributeName,
+        object[] constructorArguments,
+        string format,
+        string expected)
+    {
+        Type generatedType = Assert.Single(
+            generatedAssembly.GetTypes(),
+            type => type.Name.EndsWith($"_{attributeName}", StringComparison.Ordinal));
+        ValidationAttribute attribute = Assert.IsAssignableFrom<ValidationAttribute>(
+            Activator.CreateInstance(generatedType, constructorArguments));
+
+        Assert.Equal(expected, attribute.FormatMessage(format, "name"));
+        ArgumentNullException nullException = Assert.Throws<ArgumentNullException>(
+            () => attribute.FormatMessage(null!, "name"));
+        Assert.Equal("format", nullException.ParamName);
+        Assert.Throws<FormatException>(() => attribute.FormatMessage("{3}", "name"));
+
+        MethodInfo? formatMessage = generatedType.GetMethod(nameof(ValidationAttribute.FormatMessage));
+        Assert.NotNull(formatMessage);
+        Assert.Equal(generatedType, formatMessage.DeclaringType);
+
+        StringSyntaxAttribute syntax = Assert.Single(
+            formatMessage.GetParameters()[0].GetCustomAttributes<StringSyntaxAttribute>());
+        Assert.Equal(StringSyntaxAttribute.CompositeFormat, syntax.Syntax);
+    }
+#endif
 
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
     public async Task UsingInterfaceAsPropertyTypeForLengthAttributesTests()

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
@@ -2990,6 +2990,15 @@ namespace __OptionValidationGeneratedAttributes
             return null;
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, OtherProperty);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, OtherProperty);
+        }
     }
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -3027,6 +3036,15 @@ namespace __OptionValidationGeneratedAttributes
             return length >= Length;
         }
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
+        }
     }
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
     [global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter, AllowMultiple = false)]
@@ -3060,6 +3078,17 @@ namespace __OptionValidationGeneratedAttributes
         public bool ConvertValueInInvariantCulture { get; set; }
         public override string FormatErrorMessage(string name) =>
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
+        public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
+        {
+            if (format == null)
+            {
+                throw new global::System.ArgumentNullException(nameof(format));
+            }
+
+            EnsureInitialized();
+
+            return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);
+        }
         private readonly bool _needToConvertMinMax;
         private volatile bool _initialized;
         private readonly object _lock = new();
@@ -3067,48 +3096,7 @@ namespace __OptionValidationGeneratedAttributes
 
         public override bool IsValid(object? value)
         {
-            if (!_initialized)
-            {
-                lock (_lock)
-                {
-                    if (!_initialized)
-                    {
-                        if (Minimum is null || Maximum is null)
-                        {
-                            throw new global::System.InvalidOperationException(MinMaxError);
-                        }
-                        if (_needToConvertMinMax)
-                        {
-                            global::System.Globalization.CultureInfo culture = ParseLimitsInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
-                            if (OperandType == typeof(global::System.TimeSpan))
-                            {
-                                if (!global::System.TimeSpan.TryParse((string)Minimum, culture, out global::System.TimeSpan timeSpanMinimum) ||
-                                    !global::System.TimeSpan.TryParse((string)Maximum, culture, out global::System.TimeSpan timeSpanMaximum))
-                                {
-                                    throw new global::System.InvalidOperationException(MinMaxError);
-                                }
-                                Minimum = timeSpanMinimum;
-                                Maximum = timeSpanMaximum;
-                            }
-                            else
-                            {
-                                Minimum = ConvertValue(Minimum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
-                                Maximum = ConvertValue(Maximum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
-                            }
-                        }
-                        int cmp = ((global::System.IComparable)Minimum).CompareTo((global::System.IComparable)Maximum);
-                        if (cmp > 0)
-                        {
-                            throw new global::System.InvalidOperationException("The maximum value '{Maximum}' must be greater than or equal to the minimum value '{Minimum}'.");
-                        }
-                        else if (cmp == 0 && (MinimumIsExclusive || MaximumIsExclusive))
-                        {
-                            throw new global::System.InvalidOperationException("Cannot use exclusive bounds when the maximum value is equal to the minimum value.");
-                        }
-                        _initialized = true;
-                    }
-                }
-            }
+            EnsureInitialized();
 
             if (value is null or string { Length: 0 })
             {
@@ -3155,6 +3143,51 @@ namespace __OptionValidationGeneratedAttributes
             return
                 (MinimumIsExclusive ? min.CompareTo(convertedValue) < 0 : min.CompareTo(convertedValue) <= 0) &&
                 (MaximumIsExclusive ? max.CompareTo(convertedValue) > 0 : max.CompareTo(convertedValue) >= 0);
+        }
+        private void EnsureInitialized()
+        {
+            if (!_initialized)
+            {
+                lock (_lock)
+                {
+                    if (!_initialized)
+                    {
+                        if (Minimum is null || Maximum is null)
+                        {
+                            throw new global::System.InvalidOperationException(MinMaxError);
+                        }
+                        if (_needToConvertMinMax)
+                        {
+                            global::System.Globalization.CultureInfo culture = ParseLimitsInInvariantCulture ? global::System.Globalization.CultureInfo.InvariantCulture : global::System.Globalization.CultureInfo.CurrentCulture;
+                            if (OperandType == typeof(global::System.TimeSpan))
+                            {
+                                if (!global::System.TimeSpan.TryParse((string)Minimum, culture, out global::System.TimeSpan timeSpanMinimum) ||
+                                    !global::System.TimeSpan.TryParse((string)Maximum, culture, out global::System.TimeSpan timeSpanMaximum))
+                                {
+                                    throw new global::System.InvalidOperationException(MinMaxError);
+                                }
+                                Minimum = timeSpanMinimum;
+                                Maximum = timeSpanMaximum;
+                            }
+                            else
+                            {
+                                Minimum = ConvertValue(Minimum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
+                                Maximum = ConvertValue(Maximum, culture) ?? throw new global::System.InvalidOperationException(MinMaxError);
+                            }
+                        }
+                        int cmp = ((global::System.IComparable)Minimum).CompareTo((global::System.IComparable)Maximum);
+                        if (cmp > 0)
+                        {
+                            throw new global::System.InvalidOperationException("The maximum value '{Maximum}' must be greater than or equal to the minimum value '{Minimum}'.");
+                        }
+                        else if (cmp == 0 && (MinimumIsExclusive || MaximumIsExclusive))
+                        {
+                            throw new global::System.InvalidOperationException("Cannot use exclusive bounds when the maximum value is equal to the minimum value.");
+                        }
+                        _initialized = true;
+                    }
+                }
+            }
         }
         private string GetValidationErrorMessage()
         {

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
@@ -2992,11 +2992,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, OtherProperty);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, OtherProperty);
         }
     }
@@ -3038,11 +3033,6 @@ namespace __OptionValidationGeneratedAttributes
         public override string FormatErrorMessage(string name) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Length);
         }
     }
@@ -3080,11 +3070,6 @@ namespace __OptionValidationGeneratedAttributes
                 string.Format(global::System.Globalization.CultureInfo.CurrentCulture, GetValidationErrorMessage(), name, Minimum, Maximum);
         public override string FormatMessage([global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name)
         {
-            if (format == null)
-            {
-                throw new global::System.ArgumentNullException(nameof(format));
-            }
-
             EnsureInitialized();
 
             return string.Format(global::System.Globalization.CultureInfo.CurrentCulture, format, name, Minimum, Maximum);

--- a/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -57,6 +57,7 @@ namespace System.ComponentModel.DataAnnotations
         public string? OtherPropertyDisplayName { get { throw null; } }
         public override bool RequiresValidationContext { get { throw null; } }
         public override string FormatErrorMessage(string name) { throw null; }
+        public override string FormatMessage([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name) { throw null; }
         protected override System.ComponentModel.DataAnnotations.ValidationResult? IsValid(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
@@ -191,6 +192,7 @@ namespace System.ComponentModel.DataAnnotations
         public FileExtensionsAttribute() : base (default(System.ComponentModel.DataAnnotations.DataType)) { }
         public string Extensions { get { throw null; } set { } }
         public override string FormatErrorMessage(string name) { throw null; }
+        public override string FormatMessage([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name) { throw null; }
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false)]
@@ -227,6 +229,7 @@ namespace System.ComponentModel.DataAnnotations
         public int MaximumLength { get { throw null; } }
         public int MinimumLength { get { throw null; } }
         public override string FormatErrorMessage(string name) { throw null; }
+        public override string FormatMessage([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name) { throw null; }
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false)]
@@ -238,6 +241,7 @@ namespace System.ComponentModel.DataAnnotations
         public MaxLengthAttribute(int length) { }
         public int Length { get { throw null; } }
         public override string FormatErrorMessage(string name) { throw null; }
+        public override string FormatMessage([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name) { throw null; }
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false)]
@@ -254,6 +258,7 @@ namespace System.ComponentModel.DataAnnotations
         public MinLengthAttribute(int length) { }
         public int Length { get { throw null; } }
         public override string FormatErrorMessage(string name) { throw null; }
+        public override string FormatMessage([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name) { throw null; }
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false)]
@@ -278,6 +283,7 @@ namespace System.ComponentModel.DataAnnotations
         public System.Type OperandType { get { throw null; } }
         public bool ParseLimitsInInvariantCulture { get { throw null; } set { } }
         public override string FormatErrorMessage(string name) { throw null; }
+        public override string FormatMessage([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name) { throw null; }
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false)]
@@ -288,6 +294,7 @@ namespace System.ComponentModel.DataAnnotations
         public int MatchTimeoutInMilliseconds { get { throw null; } set { } }
         public string Pattern { get { throw null; } }
         public override string FormatErrorMessage(string name) { throw null; }
+        public override string FormatMessage([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name) { throw null; }
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false)]
@@ -310,6 +317,7 @@ namespace System.ComponentModel.DataAnnotations
         public int MaximumLength { get { throw null; } }
         public int MinimumLength { get { throw null; } set { } }
         public override string FormatErrorMessage(string name) { throw null; }
+        public override string FormatMessage([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name) { throw null; }
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
@@ -347,6 +355,7 @@ namespace System.ComponentModel.DataAnnotations
         protected string ErrorMessageString { get { throw null; } }
         public virtual bool RequiresValidationContext { get { throw null; } }
         public virtual string FormatErrorMessage(string name) { throw null; }
+        public virtual string FormatMessage([System.Diagnostics.CodeAnalysis.StringSyntaxAttribute("CompositeFormat")] string format, string name) { throw null; }
         public System.ComponentModel.DataAnnotations.ValidationResult? GetValidationResult(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext) { throw null; }
         public virtual bool IsValid(object? value) { throw null; }
         protected virtual System.ComponentModel.DataAnnotations.ValidationResult? IsValid(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext) { throw null; }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
@@ -26,8 +26,20 @@ namespace System.ComponentModel.DataAnnotations
         public override bool RequiresValidationContext => true;
 
         public override string FormatErrorMessage(string name) =>
-            string.Format(
-                CultureInfo.CurrentCulture, ErrorMessageString, name, OtherPropertyDisplayName ?? OtherProperty);
+            FormatMessage(ErrorMessageString, name);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>{0}</c> is replaced with <paramref name="name" /> and <c>{1}</c> is replaced with
+        /// <see cref="OtherPropertyDisplayName" />, or <see cref="OtherProperty" /> when no display name is available.
+        /// </remarks>
+        public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+
+            return string.Format(
+                CultureInfo.CurrentCulture, format, name, OtherPropertyDisplayName ?? OtherProperty);
+        }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
             Justification = "The ctor is marked with RequiresUnreferencedCode informing the caller to preserve the other property.")]

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
@@ -35,8 +35,6 @@ namespace System.ComponentModel.DataAnnotations
         /// </remarks>
         public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
         {
-            ArgumentNullException.ThrowIfNull(format);
-
             return string.Format(
                 CultureInfo.CurrentCulture, format, name, OtherPropertyDisplayName ?? OtherProperty);
         }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FileExtensionsAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FileExtensionsAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -40,7 +41,19 @@ namespace System.ComponentModel.DataAnnotations
         }
 
         public override string FormatErrorMessage(string name) =>
-            string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, ExtensionsFormatted);
+            FormatMessage(ErrorMessageString, name);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>{0}</c> is replaced with <paramref name="name" /> and <c>{1}</c> is replaced with the normalized,
+        /// dot-prefixed list of extensions specified by <see cref="Extensions" />.
+        /// </remarks>
+        public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+
+            return string.Format(CultureInfo.CurrentCulture, format, name, ExtensionsFormatted);
+        }
 
         public override bool IsValid(object? value) =>
             value == null || value is string valueAsString && ValidateExtension(valueAsString);

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FileExtensionsAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FileExtensionsAttribute.cs
@@ -50,8 +50,6 @@ namespace System.ComponentModel.DataAnnotations
         /// </remarks>
         public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
         {
-            ArgumentNullException.ThrowIfNull(format);
-
             return string.Format(CultureInfo.CurrentCulture, format, name, ExtensionsFormatted);
         }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/LengthAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/LengthAttribute.cs
@@ -85,8 +85,6 @@ namespace System.ComponentModel.DataAnnotations
         /// </remarks>
         public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
         {
-            ArgumentNullException.ThrowIfNull(format);
-
             return string.Format(CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
         }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/LengthAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/LengthAttribute.cs
@@ -76,8 +76,19 @@ namespace System.ComponentModel.DataAnnotations
         /// <param name="name">The name to include in the formatted string.</param>
         /// <returns>A localized string to describe the minimum acceptable length.</returns>
         public override string FormatErrorMessage(string name) =>
-            // An error occurred, so we know the value is less than the minimum
-            string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, MinimumLength, MaximumLength);
+            FormatMessage(ErrorMessageString, name);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>{0}</c> is replaced with <paramref name="name" />, <c>{1}</c> is replaced with
+        /// <see cref="MinimumLength" />, and <c>{2}</c> is replaced with <see cref="MaximumLength" />.
+        /// </remarks>
+        public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+
+            return string.Format(CultureInfo.CurrentCulture, format, name, MinimumLength, MaximumLength);
+        }
 
         /// <summary>
         ///     Checks that Length has a legal value.

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
@@ -93,8 +93,18 @@ namespace System.ComponentModel.DataAnnotations
         /// <param name="name">The name to include in the formatted string.</param>
         /// <returns>A localized string to describe the maximum acceptable length.</returns>
         public override string FormatErrorMessage(string name) =>
-            // An error occurred, so we know the value is greater than the maximum if it was specified
-            string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
+            FormatMessage(ErrorMessageString, name);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>{0}</c> is replaced with <paramref name="name" /> and <c>{1}</c> is replaced with <see cref="Length" />.
+        /// </remarks>
+        public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+
+            return string.Format(CultureInfo.CurrentCulture, format, name, Length);
+        }
 
         /// <summary>
         ///     Checks that Length has a legal value.

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MaxLengthAttribute.cs
@@ -101,8 +101,6 @@ namespace System.ComponentModel.DataAnnotations
         /// </remarks>
         public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
         {
-            ArgumentNullException.ThrowIfNull(format);
-
             return string.Format(CultureInfo.CurrentCulture, format, name, Length);
         }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
@@ -76,8 +76,18 @@ namespace System.ComponentModel.DataAnnotations
         /// <param name="name">The name to include in the formatted string.</param>
         /// <returns>A localized string to describe the minimum acceptable length.</returns>
         public override string FormatErrorMessage(string name) =>
-            // An error occurred, so we know the value is less than the minimum
-            string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Length);
+            FormatMessage(ErrorMessageString, name);
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>{0}</c> is replaced with <paramref name="name" /> and <c>{1}</c> is replaced with <see cref="Length" />.
+        /// </remarks>
+        public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+
+            return string.Format(CultureInfo.CurrentCulture, format, name, Length);
+        }
 
         /// <summary>
         ///     Checks that Length has a legal value.

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/MinLengthAttribute.cs
@@ -84,8 +84,6 @@ namespace System.ComponentModel.DataAnnotations
         /// </remarks>
         public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
         {
-            ArgumentNullException.ThrowIfNull(format);
-
             return string.Format(CultureInfo.CurrentCulture, format, name, Length);
         }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RangeAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RangeAttribute.cs
@@ -193,8 +193,6 @@ namespace System.ComponentModel.DataAnnotations
         /// <exception cref="InvalidOperationException">The attribute is not configured with a valid range.</exception>
         public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
         {
-            ArgumentNullException.ThrowIfNull(format);
-
             SetupConversion();
 
             return string.Format(CultureInfo.CurrentCulture, format, name, Minimum, Maximum);

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RangeAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RangeAttribute.cs
@@ -178,9 +178,26 @@ namespace System.ComponentModel.DataAnnotations
         /// <exception cref="InvalidOperationException"> is thrown if the current attribute is ill-formed.</exception>
         public override string FormatErrorMessage(string name)
         {
+            // Preserve range validation before resolving ErrorMessageString.
+            // FormatMessage also initializes conversion for direct callers.
             SetupConversion();
 
-            return string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum, Maximum);
+            return FormatMessage(ErrorMessageString, name);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>{0}</c> is replaced with <paramref name="name" />, <c>{1}</c> is replaced with <see cref="Minimum" />,
+        /// and <c>{2}</c> is replaced with <see cref="Maximum" />.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The attribute is not configured with a valid range.</exception>
+        public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+
+            SetupConversion();
+
+            return string.Format(CultureInfo.CurrentCulture, format, name, Minimum, Maximum);
         }
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
@@ -97,8 +97,6 @@ namespace System.ComponentModel.DataAnnotations
         /// </remarks>
         public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
         {
-            ArgumentNullException.ThrowIfNull(format);
-
             return string.Format(CultureInfo.CurrentCulture, format, name, Pattern);
         }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
@@ -88,9 +88,19 @@ namespace System.ComponentModel.DataAnnotations
         {
             SetupRegex();
 
-            return string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Pattern);
+            return FormatMessage(ErrorMessageString, name);
         }
 
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>{0}</c> is replaced with <paramref name="name" /> and <c>{1}</c> is replaced with <see cref="Pattern" />.
+        /// </remarks>
+        public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+
+            return string.Format(CultureInfo.CurrentCulture, format, name, Pattern);
+        }
 
         /// <summary>
         ///     Sets up the <see cref="Regex" /> property from the <see cref="Pattern" /> property.

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/StringLengthAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/StringLengthAttribute.cs
@@ -86,8 +86,6 @@ namespace System.ComponentModel.DataAnnotations
         /// </remarks>
         public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
         {
-            ArgumentNullException.ThrowIfNull(format);
-
             return string.Format(CultureInfo.CurrentCulture, format, name, MaximumLength, MinimumLength);
         }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/StringLengthAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/StringLengthAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace System.ComponentModel.DataAnnotations
@@ -75,7 +76,19 @@ namespace System.ComponentModel.DataAnnotations
 
             // it's ok to pass in the minLength even for the error message without a {2} param since string.Format will just
             // ignore extra arguments
-            return string.Format(CultureInfo.CurrentCulture, errorMessage, name, MaximumLength, MinimumLength);
+            return FormatMessage(errorMessage, name);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>{0}</c> is replaced with <paramref name="name" />, <c>{1}</c> is replaced with
+        /// <see cref="MaximumLength" />, and <c>{2}</c> is replaced with <see cref="MinimumLength" />.
+        /// </remarks>
+        public override string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+
+            return string.Format(CultureInfo.CurrentCulture, format, name, MaximumLength, MinimumLength);
         }
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -337,19 +337,42 @@ namespace System.ComponentModel.DataAnnotations
         ///     It applies the <paramref name="name" /> (for example, the name of a field) to the formatted error message, resulting
         ///     in something like "The field 'name' has an incorrect value".
         ///     <para>
-        ///         Derived classes can override this method to customize how errors are generated.
+        ///         Derived classes can override this method to validate their configuration or select an error message.
+        ///         Derived classes that provide additional message arguments should override <see cref="FormatMessage" />.
         ///     </para>
         ///     <para>
-        ///         The base class implementation will use <see cref="ErrorMessageString" /> to obtain a localized
-        ///         error message from properties within the current attribute.  If those have not been set, a generic
-        ///         error message will be provided.
+        ///         The base class implementation uses <see cref="ErrorMessageString" /> to obtain a localized
+        ///         error message from properties within the current attribute, then calls <see cref="FormatMessage" />.
+        ///         If those properties have not been set, a generic error message will be provided.
         ///     </para>
         /// </remarks>
         /// <param name="name">The user-visible name to include in the formatted message.</param>
         /// <returns>The localized string describing the validation error</returns>
         /// <exception cref="InvalidOperationException"> is thrown if the current attribute is malformed.</exception>
         public virtual string FormatErrorMessage(string name) =>
-            string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name);
+            FormatMessage(ErrorMessageString, name);
+
+        /// <summary>
+        ///     Formats a validation message using the specified message template and display name.
+        /// </summary>
+        /// <remarks>
+        ///     The base implementation of <see cref="FormatErrorMessage" /> calls this method after selecting the
+        ///     attribute's error message.
+        ///     The base implementation uses <see cref="CultureInfo.CurrentCulture" /> and replaces <c>{0}</c> with
+        ///     <paramref name="name" />. Derived classes can override this method to provide additional values required
+        ///     by their message templates.
+        /// </remarks>
+        /// <param name="format">The message template to format.</param>
+        /// <param name="name">The user-visible name to include in the formatted message.</param>
+        /// <returns>The formatted validation message.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format" /> is <see langword="null" />.</exception>
+        /// <exception cref="FormatException"><paramref name="format" /> is not a valid composite format string.</exception>
+        public virtual string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
+        {
+            ArgumentNullException.ThrowIfNull(format);
+
+            return string.Format(CultureInfo.CurrentCulture, format, name);
+        }
 
         /// <summary>
         ///     Gets the value indicating whether or not the specified <paramref name="value" /> is valid

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -369,8 +369,6 @@ namespace System.ComponentModel.DataAnnotations
         /// <exception cref="FormatException"><paramref name="format" /> is not a valid composite format string.</exception>
         public virtual string FormatMessage([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, string name)
         {
-            ArgumentNullException.ThrowIfNull(format);
-
             return string.Format(CultureInfo.CurrentCulture, format, name);
         }
 

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/CompareAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/CompareAttributeTests.cs
@@ -100,6 +100,30 @@ namespace System.ComponentModel.DataAnnotations.Tests
         }
 
         [Fact]
+        public static void FormatMessage_UsesSuppliedFormatAndOtherPropertyDisplayName()
+        {
+            const string ExternalFormat = "external {0}:{1}";
+            const string ErrorMessageFormat = "internal {0}:{1}";
+            CompareAttribute attribute = new CompareAttribute(nameof(CompareObject.ComparePropertyWithDisplayName))
+            {
+                ErrorMessage = ErrorMessageFormat
+            };
+
+            Assert.Equal(
+                $"external name:{nameof(CompareObject.ComparePropertyWithDisplayName)}",
+                attribute.FormatMessage(ExternalFormat, "name"));
+            Assert.Equal(
+                $"internal name:{nameof(CompareObject.ComparePropertyWithDisplayName)}",
+                attribute.FormatErrorMessage("name"));
+
+            Assert.Throws<ValidationException>(() =>
+                attribute.Validate("test1", new ValidationContext(new CompareObject("test"))));
+
+            Assert.Equal("external name:CustomDisplayName", attribute.FormatMessage(ExternalFormat, "name"));
+            Assert.Equal("internal name:CustomDisplayName", attribute.FormatErrorMessage("name"));
+        }
+
+        [Fact]
         public static void IsValid_ValidationContextNull_ThrowsArgumentNullException()
         {
             var attribute = new CompareAttribute(nameof(CompareObject.ComparePropertyWithDisplayName));

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/FileExtensionsAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/FileExtensionsAttributeTests.cs
@@ -64,5 +64,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
             attribute.Extensions = newValue;
             Assert.Equal(expected, attribute.Extensions);
         }
+
+        [Fact]
+        public static void FormatMessage_UsesSuppliedFormatAndFormattedExtensions()
+        {
+            const string ExternalFormat = "external {0}:{1}";
+            const string ErrorMessageFormat = "internal {0}:{1}";
+            FileExtensionsAttribute attribute = GetAttribute("png, .JPG");
+            attribute.ErrorMessage = ErrorMessageFormat;
+
+            Assert.Equal("external name:.png, .jpg", attribute.FormatMessage(ExternalFormat, "name"));
+            Assert.Equal("internal name:.png, .jpg", attribute.FormatErrorMessage("name"));
+        }
     }
 }

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/LengthAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/LengthAttributeTests.cs
@@ -81,6 +81,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Equal(maximumLength, attr.MaximumLength);
         }
 
+        [Fact]
+        public static void FormatMessage_UsesSuppliedFormatAndLengths()
+        {
+            const string ExternalFormat = "external {0}:{1}:{2}";
+            const string ErrorMessageFormat = "internal {0}:{1}:{2}";
+            var attribute = new LengthAttribute(10, 20) { ErrorMessage = ErrorMessageFormat };
+
+            Assert.Equal("external name:10:20", attribute.FormatMessage(ExternalFormat, "name"));
+            Assert.Equal("internal name:10:20", attribute.FormatErrorMessage("name"));
+        }
+
         [Theory]
         [MemberData(nameof(ValidValues_ICollection))]
         public void Validate_ICollection_Valid(LengthAttribute attribute, object value)

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/MaxLengthAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/MaxLengthAttributeTests.cs
@@ -80,6 +80,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Equal(length, new MaxLengthAttribute(length).Length);
         }
 
+        [Fact]
+        public static void FormatMessage_UsesSuppliedFormatAndLength()
+        {
+            const string ExternalFormat = "external {0}:{1}";
+            const string ErrorMessageFormat = "internal {0}:{1}";
+            var attribute = new MaxLengthAttribute(10) { ErrorMessage = ErrorMessageFormat };
+
+            Assert.Equal("external name:10", attribute.FormatMessage(ExternalFormat, "name"));
+            Assert.Equal("internal name:10", attribute.FormatErrorMessage("name"));
+        }
+
         [Theory]
         [MemberData(nameof(ValidValues_ICollection))]
         public void Validate_ICollection_Valid(MaxLengthAttribute attribute, object value)

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/MinLengthAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/MinLengthAttributeTests.cs
@@ -70,6 +70,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Equal(length, new MinLengthAttribute(length).Length);
         }
 
+        [Fact]
+        public static void FormatMessage_UsesSuppliedFormatAndLength()
+        {
+            const string ExternalFormat = "external {0}:{1}";
+            const string ErrorMessageFormat = "internal {0}:{1}";
+            var attribute = new MinLengthAttribute(10) { ErrorMessage = ErrorMessageFormat };
+
+            Assert.Equal("external name:10", attribute.FormatMessage(ExternalFormat, "name"));
+            Assert.Equal("internal name:10", attribute.FormatErrorMessage("name"));
+        }
+
         [Theory]
         [MemberData(nameof(ValidValues_ICollection))]
         public void Validate_ICollection_Valid(MinLengthAttribute attribute, object value)

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RangeAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RangeAttributeTests.cs
@@ -872,6 +872,30 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Equal(type, attribute.OperandType);
         }
 
+        [Fact]
+        public static void FormatMessage_UsesSuppliedFormatAndConvertedBounds()
+        {
+            const string ExternalFormat = "external {0}:{1:D2}:{2:D2}";
+            const string ErrorMessageFormat = "internal {0}:{1:D2}:{2:D2}";
+            var attribute = new RangeAttribute(typeof(int), "1", "3") { ErrorMessage = ErrorMessageFormat };
+
+            Assert.Equal("external name:01:03", attribute.FormatMessage(ExternalFormat, "name"));
+            Assert.Equal("internal name:01:03", attribute.FormatErrorMessage("name"));
+            Assert.IsType<int>(attribute.Minimum);
+            Assert.IsType<int>(attribute.Maximum);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
+        public static void FormatMessage_UsesCurrentCulture()
+        {
+            using (new ThreadCultureChange("fr-FR"))
+            {
+                var attribute = new RangeAttribute(1.5, 3.5);
+
+                Assert.Equal("name:1,5:3,5", attribute.FormatMessage("{0}:{1:F1}:{2:F1}", "name"));
+            }
+        }
+
         [Theory]
         [MemberData(nameof(GetRangeAttributeConstructorResults))]
         public static void ExclusiveBoundProperties_DefaultToFalse(RangeAttribute attribute)

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
@@ -56,6 +56,17 @@ namespace System.ComponentModel.DataAnnotations.Tests
             Assert.Equal(newValue, attribute.MatchTimeoutInMilliseconds);
         }
 
+        [Fact]
+        public static void FormatMessage_UsesSuppliedFormatAndPattern()
+        {
+            const string ExternalFormat = "external {0}:{1}";
+            const string ErrorMessageFormat = "internal {0}:{1}";
+            var attribute = new RegularExpressionAttribute("^[a-z]+$") { ErrorMessage = ErrorMessageFormat };
+
+            Assert.Equal("external name:^[a-z]+$", attribute.FormatMessage(ExternalFormat, "name"));
+            Assert.Equal("internal name:^[a-z]+$", attribute.FormatErrorMessage("name"));
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/StringLengthAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/StringLengthAttributeTests.cs
@@ -43,6 +43,31 @@ namespace System.ComponentModel.DataAnnotations.Tests
         }
 
         [Fact]
+        public static void FormatMessage_UsesSuppliedFormatAndLengths()
+        {
+            const string ExternalFormat = "external {0}:{1}:{2}";
+            const string ErrorMessageFormat = "internal {0}:{1}:{2}";
+            var attribute = new StringLengthAttribute(20)
+            {
+                ErrorMessage = ErrorMessageFormat,
+                MinimumLength = 10
+            };
+
+            Assert.Equal("external name:20:10", attribute.FormatMessage(ExternalFormat, "name"));
+            Assert.Equal("internal name:20:10", attribute.FormatErrorMessage("name"));
+        }
+
+        [Theory]
+        [InlineData(0, "The field name must be a string with a maximum length of 20.")]
+        [InlineData(10, "The field name must be a string with a minimum length of 10 and a maximum length of 20.")]
+        public static void FormatErrorMessage_DefaultTemplateUsesMinimumWhenSpecified(int minimumLength, string expected)
+        {
+            var attribute = new StringLengthAttribute(20) { MinimumLength = minimumLength };
+
+            Assert.Equal(expected, attribute.FormatErrorMessage("name"));
+        }
+
+        [Fact]
         public static void Validate_NegativeMaximumLength_ThrowsInvalidOperationException()
         {
             var attribute = new StringLengthAttribute(-1);

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationAttributeTests.cs
@@ -155,7 +155,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             yield return new object[] { new LengthAttribute(1, 2) };
             yield return new object[] { new MaxLengthAttribute(2) };
             yield return new object[] { new MinLengthAttribute(1) };
-            yield return new object[] { new RangeAttribute(typeof(int), null, null) };
+            yield return new object[] { new RangeAttribute(1, 2) };
             yield return new object[] { new RegularExpressionAttribute("pattern") };
             yield return new object[] { new StringLengthAttribute(2) };
         }

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationAttributeTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -135,6 +136,58 @@ namespace System.ComponentModel.DataAnnotations.Tests
             attribute.ErrorMessageResourceName = null;
             attribute.ErrorMessageResourceType = null;
             Assert.Equal(expected, attribute.FormatErrorMessage("name"));
+        }
+
+        [Theory]
+        [InlineData("SomeMessage", "name", "SomeMessage")]
+        [InlineData("SomeMessage with name <{0}>", "name", "SomeMessage with name <name>")]
+        public static void FormatMessage_ReturnsExpected(string format, string name, string expected)
+        {
+            var attribute = new ValidationAttributeNoOverrides();
+            Assert.Equal(expected, attribute.FormatMessage(format, name));
+        }
+
+        public static IEnumerable<object[]> FormatMessageAttributes()
+        {
+            yield return new object[] { new ValidationAttributeNoOverrides() };
+            yield return new object[] { new CompareAttribute("OtherProperty") };
+            yield return new object[] { new FileExtensionsAttribute() };
+            yield return new object[] { new LengthAttribute(1, 2) };
+            yield return new object[] { new MaxLengthAttribute(2) };
+            yield return new object[] { new MinLengthAttribute(1) };
+            yield return new object[] { new RangeAttribute(typeof(int), null, null) };
+            yield return new object[] { new RegularExpressionAttribute("pattern") };
+            yield return new object[] { new StringLengthAttribute(2) };
+        }
+
+        [Theory]
+        [MemberData(nameof(FormatMessageAttributes))]
+        public static void FormatMessage_NullFormat_ThrowsArgumentNullException(ValidationAttribute attribute)
+        {
+            AssertExtensions.Throws<ArgumentNullException>(
+                "format",
+                () => attribute.FormatMessage(null, "name"));
+        }
+
+        [Fact]
+        public static void FormatMessage_InvalidFormat_ThrowsFormatException()
+        {
+            var attribute = new ValidationAttributeNoOverrides();
+
+            Assert.Throws<FormatException>(() => attribute.FormatMessage("{1}", "name"));
+        }
+
+        [Fact]
+        public static void FormatErrorMessage_DelegatesToFormatMessage()
+        {
+            var attribute = new ValidationAttributeOverrideFormatMessage
+            {
+                ErrorMessage = "SomeMessage with name <{0}>"
+            };
+
+            Assert.Equal(
+                "SomeMessage with name <{0}>|name",
+                attribute.FormatErrorMessage("name"));
         }
 
         [Theory]
@@ -324,6 +377,11 @@ namespace System.ComponentModel.DataAnnotations.Tests
 
         public class ValidationAttributeNoOverrides : ValidationAttribute
         {
+        }
+
+        public class ValidationAttributeOverrideFormatMessage : ValidationAttribute
+        {
+            public override string FormatMessage(string format, string name) => $"{format}|{name}";
         }
 
         public class ValidationAttributeOverrideOneArgIsValid : ValidationAttribute


### PR DESCRIPTION
## Summary

Adds the approved `ValidationAttribute.FormatMessage` API so callers can supply externally localized composite-format strings while each validation attribute remains responsible for providing its placeholder arguments.

## Changes

- Add `ValidationAttribute.FormatMessage([StringSyntax("CompositeFormat")] string format, string name)`.
- Route the base `FormatErrorMessage` implementation through the new method.
- Add overrides for `CompareAttribute`, `FileExtensionsAttribute`, `LengthAttribute`, `MaxLengthAttribute`, `MinLengthAttribute`, `RangeAttribute`, `RegularExpressionAttribute`, and `StringLengthAttribute`.
- Preserve existing placeholder ordering and `CurrentCulture` formatting.
- Add coverage for supplied formats, virtual dispatch, culture-sensitive formatting, invalid formats, and null arguments.

Existing `FormatErrorMessage` behavior remains unchanged.

## Testing

- `dotnet build` — succeeded with 0 warnings and 0 errors.
- `dotnet build /t:test .\tests\System.ComponentModel.Annotations.Tests.csproj` — 1,008 passed, 0 failed, 0 skipped.

Fixes #132605

> [!NOTE]
> This pull request description was generated with GitHub Copilot.