### PR TITLE
[release/11.0] Update Helix Job Monitor to 11.0.0-beta.26427.10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -27,7 +27,7 @@
       ]
     },
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26425.121",
+      "version": "11.0.0-beta.26427.10",
       "commands": [
         "dotnet-helix-job-monitor"
       ]

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -24,7 +24,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26425.121</MicrosoftDotNetCodeAnalysisPackageVersion>
     <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26425.121</MicrosoftDotNetGenAPIPackageVersion>
     <MicrosoftDotNetGenFacadesPackageVersion>11.0.0-beta.26425.121</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26425.121</MicrosoftDotNetHelixJobMonitorPackageVersion>
+    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26427.10</MicrosoftDotNetHelixJobMonitorPackageVersion>
     <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26425.121</MicrosoftDotNetHelixSdkPackageVersion>
     <MicrosoftDotNetPackageTestingPackageVersion>11.0.0-beta.26425.121</MicrosoftDotNetPackageTestingPackageVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26425.121</MicrosoftDotNetRemoteExecutorPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -67,9 +67,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>e20a5af9c83aaf22b041bc9911de0cbfff9c7317</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26425.121">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e20a5af9c83aaf22b041bc9911de0cbfff9c7317</Sha>
+    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26427.10">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>2cdfe99944d984749c8bdfc7d8d6a2589ed15d6d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26425.121">
       <Uri>https://github.com/dotnet/dotnet</Uri>

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -50,7 +50,7 @@ pr:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:


### PR DESCRIPTION
Updates Microsoft.DotNet.Helix.JobMonitor to 11.0.0-beta.26427.10 from dotnet/arcade commit 2cdfe99944d984749c8bdfc7d8d6a2589ed15d6d.

Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3059358

Re-enables the Helix Job Monitor in the runtime pipeline. The history audit since 2026-08-22 found no recent disable commit on this release branch, so only the runtime.yml monitor variable is restored.