### PR TITLE
[wasm] Fail hard when the engine rejects a Webcil R2R image

### DIFF
--- a/src/coreclr/hosts/corerun/wasm/libCorerun.js
+++ b/src/coreclr/hosts/corerun/wasm/libCorerun.js
@@ -195,8 +195,8 @@ function libCoreRunFactory() {
                 wasmModule = new WebAssembly.Module(wasmBytes);
             } catch (e) {
                 const errorMessage = e instanceof Error ? e.message : String(e);
-                console.error("Invalid WebAssembly module for Webcil image:", { wasmPath, errorMessage });
-                throw new Error(`Invalid WebAssembly module for Webcil image '${wasmPath}': ${errorMessage}`);
+                console.error("Failed to construct WebAssembly module for Webcil image:", { wasmPath, errorMessage });
+                throw new Error(`Failed to construct WebAssembly module for Webcil image '${wasmPath}': ${errorMessage}`);
             }
 
             const tableStartIndex = wasmTable.length;

--- a/src/coreclr/hosts/corerun/wasm/libCorerun.js
+++ b/src/coreclr/hosts/corerun/wasm/libCorerun.js
@@ -195,8 +195,8 @@ function libCoreRunFactory() {
                 wasmModule = new WebAssembly.Module(wasmBytes);
             } catch (e) {
                 const errorMessage = e instanceof Error ? e.message : String(e);
-                console.error("Failed to construct WebAssembly module for Webcil image:", { wasmPath, errorMessage });
-                return false;
+                console.error("Invalid WebAssembly module for Webcil image:", { wasmPath, errorMessage });
+                throw new Error(`Invalid WebAssembly module for Webcil image '${wasmPath}': ${errorMessage}`);
             }
 
             const tableStartIndex = wasmTable.length;


### PR DESCRIPTION
## Problem

Related to #132865 / #132855.

CoreCLR-on-wasm loads a per-assembly R2R image as a `.wasm` file sitting beside the assembly's `.dll` (`src/coreclr/hosts/corerun/wasm/libCorerun.js`, `BrowserHost_ExternalAssemblyProbe`). If that `.wasm` file exists but `new WebAssembly.Module(...)` throws - for example because crossgen2 emitted a function type exceeding the wasm engine's parameter-count limit (#132855) - the probe caught the exception and returned `false`, which is exactly what happens when there's simply no R2R image for that assembly at all.

(Note: the emitted wasm is well-formed; it's rejected because it exceeds an implementation-defined engine limit, not because it's malformed.)

The result: the runtime silently falls back to fully interpreting the whole assembly. The app still runs and tests still pass, with the only trace being a generic `Ready to Run header not found: "<assembly>"` log line - indistinguishable from the normal "never R2R compiled" case. A rejected R2R image can regress to full interpretation with zero visible signal.

## Fix

Distinguish the two cases:
- The `.wasm` sibling doesn't exist -> legitimate, silent fallback (unchanged).
- The `.wasm` sibling exists but the engine rejects it during `WebAssembly.Module` construction -> this is not a normal fallback path, so it now throws instead of being swallowed.

## Verification

Reproduced against an unfixed (pre-#132865) crossgen2 targeting browser-wasm, compiling `System.Text.Json.Tests` (which contains the 1003-param `ClassWithManyConstructorParameters` type from #132855) and running it under a rebuilt `corerun.js`/`corerun.wasm`:

**Before this change:**
```
Ready to Run header not found: "System.Text.Json.Tests".
```
...followed by `Tests run: 346 Passed: 345 Failed: 1` - the whole assembly silently ran fully interpreted.

**After this change:**
```
Failed to construct WebAssembly module for Webcil image: {
  wasmPath: 'System.Text.Json.Tests.wasm',
  errorMessage: 'WebAssembly.Module(): param count of 1003 exceeds internal limit of 1000 @+1433'
}
```
process exits 1, no tests run at all - the rejection is immediately visible instead of silently degrading.

> [!NOTE]
> This PR description and commit were drafted with GitHub Copilot assistance.
