### PR TITLE
[release/10.0] Fix ConcurrentQueue.TryDequeue spuriously reporting empty during a segment freeze- #132737

### DIFF
--- a/src/libraries/System.Collections.Concurrent/tests/ConcurrentQueueTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ConcurrentQueueTests.cs
@@ -21,6 +21,51 @@ namespace System.Collections.Concurrent.Tests
         protected override string CopyToNoLengthParamName => null;
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void Concurrent_TryDequeue_DoesNotReportEmptyWhileItemsAreQueued()
+        {
+            // Each worker holds at most one of the seeded items at a time, so an item is always
+            // queued and TryDequeue must never report empty
+            const int WorkerCount = 4;
+
+            var q = new ConcurrentQueue<object>();
+            for (int i = 0; i < WorkerCount; i++) q.Enqueue(new object());
+
+            bool stop = false;
+            int falseEmpties = 0;
+
+            // Snapshotting freezes the tail segment, racing the freeze against the empty check
+            Task snapshotter = Task.Run(() =>
+            {
+                while (!Volatile.Read(ref stop)) q.ToArray();
+            });
+
+            // Workers dequeue and immediately re-enqueue, counting any spurious empty
+            Task[] workers = new Task[WorkerCount];
+            for (int i = 0; i < WorkerCount; i++)
+            {
+                workers[i] = Task.Run(() =>
+                {
+                    while (!Volatile.Read(ref stop))
+                    {
+                        if (!q.TryDequeue(out object item))
+                        {
+                            Interlocked.Increment(ref falseEmpties);
+                            item = new object();
+                        }
+                        q.Enqueue(item);
+                    }
+                });
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(200));
+            Volatile.Write(ref stop, true);
+            Task.WaitAll(workers);
+            snapshotter.Wait();
+
+            Assert.Equal(0, falseEmpties);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Concurrent_Enqueue_TryDequeue_AllItemsReceived()
         {
             int items = 1000;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueueSegment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueueSegment.cs
@@ -98,8 +98,10 @@ namespace System.Collections.Concurrent
         {
             if (!_frozenForEnqueues) // flag used to ensure we don't increase the Tail more than once if frozen more than once
             {
-                _frozenForEnqueues = true;
+                // Bump the Tail before setting the flag, as TryDequeue reads the flag and then
+                // the Tail: a set flag must guarantee that the Tail read includes the FreezeOffset.
                 Interlocked.Add(ref _headAndTail.Tail, FreezeOffset);
+                _frozenForEnqueues = true;
             }
         }
 
@@ -163,8 +165,8 @@ namespace System.Collections.Concurrent
                     // this one that are available, but we need to dequeue in order.  So before declaring
                     // failure and that the segment is empty, we check the tail to see if we're actually
                     // empty or if we're just waiting for items in flight or after this one to become available.
-                    bool frozen = _frozenForEnqueues;
-                    int currentTail = Volatile.Read(ref _headAndTail.Tail);
+                    bool frozen = Volatile.Read(ref _frozenForEnqueues);
+                    int currentTail = _headAndTail.Tail;
                     if (currentTail - currentHead <= 0 || (frozen && (currentTail - FreezeOffset - currentHead <= 0)))
                     {
                         item = default;
@@ -232,8 +234,8 @@ namespace System.Collections.Concurrent
                     // this one that are available, but we need to peek in order.  So before declaring
                     // failure and that the segment is empty, we check the tail to see if we're actually
                     // empty or if we're just waiting for items in flight or after this one to become available.
-                    bool frozen = _frozenForEnqueues;
-                    int currentTail = Volatile.Read(ref _headAndTail.Tail);
+                    bool frozen = Volatile.Read(ref _frozenForEnqueues);
+                    int currentTail = _headAndTail.Tail;
                     if (currentTail - currentHead <= 0 || (frozen && (currentTail - FreezeOffset - currentHead <= 0)))
                     {
                         result = default;


### PR DESCRIPTION
Backport of #132737 to release/10.0

/cc @VSadov @kafka1991

## Customer Impact

- [x] Customer reported
- [ ] Found internally

https://github.com/dotnet/runtime/issues/132736

A race in `ConcurrentQueue` may result in `TryDequeue`/`TryPeek` assume the queue is empty when it actually has items. 
The race is rare because it can happen only when the circular segment is completely full and the queue allocates a larger segment, while marking the old one "frozen" for more enqueues.

## Regression

- [ ] Yes
- [x] No

## Testing

A new test is included together with the fix.

## Risk

Low. 

The fix changes the order of publishing `_frozenForEnqueues` with respect to updating segment Tail position to ensure that the consuming side does not see the segment in inconsistent state.