### PR TITLE
[clr-ios] Enable ApplyUpdate tests on Apple CoreCLR

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.AppleCoreCLR.xml
+++ b/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.AppleCoreCLR.xml
@@ -1,8 +1,5 @@
 <linker>
   <!-- EnC deletion deltas reference this type through the System.Runtime.Loader facade. -->
-  <assembly fullname="System.Private.CoreLib">
-    <type fullname="System.Runtime.CompilerServices.MetadataUpdateDeletedAttribute" />
-  </assembly>
   <assembly fullname="System.Runtime.Loader">
     <type fullname="System.Runtime.CompilerServices.MetadataUpdateDeletedAttribute" />
   </assembly>

--- a/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.AppleCoreCLR.xml
+++ b/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.AppleCoreCLR.xml
@@ -1,4 +1,5 @@
 <linker>
+  <!-- EnC deletion deltas reference this type through the System.Runtime.Loader facade. -->
   <assembly fullname="System.Private.CoreLib">
     <type fullname="System.Runtime.CompilerServices.MetadataUpdateDeletedAttribute" />
   </assembly>

--- a/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.AppleCoreCLR.xml
+++ b/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.AppleCoreCLR.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Runtime.CompilerServices.MetadataUpdateDeletedAttribute" />
+  </assembly>
+  <assembly fullname="System.Runtime.Loader">
+    <type fullname="System.Runtime.CompilerServices.MetadataUpdateDeletedAttribute" />
+  </assembly>
+</linker>

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -18,6 +18,10 @@
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetsAppleMobile)' == 'true' and '$(UseMonoRuntime)' == 'false' and '$(UseNativeAotRuntime)' != 'true'">
+    <EnvironmentVariables Include="DOTNET_MODIFIABLE_ASSEMBLIES=debug" />
+  </ItemGroup>
+
   <!-- ActiveIssue https://github.com/dotnet/runtime/issues/114526 deadlocks on linux CI -->
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)' != 'true' or '$(TargetOS)' != 'browser' or '$(OS)' == 'Windows_NT'">
     <Compile Include="ApplyUpdateTest.cs" />
@@ -103,8 +107,13 @@
   <ItemGroup Condition="'$(TargetOS)' == 'browser' or ('$(TargetsAppleMobile)' == 'true' and '$(EnableAggressiveTrimming)' == 'true' and '$(UseNativeAotRuntime)' != 'true')">
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.xml" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetsAppleMobile)' == 'true' and '$(EnableAggressiveTrimming)' == 'true' and '$(UseMonoRuntime)' == 'false' and '$(UseNativeAotRuntime)' != 'true'">
+    <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.AppleCoreCLR.xml" />
+  </ItemGroup>
 
-  <Target Name="PreserveEnCAssembliesFromLinking" Condition="'$(TargetOS)' == 'browser' and '$(EnableAggressiveTrimming)' == 'true'" BeforeTargets="PrepareForILLink">
+  <Target Name="PreserveEnCAssembliesFromLinking"
+          Condition="'$(EnableAggressiveTrimming)' == 'true' and ('$(TargetOS)' == 'browser' or ('$(TargetsAppleMobile)' == 'true' and '$(UseMonoRuntime)' == 'false' and '$(UseNativeAotRuntime)' != 'true'))"
+          BeforeTargets="PrepareForILLink">
     <ItemGroup>
       <!-- want to compute the intersection: apply update test assemblies that are also resolved to link.
         -->
@@ -117,6 +126,16 @@
       <ManagedAssemblyToLink Condition="'%(FileName)%(Extension)' == '@(IntermediateAssembly->'%(FileName)%(Extension)')'">
         <TrimMode>copy</TrimMode>
       </ManagedAssemblyToLink>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ExcludeEnCAssembliesFromReadyToRun"
+          Condition="'$(TargetsAppleMobile)' == 'true' and '$(UseMonoRuntime)' == 'false' and '$(UseNativeAotRuntime)' != 'true'"
+          BeforeTargets="_PrepareForReadyToRunCompilation">
+    <ItemGroup>
+      <ResolvedFileToPublish Condition="$([System.String]::new('%(FileName)').StartsWith('$(ApplyUpdateTestPrefix)'))">
+        <ReferenceOnly>true</ReferenceOnly>
+      </ResolvedFileToPublish>
     </ItemGroup>
   </Target>
 

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -18,6 +18,7 @@
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
   </PropertyGroup>
 
+  <!-- Apple mobile cannot use RemoteExecutor, so enable metadata updates in the app process. -->
   <ItemGroup Condition="'$(TargetsAppleMobile)' == 'true' and '$(UseMonoRuntime)' == 'false' and '$(UseNativeAotRuntime)' != 'true'">
     <EnvironmentVariables Include="DOTNET_MODIFIABLE_ASSEMBLIES=debug" />
   </ItemGroup>
@@ -111,6 +112,7 @@
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.AppleCoreCLR.xml" />
   </ItemGroup>
 
+  <!-- EnC deltas must match their unmodified baseline assemblies. -->
   <Target Name="PreserveEnCAssembliesFromLinking"
           Condition="'$(EnableAggressiveTrimming)' == 'true' and ('$(TargetOS)' == 'browser' or ('$(TargetsAppleMobile)' == 'true' and '$(UseMonoRuntime)' == 'false' and '$(UseNativeAotRuntime)' != 'true'))"
           BeforeTargets="PrepareForILLink">
@@ -129,6 +131,7 @@
     </ItemGroup>
   </Target>
 
+  <!-- Updated fixtures must remain IL while the rest of the app stays ReadyToRun. -->
   <Target Name="ExcludeEnCAssembliesFromReadyToRun"
           Condition="'$(TargetsAppleMobile)' == 'true' and '$(UseMonoRuntime)' == 'false' and '$(UseNativeAotRuntime)' != 'true'"
           BeforeTargets="_PrepareForReadyToRunCompilation">


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with GitHub Copilot.

## Description

Enable the existing `System.Reflection.Metadata.ApplyUpdateTest` coverage in Apple mobile CoreCLR library legs.

- Start the test app with `DOTNET_MODIFIABLE_ASSEMBLIES=debug`.
- Keep EnC fixture assemblies unchanged by ILLink.
- Keep EnC fixture assemblies as IL references instead of compiling them into the composite ReadyToRun image.
- Preserve `MetadataUpdateDeletedAttribute` and its `System.Runtime.Loader` facade forwarder for `DeleteMemberTest`.

Depends on #132818. Without that fix, the newly enabled `FirstCallAfterUpdate` test reproduces `BadImageFormatException: Bad IL range`.

## Validation

Mac Catalyst arm64 Release with composite ReadyToRun and aggressive trimming enabled:

```text
Tests run: 212 Passed: 199 Inconclusive: 0 Failed: 0 Ignored: 13
XHarness exit code: 0
```

The EnC fixture assembly in the app bundle was byte-identical to the generated baseline assembly.
