### PR TITLE
Enable Helix job monitor for runtime perf

### DIFF
--- a/eng/pipelines/performance/perf.yml
+++ b/eng/pipelines/performance/perf.yml
@@ -31,6 +31,8 @@ resources:
 
 variables:
 - template: /eng/pipelines/common/variables.yml
+- name: enableHelixJobMonitor
+  value: true
 
 #
 # For the 'schedule' case, only wasm/jsc perf jobs are run.
@@ -53,6 +55,12 @@ extends:
     stages:
     - stage: Build
       jobs:
+
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: $(HelixApiAccessToken)
+          timeoutInMinutes: 540
+          allowNoHelixJobs: true
 
       - template: /eng/pipelines/runtime-wasm-perf-jobs.yml@performance
         parameters:


### PR DESCRIPTION
## Summary

- enable the Helix Job Monitor for the `dotnet-runtime-perf` pipeline
- run the monitor for up to 540 minutes and allow runs that fail before producing Helix jobs
- leave `dotnet-runtime-perf-build` unchanged because its `runtime-perf-build-jobs.yml` template only builds and publishes artifacts; it does not submit work to Helix

## Motivation

Recent `dotnet-runtime-perf` runs contain many `Send job to Helix` tasks. Enabling the monitor allows those submissions to return without occupying build agents while one generic job tracks completion and reports results.

## Validation

- `git diff --check`
- verified pipeline definitions 702 and 1442 map to `perf.yml` and `perf-build.yml`, respectively
- inspected the current `dotnet-performance` templates to confirm only `runtime-perf-jobs.yml` reaches `send-to-helix-step.yml`

> [!NOTE]
> This pull request description was generated with GitHub Copilot.