### PR TITLE
Fix WebProxy treating hosts with non-ASCII dot separators as local

### DIFF
--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.NonWasm.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.NonWasm.cs
@@ -20,7 +20,8 @@ namespace System.Net
                 return true;
             }
 
-            string hostString = host.Host;
+            // Use IdnHost rather than Host so that any non-ASCII dot separators (e.g. U+3002) are normalized to '.'.
+            string hostString = host.IdnHost;
 
             if (IPAddress.TryParse(hostString, out IPAddress? hostAddress))
             {

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.Wasm.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.Wasm.cs
@@ -14,7 +14,8 @@ namespace System.Net
                 return true;
             }
 
-            string hostString = host.Host;
+            // Use IdnHost rather than Host so that any non-ASCII dot separators (e.g. U+3002) are normalized to '.'.
+            string hostString = host.IdnHost;
             return
                 !IPAddress.IsValid(hostString) &&
                 !hostString.Contains('.');

--- a/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
+++ b/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
@@ -194,6 +194,8 @@ namespace System.Net.Tests
 
             yield return new object[] { new Uri($"http://nodotinhostname"), true };
             yield return new object[] { new Uri($"http://{Guid.NewGuid():N}"), true };
+            // A non-ASCII hostname without a separator stays local; its IDN form gains no dot.
+            yield return new object[] { new Uri("http://b\u00FCcher"), true };
             foreach (IPAddress address in Dns.GetHostEntryAsync(Dns.GetHostName()).GetAwaiter().GetResult().AddressList)
             {
                 if (address.AddressFamily == AddressFamily.InterNetwork)
@@ -223,6 +225,12 @@ namespace System.Net.Tests
 
             yield return new object[] { new Uri($"http://{Guid.NewGuid():N}.com"), false };
             yield return new object[] { new Uri($"http://{IPAddress.None}"), false };
+
+            // Hosts with non-ASCII dot separators that IDN maps to '.' (ideographic full stop U+3002,
+            // fullwidth full stop U+FF0E, halfwidth ideographic full stop U+FF61) are not local.
+            yield return new object[] { new Uri($"http://{Guid.NewGuid():N}\u3002com"), false };
+            yield return new object[] { new Uri($"http://{Guid.NewGuid():N}\uFF0Ecom"), false };
+            yield return new object[] { new Uri($"http://{Guid.NewGuid():N}\uFF61com"), false };
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/23428", TestPlatforms.AnyUnix)]


### PR DESCRIPTION
Fixes #132842.

`IsLocal` looked for an ASCII `.` in `Uri.Host`. A host can use one of the other characters IDN maps to a label separator, so a name like `intranet。corp` contains no ASCII dot, took the "no dot, therefore local" path, and was bypassed when `BypassProxyOnLocal` was set. The equivalent `intranet.corp` was sent through the proxy, so the same destination was reachable two ways with different proxy behaviour.

Both `IsLocal` implementations now read `Uri.IdnHost`, which maps those separators to `.`, as suggested in the issue.

## Verification

Measured on Windows 11 x64, `clr+libs -rc Release`, same command and same test file on both sides, with only the two `src` changes reverted for the "before" run:

| | `System.Net.WebProxy.Tests` |
| --- | --- |
| before | Total 60, Failed 3 |
| after | Total 60, Failed 0 |

The three failures are the new non-local cases (U+3002, U+FF0E, U+FF61). `System.Net.Requests.Tests`, the adjacent consumer of `WebProxy`, is Total 1215, Failed 0, Skipped 8 (the skips are FTP cases needing a local server, and are unrelated). No new build warnings.

The fourth new case, a non-ASCII hostname with no separator, passes both before and after. It is there as a guard that converting to the IDN form does not introduce a dot and make a local host non-local, not as evidence of the fix.

`WebProxy.Wasm.cs` is compile-checked only, through the `-browser` and `-wasi` target frameworks. I have no way to execute the browser test leg locally.

I also checked that this does not need a `PlatformDetection.IsNotInvariantGlobalization` guard the way some `System.Private.Uri` tests do: with `InvariantGlobalization=true`, `IdnHost` still maps all three separators to `.`, so the new cases behave the same in both modes.

## One behaviour change worth flagging

For IPv6, `Host` keeps the brackets and drops the scope id, while `IdnHost` drops the brackets and keeps it. `IPAddress.TryParse` accepts both bracket forms and yields the same address, but a scope id is not discarded, and `IPAddress.Equals` compares it.

That changes the `Array.IndexOf(localAddresses, hostAddress)` branch. On my machine `Dns.GetHostEntry` reports `fe80::[...]%57`, so a request to that address as `http://[fe80::[...]%57]/` previously parsed to a scope-less address, failed to match the machine's own entry and was not treated as local. It now matches. That looks like a second, separate bug being fixed rather than a regression, but it is a real change in that branch and not something the issue asked for, so I would rather point at it than let it ride. Happy to restrict the IP branch to `Host` if you would prefer this PR to stay strictly on the dot problem.

## Left alone deliberately

In `WebProxy.NonWasm.cs` the primary-domain comparison now has an IDN-form host on one side and `IPGlobalProperties.GetIPGlobalProperties().DomainName` on the other, which is not converted. If a machine's primary domain is itself an IDN name, those two could disagree. I could not reproduce it (`DomainName` is empty here) and normalising the domain name is a wider change than the issue describes, so I left it as is.
