### PR TITLE
JIT: don't truncate 64-bit constants in IsConstantInt32Assertion

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8709,7 +8709,10 @@ public:
 
         bool IsConstantInt32Assertion() const
         {
-            return CanPropEqualOrNotEqual() && GetOp2().KindIs(O2K_CONST_INT) && GetOp1().KindIs(O1K_LCLVAR, O1K_VN);
+            // Note the O2K_CONST_INT payload is an ssize_t, so it may hold a TYP_LONG constant that
+            // does not fit into an int32. Callers assume an int32-sized constant, so require that here.
+            return CanPropEqualOrNotEqual() && GetOp2().KindIs(O2K_CONST_INT) && GetOp1().KindIs(O1K_LCLVAR, O1K_VN) &&
+                   FitsIn<int>(GetOp2().GetIntConstant());
         }
 
         bool CanPropLclVar() const

--- a/src/tests/JIT/Regression/JitBlue/Runtime_132784/Runtime_132784.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_132784/Runtime_132784.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Runtime_132784;
+
+public class Runtime_132784
+{
+    // The "p1 == 0xFFFE008000000000" assertion is a TYP_LONG constant. Range inference used to
+    // truncate it to its low 32 bits (0), conclude that "0 - p1" is 0, and fold "v4 != v2" to
+    // false - sending control down the b5 path that can never be reached at runtime.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static ulong Test(ulong p1)
+    {
+        int v6 = 0, v13 = 0, v21 = 0, count = 0;
+        ulong v2 = 0, v4 = 0, v42 = 0;
+
+    b0:
+        v4 = 0 - p1;
+        v6 = p1 == 0xFFFE008000000000UL ? 1 : 0;
+        if (v6 != 0) goto b1;
+        goto b4;
+    b1:
+        v13 = v4 != v2 ? 1 : 0;
+        if (v13 != 0) goto b2;
+        goto b5;
+    b2:
+        if (v21 != 0) goto b7;
+        goto b6;
+    b4:
+        goto b0;
+    b5:
+        // Only reachable if the JIT mis-folded the branch above; bail out so we don't spin forever.
+        count++;
+        if (count > 10) return 0xBAD;
+        v42 = 0xBAD;
+        goto b1;
+    b6:
+        return 0;
+    b7:
+        return v42;
+    }
+
+    [Fact]
+    public static void LongAssertionConstantIsNotTruncated()
+    {
+        Assert.Equal(0UL, Test(0xFFFE008000000000UL));
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -131,6 +131,7 @@
     <Compile Include="JitBlue\Runtime_132268\Runtime_132268.cs" />
     <Compile Include="JitBlue\Runtime_132370\Runtime_132370.cs" />
     <Compile Include="JitBlue\Runtime_132243\Runtime_132243.cs" />
+    <Compile Include="JitBlue\Runtime_132784\Runtime_132784.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
`O2K_CONST_INT` stores an `ssize_t`, so `IsConstantInt32Assertion()` also matched TYP_LONG constants. Range inference (`MergeEdgeAssertionsWorker`) then cast the constant to `int`, so the assertion `p1 == 0xFFFE008000000000` became `p1 == 0`, giving `p1` the range `[0, 0]` and "proving" `0 - p1 == 0`.

Fix: require `FitsIn<int>` inside `IsConstantInt32Assertion()`, so the name matches the contract callers already assume.


Fixes #132784