### PR TITLE
Enable packed UTF-16 search on ARM64

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any1CharPackedIgnoreCaseSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any1CharPackedIgnoreCaseSearchValues.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
@@ -33,11 +34,13 @@ namespace System.Buffers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         internal override int IndexOfAny(ReadOnlySpan<char> span) =>
             PackedSpanHelpers.IndexOfAnyIgnoreCase(ref MemoryMarshal.GetReference(span), _lowerCase, span.Length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         internal override int IndexOfAnyExcept(ReadOnlySpan<char> span) =>
             PackedSpanHelpers.IndexOfAnyExceptIgnoreCase(ref MemoryMarshal.GetReference(span), _lowerCase, span.Length);
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any1CharPackedSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any1CharPackedSearchValues.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
@@ -23,11 +24,13 @@ namespace System.Buffers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         internal override int IndexOfAny(ReadOnlySpan<char> span) =>
             PackedSpanHelpers.IndexOf(ref MemoryMarshal.GetReference(span), _e0, span.Length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         internal override int IndexOfAnyExcept(ReadOnlySpan<char> span) =>
             PackedSpanHelpers.IndexOfAnyExcept(ref MemoryMarshal.GetReference(span), _e0, span.Length);
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2CharPackedIgnoreCaseSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2CharPackedIgnoreCaseSearchValues.cs
@@ -40,11 +40,13 @@ namespace System.Buffers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         internal override int IndexOfAny(ReadOnlySpan<char> span) =>
             PackedSpanHelpers.IndexOfAnyIgnoreCase(ref MemoryMarshal.GetReference(span), _e0, _e1, span.Length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         internal override int IndexOfAnyExcept(ReadOnlySpan<char> span) =>
             PackedSpanHelpers.IndexOfAnyExceptIgnoreCase(ref MemoryMarshal.GetReference(span), _e0, _e1, span.Length);
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2CharPackedSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2CharPackedSearchValues.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
@@ -23,11 +24,13 @@ namespace System.Buffers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         internal override int IndexOfAny(ReadOnlySpan<char> span) =>
             PackedSpanHelpers.IndexOfAny(ref MemoryMarshal.GetReference(span), _e0, _e1, span.Length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         internal override int IndexOfAnyExcept(ReadOnlySpan<char> span) =>
             PackedSpanHelpers.IndexOfAnyExcept(ref MemoryMarshal.GetReference(span), _e0, _e1, span.Length);
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -126,7 +126,7 @@ namespace System.Buffers
                 char value1 = values[1];
                 char value2 = values[2];
 
-                return PackedSpanHelpers.PackedIndexOfIsSupported && PackedSpanHelpers.CanUsePackedIndexOf(value0) && PackedSpanHelpers.CanUsePackedIndexOf(value1) && PackedSpanHelpers.CanUsePackedIndexOf(value2)
+                return Sse2.IsSupported && PackedSpanHelpers.CanUsePackedIndexOf(value0) && PackedSpanHelpers.CanUsePackedIndexOf(value1) && PackedSpanHelpers.CanUsePackedIndexOf(value2)
                     ? new Any3CharPackedSearchValues(value0, value1, value2)
                     : new Any3SearchValues<char, short>(shortValues);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValues.cs
@@ -444,10 +444,9 @@ namespace System.Buffers
 
             return new SingleStringSearchValuesThreeChars<TValueLength, TCaseSensitivity>(uniqueValues, value, ch2Offset, ch3Offset);
 
-            // Unlike with PackedSpanHelpers (Sse2 only), we are also using this approach on ARM64.
             // We use PackUnsignedSaturate on X86 and UnzipEven on ARM, so the set of allowed characters differs slightly (we can't use it for \0 and \xFF on X86).
             static bool CanUsePackedImpl(char c) =>
-                PackedSpanHelpers.PackedIndexOfIsSupported ? PackedSpanHelpers.CanUsePackedIndexOf(c) :
+                Sse2.IsSupported ? PackedSpanHelpers.CanUsePackedIndexOf(c) :
                 (AdvSimd.Arm64.IsSupported && c <= byte.MaxValue);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace System
@@ -13,9 +14,16 @@ namespace System
     // included in this file which are specific to the packed implementation.
     internal static partial class PackedSpanHelpers
     {
-        // We only do this optimization if we have support for X86 intrinsics (Sse2) as the packing is noticeably cheaper compared to ARM (AdvSimd).
-        // While the impact on the worst-case (match at the start) is minimal on X86, it's prohibitively large on ARM.
-        public static bool PackedIndexOfIsSupported => Sse2.IsSupported;
+        // Archived ARM64 measurements showed a benefit for long no-match inputs at 512 characters,
+        // while early matches regressed. Keep shorter searches non-packed and peel two NEON vectors.
+        private const int Arm64PackedIndexOfThreshold = 512;
+        private const int Arm64PackedIndexOfPeel = 16;
+
+        public static bool PackedIndexOfIsSupported => Sse2.IsSupported || AdvSimd.Arm64.IsSupported;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool ShouldUsePackedIndexOf(int length) =>
+            Sse2.IsSupported || (AdvSimd.Arm64.IsSupported && length >= Arm64PackedIndexOfThreshold);
 
         // Not all values can benefit from packing the searchSpace. See comments in PackSources below.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -30,23 +38,35 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOf(ref char searchSpace, char value, int length) =>
-            IndexOf<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            AdvSimd.Arm64.IsSupported
+                ? IndexOfArm64<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length)
+                : IndexOf<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOfAnyExcept(ref char searchSpace, char value, int length) =>
-            IndexOf<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            AdvSimd.Arm64.IsSupported
+                ? IndexOfArm64<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length)
+                : IndexOf<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOfAny(ref char searchSpace, char value0, char value1, int length) =>
-            IndexOfAny<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            AdvSimd.Arm64.IsSupported
+                ? IndexOfAnyArm64<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length)
+                : IndexOfAny<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOfAnyExcept(ref char searchSpace, char value0, char value1, int length) =>
-            IndexOfAny<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            AdvSimd.Arm64.IsSupported
+                ? IndexOfAnyArm64<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length)
+                : IndexOfAny<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
@@ -60,54 +80,97 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOfAnyIgnoreCase(ref char searchSpace, char value, int length)
         {
             Debug.Assert((value | 0x20) == value);
 
-            return IndexOf<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            return AdvSimd.Arm64.IsSupported
+                ? IndexOfArm64<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length)
+                : IndexOf<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOfAnyExceptIgnoreCase(ref char searchSpace, char value, int length)
         {
             Debug.Assert((value | 0x20) == value);
 
-            return IndexOf<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            return AdvSimd.Arm64.IsSupported
+                ? IndexOfArm64<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length)
+                : IndexOf<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOfAnyIgnoreCase(ref char searchSpace, char value0, char value1, int length)
         {
             Debug.Assert((value0 | 0x20) == value0);
             Debug.Assert((value1 | 0x20) == value1);
 
-            return IndexOfAny<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            return AdvSimd.Arm64.IsSupported
+                ? IndexOfAnyArm64<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length)
+                : IndexOfAny<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOfAnyExceptIgnoreCase(ref char searchSpace, char value0, char value1, int length)
         {
             Debug.Assert((value0 | 0x20) == value0);
             Debug.Assert((value1 | 0x20) == value1);
 
-            return IndexOfAny<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            return AdvSimd.Arm64.IsSupported
+                ? IndexOfAnyArm64<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length)
+                : IndexOfAny<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOfAnyInRange(ref char searchSpace, char lowInclusive, char rangeInclusive, int length) =>
-            IndexOfAnyInRange<SpanHelpers.DontNegate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length);
+            AdvSimd.Arm64.IsSupported
+                ? IndexOfAnyInRangeArm64<SpanHelpers.DontNegate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length)
+                : IndexOfAnyInRange<SpanHelpers.DontNegate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static int IndexOfAnyExceptInRange(ref char searchSpace, char lowInclusive, char rangeInclusive, int length) =>
-            IndexOfAnyInRange<SpanHelpers.Negate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length);
+            AdvSimd.Arm64.IsSupported
+                ? IndexOfAnyInRangeArm64<SpanHelpers.Negate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length)
+                : IndexOfAnyInRange<SpanHelpers.Negate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length);
 
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         public static bool Contains(ref short searchSpace, short value, int length)
+        {
+            if (AdvSimd.Arm64.IsSupported)
+            {
+                int nonPackedLength = GetArm64NonPackedLength(length);
+
+                if (SpanHelpers.NonPackedContainsValueType(ref searchSpace, value, nonPackedLength))
+                {
+                    return true;
+                }
+
+                if (nonPackedLength == length)
+                {
+                    return false;
+                }
+
+                return ContainsPacked(ref Unsafe.Add(ref searchSpace, nonPackedLength), value, length - nonPackedLength);
+            }
+
+            return ContainsPacked(ref searchSpace, value, length);
+        }
+
+        [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        private static bool ContainsPacked(ref short searchSpace, short value, int length)
         {
             Debug.Assert(CanUsePackedIndexOf(value));
 
@@ -309,6 +372,7 @@ namespace System
         }
 
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         private static int IndexOf<TNegator, TTransform>(ref short searchSpace, short value, int length)
             where TNegator : struct, SpanHelpers.INegator<short>
             where TTransform : struct, ITransform
@@ -512,6 +576,7 @@ namespace System
         }
 
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         private static int IndexOfAny<TNegator, TTransform>(ref short searchSpace, short value0, short value1, int length)
             where TNegator : struct, SpanHelpers.INegator<short>
             where TTransform : struct, ITransform
@@ -726,6 +791,7 @@ namespace System
         }
 
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         private static int IndexOfAny<TNegator>(ref short searchSpace, short value0, short value1, short value2, int length)
             where TNegator : struct, SpanHelpers.INegator<short>
         {
@@ -944,6 +1010,7 @@ namespace System
         }
 
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         private static int IndexOfAnyInRange<TNegator>(ref short searchSpace, short lowInclusive, short rangeInclusive, int length)
             where TNegator : struct, SpanHelpers.INegator<short>
         {
@@ -1139,6 +1206,121 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        private static int IndexOfArm64<TNegator, TTransform>(ref short searchSpace, short value, int length)
+            where TNegator : struct, SpanHelpers.INegator<short>
+            where TTransform : struct, ITransform
+        {
+            int nonPackedLength = GetArm64NonPackedLength(length);
+            int index = typeof(TTransform) == typeof(NopTransform)
+                ? SpanHelpers.NonPackedIndexOfValueType<short, TNegator>(ref searchSpace, value, nonPackedLength)
+                : SpanHelpers.NonPackedIndexOfAnyValueType<short, TNegator>(ref searchSpace, value, (short)(value & ~0x20), nonPackedLength);
+
+            if (index >= 0 || nonPackedLength == length)
+            {
+                return index;
+            }
+
+            index = IndexOf<TNegator, TTransform>(ref Unsafe.Add(ref searchSpace, nonPackedLength), value, length - nonPackedLength);
+            return AddPrefixToIndex(nonPackedLength, index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        private static int IndexOfAnyArm64<TNegator, TTransform>(ref short searchSpace, short value0, short value1, int length)
+            where TNegator : struct, SpanHelpers.INegator<short>
+            where TTransform : struct, ITransform
+        {
+            int nonPackedLength = GetArm64NonPackedLength(length);
+            int index = typeof(TTransform) == typeof(NopTransform)
+                ? SpanHelpers.NonPackedIndexOfAnyValueType<short, TNegator>(ref searchSpace, value0, value1, nonPackedLength)
+                : NonPackedIndexOfAnyIgnoreCase<TNegator>(ref searchSpace, value0, value1, nonPackedLength);
+
+            if (index >= 0 || nonPackedLength == length)
+            {
+                return index;
+            }
+
+            index = IndexOfAny<TNegator, TTransform>(ref Unsafe.Add(ref searchSpace, nonPackedLength), value0, value1, length - nonPackedLength);
+            return AddPrefixToIndex(nonPackedLength, index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
+        private static int IndexOfAnyInRangeArm64<TNegator>(ref short searchSpace, short lowInclusive, short rangeInclusive, int length)
+            where TNegator : struct, SpanHelpers.INegator<short>
+        {
+            int nonPackedLength = GetArm64NonPackedLength(length);
+            ref ushort unsignedSearchSpace = ref Unsafe.As<short, ushort>(ref searchSpace);
+            ushort low = (ushort)lowInclusive;
+            ushort high = (ushort)(lowInclusive + rangeInclusive);
+            int index = typeof(TNegator) == typeof(SpanHelpers.DontNegate<short>)
+                ? SpanHelpers.NonPackedIndexOfAnyInRangeUnsignedNumber<ushort, SpanHelpers.DontNegate<ushort>>(
+                    ref unsignedSearchSpace,
+                    low,
+                    high,
+                    nonPackedLength)
+                : SpanHelpers.NonPackedIndexOfAnyInRangeUnsignedNumber<ushort, SpanHelpers.Negate<ushort>>(
+                    ref unsignedSearchSpace,
+                    low,
+                    high,
+                    nonPackedLength);
+
+            if (index >= 0 || nonPackedLength == length)
+            {
+                return index;
+            }
+
+            index = IndexOfAnyInRange<TNegator>(ref Unsafe.Add(ref searchSpace, nonPackedLength), lowInclusive, rangeInclusive, length - nonPackedLength);
+            return AddPrefixToIndex(nonPackedLength, index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int AddPrefixToIndex(int prefixLength, int index) =>
+            index < 0 ? -1 : prefixLength + index;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetArm64NonPackedLength(int length) =>
+            length < Arm64PackedIndexOfThreshold ? length : Arm64PackedIndexOfPeel;
+
+        private static int NonPackedIndexOfAnyIgnoreCase<TNegator>(ref short searchSpace, short value0, short value1, int length)
+            where TNegator : struct, SpanHelpers.INegator<short>
+        {
+            Vector128<short> values0 = Vector128.Create(value0);
+            Vector128<short> values1 = Vector128.Create(value1);
+            Vector128<short> caseMask = Vector128.Create((short)0x20);
+            int offset = 0;
+
+            while (length >= Vector128<short>.Count)
+            {
+                Vector128<short> current = Vector128.LoadUnsafe(ref searchSpace, (nuint)offset) | caseMask;
+                Vector128<short> result = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1));
+
+                if (result != Vector128<short>.Zero)
+                {
+                    return offset + BitOperations.TrailingZeroCount(result.ExtractMostSignificantBits());
+                }
+
+                offset += Vector128<short>.Count;
+                length -= Vector128<short>.Count;
+            }
+
+            while (length > 0)
+            {
+                short current = (short)(Unsafe.Add(ref searchSpace, offset) | 0x20);
+                if (TNegator.NegateIfNeeded(current == value0 || current == value1))
+                {
+                    return offset;
+                }
+
+                offset++;
+                length--;
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx512BW))]
         internal static Vector512<byte> PackSources(Vector512<short> source0, Vector512<short> source1)
         {
@@ -1164,14 +1346,19 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
         internal static Vector128<byte> PackSources(Vector128<short> source0, Vector128<short> source1)
         {
-            Debug.Assert(Sse2.IsSupported);
+            Debug.Assert(Sse2.IsSupported || AdvSimd.IsSupported);
             // Pack two vectors of characters into bytes. While the type is Vector128<short>, these are really UInt16 characters.
-            // X86: Downcast every character using saturation.
+            // Downcast every character using unsigned saturation.
             // - Values <= 32767 result in min(value, 255).
             // - Values  > 32767 result in 0. Because of this we can't accept needles that contain 0.
-            return Sse2.PackUnsignedSaturate(source0, source1).AsByte();
+            return Sse2.IsSupported
+                ? Sse2.PackUnsignedSaturate(source0, source1).AsByte()
+                : AdvSimd.ExtractNarrowingSaturateUnsignedUpper(
+                    AdvSimd.ExtractNarrowingSaturateUnsignedLower(source0),
+                    source1);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -1461,7 +1461,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool ContainsValueType<T>(ref T searchSpace, T value, int length) where T : struct, INumber<T>
         {
-            if (PackedSpanHelpers.PackedIndexOfIsSupported && typeof(T) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value))
+            if (PackedSpanHelpers.PackedIndexOfIsSupported && PackedSpanHelpers.ShouldUsePackedIndexOf(length) && typeof(T) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value))
             {
                 return PackedSpanHelpers.Contains(ref Unsafe.As<T, short>(ref searchSpace), Unsafe.BitCast<T, short>(value), length);
             }
@@ -1644,7 +1644,7 @@ namespace System
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
         {
-            if (PackedSpanHelpers.PackedIndexOfIsSupported && typeof(TValue) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value))
+            if (PackedSpanHelpers.PackedIndexOfIsSupported && PackedSpanHelpers.ShouldUsePackedIndexOf(length) && typeof(TValue) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value))
             {
                 return typeof(TNegator) == typeof(DontNegate<short>)
                     ? PackedSpanHelpers.IndexOf(ref Unsafe.As<TValue, char>(ref searchSpace), Unsafe.BitCast<TValue, char>(value), length)
@@ -1859,7 +1859,7 @@ namespace System
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
         {
-            if (PackedSpanHelpers.PackedIndexOfIsSupported && typeof(TValue) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value0) && PackedSpanHelpers.CanUsePackedIndexOf(value1))
+            if (PackedSpanHelpers.PackedIndexOfIsSupported && PackedSpanHelpers.ShouldUsePackedIndexOf(length) && typeof(TValue) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value0) && PackedSpanHelpers.CanUsePackedIndexOf(value1))
             {
                 char char0 = Unsafe.BitCast<TValue, char>(value0);
                 char char1 = Unsafe.BitCast<TValue, char>(value1);
@@ -2119,7 +2119,7 @@ namespace System
             where TValue : struct, INumber<TValue>
             where TNegator : struct, INegator<TValue>
         {
-            if (PackedSpanHelpers.PackedIndexOfIsSupported && typeof(TValue) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value0) && PackedSpanHelpers.CanUsePackedIndexOf(value1) && PackedSpanHelpers.CanUsePackedIndexOf(value2))
+            if (System.Runtime.Intrinsics.X86.Sse2.IsSupported && typeof(TValue) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value0) && PackedSpanHelpers.CanUsePackedIndexOf(value1) && PackedSpanHelpers.CanUsePackedIndexOf(value2))
             {
                 return typeof(TNegator) == typeof(DontNegate<short>)
                     ? PackedSpanHelpers.IndexOfAny(ref Unsafe.As<TValue, char>(ref searchSpace), Unsafe.BitCast<TValue, char>(value0), Unsafe.BitCast<TValue, char>(value1), Unsafe.BitCast<TValue, char>(value2), length)
@@ -3866,7 +3866,7 @@ namespace System
             where T : struct, IUnsignedNumber<T>, IComparisonOperators<T, T, bool>
             where TNegator : struct, INegator<T>
         {
-            if (PackedSpanHelpers.PackedIndexOfIsSupported && typeof(T) == typeof(ushort) && PackedSpanHelpers.CanUsePackedIndexOf(lowInclusive) && PackedSpanHelpers.CanUsePackedIndexOf(highInclusive) && highInclusive >= lowInclusive)
+            if (PackedSpanHelpers.PackedIndexOfIsSupported && PackedSpanHelpers.ShouldUsePackedIndexOf(length) && typeof(T) == typeof(ushort) && PackedSpanHelpers.CanUsePackedIndexOf(lowInclusive) && PackedSpanHelpers.CanUsePackedIndexOf(highInclusive) && highInclusive >= lowInclusive)
             {
                 ref char charSearchSpace = ref Unsafe.As<T, char>(ref searchSpace);
                 char charLowInclusive = Unsafe.BitCast<T, char>(lowInclusive);


### PR DESCRIPTION
[Experiment for EgorBot]

Enables packed UTF-16 search on ARM64 for long inputs.

> [!NOTE]
> This description was generated by GitHub Copilot.
