### PR TITLE
Fix Microsoft.CSharp dynamic code annotations

### DIFF
--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComMetaObject.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComMetaObject.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 {
     // Note: we only need to support the operations used by ComBinder
     [RequiresUnreferencedCode(Binder.TrimmerWarning)]
+    [RequiresDynamicCode(Binder.DynamicCodeWarning)]
     internal sealed class ComMetaObject : DynamicMetaObject
     {
         internal ComMetaObject(Expression expression, BindingRestrictions restrictions, object arg)

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComObject.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComObject.cs
@@ -74,6 +74,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
         // Expression that finds or creates a ComObject that corresponds to given Rcw
         [RequiresUnreferencedCode(Binder.TrimmerWarning)]
+        [RequiresDynamicCode(Binder.DynamicCodeWarning)]
         internal static MethodCallExpression RcwToComObject(Expression rcw)
         {
             return Expression.Call(


### PR DESCRIPTION
## Summary

- annotate `ComObject.RcwToComObject` with `RequiresDynamicCode`
- propagate the requirement to `ComMetaObject`, which calls that method while constructing COM binding expressions

## Reasoning

When creating an AOT-compatiblity test application, AOT analysis reports `IL3050` from inside Microsoft.CSharp. `RcwToComObject` uses reflection to create a call to `ObjectToComObject`, which is annotated with both `RequiresUnreferencedCode` and `RequiresDynamicCode`. However, `RcwToComObject` only propagated `RequiresUnreferencedCode`. Propagating `RequiresDynamicCode` through `RcwToComObject` and `ComMetaObject` keeps the annotations consistent and prevents the warning from originating from an unannotated Microsoft.CSharp implementation path.

## Testing

- `dotnet build` in `src/libraries/Microsoft.CSharp`
- `dotnet build /t:test src/libraries/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj` (2,648 passed)

> [!NOTE]
> This pull request description was generated by GitHub Copilot.