### PR TITLE
Throw JsonException for duplicate JsonObject properties

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Node/JsonObjectConverter.cs
@@ -103,8 +103,10 @@ namespace System.Text.Json.Serialization.Converters
                 reader.Read(); // Move to the value token.
                 JsonNode? value = JsonNodeConverter.ReadAsJsonNode(ref reader, options);
 
-                // To have parity with the lazy JsonObject, we throw on duplicates.
-                jObject.Add(propertyName, value);
+                if (!jObject.TryAdd(propertyName, value))
+                {
+                    ThrowHelper.ThrowJsonException_DuplicatePropertyNotAllowed(propertyName);
+                }
             }
 
             // JSON is invalid so reader would have already thrown.

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonObjectTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonObjectTests.cs
@@ -1736,9 +1736,9 @@ namespace System.Text.Json.Nodes.Tests
             }
             else
             {
-                AssertExtensions.ThrowsContains<ArgumentException>(
+                AssertExtensions.ThrowsContains<JsonException>(
                     () => JsonSerializer.Deserialize<T>(jsonPayload, JsonTestSerializerOptions.DisallowDuplicateProperties),
-                    "An item with the same key has already been added.");
+                    "Duplicate property");
 
                 // Default options don't throw on deserialize but will throw when accessed
                 T node = JsonSerializer.Deserialize<T>(jsonPayload);
@@ -1756,14 +1756,14 @@ namespace System.Text.Json.Nodes.Tests
             string jsonPayload = """{"a":1,"A":2}""";
 
             _ = JsonSerializer.Deserialize<JsonObject>(jsonPayload); // Assert no throw
-            AssertExtensions.ThrowsContains<ArgumentException>(
+            AssertExtensions.ThrowsContains<JsonException>(
                 () => JsonSerializer.Deserialize<JsonObject>(jsonPayload, options),
-                "An item with the same key has already been added.");
+                "Duplicate property");
 
             _ = JsonSerializer.Deserialize<JsonNode>(jsonPayload); // Assert no throw
-            AssertExtensions.ThrowsContains<ArgumentException>(
+            AssertExtensions.ThrowsContains<JsonException>(
                 () => JsonSerializer.Deserialize<JsonNode>(jsonPayload, options),
-                "An item with the same key has already been added.");
+                "Duplicate property");
         }
 
         [Fact]
@@ -1774,14 +1774,14 @@ namespace System.Text.Json.Nodes.Tests
             string jsonPayload = """[{"a":1,"A":2}]""";
 
             _ = JsonSerializer.Deserialize<JsonArray>(jsonPayload); // Assert no throw
-            AssertExtensions.ThrowsContains<ArgumentException>(
+            AssertExtensions.ThrowsContains<JsonException>(
                 () => JsonSerializer.Deserialize<JsonArray>(jsonPayload, options),
-                "An item with the same key has already been added.");
+                "Duplicate property");
 
             _ = JsonSerializer.Deserialize<JsonNode>(jsonPayload); // Assert no throw
-            AssertExtensions.ThrowsContains<ArgumentException>(
+            AssertExtensions.ThrowsContains<JsonException>(
                 () => JsonSerializer.Deserialize<JsonNode>(jsonPayload, options),
-                "An item with the same key has already been added.");
+                "Duplicate property");
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #123882.

When `JsonSerializerOptions.AllowDuplicateProperties` is `false`, the eager `JsonObject` converter used `JsonObject.Add`, leaking an `ArgumentException` for duplicate properties despite the documented `JsonException` contract.

Use `TryAdd` with the existing duplicate-property throw helper, matching other System.Text.Json converters. Update tests for direct, nested, escaped, and case-insensitive duplicate properties.

**Testing**

- System.Text.Json.Tests: 53,870 passed, 0 failed

> [!NOTE]
> This pull request description was generated with GitHub Copilot.