### PR TITLE
JIT: stop EnableExtraSuperPmiQueries from changing what gets compiled

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -785,7 +785,9 @@ var_types Compiler::getReturnTypeForStruct(CORINFO_CLASS_HANDLE     clsHnd,
     //
     if (JitConfig.EnableExtraSuperPmiQueries() && IsReadyToRun())
     {
-        info.compCompHnd->getWasmLowering(clsHnd);
+        eeRunExtraSuperPmiQueries([&]() {
+            info.compCompHnd->getWasmLowering(clsHnd);
+        });
     }
 #endif // DEBUG
 #endif // defined(TARGET_WASM)
@@ -6227,31 +6229,33 @@ int Compiler::compCompileAfterInit(CORINFO_MODULE_HANDLE classPtr,
 #ifdef DEBUG
     if (JitConfig.EnableExtraSuperPmiQueries())
     {
-        // Get the assembly name, to aid finding any particular SuperPMI method context function
-        (void)eeGetClassAssemblyName(info.compClassHnd);
+        eeRunExtraSuperPmiQueries([&]() {
+            // Get the assembly name, to aid finding any particular SuperPMI method context function
+            (void)eeGetClassAssemblyName(info.compClassHnd);
 
-        // Fetch class names for the method's generic parameters.
-        //
-        CORINFO_SIG_INFO sig;
-        info.compCompHnd->getMethodSig(info.compMethodHnd, &sig, nullptr);
+            // Fetch class names for the method's generic parameters.
+            //
+            CORINFO_SIG_INFO sig;
+            info.compCompHnd->getMethodSig(info.compMethodHnd, &sig, nullptr);
 
-        const unsigned classInst = sig.sigInst.classInstCount;
-        if (classInst > 0)
-        {
-            for (unsigned i = 0; i < classInst; i++)
+            const unsigned classInst = sig.sigInst.classInstCount;
+            if (classInst > 0)
             {
-                eeGetClassName(sig.sigInst.classInst[i]);
+                for (unsigned i = 0; i < classInst; i++)
+                {
+                    eeGetClassName(sig.sigInst.classInst[i]);
+                }
             }
-        }
 
-        const unsigned methodInst = sig.sigInst.methInstCount;
-        if (methodInst > 0)
-        {
-            for (unsigned i = 0; i < methodInst; i++)
+            const unsigned methodInst = sig.sigInst.methInstCount;
+            if (methodInst > 0)
             {
-                eeGetClassName(sig.sigInst.methInst[i]);
+                for (unsigned i = 0; i < methodInst; i++)
+                {
+                    eeGetClassName(sig.sigInst.methInst[i]);
+                }
             }
-        }
+        });
     }
 #endif // DEBUG
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9862,20 +9862,14 @@ public:
     //    would then import less IL than a later replay does, and the context it recorded
     //    would be missing the data that replay goes on to ask for.
     //
-    //    The inner trap absorbs such an EE failure during collection. The outer one absorbs
-    //    SuperPMI's own "missing data" failure, for a replay that re-enables the queries
-    //    against a context collected without them.
-    //
-    //    Wrap only EE queries. JIT work must stay outside, because neither trap discriminates
-    //    by origin: a noway_assert, NOMEM or assert raised inside the functor would be quietly
-    //    absorbed instead of failing the method.
+    //    Wrap only EE queries. JIT work must stay outside, because the trap does not
+    //    discriminate by origin: a noway_assert, NOMEM or assert raised inside the functor
+    //    would be quietly absorbed instead of failing the method.
     //
     template <typename Functor>
     void eeRunExtraSuperPmiQueries(Functor f)
     {
-        eeRunFunctorWithSPMIErrorTrap([&]() {
-            eeRunFunctorWithErrorTrap(f);
-        });
+        eeRunFunctorWithErrorTrap(f);
     }
 #endif // DEBUG
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9832,6 +9832,53 @@ public:
 
     bool eeRunWithSPMIErrorTrapImp(void (*function)(void*), void* param);
 
+    template <typename Functor>
+    bool eeRunFunctorWithErrorTrap(Functor f)
+    {
+        return eeRunWithErrorTrap<Functor>(
+            [](Functor* pf) {
+            (*pf)();
+        },
+            &f);
+    }
+
+#ifdef DEBUG
+    //------------------------------------------------------------------------
+    // eeRunExtraSuperPmiQueries: make JIT-EE queries whose only purpose is to enrich
+    //    the recorded SuperPMI method context (see JitConfig.EnableExtraSuperPmiQueries).
+    //
+    // Type parameters:
+    //    Functor - callable that makes the queries
+    //
+    // Arguments:
+    //    f - the functor
+    //
+    // Notes:
+    //    Extra queries must be observationally inert: enabling them must not change what
+    //    the JIT compiles. That is not automatic, because the EE may fail a query that the
+    //    JIT would never have made on its own. An AOT compiler in particular throws for a
+    //    handle it cannot embed, such as a type outside the current version bubble, and an
+    //    escaping exception would abort the enclosing inline or method. The collection
+    //    would then import less IL than a later replay does, and the context it recorded
+    //    would be missing the data that replay goes on to ask for.
+    //
+    //    The inner trap absorbs such an EE failure during collection. The outer one absorbs
+    //    SuperPMI's own "missing data" failure, for a replay that re-enables the queries
+    //    against a context collected without them.
+    //
+    //    Wrap only EE queries. JIT work must stay outside, because neither trap discriminates
+    //    by origin: a noway_assert, NOMEM or assert raised inside the functor would be quietly
+    //    absorbed instead of failing the method.
+    //
+    template <typename Functor>
+    void eeRunExtraSuperPmiQueries(Functor f)
+    {
+        eeRunFunctorWithSPMIErrorTrap([&]() {
+            eeRunFunctorWithErrorTrap(f);
+        });
+    }
+#endif // DEBUG
+
     // Utility functions
 
     static CORINFO_METHOD_HANDLE eeFindHelper(unsigned helper);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10260,17 +10260,45 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     //
                     if (JitConfig.EnableExtraSuperPmiQueries() && !eeIsSharedInst(resolvedToken.hClass))
                     {
-                        void* pEmbedClsHnd;
-                        info.compCompHnd->embedClassHandle(resolvedToken.hClass, &pEmbedClsHnd);
-                        CORINFO_CLASS_HANDLE elemClsHnd = NO_CLASS_HANDLE;
-                        CorInfoType elemCorType = info.compCompHnd->getChildType(resolvedToken.hClass, &elemClsHnd);
-                        var_types   elemType    = JITtype2varType(elemCorType);
-                        if (elemType == TYP_STRUCT)
+                        // Each query gets its own trap so that a failure of the first, which is
+                        // the one an AOT compiler rejects for an out-of-bubble type, does not
+                        // suppress the rest.
+                        //
+                        eeRunExtraSuperPmiQueries([&]() {
+                            void* pEmbedClsHnd;
+                            info.compCompHnd->embedClassHandle(resolvedToken.hClass, &pEmbedClsHnd);
+                        });
+
+                        CORINFO_CLASS_HANDLE elemClsHnd  = NO_CLASS_HANDLE;
+                        CorInfoType          elemCorType = CORINFO_TYPE_UNDEF;
+                        eeRunExtraSuperPmiQueries([&]() {
+                            elemCorType = info.compCompHnd->getChildType(resolvedToken.hClass, &elemClsHnd);
+                        });
+
+                        if ((JITtype2varType(elemCorType) == TYP_STRUCT) && (elemClsHnd != NO_CLASS_HANDLE))
                         {
+                            // JIT work, so deliberately not trapped. It can set compFloatingPointUsed
+                            // via ClassLayout::Create -> impNormStructType, which would let the queries
+                            // change codegen, so restore that. Note this cannot fully undo the layout
+                            // being memoized, only the flag.
+                            //
+                            const bool savedFloatingPointUsed = compFloatingPointUsed;
                             typGetObjLayout(elemClsHnd);
-                            info.compCompHnd->isValueClass(elemClsHnd);
+                            compFloatingPointUsed = savedFloatingPointUsed;
+
+                            eeRunExtraSuperPmiQueries([&]() {
+                                info.compCompHnd->isValueClass(elemClsHnd);
+                            });
                         }
-                        compGetHelperFtn(CORINFO_HELP_MEMZERO);
+
+                        eeRunExtraSuperPmiQueries([&]() {
+                            // Deliberately not compGetHelperFtn, whose assert would be absorbed here.
+                            if (info.compMatchedVM)
+                            {
+                                CORINFO_CONST_LOOKUP lookup;
+                                info.compCompHnd->getHelperFtn(CORINFO_HELP_MEMZERO, &lookup);
+                            }
+                        });
                     }
 #endif
                 }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10275,7 +10275,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             elemCorType = info.compCompHnd->getChildType(resolvedToken.hClass, &elemClsHnd);
                         });
 
-                        if ((JITtype2varType(elemCorType) == TYP_STRUCT) && (elemClsHnd != NO_CLASS_HANDLE))
+                        // CORINFO_TYPE_VALUECLASS is the only type JITtype2varType maps to
+                        // TYP_STRUCT. Test it directly, since JITtype2varType asserts if the
+                        // query above was trapped and left elemCorType as CORINFO_TYPE_UNDEF.
+                        //
+                        if ((elemCorType == CORINFO_TYPE_VALUECLASS) && (elemClsHnd != NO_CLASS_HANDLE))
                         {
                             // JIT work, so deliberately not trapped. It can set compFloatingPointUsed
                             // via ClassLayout::Create -> impNormStructType, which would let the queries

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -7955,14 +7955,16 @@ void Compiler::impSetupAsyncCall(GenTreeCall*          call,
 #ifdef DEBUG
     if (JitConfig.EnableExtraSuperPmiQueries() && (call->gtCallType == CT_USER_FUNC))
     {
-        // Query the async variants (twice, to get both directions)
-        CORINFO_METHOD_HANDLE method = call->gtCallMethHnd;
-        bool                  variantIsThunk;
-        method = info.compCompHnd->getAsyncOtherVariant(method, &variantIsThunk);
-        if (method != NO_METHOD_HANDLE)
-        {
+        eeRunExtraSuperPmiQueries([&]() {
+            // Query the async variants (twice, to get both directions)
+            CORINFO_METHOD_HANDLE method = call->gtCallMethHnd;
+            bool                  variantIsThunk;
             method = info.compCompHnd->getAsyncOtherVariant(method, &variantIsThunk);
-        }
+            if (method != NO_METHOD_HANDLE)
+            {
+                method = info.compCompHnd->getAsyncOtherVariant(method, &variantIsThunk);
+            }
+        });
     }
 #endif
 }
@@ -8317,8 +8319,12 @@ void Compiler::pickGDV(GenTreeCall*           call,
         for (UINT32 i = 0; i < numberOfMethods; i++)
         {
             CORINFO_CONST_LOOKUP lookup = {};
-            info.compCompHnd->getFunctionFixedEntryPoint((CORINFO_METHOD_HANDLE)likelyMethods[i].handle, false,
-                                                         &lookup);
+            // This query is made only to dump the entry point, so it must not be able to fail
+            // the compilation: an AOT compiler throws for a method it cannot create a fixup for.
+            eeRunExtraSuperPmiQueries([&]() {
+                info.compCompHnd->getFunctionFixedEntryPoint((CORINFO_METHOD_HANDLE)likelyMethods[i].handle, false,
+                                                             &lookup);
+            });
 
             const char* methName = eeGetMethodFullName((CORINFO_METHOD_HANDLE)likelyMethods[i].handle);
             switch (lookup.accessType)

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -996,7 +996,9 @@ void Compiler::lvaClassifyParameterABI(Classifier& classifier)
             CORINFO_CLASS_HANDLE clsHnd = structLayout->GetClassHandle();
             if (clsHnd != NO_CLASS_HANDLE)
             {
-                info.compCompHnd->getWasmLowering(clsHnd);
+                eeRunExtraSuperPmiQueries([&]() {
+                    info.compCompHnd->getWasmLowering(clsHnd);
+                });
             }
         }
 #endif // DEBUG
@@ -2608,7 +2610,13 @@ void Compiler::lvaSetStruct(unsigned varNum, ClassLayout* layout, bool unsafeVal
 #ifdef DEBUG
         if (JitConfig.EnableExtraSuperPmiQueries())
         {
+            // makeExtraStructQueries runs real JIT work, so it is not trapped here. It can also set
+            // compFloatingPointUsed, via impNormStructType, GetHfaType, and ClassLayout::Create,
+            // which would let the queries change codegen, so restore that.
+            //
+            const bool savedFloatingPointUsed = compFloatingPointUsed;
             makeExtraStructQueries(layout->GetClassHandle(), 2);
+            compFloatingPointUsed = savedFloatingPointUsed;
         }
 #endif // DEBUG
     }
@@ -2657,7 +2665,8 @@ void Compiler::makeExtraStructQueries(CORINFO_CLASS_HANDLE structHandle, int lev
         size_t                   numNodes = ArrLen(nodes);
         info.compCompHnd->getTypeLayout(structHandle, nodes, &numNodes);
     };
-    queryLayout();
+    // Trapped because an AOT compiler rejects this query for an out-of-bubble type.
+    eeRunExtraSuperPmiQueries(queryLayout);
 
     // Bypass fetching instance fields of ref classes for now,
     // as it requires traversing the class hierarchy.


### PR DESCRIPTION
Contributes to #47546.

`EnableExtraSuperPmiQueries` is a DEBUG-only JIT config that makes additional JIT-EE queries so that recorded SuperPMI method contexts carry data a later replay might ask for. `superpmi.py` sets it for every collection, and forwards it to crossgen2 as `--codegenopt:EnableExtraSuperPmiQueries=1`.

Such a query has to be observationally inert. It was not, and the cost was about 3% of every non-composite crossgen2 collection.

## The bug

The EE is free to fail a query the JIT would never have made on its own. crossgen2's `embedClassHandle` throws `RequiresRuntimeJitException` for a type that does not version with the compilation bubble:

```csharp
if (!_compilation.CompilationModuleGroup.VersionsWithType(type))
    throw new RequiresRuntimeJitException(type.ToString());
```

The extra-query block that runs after a `newarr` calls exactly that, and under a non-composite collection it throws for ordinary element types such as `int[]`. The exception escapes the diagnostic block, `impJitErrorTrap` catches it, and the **enclosing inline is abandoned**.

So the collection imports less IL than a replay of the same context does. Replay reaches a call the collection never imported, asks for a token that was never recorded, and `superpmi.py --clean` discards the context.

Concretely, in `System.Linq`: collection abandons the inline of `EnumerableSorter.ComputeMap` into `SkipTakeOrderedIterator.MoveNext`; replay inlines it fully, reaches `call 0A000295`, and misses `ResolveToken`.

This is the same class of problem as #47554, where the flag crashed crossgen2 outright.

## The fix

Wrap the extra queries in `eeRunExtraSuperPmiQueries` so an EE failure cannot escape. It runs the queries under `runWithErrorTrap`, which crossgen2 implements as `catch (CorInfoExceptionClass*)` and the VM as a real EE error trap, so crossgen2's `RequiresRuntimeJitException` is absorbed instead of abandoning the inline.

Only EE queries go inside the trap. JIT work stays outside, so a `noway_assert`, `NOMEM` or `assert` still fails the method rather than being quietly absorbed — the trap does not discriminate by origin. That is also why `compGetHelperFtn` was replaced by the raw `getHelperFtn` EE call, and why the `!IsAot()`-gated site in `codegencommon.cpp` is left alone.

Where the queries run JIT work that sets `compFloatingPointUsed` (`impNormStructType`, `GetHfaType`, `ClassLayout::Create`), it is saved and restored, since that flag reaches LSRA register selection and ARM frame encoding.

## Measurements

15 framework assemblies from Core_Root, Windows x64 checked, non-composite crossgen2, merged with `mcs -merge -recursive -dedup -thin` and replayed with `superpmi.exe -p`. Baseline is the merge-base, c210d82dbc1.

| | contexts | missing | loss |
| --- | ---: | ---: | ---: |
| baseline | 30,170 | 919 | 3.05% |
| this change | 32,213 | **20** | **0.062%** |
| this change, queries disabled | 32,213 | 20 | 0.062% |

Collection also keeps 6.8% more contexts, because methods whose inlines were previously abandoned now compile.

The queries still do their job: the MCH is 6 MB larger with them than without. Collection cost is bounded at about 2.7% (crossgen2 over `System.Private.Xml`, 21.8s to 22.4s, covering the trap and the queries together).

The residual 20 (`ConstructStringLiteral` x15, `EmbedClassHandle` x4, `IsMoreSpecificType` x1) reproduce identically with the queries disabled, so they are separate pre-existing failures under #47546 and are not addressed here. The string-literal ones look like what #118217 describes.

## Validation

* Enabling the queries no longer perturbs the collection: the two rows above have the same context count and the same 20 failures, of the same three kinds, with and without them.
* A JIT-time (non-AOT, real VM) collection through `corerun` with the queries enabled: 63 contexts, 0 missing, correct program output. This covers the sites that only run in that configuration.
* Checked and release JIT builds are clean, and the changed files are clang-format clean.

## Notes

Replaying by hand with `-jitoption EnableExtraSuperPmiQueries=1` reports 3 missing out of 1158, because the collection trapped those queries and so recorded nothing for them. Nothing in the pipeline does that: the config is read once at `jitStartup` rather than per method context, so it is never recorded into the MCH — a full `mcs -dump` of a crossgen2 collection has zero config entries — and `superpmi.py` sets it only on the collect path.

`typGetObjLayout` memoizes. The extra queries can create a `ClassLayout` for a handle and set `compFloatingPointUsed`; restoring the flag leaves the cache entry, so a later real `typGetObjLayout` on that handle hits the cache and does not re-set the flag. In principle a run with the queries could then end with the flag clear where a run without them has it set. I could not construct a repro — `LinearScan::identifyCandidates` and struct promotion set the flag independently for any float or SIMD local, ahead of every consumer — so this looks latent. Restoring is still the better of the two directions, since not restoring reintroduces the divergence this change exists to remove.

> [!NOTE]
> This pull request was prepared with GitHub Copilot.

