### PR TITLE
[EventPipe] Add non-lossy Block-mode functional tests

### DIFF
--- a/src/tests/profiler/eventpipe/eventpipe.cs
+++ b/src/tests/profiler/eventpipe/eventpipe.cs
@@ -61,7 +61,9 @@ namespace EventPipeTests
 
 
                         var source2 = new EventPipeEventSource(session2.EventStream);
-                        Task.Run(() => source2.Process());
+                        Task processTask2 = Task.Run(() => source2.Process());
+                        session2.Stop();
+                        processTask2.Wait();
                     }
 
                     ManualResetEvent allEventsReceivedEvent = new ManualResetEvent(false);

--- a/src/tests/tracing/eventpipe/README.md
+++ b/src/tests/tracing/eventpipe/README.md
@@ -84,6 +84,23 @@ The optional validator has the signature `Func<EventPipeEventSource, Func<int>>`
 Register event handlers in the outer function, then return an inner `Func<int>`
 that checks the collected data and returns `100` (pass) or `-1` (fail).
 
+### Non-lossy (Block) buffering
+
+By default a session drops events when its buffer fills. Passing a `bufferingMode`
+of `EventPipeBufferingMode.Block` instead parks the producer until the drain thread
+frees capacity, so no events are lost. Pair it with a small `circularBufferMB` to
+exercise the parking path and `failOnEventsLost` to assert that nothing was dropped:
+
+```csharp
+return IpcTraceTest.RunAndValidateEventCounts(
+    expectedEventCounts,
+    eventGeneratingAction,
+    providers,
+    circularBufferMB: 1,
+    bufferingMode: EventPipeBufferingMode.Block,
+    failOnEventsLost: true);
+```
+
 ## Common providers
 
 | Provider | Purpose |

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -122,6 +122,15 @@ namespace Tracing.Tests.Common
         /// </summary>
         private EventPipeSession _eventPipeSession;
 
+        // The buffer size requested for a session for storing events.
+        private int _circularBufferMB;
+
+        // Controls event writing behavior when buffers are full. Drop the event or Block until there is space available.
+        private EventPipeBufferingMode _bufferingMode;
+
+        // Whether to fail the test if any events are lost. Only Block buffer mode tests are required to retain all events.
+        private bool _failOnEventsLost;
+
         /// <summary>
         /// This is the list of EventPipe providers for the sentinel EventSource that indicates that the process is ready
         /// </summary>
@@ -135,12 +144,17 @@ namespace Tracing.Tests.Common
             Action eventGeneratingAction,
             List<EventPipeProvider> providers,
             int circularBufferMB,
-            Func<EventPipeEventSource, Func<int>> optionalTraceValidator = null)
+            Func<EventPipeEventSource, Func<int>> optionalTraceValidator = null,
+            EventPipeBufferingMode bufferingMode = EventPipeBufferingMode.Drop,
+            bool failOnEventsLost = false)
         {
             _eventGeneratingAction = eventGeneratingAction;
             _expectedEventCounts = expectedEventCounts;
             _testProviders = providers;
+            _circularBufferMB = circularBufferMB;
             _optionalTraceValidator = optionalTraceValidator;
+            _bufferingMode = bufferingMode;
+            _failOnEventsLost = failOnEventsLost;
         }
 
         private int Fail(string message = "")
@@ -218,7 +232,13 @@ namespace Tracing.Tests.Common
                 Logger.logger.Log("Connecting to EventPipe...");
                 try
                 {
-                    _eventPipeSession = client.StartEventPipeSession(_testProviders.Concat(_sentinelProviders), enableRundownProvider);
+                    EventPipeSessionConfiguration config = new(
+                        _testProviders.Concat(_sentinelProviders),
+                        circularBufferSizeMB: _circularBufferMB,
+                        rundownKeyword: enableRundownProvider ? EventPipeSession.DefaultRundownKeyword : 0,
+                        requestStackwalk: true,
+                        bufferingMode: _bufferingMode);
+                    _eventPipeSession = client.StartEventPipeSession(config);
                 }
                 catch (DiagnosticsClientException ex)
                 {
@@ -343,6 +363,11 @@ namespace Tracing.Tests.Common
             Logger.logger.Log("Reader task finished");
             Logger.logger.Log($"Dropped {_droppedEvents} events");
 
+            if (_failOnEventsLost && _droppedEvents > 0)
+            {
+                return Fail($"Expected zero dropped events, but the reader reported {_droppedEvents} dropped events");
+            }
+
             foreach ((string provider, ExpectedEventCount expectedCount) in _expectedEventCounts)
             {
                 if (_actualEventCounts.TryGetValue(provider, out int actualCount))
@@ -438,10 +463,12 @@ namespace Tracing.Tests.Common
             List<EventPipeProvider> providers,
             int circularBufferMB = 1024,
             Func<EventPipeEventSource, Func<int>> optionalTraceValidator = null,
-            bool enableRundownProvider = true)
+            bool enableRundownProvider = true,
+            EventPipeBufferingMode bufferingMode = EventPipeBufferingMode.Drop,
+            bool failOnEventsLost = false)
         {
             Logger.logger.Log("==TEST STARTING==");
-            IpcTraceTest test = new(expectedEventCounts, eventGeneratingAction, providers, circularBufferMB, optionalTraceValidator);
+            IpcTraceTest test = new(expectedEventCounts, eventGeneratingAction, providers, circularBufferMB, optionalTraceValidator, bufferingMode, failOnEventsLost);
             // Runtime delta: surface a clean failure (and log the exception) instead of letting it propagate.
             try
             {

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -78,7 +78,7 @@ namespace Tracing.Tests.Common
     }
 
     // This event source is used by the test infra to
-    // to insure that providers have finished being enabled
+    // ensure that providers have finished being enabled
     // for the session being observed. Since the client API
     // returns the pipe for reading _before_ it finishes
     // enabling the providers to write to that session,
@@ -316,6 +316,13 @@ namespace Tracing.Tests.Common
             // Runtime delta (dotnet/runtime#47529): wait on either task so a reader that faults during connect
             // (before signaling the sentinel) surfaces its exception instead of hanging here forever.
             Task.WaitAny(readerTask, waitSentinelEventTask);
+            if (readerTask.IsCompleted)
+            {
+                sentinelEventReceived.Set();
+                sentinelTask.Wait();
+                readerTask.GetAwaiter().GetResult();
+                return Fail("Reader task completed before event generation");
+            }
 
             Logger.logger.Log("Starting event generating action...");
             _eventGeneratingAction();

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -410,7 +410,8 @@ namespace Tracing.Tests.Common
         // run into these zombie pipes if there are failures over time.
         // Note: Windows has some guarantees about named pipes not living longer
         // the process that created them, so we don't need to check on that platform.
-        private static bool EnsureCleanEnvironment()
+        // Runtime delta: diagnosticport performs this check before running its test cases.
+        public static bool EnsureCleanEnvironment()
         {
             if (!OperatingSystem.IsWindows() && !OperatingSystem.IsBrowser() && !OperatingSystem.IsWasi() && !OperatingSystem.IsIOS() && !OperatingSystem.IsTvOS())
             {

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.IO;
@@ -19,7 +19,7 @@ namespace Tracing.Tests.Common
 {
     public class Logger
     {
-        public static Logger logger = new Logger();
+        public static Logger logger = new();
         private TextWriter _log;
         private Stopwatch _sw;
         public Logger(TextWriter log = null)
@@ -31,7 +31,10 @@ namespace Tracing.Tests.Common
         public void Log(string message)
         {
             if (!_sw.IsRunning)
+            {
                 _sw.Start();
+            }
+
             _log.WriteLine($"{_sw.Elapsed.TotalSeconds,5:f1}s: {message}");
         }
     }
@@ -75,7 +78,7 @@ namespace Tracing.Tests.Common
     }
 
     // This event source is used by the test infra to
-    // to ensure that providers have finished being enabled
+    // to insure that providers have finished being enabled
     // for the session being observed. Since the client API
     // returns the pipe for reading _before_ it finishes
     // enabling the providers to write to that session,
@@ -86,8 +89,8 @@ namespace Tracing.Tests.Common
     // to synchronize.
     public sealed class SentinelEventSource : EventSource
     {
-        private SentinelEventSource() {}
-        public static SentinelEventSource Log = new SentinelEventSource();
+        private SentinelEventSource() { }
+        public static SentinelEventSource Log = new();
         public void SentinelEvent() { WriteEvent(1, "SentinelEvent"); }
     }
 
@@ -100,7 +103,8 @@ namespace Tracing.Tests.Common
         // A count of -1 indicates that you are only testing for the presence of the provider
         // and don't care about the number of events sent
         private Dictionary<string, ExpectedEventCount> _expectedEventCounts;
-        private Dictionary<string, int> _actualEventCounts = new Dictionary<string, int>();
+        private Dictionary<string, int> _actualEventCounts = new();
+        private int _droppedEvents;
 
         // A function to be called with the EventPipeEventSource _before_
         // the call to `source.Process()`.  The function should return another
@@ -121,12 +125,12 @@ namespace Tracing.Tests.Common
         /// <summary>
         /// This is the list of EventPipe providers for the sentinel EventSource that indicates that the process is ready
         /// </summary>
-        private List<EventPipeProvider> _sentinelProviders = new List<EventPipeProvider>()
+        private List<EventPipeProvider> _sentinelProviders = new()
         {
             new EventPipeProvider("SentinelEventSource", EventLevel.Verbose, -1)
         };
 
-        IpcTraceTest(
+        private IpcTraceTest(
             Dictionary<string, ExpectedEventCount> expectedEventCounts,
             Action eventGeneratingAction,
             List<EventPipeProvider> providers,
@@ -150,7 +154,7 @@ namespace Tracing.Tests.Common
             Logger.logger.Log("}\n");
             Logger.logger.Log("Expected:");
             Logger.logger.Log("{");
-            foreach (var (k, v) in _expectedEventCounts)
+            foreach ((string k, ExpectedEventCount v) in _expectedEventCounts)
             {
                 Logger.logger.Log($"\t\"{k}\" = {v}");
             }
@@ -158,7 +162,7 @@ namespace Tracing.Tests.Common
 
             Logger.logger.Log("Actual:");
             Logger.logger.Log("{");
-            foreach (var (k, v) in _actualEventCounts)
+            foreach ((string k, int v) in _actualEventCounts)
             {
                 Logger.logger.Log($"\t\"{k}\" = {v}");
             }
@@ -177,19 +181,20 @@ namespace Tracing.Tests.Common
             //
             // see: https://github.com/dotnet/runtime/pull/1794 for details on the issue
             //
-            var emptyConcurrentDictionary = new ConcurrentDictionary<string, string>();
+            ConcurrentDictionary<string, string> emptyConcurrentDictionary = new();
             emptyConcurrentDictionary["foo"] = "bar";
-            var __count = emptyConcurrentDictionary.Count;
+            int __count = emptyConcurrentDictionary.Count;
 
-            var isClean = IpcTraceTest.EnsureCleanEnvironment();
+            bool isClean = IpcTraceTest.EnsureCleanEnvironment();
             if (!isClean)
+            {
                 return -1;
+            }
             // CollectTracing returns before EventPipe::Enable has returned, so the
             // the sources we want to listen for may not have been enabled yet.
             // We'll use this sentinel EventSource to check if Enable has finished
-            ManualResetEvent sentinelEventReceived = new ManualResetEvent(false);
-            var sentinelTask = new Task(() =>
-            {
+            ManualResetEvent sentinelEventReceived = new(false);
+            Task sentinelTask = new(() => {
                 Logger.logger.Log("Started sending sentinel events...");
                 while (!sentinelEventReceived.WaitOne(50))
                 {
@@ -200,15 +205,16 @@ namespace Tracing.Tests.Common
             sentinelTask.Start();
 
             int processId = Process.GetCurrentProcess().Id;
-            object threadSync = new object(); // for locking eventpipeSession access
+            object threadSync = new(); // for locking eventpipeSession access
             Func<int> optionalTraceValidationCallback = null;
-            DiagnosticsClient client = new DiagnosticsClient(processId);
+            DiagnosticsClient client = new(processId);
 #if DIAGNOSTICS_RUNTIME
             if (OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
-                client = new DiagnosticsClient(new IpcEndpointConfig("127.0.0.1:9000", IpcEndpointConfig.TransportType.TcpSocket, IpcEndpointConfig.PortType.Listen));
-#endif
-            var readerTask = new Task(() =>
             {
+                client = new DiagnosticsClient(new IpcEndpointConfig("127.0.0.1:9000", IpcEndpointConfig.TransportType.TcpSocket, IpcEndpointConfig.PortType.Listen));
+            }
+#endif
+            Task readerTask = new(() => {
                 Logger.logger.Log("Connecting to EventPipe...");
                 try
                 {
@@ -220,96 +226,126 @@ namespace Tracing.Tests.Common
                     Logger.logger.Log(ex.ToString());
                     throw new ApplicationException("Failed to connect to EventPipe");
                 }
-                using (var eventPipeStream = new StreamProxy(_eventPipeSession.EventStream))
-                {
-                    Logger.logger.Log("Creating EventPipeEventSource...");
-                    using (EventPipeEventSource source = new EventPipeEventSource(eventPipeStream))
+
+                using StreamProxy eventPipeStream = new(_eventPipeSession.EventStream);
+                Logger.logger.Log("Creating EventPipeEventSource...");
+                using EventPipeEventSource source = new(eventPipeStream);
+                Logger.logger.Log("EventPipeEventSource created");
+
+                source.Dynamic.All += (eventData) => {
+                    try
                     {
-                        Logger.logger.Log("EventPipeEventSource created");
-
-                        source.Dynamic.All += (eventData) =>
+                        if (eventData.ProviderName == "SentinelEventSource")
                         {
-                            try
+                            if (!sentinelEventReceived.WaitOne(0))
                             {
-                                if (eventData.ProviderName == "SentinelEventSource")
-                                {
-                                    if (!sentinelEventReceived.WaitOne(0))
-                                        Logger.logger.Log("Saw sentinel event");
-                                    sentinelEventReceived.Set();
-                                }
-                                else if (_actualEventCounts.TryGetValue(eventData.ProviderName, out _))
-                                {
-                                    _actualEventCounts[eventData.ProviderName]++;
-                                }
-                                else
-                                {
-                                    Logger.logger.Log($"Saw new provider '{eventData.ProviderName}'");
-                                    _actualEventCounts[eventData.ProviderName] = 1;
-                                }
+                                Logger.logger.Log("Saw sentinel event");
                             }
-                            catch (Exception e)
-                            {
-                                Logger.logger.Log("Exception in Dynamic.All callback " + e.ToString());
-                            }
-                        };
-                        Logger.logger.Log("Dynamic.All callback registered");
 
-                        if (_optionalTraceValidator != null)
-                        {
-                            Logger.logger.Log("Running optional trace validator");
-                            optionalTraceValidationCallback = _optionalTraceValidator(source);
-                            Logger.logger.Log("Finished running optional trace validator");
+                            sentinelEventReceived.Set();
                         }
 
-                        Logger.logger.Log("Starting stream processing...");
-                        try
+                        else if (_actualEventCounts.TryGetValue(eventData.ProviderName, out _))
                         {
-                            source.Process();
+                            _actualEventCounts[eventData.ProviderName]++;
                         }
-                        catch (Exception)
+                        else
                         {
-                            Logger.logger.Log($"Exception thrown while reading; dumping culprit stream to disk...");
-                            eventPipeStream.DumpStreamToDisk();
-                            // rethrow it to fail the test
-                            throw;
+                            Logger.logger.Log($"Saw new provider '{eventData.ProviderName}'");
+                            _actualEventCounts[eventData.ProviderName] = 1;
                         }
-                        Logger.logger.Log("Stopping stream processing");
-                        Logger.logger.Log($"Dropped {source.EventsLost} events");
                     }
+                    catch (Exception e)
+                    {
+                        Logger.logger.Log("Exception in Dynamic.All callback " + e.ToString());
+                    }
+                };
+                Logger.logger.Log("Dynamic.All callback registered");
+
+                if (_optionalTraceValidator != null)
+                {
+                    Logger.logger.Log("Running optional trace validator");
+                    optionalTraceValidationCallback = _optionalTraceValidator(source);
+                    Logger.logger.Log("Finished running optional trace validator");
                 }
+
+                Logger.logger.Log("Starting stream processing...");
+                try
+                {
+                    source.Process();
+                    _droppedEvents = source.EventsLost;
+                }
+                catch (Exception)
+                {
+                    Logger.logger.Log($"Exception thrown while reading; dumping culprit stream to disk...");
+                    eventPipeStream.DumpStreamToDisk();
+                    // rethrow it to fail the test
+                    throw;
+                }
+                Logger.logger.Log("Stopping stream processing");
+                Logger.logger.Log($"Dropped {source.EventsLost} events");
             });
 
-            var waitSentinelEventTask = new Task(() => {
+            Task waitSentinelEventTask = new(() => {
                 sentinelEventReceived.WaitOne();
             });
 
             readerTask.Start();
             waitSentinelEventTask.Start();
 
-            // Will throw if the reader task throws any exceptions before signaling sentinelEventReceived.
+            // Runtime delta (dotnet/runtime#47529): wait on either task so a reader that faults during connect
+            // (before signaling the sentinel) surfaces its exception instead of hanging here forever.
             Task.WaitAny(readerTask, waitSentinelEventTask);
 
             Logger.logger.Log("Starting event generating action...");
             _eventGeneratingAction();
             Logger.logger.Log("Stopping event generating action");
 
-            var stopTask = Task.Run(() =>
-            {
+            // Should throw if the reader task throws any exceptions
+            CancellationTokenSource tokenSource = new();
+            CancellationToken ct = tokenSource.Token;
+            readerTask.ContinueWith((task) => {
+                // if our reader task died earlier, we need to break the infinite wait below.
+                // We'll allow the AggregateException to be thrown and fail the test though.
+                Logger.logger.Log($"Task stats: isFaulted: {task.IsFaulted}, Exception == null: {task.Exception == null}");
+                if (task.IsFaulted || task.Exception != null)
+                {
+                    tokenSource.Cancel();
+                }
+
+                return task;
+            });
+
+            Task stopTask = Task.Run(() => {
                 Logger.logger.Log("Sending StopTracing command...");
                 lock (threadSync) // eventpipeSession
                 {
                     _eventPipeSession.Stop();
                 }
                 Logger.logger.Log("Finished StopTracing command");
-            });
+            }, ct);
 
-            // Should throw if the reader task throws any exceptions
-            Task.WaitAll(readerTask, stopTask);
-            Logger.logger.Log("Reader task finished");
-
-            foreach (var (provider, expectedCount) in _expectedEventCounts)
+            try
             {
-                if (_actualEventCounts.TryGetValue(provider, out var actualCount))
+                Task.WaitAll(new Task[] { readerTask, stopTask }, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                Logger.logger.Log($"A task faulted");
+                Logger.logger.Log($"\treaderTask.IsFaulted = {readerTask.IsFaulted}");
+                if (readerTask.Exception != null)
+                {
+                    throw readerTask.Exception;
+                }
+                return -1;
+            }
+
+            Logger.logger.Log("Reader task finished");
+            Logger.logger.Log($"Dropped {_droppedEvents} events");
+
+            foreach ((string provider, ExpectedEventCount expectedCount) in _expectedEventCounts)
+            {
+                if (_actualEventCounts.TryGetValue(provider, out int actualCount))
                 {
                     if (!expectedCount.Validate(actualCount))
                     {
@@ -342,16 +378,16 @@ namespace Tracing.Tests.Common
         // run into these zombie pipes if there are failures over time.
         // Note: Windows has some guarantees about named pipes not living longer
         // the process that created them, so we don't need to check on that platform.
-        static public bool EnsureCleanEnvironment()
+        private static bool EnsureCleanEnvironment()
         {
             if (!OperatingSystem.IsWindows() && !OperatingSystem.IsBrowser() && !OperatingSystem.IsWasi() && !OperatingSystem.IsIOS() && !OperatingSystem.IsTvOS())
             {
-                Func<(IEnumerable<IGrouping<int,FileInfo>>, List<int>)> GetPidsAndSockets = () =>
+                Func<(IEnumerable<IGrouping<int, FileInfo>>, List<int>)> GetPidsAndSockets = () =>
                 {
-                    IEnumerable<IGrouping<int,FileInfo>> currentIpcs = Directory.GetFiles(Path.GetTempPath(), "dotnet-diagnostic*")
+                    IEnumerable<IGrouping<int, FileInfo>> currentIpcs = Directory.GetFiles(Path.GetTempPath(), "dotnet-diagnostic*")
                         .Select(filename =>
                         {
-                            var match = Regex.Match(filename, @"dotnet-diagnostic-(?<pid>\d+)");
+                            Match match = Regex.Match(filename, @"dotnet-diagnostic-(?<pid>\d+)");
                             if (match.Success && match.Groups["pid"].Success && !string.IsNullOrEmpty(match.Groups["pid"].Value))
                             {
                                 return new { pid = int.Parse(match.Groups["pid"].Value), fileInfo = new FileInfo(filename) };
@@ -400,19 +436,25 @@ namespace Tracing.Tests.Common
             Dictionary<string, ExpectedEventCount> expectedEventCounts,
             Action eventGeneratingAction,
             List<EventPipeProvider> providers,
-            int circularBufferMB=1024,
+            int circularBufferMB = 1024,
             Func<EventPipeEventSource, Func<int>> optionalTraceValidator = null,
             bool enableRundownProvider = true)
         {
             Logger.logger.Log("==TEST STARTING==");
-            var test = new IpcTraceTest(expectedEventCounts, eventGeneratingAction, providers, circularBufferMB, optionalTraceValidator);
+            IpcTraceTest test = new(expectedEventCounts, eventGeneratingAction, providers, circularBufferMB, optionalTraceValidator);
+            // Runtime delta: surface a clean failure (and log the exception) instead of letting it propagate.
             try
             {
-                var ret = test.Validate(enableRundownProvider);
+                int ret = test.Validate(enableRundownProvider);
                 if (ret == 100)
+                {
                     Logger.logger.Log("==TEST FINISHED: PASSED!==");
+                }
                 else
+                {
                     Logger.logger.Log("==TEST FINISHED: FAILED!==");
+                }
+
                 return ret;
             }
             catch (Exception e)

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/AssemblyInfo.cs
@@ -7,5 +7,6 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("common")]
 [assembly: InternalsVisibleTo("enabledisable")]
+[assembly: InternalsVisibleTo("eventpipe_common")]
 [assembly: AssemblyVersionAttribute("99.99.99.99")]
 #endif

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/DiagnosticsClient.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
     {
         private readonly IpcEndpoint _endpoint;
 
+        private const int DefaultCircularBufferMB = 256;
+
         public DiagnosticsClient(int processId) :
             this(new PidIpcEndpoint(processId))
         {
@@ -64,9 +66,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns> 
-        public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown = true, int circularBufferMB = 256)
+        public EventPipeSession StartEventPipeSession(IEnumerable<EventPipeProvider> providers, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB)
         {
-            return EventPipeSession.Start(_endpoint, providers, requestRundown, circularBufferMB);
+            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
+            return EventPipeSession.Start(_endpoint, config);
         }
 
         /// <summary>
@@ -78,9 +81,22 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns> 
-        public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown = true, int circularBufferMB = 256)
+        public EventPipeSession StartEventPipeSession(EventPipeProvider provider, bool requestRundown = true, int circularBufferMB = DefaultCircularBufferMB)
         {
-            return EventPipeSession.Start(_endpoint, new[] { provider }, requestRundown, circularBufferMB);
+            EventPipeSessionConfiguration config = new(new[] { provider }, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
+            return EventPipeSession.Start(_endpoint, config);
+        }
+
+        /// <summary>
+        /// Start tracing the application and return an EventPipeSession object
+        /// </summary>
+        /// <param name="config">The configuration for start tracing.</param>
+        /// <returns>
+        /// An EventPipeSession object representing the EventPipe session that just started.
+        /// </returns>
+        public EventPipeSession StartEventPipeSession(EventPipeSessionConfiguration config)
+        {
+            return EventPipeSession.Start(_endpoint, config);
         }
 
         /// <summary>
@@ -93,9 +109,11 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns> 
-        internal Task<EventPipeSession> StartEventPipeSessionAsync(IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB, CancellationToken token)
+        public Task<EventPipeSession> StartEventPipeSessionAsync(IEnumerable<EventPipeProvider> providers, bool requestRundown,
+            int circularBufferMB = DefaultCircularBufferMB, CancellationToken token = default)
         {
-            return EventPipeSession.StartAsync(_endpoint, providers, requestRundown, circularBufferMB, token);
+            EventPipeSessionConfiguration config = new(providers, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
+            return EventPipeSession.StartAsync(_endpoint, config, token);
         }
 
         /// <summary>
@@ -108,9 +126,24 @@ namespace Microsoft.Diagnostics.NETCore.Client
         /// <returns>
         /// An EventPipeSession object representing the EventPipe session that just started.
         /// </returns>
-        internal Task<EventPipeSession> StartEventPipeSessionAsync(EventPipeProvider provider, bool requestRundown, int circularBufferMB, CancellationToken token)
+        public Task<EventPipeSession> StartEventPipeSessionAsync(EventPipeProvider provider, bool requestRundown,
+            int circularBufferMB = DefaultCircularBufferMB, CancellationToken token = default)
         {
-            return EventPipeSession.StartAsync(_endpoint, new[] { provider }, requestRundown, circularBufferMB, token);
+            EventPipeSessionConfiguration config = new(new[] { provider }, circularBufferMB, requestRundown: requestRundown, requestStackwalk: true);
+            return EventPipeSession.StartAsync(_endpoint, config, token);
+        }
+
+        /// <summary>
+        /// Start tracing the application and return an EventPipeSession object
+        /// </summary>
+        /// <param name="configuration">Configuration of this EventPipeSession</param>
+        /// <param name="token">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// An EventPipeSession object representing the EventPipe session that just started.
+        /// </returns>
+        public Task<EventPipeSession> StartEventPipeSessionAsync(EventPipeSessionConfiguration configuration, CancellationToken token)
+        {
+            return EventPipeSession.StartAsync(_endpoint, configuration, token);
         }
 
         /// <summary>

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeProvider.cs
@@ -1,22 +1,58 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
-using System.Text;
 
 namespace Microsoft.Diagnostics.NETCore.Client
 {
+    /// <summary>
+    /// An optional per-provider filter on Event IDs, applied by the runtime after the keyword/level
+    /// filter. Requires a target runtime that supports CollectTracing5 (.NET 10+).
+    /// </summary>
+    public sealed class EventPipeProviderEventFilter
+    {
+        /// <param name="enable">
+        /// When true, <paramref name="eventIds"/> is an allow-list: only those Event IDs are enabled.
+        /// When false, it is a deny-list: every Event ID except those is enabled (so an empty list with
+        /// enable=false enables all events).
+        /// </param>
+        /// <param name="eventIds">The Event IDs to enable or disable, per <paramref name="enable"/>.</param>
+        public EventPipeProviderEventFilter(bool enable, IReadOnlyList<uint> eventIds)
+        {
+            Enable = enable;
+            EventIds = eventIds ?? (IReadOnlyList<uint>)System.Array.Empty<uint>();
+        }
+
+        public bool Enable { get; }
+
+        public IReadOnlyList<uint> EventIds { get; }
+    }
+
     public sealed class EventPipeProvider
     {
         public EventPipeProvider(string name, EventLevel eventLevel, long keywords = 0xF00000000000, IDictionary<string, string> arguments = null)
+            : this(name, eventLevel, keywords, arguments, eventFilter: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a provider that additionally filters which Event IDs are enabled. Using this overload
+        /// starts the session with CollectTracing5 (requires a .NET 10+ target runtime).
+        /// </summary>
+        /// <param name="name">The provider name.</param>
+        /// <param name="eventLevel">The verbosity level to enable.</param>
+        /// <param name="keywords">A bitmask of keywords to enable.</param>
+        /// <param name="arguments">Optional provider arguments, or null.</param>
+        /// <param name="eventFilter">The per-provider Event ID filter applied after the keyword/level filter.</param>
+        public EventPipeProvider(string name, EventLevel eventLevel, long keywords, IDictionary<string, string> arguments, EventPipeProviderEventFilter eventFilter)
         {
             Name = name;
             EventLevel = eventLevel;
             Keywords = keywords;
             Arguments = arguments;
+            EventFilter = eventFilter;
         }
 
         public long Keywords { get; }
@@ -27,27 +63,33 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         public IDictionary<string, string> Arguments { get; }
 
+        /// <summary>
+        /// An optional filter on this provider's Event IDs, applied after the keyword/level filter.
+        /// Setting it causes the session to be started with CollectTracing5 (requires a .NET 10+ target).
+        /// </summary>
+        public EventPipeProviderEventFilter EventFilter { get; }
+
         public override string ToString()
         {
             return $"{Name}:0x{Keywords:X16}:{(uint)EventLevel}{(Arguments == null ? "" : $":{GetArgumentString()}")}";
         }
-        
+
         public override bool Equals(object obj)
         {
             if (obj == null || GetType() != obj.GetType())
             {
                 return false;
             }
-            
+
             return this == (EventPipeProvider)obj;
         }
 
         public override int GetHashCode()
         {
             int hash = 0;
-            hash ^= this.Name.GetHashCode();
-            hash ^= this.Keywords.GetHashCode();
-            hash ^= this.EventLevel.GetHashCode();
+            hash ^= Name.GetHashCode();
+            hash ^= Keywords.GetHashCode();
+            hash ^= EventLevel.GetHashCode();
             hash ^= GetArgumentString().GetHashCode();
             return hash;
         }
@@ -59,7 +101,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         public static bool operator !=(EventPipeProvider left, EventPipeProvider right)
         {
-            return !(left == right);    
+            return !(left == right);
         }
 
         internal string GetArgumentString()
@@ -69,8 +111,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
                 return "";
             }
             return string.Join(";", Arguments.Select(a => {
-                var escapedKey = a.Key.Contains(";") || a.Key.Contains("=") ? $"\"{a.Key}\"" : a.Key;
-                var escapedValue = a.Value.Contains(";") || a.Value.Contains("=") ? $"\"{a.Value}\"" : a.Value;
+                string escapedKey = a.Key.Contains(';') || a.Key.Contains('=') ? $"\"{a.Key}\"" : a.Key;
+                string escapedValue = a.Value.Contains(';') || a.Value.Contains('=') ? $"\"{a.Value}\"" : a.Value;
                 return $"{escapedKey}={escapedValue}";
             }));
         }

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSession.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -12,13 +13,24 @@ namespace Microsoft.Diagnostics.NETCore.Client
 {
     public class EventPipeSession : IDisposable
     {
-        private long _sessionId;
+        //! This is CoreCLR specific keywords for native ETW events (ending up in event pipe).
+        //! The keywords below seems to correspond to:
+        //!  GCKeyword                          (0x00000001)
+        //!  LoaderKeyword                      (0x00000008)
+        //!  JitKeyword                         (0x00000010)
+        //!  NgenKeyword                        (0x00000020)
+        //!  unused_keyword                     (0x00000100)
+        //!  JittedMethodILToNativeMapKeyword   (0x00020000)
+        //!  ThreadTransferKeyword              (0x80000000)
+        internal const long DefaultRundownKeyword = 0x80020139;
+
+        private ulong _sessionId;
         private IpcEndpoint _endpoint;
-        private bool _disposedValue = false; // To detect redundant calls
-        private bool _stopped = false; // To detect redundant calls
+        private bool _disposedValue; // To detect redundant calls
+        private bool _stopped; // To detect redundant calls
         private readonly IpcResponse _response;
 
-        private EventPipeSession(IpcEndpoint endpoint, IpcResponse response, long sessionId)
+        private EventPipeSession(IpcEndpoint endpoint, IpcResponse response, ulong sessionId)
         {
             _endpoint = endpoint;
             _response = response;
@@ -27,16 +39,16 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         public Stream EventStream => _response.Continuation;
 
-        internal static EventPipeSession Start(IpcEndpoint endpoint, IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB)
+        internal static EventPipeSession Start(IpcEndpoint endpoint, EventPipeSessionConfiguration config)
         {
-            IpcMessage requestMessage = CreateStartMessage(providers, requestRundown, circularBufferMB);
+            IpcMessage requestMessage = CreateStartMessage(config);
             IpcResponse? response = IpcClient.SendMessageGetContinuation(endpoint, requestMessage);
             return CreateSessionFromResponse(endpoint, ref response, nameof(Start));
         }
 
-        internal static async Task<EventPipeSession> StartAsync(IpcEndpoint endpoint, IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB, CancellationToken cancellationToken)
+        internal static async Task<EventPipeSession> StartAsync(IpcEndpoint endpoint, EventPipeSessionConfiguration config, CancellationToken cancellationToken)
         {
-            IpcMessage requestMessage = CreateStartMessage(providers, requestRundown, circularBufferMB);
+            IpcMessage requestMessage = CreateStartMessage(config);
             IpcResponse? response = await IpcClient.SendMessageGetContinuationAsync(endpoint, requestMessage, cancellationToken).ConfigureAwait(false);
             return CreateSessionFromResponse(endpoint, ref response, nameof(StartAsync));
         }
@@ -80,10 +92,57 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
         }
 
-        private static IpcMessage CreateStartMessage(IEnumerable<EventPipeProvider> providers, bool requestRundown, int circularBufferMB)
+        // Internal for unit testing of the version/command selection logic.
+        internal static IpcMessage CreateStartMessage(EventPipeSessionConfiguration config)
         {
-            var config = new EventPipeSessionConfiguration(circularBufferMB, EventPipeSerializationFormat.NetTrace, providers, requestRundown);
-            return new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.CollectTracing2, config.SerializeV2());
+            // To keep backward compatibility with older runtimes we only use newer serialization format when needed
+            EventPipeCommandId command;
+            byte[] payload;
+            if (config.BufferingMode != EventPipeBufferingMode.Drop)
+            {
+                // V6 adds an opt-in session buffering mode
+                command = EventPipeCommandId.CollectTracing6;
+                payload = config.SerializeV6();
+            }
+            else if (HasEventFilter(config))
+            {
+                // V5 adds a per-provider event-id filter (and a session-type prefix)
+                command = EventPipeCommandId.CollectTracing5;
+                payload = config.SerializeV5();
+            }
+            else if (config.RundownKeyword != DefaultRundownKeyword && config.RundownKeyword != 0)
+            {
+                // V4 has added support to specify rundown keyword
+                command = EventPipeCommandId.CollectTracing4;
+                payload = config.SerializeV4();
+            }
+            else if (!config.RequestStackwalk)
+            {
+                // V3 has added support to disable the stacktraces
+                command = EventPipeCommandId.CollectTracing3;
+                payload = config.SerializeV3();
+            }
+            else
+            {
+                command = EventPipeCommandId.CollectTracing2;
+                payload = config.SerializeV2();
+            }
+
+            return new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)command, payload);
+        }
+
+        // A per-provider Event ID filter is available on CollectTracing5 and later.
+        private static bool HasEventFilter(EventPipeSessionConfiguration config)
+        {
+            foreach (EventPipeProvider provider in config.Providers)
+            {
+                if (provider.EventFilter != null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static EventPipeSession CreateSessionFromResponse(IpcEndpoint endpoint, ref IpcResponse? response, string operationName)
@@ -92,9 +151,9 @@ namespace Microsoft.Diagnostics.NETCore.Client
             {
                 DiagnosticsClient.ValidateResponseMessage(response.Value.Message, operationName);
 
-                long sessionId = BitConverter.ToInt64(response.Value.Message.Payload, 0);
+                ulong sessionId = BinaryPrimitives.ReadUInt64LittleEndian(new ReadOnlySpan<byte>(response.Value.Message.Payload, 0, 8));
 
-                var session = new EventPipeSession(endpoint, response.Value, sessionId);
+                EventPipeSession session = new(endpoint, response.Value, sessionId);
                 response = null;
                 return session;
             }
@@ -120,6 +179,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
             }
 
             byte[] payload = BitConverter.GetBytes(_sessionId);
+            if (!BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(payload);
+            }
 
             stopMessage = new IpcMessage(DiagnosticsServerCommandSet.EventPipe, (byte)EventPipeCommandId.StopTracing, payload);
 
@@ -128,15 +191,8 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         protected virtual void Dispose(bool disposing)
         {
-            // If session being disposed hasn't been stopped, attempt to stop it first
-            if (!_stopped)
-            {
-                try
-                {
-                    Stop();
-                }
-                catch {} // swallow any exceptions that may be thrown from Stop.
-            }
+            // Do not call Stop() here. Trying to do so now might block indefinitely if the runtime is unresponsive and we don't want blocking behavior in Dispose().
+            // If the caller wants to ensure that all rundown events are captured they should call Stop() first, then process the EventStream until it is complete, then call Dispose().
 
             if (!_disposedValue)
             {

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
@@ -115,13 +115,13 @@ namespace Microsoft.Diagnostics.NETCore.Client
             if (providers is null)
             {
                 throw new ArgumentNullException(nameof(providers));
-            };
+            }
 
             _providers = new List<EventPipeProvider>(providers);
             if (_providers.Count == 0)
             {
                 throw new ArgumentException("At least one provider must be specified.");
-            };
+            }
 
             CircularBufferSizeInMB = circularBufferSizeMB;
             Format = format;

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsClient/EventPipeSessionConfiguration.cs
@@ -14,50 +14,183 @@ namespace Microsoft.Diagnostics.NETCore.Client
         NetTrace
     }
 
-    internal class EventPipeSessionConfiguration
+    // Session type as encoded on the CollectTracing5+ wire. This is NOT the runtime's internal
+    // EventPipeSessionType; the IPC collect command maps wire 0 => IpcStream, 1 => UserEvents.
+    internal enum EventPipeSessionType : uint
     {
-        public EventPipeSessionConfiguration(int circularBufferSizeMB, EventPipeSerializationFormat format, IEnumerable<EventPipeProvider> providers, bool requestRundown=true)
+        IpcStream = 0,
+
+        // This client does not support starting/tracing a user_events session (that path needs an
+        // out-of-band file descriptor, see the IPC protocol docs); the value exists only for wire
+        // correctness when describing the CollectTracing5+ session-type field.
+        UserEvents = 1
+    }
+
+    /// <summary>
+    /// Controls how the runtime's per-session event buffer behaves when it fills faster than the
+    /// session is drained.
+    /// </summary>
+    public enum EventPipeBufferingMode
+    {
+        /// <summary>
+        /// The runtime default: a circular buffer that drops events when it overflows (lossy).
+        /// </summary>
+        Drop = 0,
+
+        /// <summary>
+        /// Non-lossy: producers block until the reader frees buffer capacity rather than dropping
+        /// events. Available on .NET 11+; useful for collections that must be complete (e.g. a heap
+        /// snapshot on a large heap).
+        /// </summary>
+        Block = 1
+    }
+
+    public sealed class EventPipeSessionConfiguration
+    {
+        /// <summary>
+        /// Creates a new configuration object for the EventPipeSession.
+        /// For details, see the documentation of each property of this object.
+        /// </summary>
+        /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
+        /// <param name="circularBufferSizeMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="requestRundown">If true, request rundown events from the runtime.</param>
+        /// <param name="requestStackwalk">If true, record a stacktrace for every emitted event.</param>
+        public EventPipeSessionConfiguration(
+            IEnumerable<EventPipeProvider> providers,
+            int circularBufferSizeMB = 256,
+            bool requestRundown = true,
+            bool requestStackwalk = true) : this(circularBufferSizeMB, EventPipeSerializationFormat.NetTrace, providers, requestStackwalk, (requestRundown ? EventPipeSession.DefaultRundownKeyword : 0))
+        {}
+
+        /// <summary>
+        /// Creates a new configuration object for the EventPipeSession.
+        /// For details, see the documentation of each property of this object.
+        /// </summary>
+        /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
+        /// <param name="circularBufferSizeMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="rundownKeyword">The keyword for rundown events.</param>
+        /// <param name="requestStackwalk">If true, record a stacktrace for every emitted event.</param>
+        public EventPipeSessionConfiguration(
+            IEnumerable<EventPipeProvider> providers,
+            int circularBufferSizeMB,
+            long rundownKeyword,
+            bool requestStackwalk = true) : this(circularBufferSizeMB, EventPipeSerializationFormat.NetTrace, providers, requestStackwalk, rundownKeyword)
+        {}
+
+        /// <summary>
+        /// Creates a new configuration object for the EventPipeSession with a specific rundown keyword and
+        /// buffering mode. For details, see the documentation of each property of this object.
+        /// </summary>
+        /// <param name="providers">An IEnumerable containing the list of Providers to turn on.</param>
+        /// <param name="circularBufferSizeMB">The size of the runtime's buffer for collecting events in MB</param>
+        /// <param name="rundownKeyword">The keyword for rundown events.</param>
+        /// <param name="requestStackwalk">If true, record a stacktrace for every emitted event.</param>
+        /// <param name="bufferingMode">The session buffering mode; Block requests non-lossy collection (CollectTracing6, .NET 11+).</param>
+        public EventPipeSessionConfiguration(
+            IEnumerable<EventPipeProvider> providers,
+            int circularBufferSizeMB,
+            long rundownKeyword,
+            bool requestStackwalk,
+            EventPipeBufferingMode bufferingMode) : this(circularBufferSizeMB, EventPipeSerializationFormat.NetTrace, providers, requestStackwalk, rundownKeyword, bufferingMode)
+        {}
+
+        private EventPipeSessionConfiguration(
+            int circularBufferSizeMB,
+            EventPipeSerializationFormat format,
+            IEnumerable<EventPipeProvider> providers,
+            bool requestStackwalk,
+            long rundownKeyword,
+            EventPipeBufferingMode bufferingMode = EventPipeBufferingMode.Drop)
         {
             if (circularBufferSizeMB == 0)
+            {
                 throw new ArgumentException($"Buffer size cannot be zero.");
-            if (format != EventPipeSerializationFormat.NetPerf && format != EventPipeSerializationFormat.NetTrace)
+            }
+
+            if (format is not EventPipeSerializationFormat.NetPerf and not EventPipeSerializationFormat.NetTrace)
+            {
                 throw new ArgumentException("Unrecognized format");
-            if (providers == null)
+            }
+
+            if (providers is null)
+            {
                 throw new ArgumentNullException(nameof(providers));
+            };
+
+            _providers = new List<EventPipeProvider>(providers);
+            if (_providers.Count == 0)
+            {
+                throw new ArgumentException("At least one provider must be specified.");
+            };
 
             CircularBufferSizeInMB = circularBufferSizeMB;
             Format = format;
-            RequestRundown = requestRundown;
-            _providers = new List<EventPipeProvider>(providers);
+            RequestStackwalk = requestStackwalk;
+            RundownKeyword = rundownKeyword;
+            BufferingMode = bufferingMode;
         }
 
-        public bool RequestRundown { get; }
-        public int CircularBufferSizeInMB { get; }
-        public EventPipeSerializationFormat Format { get; }
+        /// <summary>
+        /// If true, request rundown events from the runtime.
+        /// <list type="bullet">
+        /// <item>Rundown events are needed to correctly decode the stacktrace information for dynamically generated methods.</item>
+        /// <item>Rundown happens at the end of the session. It increases the time needed to finish the session and, for large applications, may have important impact on the final trace file size.</item>
+        /// <item>Consider to set this parameter to false if you don't need stacktrace information or if you're analyzing events on the fly.</item>
+        /// </list>
+        /// </summary>
+        public bool RequestRundown => this.RundownKeyword != 0;
 
+        /// <summary>
+        /// The size of the runtime's buffer for collecting events in MB.
+        /// If the buffer size is too small to accommodate all in-flight events some events may be lost.
+        /// </summary>
+        public int CircularBufferSizeInMB { get; }
+
+        /// <summary>
+        /// If true, record a stacktrace for every emitted event.
+        /// <list type="bullet">
+        /// <item>The support of this parameter only comes with NET 9. Before, the stackwalk is always enabled and if this property is set to false the connection attempt will fail.</item>
+        /// <item>Disabling the stackwalk makes event collection overhead considerably less</item>
+        /// <item>Note that some events may choose to omit the stacktrace regardless of this parameter, specifically the events emitted from the native runtime code.</item>
+        /// <item>If the stacktrace collection is disabled application-wide (using the env variable <c>DOTNET_EventPipeEnableStackwalk</c>) this parameter is ignored.</item>
+        /// </list>
+        /// </summary>
+        public bool RequestStackwalk { get; }
+
+        /// <summary>
+        /// The keywords enabled for the rundown provider.
+        /// </summary>
+        public long RundownKeyword { get; internal set; }
+
+        /// <summary>
+        /// Buffering mode for the session. <see cref="EventPipeBufferingMode.Block"/> requests non-lossy
+        /// collection (sent as CollectTracing6); the default keeps the runtime's lossy circular buffer.
+        /// </summary>
+        public EventPipeBufferingMode BufferingMode { get; }
+
+        /// <summary>
+        /// Providers to enable for this session.
+        /// </summary>
         public IReadOnlyCollection<EventPipeProvider> Providers => _providers.AsReadOnly();
 
         private readonly List<EventPipeProvider> _providers;
 
-        public byte[] SerializeV2()
+        internal EventPipeSerializationFormat Format { get; }
+    }
+
+    internal static class EventPipeSessionConfigurationExtensions
+    {
+        public static byte[] SerializeV2(this EventPipeSessionConfiguration config)
         {
             byte[] serializedData = null;
-            using (var stream = new MemoryStream())
-            using (var writer = new BinaryWriter(stream))
+            using (MemoryStream stream = new())
+            using (BinaryWriter writer = new(stream))
             {
-                writer.Write(CircularBufferSizeInMB);
-                writer.Write((uint)Format);
-                writer.Write(RequestRundown);
+                writer.Write(config.CircularBufferSizeInMB);
+                writer.Write((uint)config.Format);
+                writer.Write(config.RequestRundown);
 
-                writer.Write(Providers.Count);
-                foreach (var provider in Providers)
-                {
-                    writer.Write(provider.Keywords);
-                    writer.Write((uint)provider.EventLevel);
-
-                    writer.WriteString(provider.Name);
-                    writer.WriteString(provider.GetArgumentString());
-                }
+                SerializeProviders(config, writer);
 
                 writer.Flush();
                 serializedData = stream.ToArray();
@@ -66,6 +199,135 @@ namespace Microsoft.Diagnostics.NETCore.Client
             return serializedData;
         }
 
+        public static byte[] SerializeV3(this EventPipeSessionConfiguration config)
+        {
+            byte[] serializedData = null;
+            using (MemoryStream stream = new())
+            using (BinaryWriter writer = new(stream))
+            {
+                writer.Write(config.CircularBufferSizeInMB);
+                writer.Write((uint)config.Format);
+                writer.Write(config.RequestRundown);
+                writer.Write(config.RequestStackwalk);
 
+                SerializeProviders(config, writer);
+
+                writer.Flush();
+                serializedData = stream.ToArray();
+            }
+
+            return serializedData;
+        }
+
+        public static byte[] SerializeV4(this EventPipeSessionConfiguration config)
+        {
+            byte[] serializedData = null;
+            using (MemoryStream stream = new())
+            using (BinaryWriter writer = new(stream))
+            {
+                writer.Write(config.CircularBufferSizeInMB);
+                writer.Write((uint)config.Format);
+                writer.Write(config.RundownKeyword);
+                writer.Write(config.RequestStackwalk);
+
+                SerializeProviders(config, writer);
+
+                writer.Flush();
+                serializedData = stream.ToArray();
+            }
+
+            return serializedData;
+        }
+
+        public static byte[] SerializeV5(this EventPipeSessionConfiguration config)
+        {
+            byte[] serializedData = null;
+            using (MemoryStream stream = new())
+            using (BinaryWriter writer = new(stream))
+            {
+                // This client only creates streaming (IpcStream) sessions.
+                writer.Write((uint)EventPipeSessionType.IpcStream);
+                writer.Write(config.CircularBufferSizeInMB);
+                writer.Write((uint)config.Format);
+                writer.Write(config.RundownKeyword);
+                writer.Write(config.RequestStackwalk);
+
+                SerializeProvidersV5(config, writer);
+
+                writer.Flush();
+                serializedData = stream.ToArray();
+            }
+
+            return serializedData;
+        }
+
+        public static byte[] SerializeV6(this EventPipeSessionConfiguration config)
+        {
+            byte[] serializedData = null;
+            using (MemoryStream stream = new())
+            using (BinaryWriter writer = new(stream))
+            {
+                writer.Write((uint)EventPipeSessionType.IpcStream);
+                writer.Write(config.CircularBufferSizeInMB);
+                writer.Write((uint)config.Format);
+                writer.Write(config.RundownKeyword);
+                writer.Write(config.RequestStackwalk);
+
+                SerializeProvidersV5(config, writer);
+
+                writer.Write((uint)config.BufferingMode);
+
+                writer.Flush();
+                serializedData = stream.ToArray();
+            }
+
+            return serializedData;
+        }
+
+        private static void SerializeProviders(EventPipeSessionConfiguration config, BinaryWriter writer)
+        {
+            writer.Write(config.Providers.Count);
+            foreach (EventPipeProvider provider in config.Providers)
+            {
+                writer.Write(unchecked((ulong)provider.Keywords));
+                writer.Write((uint)provider.EventLevel);
+                writer.WriteString(provider.Name);
+                writer.WriteString(provider.GetArgumentString());
+            }
+        }
+
+        // CollectTracing5+ per-provider layout: the V4 fields plus a trailing event filter.
+        private static void SerializeProvidersV5(EventPipeSessionConfiguration config, BinaryWriter writer)
+        {
+            writer.Write(config.Providers.Count);
+            foreach (EventPipeProvider provider in config.Providers)
+            {
+                writer.Write(unchecked((ulong)provider.Keywords));
+                writer.Write((uint)provider.EventLevel);
+                writer.WriteString(provider.Name);
+                writer.WriteString(provider.GetArgumentString());
+                SerializeEventFilter(writer, provider.EventFilter);
+            }
+        }
+
+        // Serializes a provider's CollectTracing5+ event filter. A null filter (no explicit Event ID
+        // filter) is written as a disabled, empty filter (enable=false, count=0), which the runtime
+        // interprets as "allow all events".
+        private static void SerializeEventFilter(BinaryWriter writer, EventPipeProviderEventFilter filter)
+        {
+            if (filter == null)
+            {
+                writer.Write(false);
+                writer.Write(0u);
+                return;
+            }
+
+            writer.Write(filter.Enable);
+            writer.Write((uint)filter.EventIds.Count);
+            foreach (uint eventId in filter.EventIds)
+            {
+                writer.Write(eventId);
+            }
+        }
     }
 }

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsIpc/IpcCommands.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Diagnostics.NETCore.Client
         StopTracing     = 0x01,
         CollectTracing  = 0x02,
         CollectTracing2 = 0x03,
+        CollectTracing3 = 0x04,
+        CollectTracing4 = 0x05,
+        CollectTracing5 = 0x06,
+        CollectTracing6 = 0x07,
     }
 
     internal enum DumpCommandId : byte

--- a/src/tests/tracing/eventpipe/nonlossyblock/nonlossyblock.cs
+++ b/src/tests/tracing/eventpipe/nonlossyblock/nonlossyblock.cs
@@ -46,17 +46,23 @@ namespace Tracing.Tests.NonLossyBlockValidation
                 requestStackwalk: true,
                 bufferingMode: (EventPipeBufferingMode)2);
 
+            EventPipeSession session;
             try
             {
-                using EventPipeSession session = client.StartEventPipeSession(invalidModeConfig);
-                Logger.logger.Log("Server accepted an invalid buffering mode; expected it to be rejected.");
-                return -1;
+                session = client.StartEventPipeSession(invalidModeConfig);
             }
             catch (DiagnosticsClientException ex)
             {
                 Logger.logger.Log($"Server rejected invalid buffering mode as expected: {ex.GetType().Name}: {ex.Message}");
                 Logger.logger.Log("==Invalid buffering mode rejection: PASSED==");
                 return 100;
+            }
+
+            using (session)
+            {
+                Logger.logger.Log("Server accepted an invalid buffering mode; expected it to be rejected.");
+                session.Stop();
+                return -1;
             }
         }
 

--- a/src/tests/tracing/eventpipe/nonlossyblock/nonlossyblock.cs
+++ b/src/tests/tracing/eventpipe/nonlossyblock/nonlossyblock.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.NETCore.Client;
+using Tracing.Tests.Common;
+using Xunit;
+using TestLibrary;
+
+namespace Tracing.Tests.NonLossyBlockValidation
+{
+    public sealed class BlockModeEventSource : EventSource
+    {
+        private BlockModeEventSource() {}
+        public static BlockModeEventSource Log = new BlockModeEventSource();
+        public void BlockModeEvent() { WriteEvent(1, "BlockModeEvent"); }
+    }
+
+    public class NonLossyBlockValidation
+    {
+        // Four concurrent producers emit a serialized 100,000-event burst substantially larger than this buffer.
+        // Block mode must park producers whenever the reader cannot keep up, then deliver every event after capacity
+        // becomes available.
+        private const int CircularBufferMB = 1;
+        private const int EventCount = 100_000;
+        private const int ProducerCount = 4;
+
+        [ActiveIssue("WASM doesn't support diagnostics tracing", TestPlatforms.Browser)]
+        [ActiveIssue("Can't find file dotnet-diagnostic-{pid}-*-socket", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsRiscv64Process))]
+        [Fact]
+        public static int InvalidBufferingModeIsRejected()
+        {
+            Logger.logger.Log("==Invalid buffering mode rejection: STARTING==");
+
+            List<EventPipeProvider> providers = CreateProviders();
+
+            DiagnosticsClient client = new(Process.GetCurrentProcess().Id);
+            EventPipeSessionConfiguration invalidModeConfig = new(
+                providers,
+                circularBufferSizeMB: CircularBufferMB,
+                rundownKeyword: 0,
+                requestStackwalk: true,
+                bufferingMode: (EventPipeBufferingMode)2);
+
+            try
+            {
+                using EventPipeSession session = client.StartEventPipeSession(invalidModeConfig);
+                Logger.logger.Log("Server accepted an invalid buffering mode; expected it to be rejected.");
+                return -1;
+            }
+            catch (DiagnosticsClientException ex)
+            {
+                Logger.logger.Log($"Server rejected invalid buffering mode as expected: {ex.GetType().Name}: {ex.Message}");
+                Logger.logger.Log("==Invalid buffering mode rejection: PASSED==");
+                return 100;
+            }
+        }
+
+        [ActiveIssue("WASM doesn't support diagnostics tracing", TestPlatforms.Browser)]
+        [ActiveIssue("Can't find file dotnet-diagnostic-{pid}-*-socket", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsRiscv64Process))]
+        [Fact]
+        public static int BlockModeDoesNotDropEvents()
+        {
+            Logger.logger.Log("==Block mode no-drop: STARTING==");
+
+            return IpcTraceTest.RunAndValidateEventCounts(
+                _expectedEventCounts,
+                _eventGeneratingAction,
+                CreateProviders(),
+                circularBufferMB: CircularBufferMB,
+                optionalTraceValidator: null,
+                enableRundownProvider: false,
+                bufferingMode: EventPipeBufferingMode.Block,
+                failOnEventsLost: true);
+        }
+
+        private static List<EventPipeProvider> CreateProviders() =>
+            new()
+            {
+                new EventPipeProvider("BlockModeEventSource", EventLevel.Verbose)
+            };
+
+        private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
+        {
+            { "BlockModeEventSource", new ExpectedEventCount(EventCount, 0.0f) }
+        };
+
+        private static Action _eventGeneratingAction = () =>
+        {
+            Debug.Assert(EventCount % ProducerCount == 0);
+            int eventsPerProducer = EventCount / ProducerCount;
+
+            Parallel.For(0, ProducerCount, _ =>
+            {
+                for (int i = 0; i < eventsPerProducer; i++)
+                {
+                    BlockModeEventSource.Log.BlockModeEvent();
+                }
+            });
+        };
+    }
+}

--- a/src/tests/tracing/eventpipe/nonlossyblock/nonlossyblock.csproj
+++ b/src/tests/tracing/eventpipe/nonlossyblock/nonlossyblock.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for GCStressIncompatible, UnloadabilityIncompatible, JitOptimizationSensitive -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/eventpipe_common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>

--- a/src/tests/tracing/eventpipe/nonlossyblockenv/nonlossyblockenv.cs
+++ b/src/tests/tracing/eventpipe/nonlossyblockenv/nonlossyblockenv.cs
@@ -1,0 +1,246 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Tracing.Tests.NonLossyBlockEnv
+{
+    public sealed class NonLossyBlockEnvEventSource : EventSource
+    {
+        private NonLossyBlockEnvEventSource() {}
+        public static NonLossyBlockEnvEventSource Log = new NonLossyBlockEnvEventSource();
+        public void BlockEnvEvent() { WriteEvent(1, "BlockEnvEvent"); }
+    }
+
+    // Validates the DOTNET_EventPipeBufferingMode startup-session opt-in (env-var path in
+    // enable_default_session_via_env_variables). This complements the IPC coverage in nonlossyblock/ by exercising
+    // the file/filestream startup session and the guards that reject unsupported configurations.
+    //
+    // The test re-launches itself as a child ("tracee") with a specific env-var configuration, then inspects
+    // whether the runtime produced a trace file:
+    //   * Block + non-streaming FILE        -> rejected (ep_session_alloc), no trace file, app still runs.
+    //   * invalid buffering mode (e.g. 2)   -> rejected (ep.c reads Drop/Block only), no trace file, app still runs.
+    //   * Block + streaming FILESTREAM      -> session starts and losslessly captures every event.
+    public class NonLossyBlockEnv
+    {
+        private const string ProviderName = "NonLossyBlockEnvEventSource";
+        private const int EventCount = 50_000;
+        private const int CircularMB = 1;
+        private const int TraceeExitTimeoutMs = 120_000;
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
+            {
+                return RunTracee();
+            }
+
+            return RunOrchestrator();
+        }
+
+        // Child process: any startup EventPipe session was created from the env vars before Main ran. Force the
+        // EventSource to construct so an active session can enable it, wait briefly for that enablement, then emit.
+        private static int RunTracee()
+        {
+            NonLossyBlockEnvEventSource log = NonLossyBlockEnvEventSource.Log;
+
+            Stopwatch sw = Stopwatch.StartNew();
+            while (!log.IsEnabled() && sw.ElapsedMilliseconds < 2000)
+            {
+                Thread.Sleep(10);
+            }
+
+            Console.WriteLine($"[tracee] EventSource enabled = {log.IsEnabled()}; emitting {EventCount} events.");
+            for (int i = 0; i < EventCount; i++)
+            {
+                log.BlockEnvEvent();
+            }
+            Console.WriteLine("[tracee] finished emitting events.");
+            return 0;
+        }
+
+        private static int RunOrchestrator()
+        {
+            Console.WriteLine("==TEST STARTING==");
+
+            try
+            {
+                bool passed =
+                    RunRejectScenario("Block + non-streaming FILE", bufferingMode: "1", outputStreaming: "0") &&
+                    RunRejectScenario("invalid buffering mode (2)", bufferingMode: "2", outputStreaming: "1") &&
+                    RunPositiveScenario();
+
+                Console.WriteLine(passed ? "==TEST FINISHED: PASSED!==" : "==TEST FINISHED: FAILED!==");
+                return passed ? 100 : -1;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Platforms that cannot launch child processes (e.g. iOS, tvOS) cannot exercise this test.
+                Console.WriteLine("Skipping test: this platform does not support launching child processes.");
+                return 100;
+            }
+        }
+
+        // An unsupported configuration must fail to start the session (no trace file) without taking down the app.
+        private static bool RunRejectScenario(string name, string bufferingMode, string outputStreaming)
+        {
+            Console.WriteLine($"-- Reject scenario: {name} --");
+            string traceDir = CreateTraceDirectory();
+            string traceFilePath = Path.Combine(traceDir, "trace.nettrace");
+
+            try
+            {
+                int exitCode = LaunchTracee(bufferingMode, outputStreaming, traceFilePath);
+                if (exitCode != 0)
+                {
+                    Console.WriteLine($"FAILED: tracee exited with {exitCode}; an invalid startup config must not crash the app.");
+                    return false;
+                }
+
+                string[] produced = Directory.GetFiles(traceDir);
+                if (produced.Length != 0)
+                {
+                    Console.WriteLine($"FAILED: expected no trace file, but found: {string.Join(", ", produced)}");
+                    return false;
+                }
+
+                Console.WriteLine("PASSED: no startup session and no trace file were produced.");
+                return true;
+            }
+            finally
+            {
+                TryDeleteDirectory(traceDir);
+            }
+        }
+
+        // Block on a streaming FILESTREAM session must capture every event with no drops.
+        private static bool RunPositiveScenario()
+        {
+            Console.WriteLine("-- Positive scenario: Block + streaming FILESTREAM --");
+            string traceDir = CreateTraceDirectory();
+            string traceFilePath = Path.Combine(traceDir, "trace.nettrace");
+
+            try
+            {
+                int exitCode = LaunchTracee(bufferingMode: "1", outputStreaming: "1", traceFilePath);
+                if (exitCode != 0)
+                {
+                    Console.WriteLine($"FAILED: tracee exited with {exitCode}, expected 0.");
+                    return false;
+                }
+                if (!File.Exists(traceFilePath))
+                {
+                    Console.WriteLine($"FAILED: expected a trace file at {traceFilePath}, but none was produced.");
+                    return false;
+                }
+
+                int actualCount = 0;
+                long eventsLost;
+                using (EventPipeEventSource source = new EventPipeEventSource(traceFilePath))
+                {
+                    source.Dynamic.All += (TraceEvent e) =>
+                    {
+                        if (e.ProviderName == ProviderName && (int)e.ID == 1)
+                        {
+                            actualCount++;
+                        }
+                    };
+                    source.Process();
+                    eventsLost = source.EventsLost;
+                }
+
+                Console.WriteLine($"Observed {actualCount} '{ProviderName}' events; EventsLost = {eventsLost}.");
+
+                if (eventsLost != 0)
+                {
+                    Console.WriteLine($"FAILED: expected zero dropped events, but the trace reported {eventsLost}.");
+                    return false;
+                }
+                if (actualCount != EventCount)
+                {
+                    Console.WriteLine($"FAILED: expected exactly {EventCount} events, but saw {actualCount}.");
+                    return false;
+                }
+
+                Console.WriteLine("PASSED: the Block startup session delivered every event losslessly.");
+                return true;
+            }
+            finally
+            {
+                TryDeleteDirectory(traceDir);
+            }
+        }
+
+        private static int LaunchTracee(string bufferingMode, string outputStreaming, string traceFilePath)
+        {
+            ProcessStartInfo psi = new();
+            psi.FileName = Environment.ProcessPath
+                ?? throw new InvalidOperationException("Environment.ProcessPath is null");
+
+            // NativeAOT runs the test as a native executable (Assembly.Location is empty); CoreCLR/Mono run it
+            // through the host (e.g. corerun) with the managed assembly path as the first argument.
+            string assemblyLocation = Assembly.GetExecutingAssembly().Location;
+            if (!string.IsNullOrEmpty(assemblyLocation))
+            {
+                psi.ArgumentList.Add(assemblyLocation);
+            }
+            psi.ArgumentList.Add("tracee");
+
+            psi.UseShellExecute = false;
+            psi.RedirectStandardOutput = true;
+            psi.RedirectStandardError = true;
+
+            psi.Environment["DOTNET_EnableEventPipe"] = "1";
+            psi.Environment["DOTNET_EventPipeConfig"] = $"{ProviderName}:0:4";
+            psi.Environment["DOTNET_EventPipeOutputPath"] = traceFilePath;
+            psi.Environment["DOTNET_EventPipeCircularMB"] = CircularMB.ToString();
+            psi.Environment["DOTNET_EventPipeBufferingMode"] = bufferingMode;
+            psi.Environment["DOTNET_EventPipeOutputStreaming"] = outputStreaming;
+
+            Console.WriteLine($"Launching tracee: {psi.FileName} {string.Join(" ", psi.ArgumentList)}");
+            Console.WriteLine($"  DOTNET_EventPipeBufferingMode={bufferingMode} DOTNET_EventPipeOutputStreaming={outputStreaming} DOTNET_EventPipeCircularMB={CircularMB}");
+
+            using Process process = Process.Start(psi);
+            process.OutputDataReceived += (_, e) => { if (!string.IsNullOrEmpty(e.Data)) Console.WriteLine($"[tracee][stdout] {e.Data}"); };
+            process.ErrorDataReceived += (_, e) => { if (!string.IsNullOrEmpty(e.Data)) Console.WriteLine($"[tracee][stderr] {e.Data}"); };
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            if (!process.WaitForExit(TraceeExitTimeoutMs))
+            {
+                Console.WriteLine($"Tracee did not exit within {TraceeExitTimeoutMs}ms; killing it.");
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit();
+                return -1;
+            }
+            process.WaitForExit(); // ensure async output is flushed
+            return process.ExitCode;
+        }
+
+        private static string CreateTraceDirectory()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "nonlossyblockenv-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        private static void TryDeleteDirectory(string dir)
+        {
+            try
+            {
+                if (Directory.Exists(dir))
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/nonlossyblockenv/nonlossyblockenv.cs
+++ b/src/tests/tracing/eventpipe/nonlossyblockenv/nonlossyblockenv.cs
@@ -206,7 +206,8 @@ namespace Tracing.Tests.NonLossyBlockEnv
             Console.WriteLine($"Launching tracee: {psi.FileName} {string.Join(" ", psi.ArgumentList)}");
             Console.WriteLine($"  DOTNET_EventPipeBufferingMode={bufferingMode} DOTNET_EventPipeOutputStreaming={outputStreaming} DOTNET_EventPipeCircularMB={CircularMB}");
 
-            using Process process = Process.Start(psi);
+            using Process process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start tracee process.");
             process.OutputDataReceived += (_, e) => { if (!string.IsNullOrEmpty(e.Data)) Console.WriteLine($"[tracee][stdout] {e.Data}"); };
             process.ErrorDataReceived += (_, e) => { if (!string.IsNullOrEmpty(e.Data)) Console.WriteLine($"[tracee][stderr] {e.Data}"); };
             process.BeginOutputReadLine();

--- a/src/tests/tracing/eventpipe/nonlossyblockenv/nonlossyblockenv.csproj
+++ b/src/tests/tracing/eventpipe/nonlossyblockenv/nonlossyblockenv.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Tracing tests routinely time out with jitstress and gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Self-relaunching child-process test with a custom Main; no xUnit wrapper. -->
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <!-- Browser/WASI are single-threaded (no drain thread) and cannot launch child processes. -->
+    <CLRTestTargetUnsupported Condition="'$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Add end-to-end test coverage for EventPipe's non-lossy `Block` buffering mode.

- Re-sync the vendored `Microsoft.Diagnostics.NETCore.Client` and `IpcTraceTest` infrastructure with `dotnet/diagnostics` at `95035e6c3f122c513f8c2303b058c2c4750401a7`, while preserving the runtime- and mobile-specific adaptations.
- Add IPC coverage for CollectTracing6:
  - Reject an invalid buffering mode.
  - Start a Block-mode session with a 1 MB buffer.
  - Generate 100,000 events from four concurrent producers.
  - Require the exact event count with zero dropped events.
- Add startup environment-variable coverage for `DOTNET_EventPipeBufferingMode`:
  - Reject Block mode for a non-streaming file session.
  - Reject an invalid buffering mode.
  - Verify that a streaming Block-mode session captures exactly 50,000 events with zero loss.
- Ensure `IpcTraceTest` honors its requested circular buffer size and lets the client select the minimum required CollectTracing protocol version.