### PR TITLE
JIT: add JitEnablePhaseChecks, and disable it for the base SuperPMI asm diffs JIT

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -196,6 +196,7 @@ CONFIG_INTEGER(JitProfileChecks, "JitProfileChecks", -1)
 CONFIG_INTEGER(JitRequired, "JITRequired", -1)
 CONFIG_INTEGER(JitStackAllocToLocalSize, "JitStackAllocToLocalSize", DEFAULT_MAX_LOCALLOC_TO_LOCAL_SIZE)
 CONFIG_INTEGER(JitSkipArrayBoundCheck, "JitSkipArrayBoundCheck", 0)
+CONFIG_INTEGER(JitEnablePhaseChecks, "JitEnablePhaseChecks", 1) // Run the phase IR checks
 
 // On ARM, use this as the maximum function/funclet size for creating function fragments (and creating
 // multiple RUNTIME_FUNCTION entries)

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -116,11 +116,11 @@ void Phase::PostPhase(PhaseStatus status)
 
     // Don't dump or check post phase unless the phase made changes.
     //
-    const bool madeChanges       = (status != PhaseStatus::MODIFIED_NOTHING);
-    const bool doPostPhase       = madeChanges;
+    const bool madeChanges = (status != PhaseStatus::MODIFIED_NOTHING);
+    const bool doPostPhase = madeChanges;
     const bool doPostPhaseChecks =
         (m_compiler->activePhaseChecks != PhaseChecks::CHECK_NONE) && (JitConfig.JitEnablePhaseChecks() != 0);
-    const bool doPostPhaseDumps  = (m_compiler->activePhaseDumps == PhaseDumps::DUMP_ALL);
+    const bool doPostPhaseDumps = (m_compiler->activePhaseDumps == PhaseDumps::DUMP_ALL);
 
     const char* const statusMessage = madeChanges ? "" : " [no changes]";
 

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -118,7 +118,8 @@ void Phase::PostPhase(PhaseStatus status)
     //
     const bool madeChanges       = (status != PhaseStatus::MODIFIED_NOTHING);
     const bool doPostPhase       = madeChanges;
-    const bool doPostPhaseChecks = (m_compiler->activePhaseChecks != PhaseChecks::CHECK_NONE);
+    const bool doPostPhaseChecks =
+        (m_compiler->activePhaseChecks != PhaseChecks::CHECK_NONE) && (JitConfig.JitEnablePhaseChecks() != 0);
     const bool doPostPhaseDumps  = (m_compiler->activePhaseDumps == PhaseDumps::DUMP_ALL);
 
     const char* const statusMessage = madeChanges ? "" : " [no changes]";

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1768,7 +1768,7 @@ class SuperPMIReplay:
             common_flags += repro_flags
 
             if self.coreclr_args.no_ir_checks:
-                common_flags += [ "-jitoption", "JitEnablePhaseChecks=0" ]
+                common_flags += [ "-jitoption", "force", "JitEnablePhaseChecks=0" ]
 
             # For each MCH file that we are going to replay, do the replay and replay post-processing.
             #
@@ -2216,10 +2216,16 @@ class SuperPMIReplayAsmDiffs:
         # The base JIT is already validated, so the phase IR checks are turned off for it by
         # default and left on for the diff JIT, which is the one under test. -full_ir_checks
         # turns them back on for the base JIT, and -no_ir_checks turns them off everywhere.
+        #
+        # The diff artifact runs compare the base and diff JitDumps textually, so the checks
+        # have to be configured identically there. That rules out the asymmetric default, but
+        # -no_ir_checks applies to both JITs and can be passed along.
         if not self.coreclr_args.full_ir_checks:
-            base_option_flags += [ "-jitoption", "JitEnablePhaseChecks=0" ]
+            base_option_flags += [ "-jitoption", "force", "JitEnablePhaseChecks=0" ]
         if self.coreclr_args.no_ir_checks:
-            diff_option_flags += [ "-jit2option", "JitEnablePhaseChecks=0" ]
+            diff_option_flags += [ "-jit2option", "force", "JitEnablePhaseChecks=0" ]
+            base_option_flags_for_diff_artifact += [ "-jitoption", "force", "JitEnablePhaseChecks=0" ]
+            diff_option_flags_for_diff_artifact += [ "-jitoption", "force", "JitEnablePhaseChecks=0" ]
 
         if self.coreclr_args.altjit:
             altjit_asm_diffs_flags += [
@@ -3117,8 +3123,8 @@ class SuperPMIReplayThroughputDiff:
         # Both JITs have to be configured the same way here, since this measures the base
         # against the diff.
         if self.coreclr_args.no_ir_checks:
-            base_option_flags += [ "-jitoption", "JitEnablePhaseChecks=0" ]
-            diff_option_flags += [ "-jit2option", "JitEnablePhaseChecks=0" ]
+            base_option_flags += [ "-jitoption", "force", "JitEnablePhaseChecks=0" ]
+            diff_option_flags += [ "-jit2option", "force", "JitEnablePhaseChecks=0" ]
 
         base_jit_build_string_decoded = decode_clrjit_build_string(self.base_jit_path)
         diff_jit_build_string_decoded = decode_clrjit_build_string(self.diff_jit_path)
@@ -3479,8 +3485,8 @@ class SuperPMIReplayMetricDiff:
         # Both JITs have to be configured the same way here, since this compares metrics
         # from the base against the diff.
         if self.coreclr_args.no_ir_checks:
-            base_option_flags += [ "-jitoption", "JitEnablePhaseChecks=0" ]
-            diff_option_flags += [ "-jit2option", "JitEnablePhaseChecks=0" ]
+            base_option_flags += [ "-jitoption", "force", "JitEnablePhaseChecks=0" ]
+            diff_option_flags += [ "-jit2option", "force", "JitEnablePhaseChecks=0" ]
 
         metric_diffs = []
 
@@ -5394,6 +5400,11 @@ def setup_args(args):
                             "details",  # The replay code checks this, so make sure it's set
                             lambda unused: True,
                             "Unable to set details")
+
+        coreclr_args.verify(args,
+                            "no_ir_checks",  # The replay code checks this, so make sure it's set
+                            lambda unused: True,
+                            "Unable to set no_ir_checks.")
 
         coreclr_args.verify(args,
                             "collection_command",

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -348,6 +348,7 @@ replay_common_parser.add_argument("-private_store", action="append", help=privat
 replay_common_parser.add_argument("-compile", "-c", help=compile_help)
 replay_common_parser.add_argument("--produce_repro", action="store_true", help=produce_repro_help)
 replay_common_parser.add_argument("-details", help="Specify full path to details file or folder")
+replay_common_parser.add_argument("-no_ir_checks", action="store_true", help="Disable the phase IR checks in every JIT that is invoked.")
 
 # subparser for replay
 replay_parser = subparsers.add_parser("replay", description=replay_description, parents=[core_root_parser, target_parser, superpmi_common_parser, replay_common_parser])
@@ -376,6 +377,7 @@ asm_diff_parser.add_argument("-tag", help="Specify a word to add to the director
 asm_diff_parser.add_argument("-metrics", action="append", help="Metrics option to pass to jit-analyze. Can be specified multiple times, one for each metric.")
 asm_diff_parser.add_argument("--diff_with_release", action="store_true", help="Specify if this is asmdiff using release binaries.")
 asm_diff_parser.add_argument("--git_diff", action="store_true", help="Produce a '.diff' file from 'base' and 'diff' folders if there were any differences.")
+asm_diff_parser.add_argument("-full_ir_checks", action="store_true", help="Run the phase IR checks in the base JIT as well. By default they are only run in the diff JIT, since the base JIT is already validated.")
 
 # subparser for throughput
 throughput_parser = subparsers.add_parser("tpdiff", description=throughput_description, parents=[target_parser, superpmi_common_parser, replay_common_parser, base_diff_parser])
@@ -1765,6 +1767,9 @@ class SuperPMIReplay:
 
             common_flags += repro_flags
 
+            if self.coreclr_args.no_ir_checks:
+                common_flags += [ "-jitoption", "JitEnablePhaseChecks=0" ]
+
             # For each MCH file that we are going to replay, do the replay and replay post-processing.
             #
             # Consider: currently, we loop over all the steps for each MCH file, including (1) invoke
@@ -2207,6 +2212,14 @@ class SuperPMIReplayAsmDiffs:
             for o in self.coreclr_args.jitoption:
                 diff_option_flags += "-jit2option", o
                 diff_option_flags_for_diff_artifact += "-jitoption", o
+
+        # The base JIT is already validated, so the phase IR checks are turned off for it by
+        # default and left on for the diff JIT, which is the one under test. -full_ir_checks
+        # turns them back on for the base JIT, and -no_ir_checks turns them off everywhere.
+        if not self.coreclr_args.full_ir_checks:
+            base_option_flags += [ "-jitoption", "JitEnablePhaseChecks=0" ]
+        if self.coreclr_args.no_ir_checks:
+            diff_option_flags += [ "-jit2option", "JitEnablePhaseChecks=0" ]
 
         if self.coreclr_args.altjit:
             altjit_asm_diffs_flags += [
@@ -3101,6 +3114,12 @@ class SuperPMIReplayThroughputDiff:
             for o in self.coreclr_args.jitoption:
                 diff_option_flags += "-jit2option", o
 
+        # Both JITs have to be configured the same way here, since this measures the base
+        # against the diff.
+        if self.coreclr_args.no_ir_checks:
+            base_option_flags += [ "-jitoption", "JitEnablePhaseChecks=0" ]
+            diff_option_flags += [ "-jit2option", "JitEnablePhaseChecks=0" ]
+
         base_jit_build_string_decoded = decode_clrjit_build_string(self.base_jit_path)
         diff_jit_build_string_decoded = decode_clrjit_build_string(self.diff_jit_path)
 
@@ -3456,6 +3475,12 @@ class SuperPMIReplayMetricDiff:
         if self.coreclr_args.jitoption:
             for o in self.coreclr_args.jitoption:
                 diff_option_flags += "-jit2option", o
+
+        # Both JITs have to be configured the same way here, since this compares metrics
+        # from the base against the diff.
+        if self.coreclr_args.no_ir_checks:
+            base_option_flags += [ "-jitoption", "JitEnablePhaseChecks=0" ]
+            diff_option_flags += [ "-jit2option", "JitEnablePhaseChecks=0" ]
 
         metric_diffs = []
 
@@ -5220,6 +5245,11 @@ def setup_args(args):
         verify_jit_ee_version_arg()
 
         coreclr_args.verify(args,
+                            "no_ir_checks",
+                            lambda unused: True,
+                            "Unable to set no_ir_checks.")
+
+        coreclr_args.verify(args,
                             "force_download",
                             lambda unused: True,
                             "Unable to set force_download")
@@ -5694,6 +5724,15 @@ def setup_args(args):
                             "git_diff",
                             lambda unused: True,
                             "Unable to set git_diff.")
+
+        coreclr_args.verify(args,
+                            "full_ir_checks",
+                            lambda unused: True,
+                            "Unable to set full_ir_checks.")
+
+        if coreclr_args.full_ir_checks and coreclr_args.no_ir_checks:
+            print("Warning: both -full_ir_checks and -no_ir_checks were specified; ignoring -no_ir_checks.")
+            coreclr_args.no_ir_checks = False
 
         process_base_jit_path_arg(coreclr_args)
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1765,10 +1765,12 @@ class SuperPMIReplay:
                 for o in self.coreclr_args.jitoption:
                     repro_flags += "-jitoption", o
 
-            common_flags += repro_flags
-
             if self.coreclr_args.no_ir_checks:
-                common_flags += [ "-jitoption", "force", "JitEnablePhaseChecks=0" ]
+                # This changes what the JIT does, so it has to be part of the repro command
+                # line as well.
+                repro_flags += [ "-jitoption", "force", "JitEnablePhaseChecks=0" ]
+
+            common_flags += repro_flags
 
             # For each MCH file that we are going to replay, do the replay and replay post-processing.
             #

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -266,6 +266,7 @@ class Diff:
             "-spmi_location", self.spmi_location,
             "-error_limit", "100",
             "--summary_as_json",
+            "-full_ir_checks",
             "-log_level", "debug",
             "-log_file", log_file] + self.create_jit_options_args())
 


### PR DESCRIPTION
The baseline JIT is already validated, so re-running the phase IR checks on it during asm diffs is unnecessary. Add a JitEnablePhaseChecks config and turn it off for the base JIT. It stays on for the diff JIT, which is the one under test.

Add -full_ir_checks to asmdiffs to run them in the base JIT as well, and -no_ir_checks to replay, asmdiffs, tpdiff and metricdiff to turn them off everywhere. tpdiff and metricdiff only ever configure both JITs the same way, since they compare the base against the diff. The asm diffs CI pipeline passes -full_ir_checks.

The diff artifact runs are left alone: --diff_jit_dump compares the base and diff JitDumps textually and the checks are visible there, so both sides have to be configured identically.

asmdiffs over benchmarks.run_pgo (92,134 contexts, min of 3):

  -full_ir_checks   12.23s
  default           10.88s  (-11.0%)
  -no_ir_checks      9.57s  (-21.8%)