### PR TITLE
Invalidate SmtpClient cached connection when connection-affecting properties change

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -365,9 +365,8 @@ namespace System.Net.Mail
                 if (value != _targetName)
                 {
                     _targetName = value;
-                    // The target name participates in connection establishment (authentication
-                    // and TLS), so invalidate any cached connection to force a new one on the
-                    // next send.
+                    // The target name is the SPN used during authentication, so invalidate any
+                    // cached connection to force a new one on the next send.
                     _transport.InvalidateCachedConnection();
                 }
             }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -352,6 +352,11 @@ namespace System.Net.Mail
             get { return _targetName; }
             set
             {
+                if (_inCall)
+                {
+                    throw new InvalidOperationException(SR.SmtpInvalidOperationDuringSend);
+                }
+
                 if (value != _targetName)
                 {
                     _targetName = value;

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -164,6 +164,9 @@ namespace System.Net.Mail
                 {
                     _host = value;
                     _servicePoint = null;
+                    // The cached connection targets the previous host, so release it
+                    // to force a new connection to be established on the next send.
+                    _transport.ReleaseConnection();
                 }
             }
         }
@@ -187,6 +190,9 @@ namespace System.Net.Mail
                 {
                     _port = value;
                     _servicePoint = null;
+                    // The cached connection targets the previous port, so release it
+                    // to force a new connection to be established on the next send.
+                    _transport.ReleaseConnection();
                 }
             }
         }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -332,6 +332,11 @@ namespace System.Net.Mail
             }
             set
             {
+                if (_inCall)
+                {
+                    throw new InvalidOperationException(SR.SmtpInvalidOperationDuringSend);
+                }
+
                 _transport.EnableSsl = value;
             }
         }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -43,6 +43,7 @@ namespace System.Net.Mail
         private bool _inCall;
         private bool _timedOut;
         private string? _targetName;
+        private const string DefaultTargetNamePrefix = "SMTPSVC/";
         private SmtpDeliveryMethod _deliveryMethod = SmtpDeliveryMethod.Network;
         private SmtpDeliveryFormat _deliveryFormat = SmtpDeliveryFormat.SevenBit; // Non-EAI default
         private string? _pickupDirectoryLocation;
@@ -103,7 +104,7 @@ namespace System.Net.Mail
                 _port = DefaultPort;
             }
 
-            _targetName ??= "SMTPSVC/" + _host;
+            _targetName ??= DefaultTargetNamePrefix + _host;
 
             if (_clientDomain == null)
             {
@@ -162,6 +163,15 @@ namespace System.Net.Mail
 
                 if (value != _host)
                 {
+                    // If TargetName is still the default derived from the current host, keep it in
+                    // sync with the new host so Negotiate/NTLM authentication uses the correct SPN.
+                    // A TargetName explicitly set by the caller (not matching the default) is left
+                    // untouched.
+                    if (_targetName == DefaultTargetNamePrefix + _host)
+                    {
+                        _targetName = DefaultTargetNamePrefix + value;
+                    }
+
                     _host = value;
                     _servicePoint = null;
                     // The cached connection targets the previous host, so invalidate it to force

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -164,9 +164,9 @@ namespace System.Net.Mail
                 {
                     _host = value;
                     _servicePoint = null;
-                    // The cached connection targets the previous host, so release it
-                    // to force a new connection to be established on the next send.
-                    _transport.ReleaseConnection();
+                    // The cached connection targets the previous host, so invalidate it to force
+                    // a new connection to be established on the next send.
+                    _transport.InvalidateCachedConnection();
                 }
             }
         }
@@ -190,9 +190,9 @@ namespace System.Net.Mail
                 {
                     _port = value;
                     _servicePoint = null;
-                    // The cached connection targets the previous port, so release it
-                    // to force a new connection to be established on the next send.
-                    _transport.ReleaseConnection();
+                    // The cached connection targets the previous port, so invalidate it to force
+                    // a new connection to be established on the next send.
+                    _transport.InvalidateCachedConnection();
                 }
             }
         }
@@ -340,7 +340,17 @@ namespace System.Net.Mail
         public string? TargetName
         {
             get { return _targetName; }
-            set { _targetName = value; }
+            set
+            {
+                if (value != _targetName)
+                {
+                    _targetName = value;
+                    // The target name participates in connection establishment (authentication
+                    // and TLS), so invalidate any cached connection to force a new one on the
+                    // next send.
+                    _transport.InvalidateCachedConnection();
+                }
+            }
         }
 
         private bool ServerSupportsEai

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -20,7 +20,10 @@ namespace System.Net.Mail
         private readonly SmtpClient _client;
         private ICredentialsByHost? _credentials;
         private bool _shouldAbort;
-        private bool _stale;
+        // Written (set true) from property setters without holding the transport lock and read
+        // from IsConnected on the send path, so it is volatile to make an invalidating
+        // configuration change reliably observable across threads without widening locking.
+        private volatile bool _stale;
 
         private bool _enableSsl;
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -98,11 +98,24 @@ namespace System.Net.Mail
         {
             lock (this)
             {
-                // Gracefully release any previously cached connection (for example one that
-                // became stale after a configuration change) before establishing a new one so
-                // its socket is not leaked. This keeps the potentially blocking shutdown work on
-                // the send path rather than in the property setters that invalidated it.
-                _connection?.ReleaseConnection();
+                // Release any previously cached connection (for example one that became stale
+                // after a configuration change, or one whose connect attempt failed) before
+                // establishing a new one so its socket is not leaked. Only a connection that was
+                // actually established can be shut down gracefully (QUIT); a connection that never
+                // connected may not have an initialized stream, so it is aborted instead. This
+                // keeps the potentially blocking shutdown work on the send path rather than in the
+                // property setters that invalidated it.
+                if (_connection is not null)
+                {
+                    if (_connection.IsConnected)
+                    {
+                        _connection.ReleaseConnection();
+                    }
+                    else
+                    {
+                        _connection.Abort();
+                    }
+                }
                 _stale = false;
                 _connection = new SmtpConnection(this, _client, _credentials, _authenticationModules);
                 if (_shouldAbort)

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -99,37 +99,17 @@ namespace System.Net.Mail
         internal Task GetConnectionAsync<TIOAdapter>(string host, int port, CancellationToken cancellationToken = default)
             where TIOAdapter : IReadWriteAdapter
         {
-            // Detach any previously cached connection (for example one that became stale after a
-            // configuration change, or one whose connect attempt failed) so its socket is not
-            // leaked. Sends are serialized by SmtpClient._inCall, so no other GetConnectionAsync
-            // can run concurrently here.
-            SmtpConnection? previousConnection;
             lock (this)
             {
-                previousConnection = _connection;
-                _connection = null;
+                // Abort any previously cached connection (for example one that became stale after a
+                // configuration change, or one whose connect attempt failed) so its socket is not
+                // leaked. Abort() only force-closes the socket without any network round-trip, so it
+                // is safe to run under the lock and does not block this async send path. A graceful
+                // QUIT is unnecessary for a connection we are discarding. Sends are serialized by
+                // SmtpClient._inCall, so no other GetConnectionAsync can run concurrently here.
+                _connection?.Abort();
                 _stale = false;
-            }
 
-            // Shut the previous connection down outside the lock: a graceful release performs a
-            // blocking QUIT over the network, and holding the transport lock across that I/O would
-            // delay a concurrent Abort() (for example from the send-timeout path). Only a
-            // connection that was actually established can be shut down gracefully; one that never
-            // connected may not have an initialized stream, so it is aborted instead.
-            if (previousConnection is not null)
-            {
-                if (previousConnection.IsConnected)
-                {
-                    previousConnection.ReleaseConnection();
-                }
-                else
-                {
-                    previousConnection.Abort();
-                }
-            }
-
-            lock (this)
-            {
                 _connection = new SmtpConnection(this, _client, _credentials, _authenticationModules);
                 if (_shouldAbort)
                 {
@@ -188,10 +168,10 @@ namespace System.Net.Mail
             _connection?.ReleaseConnection();
         }
 
-        // Marks any cached connection as stale without performing blocking work. The connection
-        // is gracefully released and replaced the next time one is established (see
-        // GetConnectionAsync). This is called when a property that affects how the connection is
-        // established (host, port, credentials, SSL settings, target name) changes.
+        // Marks any cached connection as stale without performing blocking work. The connection is
+        // aborted and replaced the next time one is established (see GetConnectionAsync). This is
+        // called when a property that affects how the connection is established (host, port,
+        // credentials, SSL settings, target name) changes.
         internal void InvalidateCachedConnection()
         {
             _stale = true;

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -20,6 +20,7 @@ namespace System.Net.Mail
         private readonly SmtpClient _client;
         private ICredentialsByHost? _credentials;
         private bool _shouldAbort;
+        private bool _stale;
 
         private bool _enableSsl;
 
@@ -43,7 +44,11 @@ namespace System.Net.Mail
             }
             set
             {
-                _credentials = value;
+                if (!ReferenceEquals(value, _credentials))
+                {
+                    _credentials = value;
+                    InvalidateCachedConnection();
+                }
             }
         }
 
@@ -51,7 +56,7 @@ namespace System.Net.Mail
         {
             get
             {
-                return _connection != null && _connection.IsConnected;
+                return _connection != null && _connection.IsConnected && !_stale;
             }
         }
 
@@ -63,7 +68,11 @@ namespace System.Net.Mail
             }
             set
             {
-                _enableSsl = value;
+                if (value != _enableSsl)
+                {
+                    _enableSsl = value;
+                    InvalidateCachedConnection();
+                }
             }
         }
 
@@ -89,6 +98,12 @@ namespace System.Net.Mail
         {
             lock (this)
             {
+                // Gracefully release any previously cached connection (for example one that
+                // became stale after a configuration change) before establishing a new one so
+                // its socket is not leaked. This keeps the potentially blocking shutdown work on
+                // the send path rather than in the property setters that invalidated it.
+                _connection?.ReleaseConnection();
+                _stale = false;
                 _connection = new SmtpConnection(this, _client, _credentials, _authenticationModules);
                 if (_shouldAbort)
                 {
@@ -145,6 +160,15 @@ namespace System.Net.Mail
         internal void ReleaseConnection()
         {
             _connection?.ReleaseConnection();
+        }
+
+        // Marks any cached connection as stale without performing blocking work. The connection
+        // is gracefully released and replaced the next time one is established (see
+        // GetConnectionAsync). This is called when a property that affects how the connection is
+        // established (host, port, credentials, SSL settings, target name) changes.
+        internal void InvalidateCachedConnection()
+        {
+            _stale = true;
         }
 
         internal void Abort()

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -99,27 +99,37 @@ namespace System.Net.Mail
         internal Task GetConnectionAsync<TIOAdapter>(string host, int port, CancellationToken cancellationToken = default)
             where TIOAdapter : IReadWriteAdapter
         {
+            // Detach any previously cached connection (for example one that became stale after a
+            // configuration change, or one whose connect attempt failed) so its socket is not
+            // leaked. Sends are serialized by SmtpClient._inCall, so no other GetConnectionAsync
+            // can run concurrently here.
+            SmtpConnection? previousConnection;
             lock (this)
             {
-                // Release any previously cached connection (for example one that became stale
-                // after a configuration change, or one whose connect attempt failed) before
-                // establishing a new one so its socket is not leaked. Only a connection that was
-                // actually established can be shut down gracefully (QUIT); a connection that never
-                // connected may not have an initialized stream, so it is aborted instead. This
-                // keeps the potentially blocking shutdown work on the send path rather than in the
-                // property setters that invalidated it.
-                if (_connection is not null)
-                {
-                    if (_connection.IsConnected)
-                    {
-                        _connection.ReleaseConnection();
-                    }
-                    else
-                    {
-                        _connection.Abort();
-                    }
-                }
+                previousConnection = _connection;
+                _connection = null;
                 _stale = false;
+            }
+
+            // Shut the previous connection down outside the lock: a graceful release performs a
+            // blocking QUIT over the network, and holding the transport lock across that I/O would
+            // delay a concurrent Abort() (for example from the send-timeout path). Only a
+            // connection that was actually established can be shut down gracefully; one that never
+            // connected may not have an initialized stream, so it is aborted instead.
+            if (previousConnection is not null)
+            {
+                if (previousConnection.IsConnected)
+                {
+                    previousConnection.ReleaseConnection();
+                }
+                else
+                {
+                    previousConnection.Abort();
+                }
+            }
+
+            lock (this)
+            {
                 _connection = new SmtpConnection(this, _client, _credentials, _authenticationModules);
                 if (_shouldAbort)
                 {

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
@@ -137,7 +137,7 @@ namespace System.Net.Mail.Tests
                     Assert.Equal("SMTPSVC/127.0.0.1", Smtp.TargetName);
                     break;
                 case ConnectionAffectingProperty.Credentials:
-                    Smtp.Credentials = new NetworkCredential("user", "password");
+                    Smtp.Credentials = new NetworkCredential("foo", "bar");
                     break;
                 case ConnectionAffectingProperty.TargetName:
                     Smtp.TargetName = "SMTPSVC/example.com";

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
@@ -9,6 +9,13 @@ using Xunit.Abstractions;
 
 namespace System.Net.Mail.Tests
 {
+    public enum ConnectionAffectingProperty
+    {
+        Host,
+        Credentials,
+        TargetName,
+    }
+
     public abstract class SmtpClientConnectionTest<TSendMethod> : LoopbackServerTestBase<TSendMethod>
         where TSendMethod : ISendMethodProvider
     {
@@ -106,8 +113,11 @@ namespace System.Net.Mail.Tests
             Assert.Equal("<first@example.com>", Server.MailFrom);
         }
 
-        [Fact]
-        public async Task ChangingHost_EstablishesNewConnection()
+        [Theory]
+        [InlineData(ConnectionAffectingProperty.Host)]
+        [InlineData(ConnectionAffectingProperty.Credentials)]
+        [InlineData(ConnectionAffectingProperty.TargetName)]
+        public async Task ChangingConnectionProperty_EstablishesNewConnection(ConnectionAffectingProperty property)
         {
             Server.ReceiveMultipleConnections = true;
 
@@ -115,9 +125,21 @@ namespace System.Net.Mail.Tests
             Assert.Equal(1, Server.ConnectionCount);
             Assert.Equal("<first@example.com>", Server.MailFrom);
 
-            // Change the host to another value that still resolves to the loopback server.
-            // The cached connection must be dropped and a new one established.
-            Smtp.Host = "127.0.0.1";
+            // Change a property that affects how the connection is established. The cached
+            // connection must be invalidated and a new one established on the next send.
+            switch (property)
+            {
+                case ConnectionAffectingProperty.Host:
+                    // A different value that still resolves to the loopback server.
+                    Smtp.Host = "127.0.0.1";
+                    break;
+                case ConnectionAffectingProperty.Credentials:
+                    Smtp.Credentials = new NetworkCredential("user", "password");
+                    break;
+                case ConnectionAffectingProperty.TargetName:
+                    Smtp.TargetName = "SMTPSVC/example.com";
+                    break;
+            }
 
             await SendMail(new MailMessage("second@example.com", "everyone@novell.com", "introduction", "hello"));
             Assert.Equal(2, Server.ConnectionCount);

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
@@ -84,6 +84,45 @@ namespace System.Net.Mail.Tests
             await SendMail(new MailMessage("mono@novell.com", "everyone@novell.com", "introduction", "hello"));
             Assert.True(helloReceived, "HELO command was not received.");
         }
+
+        [Fact]
+        public async Task ChangingPort_DoesNotReuseConnectionToPreviousServer()
+        {
+            using LoopbackSmtpServer server2 = new LoopbackSmtpServer(Output);
+
+            await SendMail(new MailMessage("first@example.com", "everyone@novell.com", "introduction", "hello"));
+            Assert.Equal("<first@example.com>", Server.MailFrom);
+
+            // Point the client at a different server. The cached connection to the original
+            // server must be dropped so the next message is delivered to the new server.
+            Smtp.Port = server2.Port;
+
+            await SendMail(new MailMessage("second@example.com", "everyone@novell.com", "introduction", "hello"));
+
+            Assert.Equal("<second@example.com>", server2.MailFrom);
+            Assert.Equal(1, server2.ConnectionCount);
+
+            // The original server must not have received the second message.
+            Assert.Equal("<first@example.com>", Server.MailFrom);
+        }
+
+        [Fact]
+        public async Task ChangingHost_EstablishesNewConnection()
+        {
+            Server.ReceiveMultipleConnections = true;
+
+            await SendMail(new MailMessage("first@example.com", "everyone@novell.com", "introduction", "hello"));
+            Assert.Equal(1, Server.ConnectionCount);
+            Assert.Equal("<first@example.com>", Server.MailFrom);
+
+            // Change the host to another value that still resolves to the loopback server.
+            // The cached connection must be dropped and a new one established.
+            Smtp.Host = "127.0.0.1";
+
+            await SendMail(new MailMessage("second@example.com", "everyone@novell.com", "introduction", "hello"));
+            Assert.Equal(2, Server.ConnectionCount);
+            Assert.Equal("<second@example.com>", Server.MailFrom);
+        }
     }
 
     public class SmtpClientConnectionTest_Send : SmtpClientConnectionTest<SyncSendMethod>

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientConnectionTest.cs
@@ -130,8 +130,11 @@ namespace System.Net.Mail.Tests
             switch (property)
             {
                 case ConnectionAffectingProperty.Host:
-                    // A different value that still resolves to the loopback server.
+                    // A different value that still resolves to the loopback server. The default
+                    // TargetName should follow the host so authentication uses the correct SPN.
+                    Assert.Equal("SMTPSVC/localhost", Smtp.TargetName);
                     Smtp.Host = "127.0.0.1";
+                    Assert.Equal("SMTPSVC/127.0.0.1", Smtp.TargetName);
                     break;
                 case ConnectionAffectingProperty.Credentials:
                     Smtp.Credentials = new NetworkCredential("user", "password");
@@ -144,6 +147,20 @@ namespace System.Net.Mail.Tests
             await SendMail(new MailMessage("second@example.com", "everyone@novell.com", "introduction", "hello"));
             Assert.Equal(2, Server.ConnectionCount);
             Assert.Equal("<second@example.com>", Server.MailFrom);
+        }
+
+        [Fact]
+        public async Task ChangingHost_PreservesExplicitlySetTargetName()
+        {
+            // A TargetName explicitly set by the caller must not be overwritten when the host
+            // changes, even though the default (host-derived) TargetName does follow the host.
+            Smtp.TargetName = "SMTPSVC/explicit.example.com";
+
+            await SendMail(new MailMessage("first@example.com", "everyone@novell.com", "introduction", "hello"));
+            Assert.Equal("SMTPSVC/explicit.example.com", Smtp.TargetName);
+
+            Smtp.Host = "127.0.0.1";
+            Assert.Equal("SMTPSVC/explicit.example.com", Smtp.TargetName);
         }
     }
 

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTlsTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTlsTest.cs
@@ -185,6 +185,27 @@ namespace System.Net.Mail.Tests
             Assert.Equal(clientCert, receivedClientCert);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120959", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot), nameof(PlatformDetection.IsAndroid))]
+        [Fact]
+        public async Task EnableSsl_ChangedAfterConnect_EstablishesNewEncryptedConnection()
+        {
+            Server.ReceiveMultipleConnections = true;
+            _serverCertValidationCallback = (cert, chain, errors) => true;
+
+            // First send happens over a plaintext connection.
+            await SendMail(new MailMessage("foo@example.com", "bar@example.com", "hello", "howdydoo"));
+            Assert.Equal(1, Server.ConnectionCount);
+            Assert.False(Server.IsEncrypted, "First connection should not be encrypted.");
+
+            // Enabling SSL must invalidate the cached plaintext connection so the next send
+            // establishes a new, encrypted connection instead of reusing the old one.
+            Smtp.EnableSsl = true;
+
+            await SendMail(new MailMessage("foo@example.com", "bar@example.com", "hello", "howdydoo"));
+            Assert.Equal(2, Server.ConnectionCount);
+            Assert.True(Server.IsEncrypted, "Second connection should be encrypted after enabling SSL.");
+        }
+
         private bool ServerCertValidationCallback(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors)
         {
             if (_serverCertValidationCallback != null)


### PR DESCRIPTION
## Why

`SmtpClient` caches a live `SmtpConnection` in its transport and reuses it across `Send` calls. However, the connection-affecting property setters never dropped the cached connection. As a result, changing configuration between sends kept delivering mail over the *original* connection instead of re-establishing one for the new configuration. The most visible case was `Host`/`Port` (mail kept going to the original server), but the same stale-reuse problem applied to every property that determines how the connection is established.

## What

When a connection-affecting property actually changes, the cached transport connection is invalidated so the next send re-establishes a fresh connection for the new configuration. This now covers:

- `Host` and `Port`
- `Credentials` / `UseDefaultCredentials` (SMTP AUTH is per-connection)
- `EnableSsl`
- `TargetName` (the SPN used for authentication)

Changing `Host` also updates the default `TargetName` (`SMTPSVC/<host>`) when the target name was not set explicitly, so authentication targets the new host.

Rather than doing potentially blocking work in a property setter, the setters simply mark the transport as stale (a non-blocking flag). The stale connection is aborted and replaced lazily on the next send inside `GetConnectionAsync`. Aborting (rather than a graceful QUIT) avoids synchronous network I/O on the async send path. Normal connection reuse is preserved when a value is unchanged, and the setters throw `InvalidOperationException` (SmtpInvalidOperationDuringSend) if changed while a send is in progress, so invalidation never races an active send.

## Tests

Added regression tests in `SmtpClientConnectionTest` and `SmtpClientTlsTest`, running across all three send paths (`Send`, `SendAsync`, `SendMailAsync`):

- `ChangingConnectionProperty_EstablishesNewConnection` - theory over `Host`, `Credentials`, and `TargetName`; asserts a new connection is established and, for the `Host` case, that the default `TargetName` follows the new host.
- `ChangingHost_PreservesExplicitlySetTargetName` - an explicitly set `TargetName` is not overwritten when `Host` changes.
- `ChangingPort_DoesNotReuseConnectionToPreviousServer` - points the client at a second loopback server and asserts the next message reaches the new server, not the original.
- `EnableSsl_ChangedAfterConnect_EstablishesNewEncryptedConnection` - toggling `EnableSsl` after a plaintext connection forces a new encrypted connection.

The targeted `SmtpClientConnectionTest` and `SmtpClientTlsTest` classes (60 tests across the three send modes) pass; the connection-property tests were confirmed to fail without the fix and pass with it.

> [!NOTE]
> This PR was authored by GitHub Copilot.