### PR TITLE
[release/10.0] Detect circular dependencies in factory-based service registrations at runtime

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
@@ -37,6 +37,8 @@
     <Compile Include="$(CommonPath)Extensions\ParameterDefaultValue\ParameterDefaultValue.netstandard.cs"
              Link="Common\src\Extensions\ParameterDefaultValue\ParameterDefaultValue.netstandard.cs" />
 
+    <Compile Include="$(CoreLibSharedDir)System\Collections\Generic\ReferenceEqualityComparer.cs"
+             Link="Common\src\CoreLib\System\Collections\Generic\ReferenceEqualityComparer.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresDynamicCodeAttribute.cs" />

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -6,14 +6,21 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal sealed class CallSiteRuntimeResolver : CallSiteVisitor<RuntimeResolverContext, object?>
     {
         public static CallSiteRuntimeResolver Instance { get; } = new();
+
+        // ThreadStatic set to track call sites currently being resolved on this thread.
+        // Used to detect circular dependencies that occur through factory functions.
+        [ThreadStatic]
+        private static HashSet<ServiceCallSite>? t_resolving;
 
         private CallSiteRuntimeResolver()
         {
@@ -89,14 +96,30 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     return callSiteValue;
                 }
 
-                object? resolved = VisitCallSiteMain(callSite, new RuntimeResolverContext
+                // Detect circular dependencies by tracking what we're currently resolving on this thread
+                t_resolving ??= new HashSet<ServiceCallSite>(ReferenceEqualityComparer.Instance);
+                if (!t_resolving.Add(callSite))
                 {
-                    Scope = serviceProviderEngine,
-                    AcquiredLocks = context.AcquiredLocks | lockType
-                });
-                serviceProviderEngine.CaptureDisposable(resolved);
-                callSite.Value = resolved;
-                return resolved;
+                    // We're already resolving this call site on this thread - circular dependency detected
+                    throw new InvalidOperationException(
+                        SR.Format(SR.CircularDependencyException, TypeNameHelper.GetTypeDisplayName(callSite.ServiceType)));
+                }
+
+                try
+                {
+                    object? resolved = VisitCallSiteMain(callSite, new RuntimeResolverContext
+                    {
+                        Scope = serviceProviderEngine,
+                        AcquiredLocks = context.AcquiredLocks | lockType
+                    });
+                    serviceProviderEngine.CaptureDisposable(resolved);
+                    callSite.Value = resolved;
+                    return resolved;
+                }
+                finally
+                {
+                    t_resolving.Remove(callSite);
+                }
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using Microsoft.Extensions.Internal;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CircularDependencyTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CircularDependencyTests.cs
@@ -204,5 +204,67 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             Assert.Equal(expectedMessage, exception.Message);
         }
+
+        [Fact]
+        public void FactoryCircularDependency_DetectedAtResolutionTime()
+        {
+            // This test demonstrates circular dependency through factory functions
+            // Service A has constructor dependency on Service B
+            // Service B is registered with a factory that requests Service A from IServiceProvider
+            // This creates a circular dependency: A -> B -> A
+            //
+            // Factory-based circular dependencies cannot be detected during call site construction
+            // because factories are opaque. The re-entrance detection in VisitRootCache detects
+            // these at resolution time, preventing deadlock and providing a clear error message.
+
+            var services = new ServiceCollection();
+            services.AddSingleton<FactoryCircularDependencyA>();
+            services.AddSingleton<FactoryCircularDependencyB>(sp =>
+            {
+                // Factory tries to resolve FactoryCircularDependencyA, creating a circle
+                _ = sp.GetRequiredService<FactoryCircularDependencyA>();
+                return new FactoryCircularDependencyB();
+            });
+
+            // Build succeeds - circular dependency cannot be detected until resolution
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Resolution should throw InvalidOperationException for circular dependency
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = serviceProvider.GetRequiredService<FactoryCircularDependencyA>();
+            });
+
+            // Verify it's a circular dependency error with proper service type
+            Assert.Contains("circular dependency", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("FactoryCircularDependencyA", exception.Message);
+        }
+
+        [Fact]
+        public void FactoryCircularDependency_NotDetectedByValidateOnBuild()
+        {
+            // This test verifies that ValidateOnBuild does NOT detect factory-based circular
+            // dependencies because factories are opaque during call site construction.
+            // The circular dependency is only detected at actual resolution time.
+
+            var services = new ServiceCollection();
+            services.AddSingleton<FactoryCircularDependencyA>();
+            services.AddSingleton<FactoryCircularDependencyB>(sp =>
+            {
+                _ = sp.GetRequiredService<FactoryCircularDependencyA>();
+                return new FactoryCircularDependencyB();
+            });
+
+            // BuildServiceProvider with ValidateOnBuild succeeds because factories are not invoked during validation
+            var serviceProvider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+
+            // But resolution fails with circular dependency error
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                serviceProvider.GetRequiredService<FactoryCircularDependencyA>());
+
+            // Verify it's a circular dependency error
+            Assert.Contains("circular dependency", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("FactoryCircularDependencyA", exception.Message);
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Fakes/CircularReferences/FactoryCircularDependencyA.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Fakes/CircularReferences/FactoryCircularDependencyA.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
+{
+    public class FactoryCircularDependencyA
+    {
+        public FactoryCircularDependencyB B { get; }
+
+        public FactoryCircularDependencyA(FactoryCircularDependencyB b)
+        {
+            B = b;
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Fakes/CircularReferences/FactoryCircularDependencyB.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/Fakes/CircularReferences/FactoryCircularDependencyB.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
+{
+    /// <summary>
+    /// Test helper class used with FactoryCircularDependencyA to test factory-based
+    /// circular dependency detection (issue #88390).
+    /// </summary>
+    public class FactoryCircularDependencyB
+    {
+    }
+}


### PR DESCRIPTION
Backport of #124331 to release/10.0

/cc @anicka-net @tarekgh

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Applications with a circular dependency hidden inside a singleton factory can deadlock indefinitely during service resolution rather than receiving an actionable exception. This was reported in #88390.

## Regression

- [ ] Yes
- [x] No

This is long-standing behaviour. The original report reproduced it on .NET 6 and cites a similar pattern documented in 2021.

## Testing

This is an exact cherry-pick of the merged change from #124331; its patch ID matches the source PR.

- Microsoft.Extensions.DependencyInjection builds successfully across all target frameworks with SDK 10.0.111.
- Both new factory-circular-dependency regression tests pass.
- All 534 external-container tests pass.
- In the main DI suite, 1,330 tests pass. The remaining 26 RemoteExecutor tests cannot start locally because this branch requests the not-yet-published 10.0.12 testhost; none exercise the changed scenario. CI will provide the branch-native testhost.

## Risk

Low. This is an exact backport of a change that has been in `main` for nearly six months. It has no public API impact, affects only first-time singleton resolution, uses reference equality to avoid false matches, and always removes tracking state in a `finally` block. Cached singleton resolution remains unchanged.