### PR TITLE
Allow async variants of ComImport methods

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2128,13 +2128,6 @@ namespace Internal.JitInterface
                 return false;
             }
 
-            // Don't get async variant of ComImport methods since we do not
-            // generate any runtime async entry points for them.
-            if (method.OwningType.IsComImport)
-            {
-                return false;
-            }
-
             return true;
         }
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1084,9 +1084,7 @@ void CEEInfo::resolveToken(/* IN, OUT */ CORINFO_RESOLVED_TOKEN * pResolvedToken
                 // in rare cases a method that returns Task is not actually TaskReturning (i.e. returns T).
                 // we cannot resolve to an Async variant in such case.
                 // return NULL, so that caller would re-resolve as a regular method call
-                // For COM-import interface calls we do not have an async variant of the COM interop stub, and
-                // in any case there would be no benefit of creating one.
-                pMD = pMD->ReturnsTaskOrValueTask() && !pMD->GetClass()->IsComImport() ? pMD->GetAsyncVariant(/*allowInstParam*/FALSE) : NULL;
+                pMD = pMD->ReturnsTaskOrValueTask() ? pMD->GetAsyncVariant(/*allowInstParam*/FALSE) : NULL;
             }
             break;
 
@@ -9081,7 +9079,7 @@ CORINFO_METHOD_HANDLE CEEInfo::getAsyncOtherVariant(
     MethodDesc* pMD = GetMethod(ftn);
     MethodDesc* pAsyncOtherVariant = NULL;
 
-    if (pMD->ReturnsTaskOrValueTask() && !pMD->GetClass()->IsComImport())
+    if (pMD->ReturnsTaskOrValueTask())
     {
          pAsyncOtherVariant = pMD->GetAsyncVariant();
     }


### PR DESCRIPTION
Now that CLR->COM stubs are generated as transient IL (#131494), the async version of a COM interface method compiles from the same marshalling IL as the ordinary variant, so the special-casing added to work around the missing async entry points is no longer needed.