### PR TITLE
[browser] Fix WebAssembly publish output path message

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -968,6 +968,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     DependsOnTargets="PrepareResourceNames;ComputeIntermediateSatelliteAssemblies;ResolveAssemblyReferences"
     BeforeTargets="PrepareForPublish" />
 
+  <Target Name="_PrintWasmBrowserPublishOutputDirectory" AfterTargets="Publish" Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
+    <Message Importance="High" Text="$(MSBuildProjectName) (wwwroot) -&gt; $([MSBuild]::NormalizeDirectory('$(PublishDir)', 'wwwroot'))" />
+  </Target>
+
+  <Target Name="_PrintWasmBrowserBuildOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
+    <Message
+      Importance="High"
+      Text="$(MSBuildProjectName) (wwwroot) -&gt; $([MSBuild]::NormalizeDirectory('$(TargetDir)', 'wwwroot'))"
+      Condition="'$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)' != 'true'" />
+  </Target>
+
   <!-- Wasm's Nested publish is run just to build the native bits. We don't need to run blazor targets for that -->
   <Target Name="ProcessPublishFilesForWasm" DependsOnTargets="_ResolveWasmConfiguration;LoadStaticWebAssetsBuildManifest;_GatherWasmFilesToPublish" AfterTargets="ILLink" Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
     <!-- The list of static web assets already contains all the assets from the build. We want to correct certain assets that might

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -961,7 +961,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
   </Target>
 
-  <!-- Publish starts here -->
+  <!-- Publish targets and output directory messages start here -->
 
   <!-- Make sure that ResolveAssemblyReferences runs early enough to ensure satellite assemblies are populated in the ResolvedFilesToPublish -->
   <Target Name="_WasmPrepareForPublish"

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
@@ -51,6 +51,36 @@ namespace Wasm.Build.Tests
             PublishProject(info, config, new PublishOptions(UseCache: false));
         }
 
+        [Theory, TestCategory("no-fingerprinting"), TestCategory("workload")]
+        [InlineData(Configuration.Debug)]
+        [InlineData(Configuration.Release)]
+        public void BrowserBuildAndPublishOutputDirectories(Configuration config)
+        {
+            ProjectInfo info = CreateWasmTemplateProject(Template.WasmBrowser, config, aot: false, "output_directory");
+            (string projectDir, string buildOutput) = BuildProject(info, config);
+
+            string buildOutputDirectory = Path.Combine(
+                projectDir,
+                "bin",
+                config.ToString(),
+                DefaultTargetFramework,
+                "wwwroot") + Path.DirectorySeparatorChar;
+            string buildMessage = $"{info.ProjectName} (wwwroot) -> {buildOutputDirectory}";
+            Assert.Equal(1, buildOutput.Split(buildMessage).Length - 1);
+
+            (_, string publishOutput) = PublishProject(info, config, new PublishOptions(UseCache: false));
+
+            string publishOutputDirectory = Path.Combine(
+                projectDir,
+                "bin",
+                config.ToString(),
+                DefaultTargetFramework,
+                "publish",
+                "wwwroot") + Path.DirectorySeparatorChar;
+            string publishMessage = $"{info.ProjectName} (wwwroot) -> {publishOutputDirectory}";
+            Assert.Equal(1, publishOutput.Split(publishMessage).Length - 1);
+        }
+
         public static TheoryData<bool, string> TestDataForAppBundleDir()
         {
             var data = new TheoryData<bool, string>();


### PR DESCRIPTION
Fixes #99292
Related change in SDK https://github.com/dotnet/sdk/pull/55963

`wasmbrowser` publish currently reports the generic `publish/` directory even though the servable application is under `publish/wwwroot/`. Add shared WebAssembly build and publish messages that identify the `wwwroot` output directory, while suppressing nested-publish duplicates.

The Wasm template tests assert the exact build and publish paths and require one occurrence per phase.

Expected console output:

```text
Before:
app -> bin/Release/net8.0/publish/

After:
app -> bin/Release/net8.0/publish/
app (wwwroot) -> bin/Release/net8.0/publish/wwwroot/
```

The corresponding `dotnet/sdk` change should remove the obsolete Blazor 6.0 `_BlazorCopyFilesToOutputDirectory` output message so the shared target is the single source of truth. That change is outside this repository.

Validation: Mono/libraries baselines and browser-wasm package build succeeded. The focused WBT test assembly builds, but test execution is blocked in this environment by the local workload package-version check in `eng/testing/workloads-browser.targets`.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.