### PR TITLE
JIT: extend relaxed checks through morph

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -455,7 +455,8 @@ enum BasicBlockFlags : uint64_t
     // Flags to update when two blocks are compacted
 
     BBF_COMPACT_UPD = BBF_GC_SAFE_POINT | BBF_NEEDS_GCPOLL | BBF_HAS_JMP | BBF_BACKWARD_JUMP | \
-                      BBF_HAS_NEWOBJ | BBF_HAS_NEWARR | BBF_HAS_MDARRAYREF | BBF_MAY_HAVE_BOUNDS_CHECKS,
+                      BBF_HAS_NEWOBJ | BBF_HAS_NEWARR | BBF_HAS_MDARRAYREF | BBF_MAY_HAVE_BOUNDS_CHECKS | \
+                      BBF_RECURSIVE_TAILCALL,
 
     // Flags a block should not have had before it is split.
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4338,9 +4338,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     DoPhase(this, PHASE_INDXCALL, &Compiler::fgTransformIndirectCalls);
 
-    // Relaxed IR checks are currently only enabled through indirect call transformation.
-    activePhaseChecks &= ~(PhaseChecks::CHECK_IR | PhaseChecks::CHECK_IR_RELAXED);
-
     // Cleanup un-imported BBs, cleanup un-imported or
     // partially imported try regions, add OSR step blocks.
     //
@@ -4506,6 +4503,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Apply the type update to implicit byref parameters; also choose (based on address-exposed
     // analysis) which implicit byref promotions to keep (requires copy to initialize) or discard.
     //
+    INDEBUG(fgImplicitByRefLclFldsStale = true);
     DoPhase(this, PHASE_MORPH_IMPBYREF, &Compiler::fgRetypeImplicitByRefArgs);
 
 #ifdef DEBUG
@@ -4516,8 +4514,12 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     // Morph the trees in all the blocks of the method
     //
+    INDEBUG(fgImplicitByRefLclFldsStale = false);
     unsigned const preMorphBBCount = fgBBcount;
     DoPhase(this, PHASE_MORPH_GLOBAL, &Compiler::fgMorphBlocks);
+
+    // Global morph restores the strict IR flag invariants.
+    activePhaseChecks &= ~PhaseChecks::CHECK_IR_RELAXED;
 
     auto postMorphPhase = [this]() {
         // Fix any LclVar annotations on discarded struct promotion temps for implicit by-ref args

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6119,6 +6119,12 @@ public:
 
     bool fgGlobalMorphDone = false;
 
+#ifdef DEBUG
+    // Retyping implicit byref parameters temporarily leaves existing local field
+    // accesses described using their pre-retyping struct types.
+    bool fgImplicitByRefLclFldsStale = false;
+#endif
+
     bool     impBoxTempInUse; // the temp below is valid and available
     unsigned impBoxTemp;      // a temporary that is used for boxing
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3377,7 +3377,12 @@ void Compiler::fgDebugCheckFlagsAndTypes(GenTree* tree, BasicBlock* block)
         case GT_STORE_LCL_VAR:
         case GT_STORE_LCL_FLD:
             assert((tree->gtFlags & GTF_VAR_DEF) != 0);
-            assert(((tree->gtFlags & GTF_VAR_USEASG) != 0) == tree->IsPartialLclFld(this));
+            if (!fgImplicitByRefLclFldsStale || !tree->OperIs(GT_STORE_LCL_FLD) ||
+                !lvaGetDesc(tree->AsLclFld())->TypeIs(TYP_BYREF) ||
+                !lvaIsImplicitByRefLocal(tree->AsLclFld()->GetLclNum()))
+            {
+                assert(((tree->gtFlags & GTF_VAR_USEASG) != 0) == tree->IsPartialLclFld(this));
+            }
             break;
 
         case GT_CATCH_ARG:
@@ -4020,7 +4025,7 @@ void Compiler::fgDebugCheckStmtsList(BasicBlock* block)
         }
 
         // For each statement check that the nodes are threaded correctly - m_treeList.
-        if (fgNodeThreading != NodeThreading::None)
+        if ((fgNodeThreading == NodeThreading::AllTrees) || (fgNodeThreading == NodeThreading::LIR))
         {
             fgDebugCheckNodeLinks(block, stmt);
         }

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -371,6 +371,11 @@ public:
     fgWalkResult PostOrderVisit(GenTree** use, GenTree* user)
     {
         LateDevirtualization(use, user);
+        GenTree* tree = *use;
+        tree->VisitOperands([tree](GenTree* operand) -> GenTree::VisitResult {
+            tree->gtFlags |= operand->gtFlags & GTF_ALL_EFFECT;
+            return GenTree::VisitResult::Continue;
+        });
         return fgWalkResult::WALK_CONTINUE;
     }
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -371,11 +371,10 @@ public:
     fgWalkResult PostOrderVisit(GenTree** use, GenTree* user)
     {
         LateDevirtualization(use, user);
-        GenTree* tree = *use;
-        tree->VisitOperands([tree](GenTree* operand) -> GenTree::VisitResult {
-            tree->gtFlags |= operand->gtFlags & GTF_ALL_EFFECT;
-            return GenTree::VisitResult::Continue;
-        });
+        if ((*use != nullptr) && (user != nullptr))
+        {
+            user->gtFlags |= (*use)->gtFlags & GTF_ALL_EFFECT;
+        }
         return fgWalkResult::WALK_CONTINUE;
     }
 

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -922,6 +922,11 @@ public:
         assert(m_valueStack.Empty());
         m_madeChanges |= m_stmtModified;
 
+        if (m_stmtModified)
+        {
+            m_compiler->gtUpdateStmtSideEffects(stmt);
+        }
+
         if (m_sequencer != nullptr)
         {
             if (m_stmtModified)
@@ -1518,6 +1523,7 @@ private:
                 {
                     m_compiler->lvaSetHiddenBufferStructArg(lclNum);
                     callUser->gtCallMoreFlags |= GTF_CALL_M_RETBUFFARG_LCLOPT;
+                    callUser->gtFlags |= GTF_ASG;
                     defSize = m_compiler->typGetObjLayout(callUser->gtRetClsHnd)->GetSize();
                 }
             }

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -865,9 +865,10 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
     };
 
     ArrayStack<Value>               m_valueStack;
-    bool                            m_stmtModified    = false;
-    bool                            m_madeChanges     = false;
-    bool                            m_propagatedAddrs = false;
+    bool                            m_stmtModified            = false;
+    bool                            m_stmtSideEffectsModified = false;
+    bool                            m_madeChanges             = false;
+    bool                            m_propagatedAddrs         = false;
     LocalSequencer*                 m_sequencer;
     LocalEqualsLocalAddrAssertions* m_lclAddrAssertions;
 
@@ -907,7 +908,8 @@ public:
         }
 #endif // DEBUG
 
-        m_stmtModified = false;
+        m_stmtModified            = false;
+        m_stmtSideEffectsModified = false;
 
         if (m_sequencer != nullptr)
         {
@@ -922,7 +924,7 @@ public:
         assert(m_valueStack.Empty());
         m_madeChanges |= m_stmtModified;
 
-        if (m_stmtModified)
+        if (m_stmtSideEffectsModified)
         {
             m_compiler->gtUpdateStmtSideEffects(stmt);
         }
@@ -1539,7 +1541,9 @@ private:
             {
                 INDEBUG(varDsc->SetDefinedViaAddress(true));
                 escapeAddr = false;
-                defFlags   = GTF_VAR_DEF | GTF_ASG;
+                defFlags   = GTF_VAR_DEF;
+                m_stmtSideEffectsModified |= (callUser->gtFlags & GTF_ASG) == 0;
+                callUser->gtFlags |= GTF_ASG;
 
                 if (!m_compiler->IsEntireAccess(lclNum, val.Offset(), ValueSize(defSize)))
                 {
@@ -1626,6 +1630,7 @@ private:
 
             MorphLocalAddress(node->AsIndir()->Addr(), lclNum, offset);
             node->gtFlags |= GTF_GLOB_REF; // GLOB_REF may not be set already in the "large offset" case.
+            m_stmtSideEffectsModified = true;
         }
         else
         {
@@ -1933,8 +1938,9 @@ private:
             }
         }
 
-        lclNode->gtFlags = lclNodeFlags;
-        m_stmtModified   = true;
+        lclNode->gtFlags          = lclNodeFlags;
+        m_stmtModified            = true;
+        m_stmtSideEffectsModified = true;
     }
 
     //------------------------------------------------------------------------

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1498,7 +1498,7 @@ private:
         unsigned   lclNum = val.LclNum();
         LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
 
-        GenTreeFlags defFlag    = GTF_EMPTY;
+        GenTreeFlags defFlags   = GTF_EMPTY;
         GenTreeCall* callUser   = (user != nullptr) && user->IsCall() ? user->AsCall() : nullptr;
         bool         escapeAddr = true;
         if ((callUser != nullptr) && m_compiler->IsValidLclAddr(lclNum, val.Offset()))
@@ -1523,7 +1523,6 @@ private:
                 {
                     m_compiler->lvaSetHiddenBufferStructArg(lclNum);
                     callUser->gtCallMoreFlags |= GTF_CALL_M_RETBUFFARG_LCLOPT;
-                    callUser->gtFlags |= GTF_ASG;
                     defSize = m_compiler->typGetObjLayout(callUser->gtRetClsHnd)->GetSize();
                 }
             }
@@ -1540,11 +1539,11 @@ private:
             {
                 INDEBUG(varDsc->SetDefinedViaAddress(true));
                 escapeAddr = false;
-                defFlag    = GTF_VAR_DEF;
+                defFlags   = GTF_VAR_DEF | GTF_ASG;
 
                 if (!m_compiler->IsEntireAccess(lclNum, val.Offset(), ValueSize(defSize)))
                 {
-                    defFlag |= GTF_VAR_USEASG;
+                    defFlags |= GTF_VAR_USEASG;
                 }
             }
         }
@@ -1579,7 +1578,7 @@ private:
 #endif // TARGET_64BIT
 
         MorphLocalAddress(val.Node(), lclNum, val.Offset());
-        val.Node()->gtFlags |= defFlag;
+        val.Node()->gtFlags |= defFlags;
 
         INDEBUG(val.Consume();)
     }

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -2933,6 +2933,7 @@ void ObjectAllocator::RewriteUses()
                         //
                         indir->Addr() = actualAddr;
                         indir->gtFlags &= ~GTF_SIDE_EFFECT;
+                        indir->gtFlags |= GTF_IND_NONFAULTING;
                         GenTree* const newComma =
                             m_compiler->gtNewOperNode(GT_COMMA, indir->TypeGet(), sideEffects, indir);
                         *use = newComma;


### PR DESCRIPTION
## Summary

- extend relaxed IR flag checking through global morph
- refresh statement side effects after local morph changes
- preserve required flags during inlining and object allocation rewrites

## Testing

- x64 Checked JIT build
- full SuperPMI replay
- jit-format

> [!NOTE]
> This pull request description was generated with GitHub Copilot.