### PR TITLE
[release/11.0] Re-enable Helix Job Monitor

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -32,7 +32,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -3,7 +3,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/crossgen2-gcstress.yml
+++ b/eng/pipelines/coreclr/crossgen2-gcstress.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/gc-longrunning.yml
+++ b/eng/pipelines/coreclr/gc-longrunning.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/gc-simulator.yml
+++ b/eng/pipelines/coreclr/gc-simulator.yml
@@ -13,7 +13,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/gc-standalone.yml
+++ b/eng/pipelines/coreclr/gc-standalone.yml
@@ -13,7 +13,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/gcstress-extra.yml
+++ b/eng/pipelines/coreclr/gcstress-extra.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/hardware-intrinsics-arm64.yml
+++ b/eng/pipelines/coreclr/hardware-intrinsics-arm64.yml
@@ -15,7 +15,7 @@ pr:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/hardware-intrinsics.yml
+++ b/eng/pipelines/coreclr/hardware-intrinsics.yml
@@ -16,7 +16,7 @@ pr:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/interpreter.yml
+++ b/eng/pipelines/coreclr/interpreter.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/libraries-gcstress-extra.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress-extra.yml
@@ -12,7 +12,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
@@ -12,7 +12,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/libraries-interpreter.yml
+++ b/eng/pipelines/coreclr/libraries-interpreter.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/libraries-jitstress-random.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress-random.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/libraries-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstressregs.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/libraries-pgo.yml
+++ b/eng/pipelines/coreclr/libraries-pgo.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/r2r-extra.yml
+++ b/eng/pipelines/coreclr/r2r-extra.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -13,7 +13,7 @@ pr: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/release-tests.yml
+++ b/eng/pipelines/coreclr/release-tests.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/runincontext.yml
+++ b/eng/pipelines/coreclr/runincontext.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/runtime-nativeaot-outerloop.yml
+++ b/eng/pipelines/coreclr/runtime-nativeaot-outerloop.yml
@@ -38,7 +38,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/coreclr/tieringtest.yml
+++ b/eng/pipelines/coreclr/tieringtest.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/libraries/outerloop-mono.yml
+++ b/eng/pipelines/libraries/outerloop-mono.yml
@@ -11,7 +11,7 @@ schedules:
 variables:
   - template: variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/libraries/outerloop.yml
+++ b/eng/pipelines/libraries/outerloop.yml
@@ -12,7 +12,7 @@ schedules:
 variables:
   - template: variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/runtime-android.yml
+++ b/eng/pipelines/runtime-android.yml
@@ -7,7 +7,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/runtime-androidemulator.yml
+++ b/eng/pipelines/runtime-androidemulator.yml
@@ -8,7 +8,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/runtime-cet.yml
+++ b/eng/pipelines/runtime-cet.yml
@@ -29,7 +29,7 @@ pr:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -36,7 +36,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/runtime-ioslike.yml
+++ b/eng/pipelines/runtime-ioslike.yml
@@ -7,7 +7,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/runtime-ioslikesimulator.yml
+++ b/eng/pipelines/runtime-ioslikesimulator.yml
@@ -8,7 +8,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/runtime-llvm.yml
+++ b/eng/pipelines/runtime-llvm.yml
@@ -56,7 +56,7 @@ pr:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/runtime-maccatalyst.yml
+++ b/eng/pipelines/runtime-maccatalyst.yml
@@ -7,7 +7,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/runtime-sanitized.yml
+++ b/eng/pipelines/runtime-sanitized.yml
@@ -12,7 +12,7 @@ schedules:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
 
 extends:

--- a/eng/pipelines/runtime-wasm-dbgtests.yml
+++ b/eng/pipelines/runtime-wasm-dbgtests.yml
@@ -4,7 +4,7 @@ pr: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/runtime-wasm-libtests.yml
+++ b/eng/pipelines/runtime-wasm-libtests.yml
@@ -3,7 +3,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/runtime-wasm-non-libtests.yml
+++ b/eng/pipelines/runtime-wasm-non-libtests.yml
@@ -3,7 +3,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/runtime-wasm-optional.yml
+++ b/eng/pipelines/runtime-wasm-optional.yml
@@ -4,7 +4,7 @@ pr: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/runtime-wasm.yml
+++ b/eng/pipelines/runtime-wasm.yml
@@ -7,7 +7,7 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -40,7 +40,7 @@ pr:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: false
+    value: true
   - template: /eng/pipelines/helix-platforms.yml
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
     - name: TeamName


### PR DESCRIPTION
Re-enables the Helix Job Monitor configurations temporarily disabled by #132880.

The fixed `11.0.0-beta.26427.10` package is now present through #132869. This keeps the conditional stage behavior added by #132883 and #132885.