### PR TITLE
Prototype manifest AssemblyRefs for precomputed TypeMaps

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
@@ -50,6 +50,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly List<Guid> _manifestAssemblyMvids;
 
         /// <summary>
+        /// Assembly references that must be emitted in addition to those represented by module IDs.
+        /// </summary>
+        private readonly List<AssemblyNameInfo> _additionalAssemblyReferences;
+
+        /// <summary>
         /// Registered signature emitters.
         /// </summary>
         private readonly List<ISignatureEmitter> _signatureEmitters;
@@ -70,6 +75,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private ConcurrentBag<EcmaModule> _modulesWhichMustBeIndexable = new ConcurrentBag<EcmaModule>();
 
         /// <summary>
+        /// Modules whose assembly identities must be present in the manifest metadata.
+        /// </summary>
+        private ConcurrentBag<EcmaModule> _modulesWhichMustHaveAssemblyReferences = new ConcurrentBag<EcmaModule>();
+
+        /// <summary>
         /// Set to true after GetData has been called. After that, ModuleToIndex may be called no more.
         /// </summary>
         private bool _emissionCompleted;
@@ -86,6 +96,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _assemblyRefToModuleIdMap = new Dictionary<string, int>();
             _moduleIdToAssemblyNameMap = new Dictionary<int, AssemblyNameInfo>();
             _manifestAssemblyMvids = new List<Guid>();
+            _additionalAssemblyReferences = new List<AssemblyNameInfo>();
             _signatureEmitters = new List<ISignatureEmitter>();
             _nodeFactory = nodeFactory;
             _nextModuleId = 2;
@@ -117,6 +128,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                                manifestAssemblyVersion,
                                                hashAlgorithm,
                                                ModuleToIndexSingleThreadedAndSorted,
+                                               EnsureAssemblyReferenceInManifest,
                                                nodeFactory.CompilationModuleGroup);
 
             if (!_nodeFactory.CompilationModuleGroup.IsCompositeBuildMode)
@@ -215,6 +227,19 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
         }
 
+        private void EnsureAssemblyReferenceInManifest(ModuleDesc module)
+        {
+            if (_emissionCompleted)
+            {
+                throw new InvalidOperationException("Adding a new assembly after signatures have been materialized.");
+            }
+
+            if (module is EcmaModule ecmaModule)
+            {
+                _modulesWhichMustHaveAssemblyReferences.Add(ecmaModule);
+            }
+        }
+
         private int ModuleToIndexInternal(IEcmaModule module)
         {
             Debug.Assert(module != null);
@@ -286,6 +311,27 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     ModuleToIndex(module);
                 }
 
+                moduleArray = _modulesWhichMustHaveAssemblyReferences.ToArray();
+                Array.Sort(moduleArray, (EcmaModule moduleA, EcmaModule moduleB) => moduleA.CompareTo(moduleB));
+                HashSet<string> additionalAssemblyNames = new HashSet<string>();
+                foreach (EcmaModule module in moduleArray)
+                {
+                    int moduleId = ModuleToIndex(module);
+                    if (moduleId <= _assemblyRefCount)
+                    {
+                        AssemblyNameInfo assemblyName = module.Assembly.GetName();
+                        if (additionalAssemblyNames.Add(assemblyName.FullName))
+                        {
+                            _additionalAssemblyReferences.Add(assemblyName);
+                        }
+                    }
+                }
+
+                for (int i = 0; i < _additionalAssemblyReferences.Count; i++)
+                {
+                    _manifestAssemblyMvids.Add(default(Guid));
+                }
+
                 _emissionCompleted = true;
             }
         }
@@ -305,6 +351,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 var handle = _mutableModule.TryGetAssemblyRefHandle(assemblyName);
                 Debug.Assert(handle.HasValue);
                 Debug.Assert(((handle.Value & 0xFFFFFF) + (_assemblyRefCount)) == (idAndAssemblyName.Key - 1));
+            }
+
+            foreach (AssemblyNameInfo assemblyName in _additionalAssemblyReferences)
+            {
+                int? handle = _mutableModule.TryGetAssemblyRefHandle(assemblyName);
+                Debug.Assert(handle.HasValue);
             }
 
             // After this point new tokens will not be embedded in the final image
@@ -337,6 +389,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public void Dispose()
         {
             _modulesWhichMustBeIndexable = null;
+            _modulesWhichMustHaveAssemblyReferences = null;
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -58,9 +58,17 @@ namespace Internal.TypeSystem.Ecma
                         }
                         else
                         {
-                            // Further dependencies are handled by specifying a module which has a further assembly dependency on the correct module
-                            string asmReferenceName = GetNameOfAssemblyRefWhichResolvesToType(_mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences, metadataType);
-                            int index = _moduleToIndex(_mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences);
+                            ModuleDesc assemblyRefSource = _mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences;
+                            string asmReferenceName = GetNameOfAssemblyRefWhichResolvesToType(assemblyRefSource, metadataType);
+                            if (asmReferenceName is null)
+                            {
+                                _mutableModule._ensureAssemblyReferenceInManifest(module);
+                                assemblyRefSource = _mutableModule;
+                                asmReferenceName = ((EcmaModule)module).Assembly.GetName().Name;
+                            }
+
+                            // Further dependencies are handled by specifying a module which has an assembly dependency on the correct module.
+                            int index = _moduleToIndex(assemblyRefSource);
                             Debug.Assert(index != -1);
                             moduleRefString = $"#{asmReferenceName}:{index.ToStringInvariant()}";
                         }
@@ -137,15 +145,20 @@ namespace Internal.TypeSystem.Ecma
                     return assemblyName;
                 }
 
-                // Some producers encode type map custom attributes without emitting matching TypeRef rows
-                // for the referenced types. In that case, fall back to the target type's defining assembly.
                 if (module is EcmaModule ecmaModule && type.Module is EcmaModule targetTypeModule)
                 {
                     string targetAssemblyName = targetTypeModule.Assembly.GetName().Name;
-                    return targetAssemblyName;
+                    MetadataReader reader = ecmaModule.MetadataReader;
+                    foreach (AssemblyReferenceHandle assemblyRefHandle in reader.AssemblyReferences)
+                    {
+                        if (reader.StringComparer.Equals(reader.GetAssemblyReference(assemblyRefHandle).Name, targetAssemblyName))
+                        {
+                            return targetAssemblyName;
+                        }
+                    }
                 }
 
-                throw new KeyNotFoundException($"Unable to resolve an assembly reference from module '{module}' to type '{type}'.");
+                return null;
             }
         }
 
@@ -305,10 +318,12 @@ namespace Internal.TypeSystem.Ecma
                              Version version,
                              AssemblyHashAlgorithm hashAlgorithm,
                              Func<ModuleDesc, int> moduleToIndex,
+                             Action<ModuleDesc> ensureAssemblyReferenceInManifest,
                              ReadyToRunCompilationModuleGroupBase compilationGroup) : base(context, null)
         {
             _compilationGroup = compilationGroup;
             _cache = new Cache(this, assemblyName, assemblyFlags, publicKeyArray, version, hashAlgorithm, moduleToIndex);
+            _ensureAssemblyReferenceInManifest = ensureAssemblyReferenceInManifest;
             TryGetHandle = _cache.CreateCacheFunc<TypeSystemEntity>(GetHandleForTypeSystemEntity);
             TryGetStringHandle = _cache.CreateCacheFunc<string>(GetUserStringHandle);
             TryGetAssemblyRefHandle = _cache.CreateCacheFunc<AssemblyNameInfo>(GetAssemblyRefHandle);
@@ -319,6 +334,7 @@ namespace Internal.TypeSystem.Ecma
         public bool DisableNewTokens;
         public ModuleDesc ModuleThatIsCurrentlyTheSourceOfNewReferences;
         private ReadyToRunCompilationModuleGroupBase _compilationGroup;
+        private readonly Action<ModuleDesc> _ensureAssemblyReferenceInManifest;
         private Dictionary<ModuleDesc, string> _moduleToModuleRefString = new Dictionary<ModuleDesc, string>();
 
         private int GetHandleForTypeSystemEntity(TypeSystemMetadataEmitter emitter, object type)

--- a/src/coreclr/vm/nativeimage.h
+++ b/src/coreclr/vm/nativeimage.h
@@ -60,9 +60,10 @@ class ReadyToRunInfo;
 class ReadyToRunLoadedImage;
 class PEAssembly;
 class PEImage;
+class NativeImage;
 
 #ifndef DACCESS_COMPILE
-ModuleBase* CreateNativeManifestModule(LoaderAllocator* pLoaderAllocator, IMDInternalImport *m_pManifestMetadata, Module* pModule, AllocMemTracker *pamTracker);
+ModuleBase* CreateNativeManifestModule(LoaderAllocator* pLoaderAllocator, IMDInternalImport *m_pManifestMetadata, Module* pModule, NativeImage* pNativeImage, AllocMemTracker *pamTracker);
 #endif
 
 // This class represents a  ReadyToRun image with native OS-specific envelope. As of today,

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -860,7 +860,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, LoaderAllocator* pLoaderAllocat
 
                 while (pNativeMDImport->EnumNext(&assemblyEnum, &assemblyRef))
                 {
-                    const GUID *componentMvid = &componentMvids[manifestAssemblyCount];
+                    const GUID *componentMvid = &componentMvids[manifestAssemblyCount++];
 
                     if (IsEqualGUID(*componentMvid, emptyGuid))
                     {
@@ -870,9 +870,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, LoaderAllocator* pLoaderAllocat
 
                     LPCSTR assemblyName;
                     IfFailThrow(pNativeMDImport->GetAssemblyRefProps(assemblyRef, NULL, NULL, &assemblyName, NULL, NULL, NULL, NULL));
-
                     binder->DeclareDependencyOnMvid(assemblyName, *componentMvid, pNativeImage != NULL, pModule != NULL ? pModule->GetSimpleName() : pNativeImage->GetFileName());
-                    manifestAssemblyCount++;
                 }
             }
         }
@@ -881,7 +879,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, LoaderAllocator* pLoaderAllocat
             pNativeMDImport = NULL;
         }
 
-        m_pNativeManifestModule = CreateNativeManifestModule(pLoaderAllocator, pNativeMDImport, pModule, pamTracker);
+        m_pNativeManifestModule = CreateNativeManifestModule(pLoaderAllocator, pNativeMDImport, pModule, pNativeImage, pamTracker);
         m_pLoadedImageBase = m_pComposite->GetLayout()->GetBase();
     }
 
@@ -2055,18 +2053,17 @@ COUNT_T ReadyToRunInfo::GetTypeMapAssemblyTargets(MethodTable* pGroupType, Modul
 class NativeManifestModule : public ModuleBase
 {
     IMDInternalImport* m_pMDImport;
-    ReadyToRunInfo *m_pReadyToRunInfo;
     Module* m_pILModule;
+    NativeImage* m_pNativeImage;
 
     // Mapping of ModuleRef token to Module *
     LookupMap<PTR_Module>           m_ModuleReferencesMap;
 public:
 
-    NativeManifestModule(LoaderAllocator* pLoaderAllocator, IMDInternalImport *pManifestMetadata, Module* pModule, AllocMemTracker *pamTracker)
+    NativeManifestModule(LoaderAllocator* pLoaderAllocator, IMDInternalImport *pManifestMetadata, Module* pModule, NativeImage* pNativeImage, AllocMemTracker *pamTracker)
     {
-        // NOTE: Composite images will not set m_pILModule to anything other than NULL. This implies that cross module
-        // type loading outside of System.Private.CoreLib is not supported
         m_pILModule = pModule;
+        m_pNativeImage = pNativeImage;
         m_loaderAllocator = pLoaderAllocator;
         m_pMDImport = pManifestMetadata;
         m_LookupTableCrst.Init(CrstModuleLookupTable, CrstFlags(CRST_UNSAFE_ANYMODE | CRST_DEBUGGER_THREAD));
@@ -2124,8 +2121,30 @@ public:
     Assembly * LoadAssemblyImpl(mdAssemblyRef kAssemblyRef) final
     {
         STANDARD_VM_CONTRACT;
-        // Since we can only load via ModuleRef, this should never fail unless the module is improperly formatted
-        COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+
+        Assembly *pAssembly = LookupAssemblyRef(kAssemblyRef);
+        if (pAssembly == nullptr)
+        {
+            AssemblySpec spec;
+            spec.InitializeSpec(kAssemblyRef, m_pMDImport, m_pILModule != nullptr ? m_pILModule->GetAssembly() : nullptr);
+            if (m_pNativeImage != nullptr)
+            {
+                spec.SetBinder(m_pNativeImage->GetAssemblyBinder());
+            }
+            pAssembly = spec.LoadAssembly(FILE_LOADED);
+            m_ManifestModuleReferencesMap.TrySetElement(RidFromToken(kAssemblyRef), pAssembly->GetModule());
+        }
+
+        return pAssembly;
+    }
+
+    Assembly * GetAssemblyIfLoaded(
+        mdAssemblyRef kAssemblyRef,
+        IMDInternalImport *pMDImportOverride = nullptr,
+        AssemblyBinder *pBinderForLoadedAssembly = nullptr) final
+    {
+        LIMITED_METHOD_CONTRACT;
+        return LookupAssemblyRef(kAssemblyRef);
     }
 
     // Decompose a null terminated moduleName into a pointer to an internal assemblyName, the length of that, and the associate module index
@@ -2167,9 +2186,9 @@ public:
     }
 
     // Find the assemblyRef with a given simple name in a module, or return mdTokenNil
-    HRESULT GetAssemblyRefTokenOfIndirectDependency(Module* module, LPCSTR assemblyName, size_t assemblyNameLen, mdToken *pAssemblyRef)
+    HRESULT GetAssemblyRefTokenOfIndirectDependency(ModuleBase* module, LPCSTR assemblyName, size_t assemblyNameLen, mdToken *pAssemblyRef)
     {
-        auto pMDImport = module->GetMDImport();
+        IMDInternalImport *pMDImport = module->GetMDImport();
         //Get the assembly refs.
         HENUMInternalHolder hEnumTypeRefs(pMDImport);
         mdToken assemblyRef = mdTokenNil;
@@ -2249,20 +2268,16 @@ public:
         }
         else if (DecomposeModuleRef(moduleName, &assemblyNameInModuleRef, &assemblyNameLen, &index))
         {
-            // This disable cross module inlining beyond System.Private.CoreLib for composite images
-            if (m_pILModule == NULL)
-                return NULL;
+            ModuleBase *moduleBase = m_pILModule != nullptr ?
+                m_pILModule->GetModuleFromIndexIfLoaded(index) :
+                (index == 1 ? this : nullptr);
 
-            auto moduleBase = m_pILModule->GetModuleFromIndexIfLoaded(index);
-            _ASSERTE(moduleBase == NULL || moduleBase->IsFullModule());
-            module = static_cast<Module*>(moduleBase);
-
-            if (module != NULL)
+            if (moduleBase != nullptr)
             {
                 if (assemblyNameLen != 0) // #:<num> is a direct reference to a module index, #<assemblyName>:<num> is indirect
                 {
                     mdToken assemblyRef;
-                    if (FAILED(GetAssemblyRefTokenOfIndirectDependency(module, assemblyNameInModuleRef, assemblyNameLen, &assemblyRef)))
+                    if (FAILED(GetAssemblyRefTokenOfIndirectDependency(moduleBase, assemblyNameInModuleRef, assemblyNameLen, &assemblyRef)))
                     {
                         return NULL;
                     }
@@ -2273,10 +2288,15 @@ public:
                     }
                     else
                     {
-                        auto assemblyOfFinalModule = module->GetAssemblyIfLoaded(assemblyRef);
+                        Assembly *assemblyOfFinalModule = moduleBase->GetAssemblyIfLoaded(assemblyRef);
                         if (assemblyOfFinalModule != NULL)
                             module = assemblyOfFinalModule->GetModule();
                     }
+                }
+                else
+                {
+                    _ASSERTE(moduleBase->IsFullModule());
+                    module = static_cast<Module*>(moduleBase);
                 }
             }
         }
@@ -2315,25 +2335,29 @@ public:
         }
         else if (DecomposeModuleRef(moduleName, &assemblyNameInModuleRef, &assemblyNameLen, &index))
         {
-            // This disable cross module inlining beyond System.Private.CoreLib for composite images
-            if (m_pILModule == NULL)
+            ModuleBase *moduleBase = m_pILModule != nullptr ?
+                m_pILModule->GetModuleFromIndex(index) :
+                (index == 1 ? this : nullptr);
+
+            if (moduleBase == nullptr)
                 COMPlusThrowHR(COR_E_FILENOTFOUND);
 
-            auto moduleBase = m_pILModule->GetModuleFromIndex(index);
-            _ASSERTE(moduleBase == NULL || moduleBase->IsFullModule());
-            module = static_cast<Module*>(moduleBase);
-
-            if (assemblyNameLen != 0) // #:<num> is a direct reference to a module index, #<assemblyName>:<num> is indirect
+            if (moduleBase != nullptr && assemblyNameLen != 0) // #:<num> is a direct reference to a module index, #<assemblyName>:<num> is indirect
             {
                 mdToken assemblyRef;
 
-                IfFailThrow(GetAssemblyRefTokenOfIndirectDependency(module, assemblyNameInModuleRef, assemblyNameLen, &assemblyRef));
+                IfFailThrow(GetAssemblyRefTokenOfIndirectDependency(moduleBase, assemblyNameInModuleRef, assemblyNameLen, &assemblyRef));
                 if (assemblyRef == mdTokenNil)
                 {
                     COMPlusThrowHR(COR_E_FILENOTFOUND);
                 }
-                auto domainAssemblyOfFinalModule = module->LoadAssembly(assemblyRef);
+                Assembly *domainAssemblyOfFinalModule = moduleBase->LoadAssembly(assemblyRef);
                 module = domainAssemblyOfFinalModule->GetModule();
+            }
+            else
+            {
+                _ASSERTE(moduleBase == nullptr || moduleBase->IsFullModule());
+                module = static_cast<Module*>(moduleBase);
             }
         }
         else
@@ -2359,10 +2383,10 @@ public:
     }
 };
 
-ModuleBase* CreateNativeManifestModule(LoaderAllocator* pLoaderAllocator, IMDInternalImport *pManifestMetadata, Module* pModule, AllocMemTracker *pamTracker)
+ModuleBase* CreateNativeManifestModule(LoaderAllocator* pLoaderAllocator, IMDInternalImport *pManifestMetadata, Module* pModule, NativeImage* pNativeImage, AllocMemTracker *pamTracker)
 {
     void *mem = pamTracker->Track(pLoaderAllocator->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(NativeManifestModule))));
-    return new (mem) NativeManifestModule(pLoaderAllocator, pManifestMetadata, pModule, pamTracker);
+    return new (mem) NativeManifestModule(pLoaderAllocator, pManifestMetadata, pModule, pNativeImage, pamTracker);
 }
 #endif // DACCESS_COMPILE
 


### PR DESCRIPTION
## Discussion prototype

This is one possible fix for #132811, published as a draft to make the implementation and tradeoffs concrete. It is not intended to establish the final design before discussion.

PR #131610 made Crossgen2 synthesize TypeRefs for types that appear only as `System.Type` values in custom-attribute blobs. When the originating module has no matching `AssemblyRef`, the resulting synthetic `#<assembly-name>:<source-module-index>` ModuleRef cannot be resolved by CoreCLR.

This prototype keeps the existing source-module route when a real source `AssemblyRef` exists. Otherwise, it:

- registers the resolved target assembly deterministically in mutable manifest metadata;
- emits its full identity as a manifest `AssemblyRef`;
- scopes the synthesized TypeRef through the native manifest module;
- allows `NativeManifestModule` to load and cache those references;
- uses the native-image binder for composite images; and
- preserves positional alignment when manifest MVID entries are empty.

## Tradeoffs

This reuses standard metadata identity and existing assembly-binding semantics, but expands the native manifest module from a lightweight module-index scope into an assembly-reference binding scope. An alternative draft uses versioned TypeMap entries that retain the original serialized type name and resolve it lazily during the TypeMap API call.

## Validation

The existing `TypeMapBlobOnlyLib` case fails before this change with `FileNotFoundException` from `FindPrecachedExternalTypeMapEntry`. With this prototype, ordinary execution, non-composite Crossgen2, and composite Crossgen2 TypeMap runs pass using a Checked CoreCLR build.

> [!NOTE]
> This draft PR description was generated with assistance from GitHub Copilot.