### PR TITLE
Detect ephemeral client cert key via SEC_E_UNKNOWN_CREDENTIALS in QUIC

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -288,7 +288,11 @@ internal static partial class MsQuicConfiguration
                 ThrowHelper.ThrowIfMsQuicError(status, SR.net_quic_tls_version_notsupported);
             }
 
-            if (status == MsQuic.QUIC_STATUS_CERT_NO_CERT && certificate != null && certificate.HasPrivateKey())
+            // Schannel reports SEC_E_NO_CREDENTIALS (mapped to QUIC_STATUS_CERT_NO_CERT) for
+            // server certificates and SEC_E_UNKNOWN_CREDENTIALS for client certificates when the
+            // private key is ephemeral, which is not supported on Windows.
+            if ((status == MsQuic.QUIC_STATUS_CERT_NO_CERT || (Interop.SECURITY_STATUS)status == Interop.SECURITY_STATUS.UnknownCredentials) &&
+                certificate is not null && certificate.HasPrivateKey())
             {
                 using Microsoft.Win32.SafeHandles.SafeCertContextHandle safeCertContextHandle = Interop.Crypt32.CertDuplicateCertificateContext(certificate.Handle);
                 if (safeCertContextHandle.HasEphemeralPrivateKey)


### PR DESCRIPTION
## Why

`System.Net.Quic.Tests.MsQuicTests.Client_CertificateWithEphemeralKey_Throws` started failing in CI with a raw:

```
System.Net.Quic.QuicException : An internal error has occurred. ConfigurationLoadCredential failed: Unknown (0x8009030d)
```

instead of the expected `AuthenticationException` whose message contains "ephemeral".

## Root cause

The Windows ephemeral-key diagnostic in `MsQuicConfiguration` only triggers when the native status equals `QUIC_STATUS_CERT_NO_CERT`, which on Windows maps to `SEC_E_NO_CREDENTIALS` (`0x8009030E`). Schannel returns that status for **server** certificates, but for **client** certificates with an ephemeral private key it now returns `SEC_E_UNKNOWN_CREDENTIALS` (`0x8009030D`). Because the guard did not match `0x8009030D`, the ephemeral check was skipped and `ThrowHelper.ThrowIfMsQuicError` surfaced the raw `QuicException` (`GetErrorMessageForStatus` has no name for `0x8009030D`, hence the `Unknown (0x8009030d)` text). The server-side test still returns `0x8009030E`, which is why only the client test regressed.

## Fix

Broaden the status check to also handle `SEC_E_UNKNOWN_CREDENTIALS`, reusing the existing `Interop.SECURITY_STATUS` cast pattern already used a few lines above for `AlgorithmMismatch`. The block remains gated by `certificate.HasPrivateKey()` and `safeCertContextHandle.HasEphemeralPrivateKey`, so any non-ephemeral `UnknownCredentials` failure falls through to `ThrowIfMsQuicError` unchanged. No false positives.

The existing `Client_CertificateWithEphemeralKey_Throws` test is the regression coverage, so no new test is added.

## Notes

- Scope is QUIC only. `SslStream` (`SslStreamPal.Windows.AcquireCredentialsHandle`) has an analogous handler that catches only `NoCredentials`; it is a separate, non-failing code path and intentionally left out of this change.
- No public API change.
- The `0x8009030D` vs `0x8009030E` behavior is dependent on the Windows/Schannel version, so this is validated by CI rather than local runs.

Fixes: #132831

> [!NOTE]
> This pull request was authored by GitHub Copilot.