### PR TITLE
Fix "Bad IL range" when applying a hot reload update without FEATURE_REJIT

### DIFF
--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -1524,11 +1524,6 @@ ILCodeVersion CodeVersionManager::GetILCodeVersion(PTR_MethodDesc pMethod, ReJIT
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    // Note: non-default IL code versions are not exclusive to ReJIT - EnC (FEATURE_METADATA_UPDATER)
-    // creates them as well, and that feature is available even when FEATURE_REJIT is off (which is
-    // the case on the platforms without a JIT, such as the Apple mobile platforms). Unconditionally
-    // returning the default IL code version in that case makes the runtime read the IL of an updated
-    // method from the baseline image using a delta-relative RVA, which throws "Bad IL range".
     if (rejitId == 0)
     {
         return ILCodeVersion(dac_cast<PTR_Module>(pMethod->GetModule()), pMethod->GetMemberDef());

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -1524,11 +1524,6 @@ ILCodeVersion CodeVersionManager::GetILCodeVersion(PTR_MethodDesc pMethod, ReJIT
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    if (rejitId == 0)
-    {
-        return ILCodeVersion(dac_cast<PTR_Module>(pMethod->GetModule()), pMethod->GetMemberDef());
-    }
-
     ILCodeVersionCollection collection = GetILCodeVersions(pMethod);
     for (ILCodeVersionIterator cur = collection.Begin(), end = collection.End(); cur != end; cur++)
     {

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -1524,7 +1524,16 @@ ILCodeVersion CodeVersionManager::GetILCodeVersion(PTR_MethodDesc pMethod, ReJIT
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-#ifdef FEATURE_REJIT
+    // Note: non-default IL code versions are not exclusive to ReJIT - EnC (FEATURE_METADATA_UPDATER)
+    // creates them as well, and that feature is available even when FEATURE_REJIT is off (which is
+    // the case on the platforms without a JIT, such as the Apple mobile platforms). Unconditionally
+    // returning the default IL code version in that case makes the runtime read the IL of an updated
+    // method from the baseline image using a delta-relative RVA, which throws "Bad IL range".
+    if (rejitId == 0)
+    {
+        return ILCodeVersion(dac_cast<PTR_Module>(pMethod->GetModule()), pMethod->GetMemberDef());
+    }
+
     ILCodeVersionCollection collection = GetILCodeVersions(pMethod);
     for (ILCodeVersionIterator cur = collection.Begin(), end = collection.End(); cur != end; cur++)
     {
@@ -1534,10 +1543,6 @@ ILCodeVersion CodeVersionManager::GetILCodeVersion(PTR_MethodDesc pMethod, ReJIT
         }
     }
     return ILCodeVersion();
-#else // FEATURE_REJIT
-    _ASSERTE(rejitId == 0);
-    return ILCodeVersion(dac_cast<PTR_Module>(pMethod->GetModule()), pMethod->GetMemberDef());
-#endif // FEATURE_REJIT
 }
 
 NativeCodeVersionCollection CodeVersionManager::GetNativeCodeVersions(PTR_MethodDesc pMethod) const


### PR DESCRIPTION
On the platforms without a JIT (the Apple mobile platforms, WASM), the CoreCLR build doesn't set `FEATURE_DYNAMIC_CODE_COMPILED`, and thus doesn't set `FEATURE_REJIT` either ([`clrfeatures.cmake`](https://github.com/dotnet/runtime/blob/main/src/coreclr/clrfeatures.cmake#L10-L14)):

```cmake
if (FEATURE_DYNAMIC_CODE_COMPILED)
  set(FEATURE_TIERED_COMPILATION 1)
  set(FEATURE_REJIT 1)
  set(FEATURE_PGO 1)
endif()
```

However, `FEATURE_CODE_VERSIONING` *is* still enabled on those platforms, because `FEATURE_METADATA_UPDATER` (Edit and Continue / hot reload) is enabled ([`clrdefinitions.cmake:58`](https://github.com/dotnet/runtime/blob/main/src/coreclr/clrdefinitions.cmake#L58)). So EnC creates real, non-default `ILCodeVersion` nodes there.

`CodeVersionManager::GetILCodeVersion (PTR_MethodDesc, ReJITID)` was guarded on `FEATURE_REJIT`, and when that feature is off it unconditionally returned the **default** IL code version:

```cpp
#else // FEATURE_REJIT
    _ASSERTE(rejitId == 0);
    return ILCodeVersion(dac_cast<PTR_Module>(pMethod->GetModule()), pMethod->GetMemberDef());
#endif // FEATURE_REJIT
```

That's wrong: non-default IL code versions are not exclusive to ReJIT, so the lookup must work whenever code versioning is available.

## Consequence

After applying a hot reload update:

1. `EditAndContinueModule::ApplyEditAndContinue` correctly adds the EnC `ILCodeVersion` and makes it the active one.
2. The method is reset to its prestub, and code preparation runs `NativeCodeVersionNode::GetILCodeVersion()` → `GetILCodeVersion (pMD, GetILVersionId ())`.
3. That returns the **default** version instead of the EnC one.
4. `ILCodeVersion::GetIL()` then takes the default-version path: `GetMethodImplProps (methodDef, &rva)` + `pModule->GetIL (rva)`. After a delta, that RVA is *delta-relative* (`0x4` in the repro below), so it's out of range in the baseline image, `PEAssembly::GetIL` fails the `CheckILMethod` range check, and the app crashes with:

```
Unhandled exception. System.BadImageFormatException: Bad IL range.
   at System.Reflection.Metadata.MetadataUpdater.ApplyUpdate(...)
```

### Instrumented evidence

From an instrumented CoreCLR build (printf probes, not part of this PR):

```
[ENCDIAG] ApplyEnC AddILCodeVersion module=0x10807d450 token=0x06000001 deltaRVA=4
[ENCDIAG] SetActiveILCodeVersions module=0x10807d450 token=0x06000001 state=0x782ec48900 setIsDefault=0 nowIsDefault=0
[ENCDIAG] GetActiveILCodeVersion module=0x10807d450 token=0x06000001 state=0x782ec48900 activeIsDefault=0
dotnet watch 🔥 C# and Razor changes applied in 588ms.
[ENCDIAG] GetActiveILCodeVersion module=0x10807d450 token=0x06000001 state=0x782ec48900 activeIsDefault=0
[ENCDIAG] VersionedPrepareCodeConfig::GetILHeader token=0x06000001 isDefaultVer=1 source=0
[ENCDIAG] *** BAD IL RANGE *** rva=0x4
Unhandled exception. System.BadImageFormatException: Bad IL range.
```

Note the contradiction on the last three lines: the *active* IL version is correctly the EnC one (`activeIsDefault=0`), but the version code preparation actually ends up with is the default one (`isDefaultVer=1 source=0`, where `source=0` is `kUnknown` rather than `kEnC=2`). That's the `NativeCodeVersion` → `ILCodeVersion` mapping going through the broken lookup.

## Fix

Don't make the lookup conditional on `FEATURE_REJIT`.

A `rejitId` of 0 always means the default version (`ILCodeVersion::GetVersionId ()` returns 0 for the default version), so short-circuiting that case preserves the existing behavior for **both** configurations, while making non-default versions findable when `FEATURE_REJIT` is off.

## Verification

Built for `maccatalyst-arm64` Release and swapped into the app bundle of a Mac Catalyst test app. The same `dotnet watch` hot reload repro that reproduced the crash 100% of the time now applies the edit successfully and the app exits cleanly:

```
dotnet watch 🔥 C# and Razor changes applied in 576ms.
2026-08-27 01:54:38.278 HotReloadTestApp[15315:3769295] 77 Variable=Variable has changed
dotnet watch ⌚ [HotReloadTestApp (net11.0-maccatalyst)] Exited
```

This is currently causing hot reload to be completely broken with CoreCLR on iOS, tvOS and Mac Catalyst — see dotnet/macios#26470, where the affected tests had to be disabled.

Fixes https://github.com/dotnet/runtime/issues/132804

🤖 Pull request created by Copilot
