### PR TITLE
Check for SIG_IGN and SIG_DFL before calling previous signal handler

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -1055,6 +1055,26 @@ uint16_t PalCaptureStackBackTrace(uint32_t arg1, uint32_t arg2, void* arg3, uint
 #ifdef FEATURE_HIJACK
 static struct sigaction g_previousActivationHandler;
 
+static bool IsSaSigInfo(struct sigaction* action)
+{
+    return (action->sa_flags & SA_SIGINFO) != 0;
+}
+
+static bool IsSigDfl(struct sigaction* action)
+{
+    // macOS can return sigaction with SIG_DFL and SA_SIGINFO.
+    // SA_SIGINFO means we should use sa_sigaction, but here we want to check sa_handler.
+    // So we ignore SA_SIGINFO when sa_sigaction and sa_handler are at the same address.
+    return (&action->sa_handler == (void*)&action->sa_sigaction || !IsSaSigInfo(action)) &&
+            action->sa_handler == SIG_DFL;
+}
+
+static bool IsSigIgn(struct sigaction* action)
+{
+    return (&action->sa_handler == (void*)&action->sa_sigaction || !IsSaSigInfo(action)) &&
+            action->sa_handler == SIG_IGN;
+}
+
 static void ActivationHandler(int code, siginfo_t* siginfo, void* context)
 {
     Thread* pThread = ThreadStore::GetCurrentThreadIfAvailableAsyncSafe();
@@ -1079,15 +1099,14 @@ static void ActivationHandler(int code, siginfo_t* siginfo, void* context)
     }
 
     // Call the original handler when it is not ignored or default (terminate).
-    if (g_previousActivationHandler.sa_flags & SA_SIGINFO)
+    if (!IsSigDfl(&g_previousActivationHandler) && !IsSigIgn(&g_previousActivationHandler))
     {
-        _ASSERTE(g_previousActivationHandler.sa_sigaction != NULL);
-        g_previousActivationHandler.sa_sigaction(code, siginfo, context);
-    }
-    else
-    {
-        if (g_previousActivationHandler.sa_handler != SIG_IGN &&
-            g_previousActivationHandler.sa_handler != SIG_DFL)
+        if (IsSaSigInfo(&g_previousActivationHandler))
+        {
+            _ASSERTE(g_previousActivationHandler.sa_sigaction != NULL);
+            g_previousActivationHandler.sa_sigaction(code, siginfo, context);
+        }
+        else
         {
             _ASSERTE(g_previousActivationHandler.sa_handler != NULL);
             g_previousActivationHandler.sa_handler(code);

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -975,15 +975,14 @@ static void inject_activation_handler(int code, siginfo_t *siginfo, void *contex
     else
     {
         // Call the original handler when it is not ignored or default (terminate).
-        if (g_previous_activation.sa_flags & SA_SIGINFO)
+        if (!IsSigDfl(&g_previous_activation) && !IsSigIgn(&g_previous_activation))
         {
-            _ASSERTE(g_previous_activation.sa_sigaction != NULL);
-            g_previous_activation.sa_sigaction(code, siginfo, context);
-        }
-        else
-        {
-            if (g_previous_activation.sa_handler != SIG_IGN &&
-                g_previous_activation.sa_handler != SIG_DFL)
+            if (IsSaSigInfo(&g_previous_activation))
+            {
+                _ASSERTE(g_previous_activation.sa_sigaction != NULL);
+                g_previous_activation.sa_sigaction(code, siginfo, context);
+            }
+            else
             {
                 _ASSERTE(g_previous_activation.sa_handler != NULL);
                 g_previous_activation.sa_handler(code);

--- a/src/tests/Regressions/coreclr/GitHub_132581/CMakeLists.txt
+++ b/src/tests/Regressions/coreclr/GitHub_132581/CMakeLists.txt
@@ -1,0 +1,8 @@
+# The test is valid only on macOS.
+if (CLR_CMAKE_TARGET_OSX)
+  include_directories(${INC_PLATFORM_DIR})
+
+  add_library(nativetest132581 ${TEST_LIB_TYPE} nativetest132581.cpp)
+
+  install(TARGETS nativetest132581 DESTINATION bin)
+endif()

--- a/src/tests/Regressions/coreclr/GitHub_132581/nativetest132581.cpp
+++ b/src/tests/Regressions/coreclr/GitHub_132581/nativetest132581.cpp
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <platformdefines.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void SignalHandler(int, siginfo_t*, void*)
+{
+}
+
+extern "C" DLL_EXPORT int InstallSignalHandlerAndExec(const char* executable, const char* managedAssembly)
+{
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_sigaction = SignalHandler;
+    action.sa_flags = SA_SIGINFO | SA_RESTART;
+    sigemptyset(&action.sa_mask);
+
+    if (sigaction(SIGUSR1, &action, nullptr) != 0)
+    {
+        return errno;
+    }
+
+    if (setenv("DOTNET_TEST_132581_CHILD", "1", 1) != 0)
+    {
+        return errno;
+    }
+
+    char* arguments[4];
+    int index = 0;
+    arguments[index++] = const_cast<char*>(executable);
+    if (managedAssembly[0] != '\0')
+    {
+        arguments[index++] = const_cast<char*>(managedAssembly);
+    }
+    arguments[index++] = const_cast<char*>("--child");
+    arguments[index] = nullptr;
+
+    execv(executable, arguments);
+    return errno;
+}
+
+extern "C" DLL_EXPORT int SendSignalFromChildProcess()
+{
+    pid_t child = fork();
+    if (child == -1)
+    {
+        return errno;
+    }
+
+    if (child == 0)
+    {
+        int result = kill(getppid(), SIGUSR1);
+        _exit(result == 0 ? 0 : 1);
+    }
+
+    int status;
+    pid_t result;
+    do
+    {
+        result = waitpid(child, &status, 0);
+    }
+    while ((result == -1) && (errno == EINTR));
+
+    return (result == child) && WIFEXITED(status) && (WEXITSTATUS(status) == 0) ? 0 : -1;
+}

--- a/src/tests/Regressions/coreclr/GitHub_132581/test132581.cs
+++ b/src/tests/Regressions/coreclr/GitHub_132581/test132581.cs
@@ -5,7 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
-public class Program
+public class HandleMacosSAFlagsOddityAcrossExec
 {
     private const string ChildEnvironmentVariable = "DOTNET_TEST_132581_CHILD";
 
@@ -15,8 +15,15 @@ public class Program
     [DllImport("nativetest132581")]
     private static extern int SendSignalFromChildProcess();
 
+    /// <summary>
+    /// MacOS leaks the exec-ing process's sa_flags across execve, but clears the sa_handler and sa_sigaction function
+    /// pointers, which creates a mismatched sa_flags in the process that is exec-ed into that says to use sa_sigaction
+    /// to handle the signal (instead of sa_handler). If the runtime doesn't also check that sa_sigaction is not SIG_IGN
+    /// or SIG_DFL, a crash occurs. This test ensures that the cleared signal handler, sa_sigaction, is not called when
+    /// it is set to SIG_IGN (ignore signal) or SIG_DFL (use default handler) even if the sa_flags says to use it.
+    /// </summary>
     [Fact]
-    public static void TestEntryPoint()
+    public static void DoNotCallPreviousSignalHandlerIfHandlerIsNotSet()
     {
         if (Environment.GetEnvironmentVariable(ChildEnvironmentVariable) is null)
         {

--- a/src/tests/Regressions/coreclr/GitHub_132581/test132581.cs
+++ b/src/tests/Regressions/coreclr/GitHub_132581/test132581.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public class Program
+{
+    private const string ChildEnvironmentVariable = "DOTNET_TEST_132581_CHILD";
+
+    [DllImport("nativetest132581")]
+    private static extern int InstallSignalHandlerAndExec(string executable, string managedAssembly);
+
+    [DllImport("nativetest132581")]
+    private static extern int SendSignalFromChildProcess();
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        if (Environment.GetEnvironmentVariable(ChildEnvironmentVariable) is null)
+        {
+            string executable = Environment.ProcessPath ?? throw new InvalidOperationException("The process path is unavailable.");
+            string command = Environment.GetCommandLineArgs()[0];
+            string managedAssembly = string.Equals(executable, command, StringComparison.Ordinal) ? string.Empty : command;
+
+            int error = InstallSignalHandlerAndExec(executable, managedAssembly);
+            throw new InvalidOperationException($"execv failed with error {error}.");
+        }
+
+        Assert.Equal(0, SendSignalFromChildProcess());
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_132581/test132581.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_132581/test132581.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- Installs a custom signal handler. -->
-
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true'">true</CLRTestTargetUnsupported>
     <CLRTestPriority>1</CLRTestPriority>

--- a/src/tests/Regressions/coreclr/GitHub_132581/test132581.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_132581/test132581.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestTargetUnsupported and CMakeProjectReference -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true'">true</CLRTestTargetUnsupported>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test132581.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_132581/test132581.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_132581/test132581.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Needed for CLRTestTargetUnsupported and CMakeProjectReference -->
+    <!-- Installs a custom signal handler. -->
+
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true'">true</CLRTestTargetUnsupported>
     <CLRTestPriority>1</CLRTestPriority>


### PR DESCRIPTION
macOS doesn't clear sa_flags when calling execve. When dotnet is started from a process that sets a signal handler, the handler is cleared, but not the sa_flags. When the runtime gets a signal from an external source, it sees a stale SA_SIGINGO and tries to call the previous signal handler, but the pointer is set to SIG_IGN or SIG_DFL, which causes a crash. This change checks for those values before calling the previous signal handler. Also adds a regression test for the issue.

Fixes https://github.com/dotnet/runtime/issues/132581