### PR TITLE
Avoid unnecessary JIT data section constants

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7880,12 +7880,7 @@ UNATIVE_OFFSET emitter::emitDataGenBeg(unsigned size, unsigned alignment, var_ty
     //
     assert((size != 0) && ((size % dataSection::MIN_DATA_ALIGN) == 0));
 
-    // Place the constant at an offset that satisfies its required alignment. This ensures
-    // aligned loads of the constant address a properly aligned location, and it lets the
-    // duplicate-constant matching in emitDataGenFind reuse an existing entry (that search
-    // only considers candidates sitting at a suitably aligned offset). Compilers targeting
-    // SMALL_CODE request a smaller alignment in the const-emission helpers and so still get
-    // tight packing.
+    // Keep the logical layout in sync with the per-chunk alignment used by the EE.
     unsigned secOffs = AlignUp(emitConsDsc.dsdOffs, alignment);
     /* Advance the current offset */
     emitConsDsc.dsdOffs = secOffs + size;
@@ -8095,13 +8090,10 @@ UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, u
         // We match the bit pattern, so the dataType can be different
         // Only match constants when the dsType is 'data'
         //
-        // The existing entry must also sit at an offset that satisfies the requested alignment;
-        // emitDataGenBeg aligns every entry's offset to its own alignment, so this normally holds
-        // for equally-aligned constants but can still fail when reusing a more-strictly-aligned
-        // request against a less-aligned entry.
+        // The existing entry must also satisfy the requested alignment.
         //
         if ((secDesc->dsType == dataSection::data) && (secDesc->dsSize >= cnsSize) &&
-            ((secDesc->dsOffset % alignment) == 0))
+            (secDesc->dsAlignment >= alignment))
         {
             if (memcmp(cnsAddr, secDesc->Data(), cnsSize) == 0)
             {
@@ -8712,7 +8704,8 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
             {
                 if (i > 0)
                 {
-                    sprintf_s(label, ArrLen(label), "RWD%02zu", i * sizeof(CORINFO_AsyncResumeInfo));
+                    sprintf_s(label, ArrLen(label), "RWD%02zu",
+                              static_cast<size_t>(data->dsOffset) + (i * sizeof(CORINFO_AsyncResumeInfo)));
                     printf(labelFormat, label);
                 }
 
@@ -9359,7 +9352,9 @@ BYTE* emitter::emitDataOffsetToPtr(UNATIVE_OFFSET offset)
     }
 
     assert((min > 0) && (min <= emitNumDataChunks));
-    return emitDataChunks[min - 1].block + (offset - emitDataChunkOffsets[min - 1]);
+    const unsigned chunkIndex = min - 1;
+    assert((offset - emitDataChunkOffsets[chunkIndex]) < emitDataChunks[chunkIndex].size);
+    return emitDataChunks[chunkIndex].block + (offset - emitDataChunkOffsets[chunkIndex]);
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6977,7 +6977,6 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
     AllocMemChunk* dataChunk       = emitDataChunks;
     unsigned*      dataChunkOffset = emitDataChunkOffsets;
 
-    unsigned cumulativeOffset = 0;
     for (dataSection* sec = emitConsDsc.dsdList; sec != nullptr; sec = sec->dsNext, dataChunk++, dataChunkOffset++)
     {
         comp->Metrics.ReadOnlyDataBytes += sec->dsSize;
@@ -6991,8 +6990,10 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
             dataChunk->flags = CORJIT_ALLOCMEM_READONLY_DATA | CORJIT_ALLOCMEM_HAS_POINTERS_TO_CODE;
         }
 
-        *dataChunkOffset = cumulativeOffset;
-        cumulativeOffset += sec->dsSize;
+        // The logical offset assigned to each section (see emitDataGenBeg) is what instructions
+        // reference and what emitDataOffsetToPtr maps back to a chunk, so use it here rather than
+        // recomputing a packed offset that would ignore inter-section alignment padding.
+        *dataChunkOffset = sec->dsOffset;
     }
 
     comp->Metrics.AllocatedHotCodeBytes  = emitTotalHotCodeSize;
@@ -7879,9 +7880,15 @@ UNATIVE_OFFSET emitter::emitDataGenBeg(unsigned size, unsigned alignment, var_ty
     //
     assert((size != 0) && ((size % dataSection::MIN_DATA_ALIGN) == 0));
 
-    unsigned secOffs = emitConsDsc.dsdOffs;
+    // Place the constant at an offset that satisfies its required alignment. This ensures
+    // aligned loads of the constant address a properly aligned location, and it lets the
+    // duplicate-constant matching in emitDataGenFind reuse an existing entry (that search
+    // only considers candidates sitting at a suitably aligned offset). Compilers targeting
+    // SMALL_CODE request a smaller alignment in the const-emission helpers and so still get
+    // tight packing.
+    unsigned secOffs = AlignUp(emitConsDsc.dsdOffs, alignment);
     /* Advance the current offset */
-    emitConsDsc.dsdOffs += size;
+    emitConsDsc.dsdOffs = secOffs + size;
 
     /* Allocate a data section descriptor and add it to the list */
 
@@ -7892,6 +7899,8 @@ UNATIVE_OFFSET emitter::emitDataGenBeg(unsigned size, unsigned alignment, var_ty
     secDesc->dsSize = size;
 
     secDesc->dsAlignment = alignment;
+
+    secDesc->dsOffset = secOffs;
 
     secDesc->dsDataType = dataType;
 
@@ -7928,13 +7937,13 @@ UNATIVE_OFFSET emitter::emitBBTableDataGenBeg(unsigned numEntries, bool relative
 
     UNATIVE_OFFSET emittedSize = numEntries * elemSize;
 
-    /* Get hold of the current offset */
+    /* Get hold of the current offset, aligned for the element size */
 
-    secOffs = emitConsDsc.dsdOffs;
+    secOffs = AlignUp(emitConsDsc.dsdOffs, elemSize);
 
     /* Advance the current offset */
 
-    emitConsDsc.dsdOffs += emittedSize;
+    emitConsDsc.dsdOffs = secOffs + emittedSize;
 
     /* Allocate a data section descriptor and add it to the list */
 
@@ -7945,6 +7954,8 @@ UNATIVE_OFFSET emitter::emitBBTableDataGenBeg(unsigned numEntries, bool relative
     secDesc->dsSize = emittedSize;
 
     secDesc->dsAlignment = elemSize;
+
+    secDesc->dsOffset = secOffs;
 
     secDesc->dsDataType = TYP_UNKNOWN;
 
@@ -7975,9 +7986,9 @@ UNATIVE_OFFSET emitter::emitBBTableDataGenBeg(unsigned numEntries, bool relative
 //
 void emitter::emitAsyncResumeTable(unsigned numEntries, UNATIVE_OFFSET* dataSecOffs, emitter::dataSection** dataSec)
 {
-    UNATIVE_OFFSET secOffs     = emitConsDsc.dsdOffs;
     unsigned       emittedSize = sizeof(CORINFO_AsyncResumeInfo) * numEntries;
-    emitConsDsc.dsdOffs += emittedSize;
+    UNATIVE_OFFSET secOffs     = AlignUp(emitConsDsc.dsdOffs, TARGET_POINTER_SIZE);
+    emitConsDsc.dsdOffs        = secOffs + emittedSize;
 
     dataSection* secDesc = (dataSection*)emitGetMem(sizeof(dataSection));
     secDesc->dsType      = dataSection::asyncResumeInfo;
@@ -7988,6 +7999,7 @@ void emitter::emitAsyncResumeTable(unsigned numEntries, UNATIVE_OFFSET* dataSecO
 
     secDesc->dsSize      = emittedSize;
     secDesc->dsAlignment = TARGET_POINTER_SIZE;
+    secDesc->dsOffset    = secOffs;
     secDesc->dsDataType  = TYP_UNKNOWN;
     secDesc->dsNext      = nullptr;
 
@@ -8074,7 +8086,6 @@ UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, u
 {
     UNATIVE_OFFSET cnum     = INVALID_UNATIVE_OFFSET;
     unsigned       cmpCount = 0;
-    unsigned       curOffs  = 0;
     dataSection*   secDesc  = emitConsDsc.dsdList;
     while (secDesc != nullptr)
     {
@@ -8084,11 +8095,17 @@ UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, u
         // We match the bit pattern, so the dataType can be different
         // Only match constants when the dsType is 'data'
         //
-        if ((secDesc->dsType == dataSection::data) && (secDesc->dsSize >= cnsSize) && ((curOffs % alignment) == 0))
+        // The existing entry must also sit at an offset that satisfies the requested alignment;
+        // emitDataGenBeg aligns every entry's offset to its own alignment, so this normally holds
+        // for equally-aligned constants but can still fail when reusing a more-strictly-aligned
+        // request against a less-aligned entry.
+        //
+        if ((secDesc->dsType == dataSection::data) && (secDesc->dsSize >= cnsSize) &&
+            ((secDesc->dsOffset % alignment) == 0))
         {
             if (memcmp(cnsAddr, secDesc->Data(), cnsSize) == 0)
             {
-                cnum = curOffs;
+                cnum = secDesc->dsOffset;
 
                 // We also might want to update the dsDataType
                 //
@@ -8105,7 +8122,6 @@ UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, u
             }
         }
 
-        curOffs += secDesc->dsSize;
         secDesc = secDesc->dsNext;
 
         if (++cmpCount > 64)
@@ -8449,8 +8465,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
 
     /* Walk and emit the contents of all the data blocks */
 
-    size_t         curOffs = 0;
-    AllocMemChunk* chunk   = chunks;
+    AllocMemChunk* chunk = chunks;
 
     for (dataSection* dsc = sec->dsdList; dsc; dsc = dsc->dsNext, chunk++)
     {
@@ -8560,7 +8575,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
 #ifdef DEBUG
             if (EMITVERBOSE)
             {
-                printf("  section %3u, size %2zu, RWD%2zu:\t", secNum++, dscSize, curOffs);
+                printf("  section %3u, size %2zu, RWD%2zu:\t", secNum++, dscSize, (size_t)dsc->dsOffset);
 
                 for (size_t i = 0; i < dscSize; i++)
                 {
@@ -8586,8 +8601,6 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
             }
 #endif // DEBUG
         }
-
-        curOffs += dscSize;
     }
 }
 
@@ -8607,8 +8620,7 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
 {
     printf("\n");
 
-    unsigned       offset = 0;
-    AllocMemChunk* chunk  = dataChunks;
+    AllocMemChunk* chunk = dataChunks;
 
     for (dataSection* data = section->dsdList; data != nullptr; data = data->dsNext, chunk++)
     {
@@ -8621,9 +8633,8 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
 
         const char* labelFormat = "%-7s";
         char        label[64];
-        sprintf_s(label, ArrLen(label), "RWD%02u", offset);
+        sprintf_s(label, ArrLen(label), "RWD%02zu", (size_t)data->dsOffset);
         printf(labelFormat, label);
-        offset += data->dsSize;
 
         if ((data->dsType == dataSection::blockRelative32) || (data->dsType == dataSection::blockAbsoluteAddr))
         {

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -3630,6 +3630,7 @@ public:
 
         dataSection*   dsNext;
         UNATIVE_OFFSET dsAlignment;
+        UNATIVE_OFFSET dsOffset;
         UNATIVE_OFFSET dsSize;
         sectionType    dsType;
         var_types      dsDataType;

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -7293,24 +7293,19 @@ void emitter::emitDispInsHelp(
             emitDispReg(id->idReg1(), attr, true);
             imm = emitGetInsSC(id);
             {
-                dataSection*  jdsc = nullptr;
-                NATIVE_OFFSET offs = 0;
+                dataSection* jdsc = nullptr;
 
                 /* Find the appropriate entry in the data section list */
 
                 for (jdsc = emitConsDsc.dsdList; jdsc; jdsc = jdsc->dsNext)
                 {
-                    UNATIVE_OFFSET size = jdsc->dsSize;
-
                     /* Is this a label table? */
 
                     if (jdsc->dsType == dataSection::blockAbsoluteAddr)
                     {
-                        if (offs == imm)
+                        if (jdsc->dsOffset == (UNATIVE_OFFSET)imm)
                             break;
                     }
-
-                    offs += size;
                 }
 
                 if (id->idIsDspReloc())

--- a/src/coreclr/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenxarch.cpp
@@ -2449,9 +2449,6 @@ void CodeGen::genBaseIntrinsic(GenTreeHWIntrinsic* node, insOpts instOptions)
             {
                 divTypeSize = EA_32BYTE;
             }
-            simd_t               negOneIntVec = simd_t::AllBitsSet();
-            CORINFO_FIELD_HANDLE negOneFld    = emit->emitSimdConst(&negOneIntVec, typeSize);
-
             // div-by-zero check
             emit->emitIns_SIMD_R_R_R(INS_xorpd, typeSize, tmpReg2, tmpReg2, tmpReg2, instOptions);
             emit->emitIns_SIMD_R_R_R(INS_pcmpeqd, typeSize, tmpReg2, tmpReg2, op2Reg, instOptions);
@@ -2468,6 +2465,9 @@ void CodeGen::genBaseIntrinsic(GenTreeHWIntrinsic* node, insOpts instOptions)
                     minValueInt.i32[i] = INT_MIN;
                 }
                 CORINFO_FIELD_HANDLE minValueFld = emit->emitSimdConst(&minValueInt, typeSize);
+
+                simd_t               negOneIntVec = simd_t::AllBitsSet();
+                CORINFO_FIELD_HANDLE negOneFld    = emit->emitSimdConst(&negOneIntVec, typeSize);
 
                 emit->emitIns_SIMD_R_R_C(INS_pcmpeqd, typeSize, tmpReg2, op1Reg, minValueFld, 0, instOptions);
                 emit->emitIns_SIMD_R_R_C(INS_pcmpeqd, typeSize, tmpReg3, op2Reg, negOneFld, 0, instOptions);


### PR DESCRIPTION
Avoid unnecessary entries in the JIT data section.

Data-section entries now honor their requested alignment and retain their logical offset, allowing duplicate constant lookup and all offset consumers to reference the same aligned location rather than emitting another copy.

The SIMD integer division codegen also emits its all-bits-set constant only for signed division, where the overflow check consumes it.

### Linux Arm64

Collection | Base | Diff | PDIFF
-- | -- | -- | --
aspnet2.run.linux.arm64.checked.mch | 94,812 | 93,460 | -1.43%
benchmarks.run.linux.arm64.checked.mch | 509,440 | 505,592 | -0.76%
benchmarks.run_pgo.linux.arm64.checked.mch | 365,688 | 363,808 | -0.51%
benchmarks.run_pgo_optrepeat.linux.arm64.checked.mch | 509,404 | 505,556 | -0.76%
coreclr_tests.run.linux.arm64.checked.mch | 3,181,176 | 3,161,960 | -0.60%
libraries.crossgen2.linux.arm64.checked.mch | 418,264 | 417,688 | -0.14%
libraries.pmi.linux.arm64.checked.mch | 671,120 | 660,512 | -1.58%
libraries_tests.run.linux.arm64.Release.mch | 2,378,804 | 2,341,772 | -1.56%
libraries_tests_no_tiered_compilation.run.linux.arm64.Release.mch | 1,615,112 | 1,546,728 | -4.23%
realworld.run.linux.arm64.checked.mch | 108,512 | 104,528 | -3.67%
smoke_tests.nativeaot.linux.arm64.checked.mch | 25,896 | 25,888 | -0.03%

### Linux x64
Collection | Base | Diff | PDIFF
-- | -- | -- | --
benchmarks.run.linux.x64.checked.mch | 213,036 | 210,092 | -1.38%
benchmarks.run_pgo.linux.x64.checked.mch | 435,512 | 430,128 | -1.24%
benchmarks.run_pgo_optrepeat.linux.x64.checked.mch | 245,076 | 240,948 | -1.68%
coreclr_tests.run.linux.x64.checked.mch | 2,118,136 | 2,009,296 | -5.14%
libraries.crossgen2.linux.x64.checked.mch | 462,608 | 455,296 | -1.58%
libraries.pmi.linux.x64.checked.mch | 735,680 | 715,656 | -2.72%
libraries_tests.run.linux.x64.Release.mch | 2,923,348 | 2,787,164 | -4.66%
libraries_tests_no_tiered_compilation.run.linux.x64.Release.mch | 1,537,116 | 1,482,768 | -3.54%
realworld.run.linux.x64.checked.mch | 119,044 | 111,436 | -6.39%
smoke_tests.nativeaot.linux.x64.checked.mch | 44,000 | 43,344 | -1.49%

### Windows Arm64
Collection | Base | Diff | PDIFF
-- | -- | -- | --
aspnet2.run.windows.arm64.checked.mch | 96,296 | 94,944 | -1.40%
benchmarks.run.windows.arm64.checked.mch | 521,668 | 518,236 | -0.66%
benchmarks.run_pgo.windows.arm64.checked.mch | 328,072 | 326,272 | -0.55%
benchmarks.run_pgo_optrepeat.windows.arm64.checked.mch | 301,000 | 297,568 | -1.14%
coreclr_tests.run.windows.arm64.checked.mch | 2,983,704 | 2,964,248 | -0.65%
libraries.crossgen2.windows.arm64.checked.mch | 420,792 | 420,216 | -0.14%
libraries.pmi.windows.arm64.checked.mch | 690,928 | 680,144 | -1.56%
libraries_tests.run.windows.arm64.Release.mch | 2,146,388 | 2,125,812 | -0.96%
libraries_tests_no_tiered_compilation.run.windows.arm64.Release.mch | 1,683,328 | 1,612,640 | -4.20%
realworld.run.windows.arm64.checked.mch | 105,224 | 101,368 | -3.66%
smoke_tests.nativeaot.windows.arm64.checked.mch | 30,068 | 30,060 | -0.03%

### Windows x64
Collection | Base | Diff | PDIFF
-- | -- | -- | --
aspnet2.run.windows.x64.checked.mch | 89,196 | 84,924 | -4.79%
benchmarks.run.windows.x64.checked.mch | 253,200 | 251,104 | -0.83%
benchmarks.run_pgo.windows.x64.checked.mch | 349,768 | 346,568 | -0.91%
benchmarks.run_pgo_optrepeat.windows.x64.checked.mch | 368,380 | 366,284 | -0.57%
coreclr_tests.run.windows.x64.checked.mch | 2,128,256 | 2,047,560 | -3.79%
libraries.crossgen2.windows.x64.checked.mch | 474,800 | 467,008 | -1.64%
libraries.pmi.windows.x64.checked.mch | 839,496 | 824,856 | -1.74%
libraries_tests.run.windows.x64.Release.mch | 2,094,916 | 2,039,628 | -2.64%
libraries_tests_no_tiered_compilation.run.windows.x64.Release.mch | 1,534,156 | 1,481,736 | -3.42%
realworld.run.windows.x64.checked.mch | 105,768 | 100,832 | -4.67%
smoke_tests.nativeaot.windows.x64.checked.mch | 48,408 | 47,800 | -1.26%

> [!NOTE]
> This pull request description was generated with GitHub Copilot.