### PR TITLE
[wasm] Carry R2R function names in a name section, not the export table

### DIFF
--- a/docs/design/mono/webcil.md
+++ b/docs/design/mono/webcil.md
@@ -87,6 +87,12 @@ of the `WebcilHeader`.
 
 The memory of the WebcilPayload must also be allocated with 16 byte alignment.
 
+The module shall not export its compiled functions. Exports count towards the engine's
+effective-type-size limit, so a module carrying a framework-sized function count becomes unloadable
+if each function is exported; the element segment, not the export table, is what makes a function
+reachable. Function names shall instead be carried in the `name` custom section, which is ignored by
+engines, counts towards no limit, and may be stripped when size matters.
+
 ``` wat
 (module
   (data "\0f\00\00\00\01\00\00\00") ;; data segment 0: two little-endian u32 values (payloadSize, tableSize). This specifies a Webcil payload of size 15 bytes with 1 required table entry

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmNameSection.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmNameSection.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
+using System.Linq;
 using Internal.Text;
 
 namespace ILCompiler.ObjectWriter
@@ -23,50 +23,64 @@ namespace ILCompiler.ObjectWriter
     internal sealed class WasmNameSection : IWasmEmittable
     {
         private const byte FunctionNameSubsectionId = 1;
-        private static readonly byte[] SectionName = "name"u8.ToArray();
+        private static ReadOnlySpan<byte> SectionName => "name"u8;
 
-        private readonly byte[] _payload;
+        private readonly WasmSymbol[] _functionSymbols;
+        private readonly int _subsectionSize;
+        private readonly int _payloadSize;
 
         public WasmNameSection(IEnumerable<WasmSymbol> functionSymbols)
         {
-            _payload = EncodePayload(functionSymbols);
+            _functionSymbols = functionSymbols.ToArray();
+
+            // Sized in a first pass so that the payload can be written straight to the output stream.
+            // At framework scale the payload is tens of megabytes, so buffering it would put several
+            // copies of it on the large object heap.
+            long nameMapSize = 0;
+            foreach (WasmSymbol symbol in _functionSymbols)
+            {
+                int nameLength = symbol.Name.Length;
+                nameMapSize += DwarfHelper.SizeOfULEB128((ulong)symbol.Index)
+                    + DwarfHelper.SizeOfULEB128((ulong)nameLength)
+                    + nameLength;
+            }
+
+            _subsectionSize = checked((int)(DwarfHelper.SizeOfULEB128((ulong)_functionSymbols.Length) + nameMapSize));
+            _payloadSize = checked(
+                (int)DwarfHelper.SizeOfULEB128((ulong)SectionName.Length) + SectionName.Length +
+                1 + // subsection id
+                (int)DwarfHelper.SizeOfULEB128((ulong)_subsectionSize) + _subsectionSize);
         }
 
         /// <summary>Number of functions named by this section.</summary>
-        public int FunctionCount { get; private set; }
+        public int FunctionCount => _functionSymbols.Length;
 
-        private byte[] EncodePayload(IEnumerable<WasmSymbol> functionSymbols)
+        public int EncodeSize() =>
+            1 + (int)DwarfHelper.SizeOfULEB128((ulong)_payloadSize) + _payloadSize;
+
+        public int EmitToStream(Stream outputFileStream)
         {
+            outputFileStream.WriteByte((byte)WasmSectionType.Custom);
+            WriteULEB128(outputFileStream, (ulong)_payloadSize);
+
+            WriteName(outputFileStream, SectionName);
+            outputFileStream.WriteByte(FunctionNameSubsectionId);
+            WriteULEB128(outputFileStream, (ulong)_subsectionSize);
+            WriteULEB128(outputFileStream, (ulong)_functionSymbols.Length);
+
             // The name map must be sorted by index and free of duplicates. GetDefinitions already
-            // orders by index, so only assert here rather than re-sorting a very large sequence.
-            MemoryStream nameMap = new MemoryStream();
-            int count = 0;
+            // orders by index, so this only asserts rather than re-sorting a very large sequence.
             int previousIndex = -1;
-            foreach (WasmSymbol symbol in functionSymbols)
+            foreach (WasmSymbol symbol in _functionSymbols)
             {
                 Debug.Assert(symbol.Index > previousIndex, "Function name map must be sorted by index and duplicate-free");
                 previousIndex = symbol.Index;
 
-                WriteULEB128(nameMap, (ulong)symbol.Index);
-                WriteName(nameMap, symbol.Name.AsSpan());
-                count++;
+                WriteULEB128(outputFileStream, (ulong)symbol.Index);
+                WriteName(outputFileStream, symbol.Name.AsSpan());
             }
 
-            FunctionCount = count;
-
-            MemoryStream subsection = new MemoryStream();
-            WriteULEB128(subsection, (ulong)count);
-            nameMap.Position = 0;
-            nameMap.CopyTo(subsection);
-
-            MemoryStream payload = new MemoryStream();
-            WriteName(payload, SectionName);
-            payload.WriteByte(FunctionNameSubsectionId);
-            WriteULEB128(payload, (ulong)subsection.Length);
-            subsection.Position = 0;
-            subsection.CopyTo(payload);
-
-            return payload.ToArray();
+            return EncodeSize();
         }
 
         private static void WriteName(Stream stream, ReadOnlySpan<byte> utf8Name)
@@ -80,18 +94,6 @@ namespace ILCompiler.ObjectWriter
             Span<byte> buffer = stackalloc byte[(int)DwarfHelper.SizeOfULEB128(value)];
             int written = DwarfHelper.WriteULEB128(buffer, value);
             stream.Write(buffer.Slice(0, written));
-        }
-
-        public int EncodeSize() =>
-            1 + (int)DwarfHelper.SizeOfULEB128((ulong)_payload.Length) + _payload.Length;
-
-        public int EmitToStream(Stream outputFileStream)
-        {
-            outputFileStream.WriteByte((byte)WasmSectionType.Custom);
-            WriteULEB128(outputFileStream, (ulong)_payload.Length);
-            outputFileStream.Write(_payload);
-
-            return EncodeSize();
         }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmNameSection.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmNameSection.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Internal.Text;
+
+namespace ILCompiler.ObjectWriter
+{
+    /// <summary>
+    /// The <c>name</c> custom section, carrying the module's function names.
+    /// </summary>
+    /// <remarks>
+    /// Function names would otherwise have to be carried by the export section, which does not scale:
+    /// exports count towards the engine's effective-type-size limit, and a framework-sized composite
+    /// exceeds it. A custom section is ignored by engines, counts towards no limit, and can be
+    /// stripped when size matters, so it is the only one of the three properties - loadable at scale,
+    /// named, and small - that does not cost the other two.
+    /// </remarks>
+    internal sealed class WasmNameSection : IWasmEmittable
+    {
+        private const byte FunctionNameSubsectionId = 1;
+        private static readonly byte[] SectionName = "name"u8.ToArray();
+
+        private readonly byte[] _payload;
+
+        public WasmNameSection(IEnumerable<WasmSymbol> functionSymbols)
+        {
+            _payload = EncodePayload(functionSymbols);
+        }
+
+        /// <summary>Number of functions named by this section.</summary>
+        public int FunctionCount { get; private set; }
+
+        private byte[] EncodePayload(IEnumerable<WasmSymbol> functionSymbols)
+        {
+            // The name map must be sorted by index and free of duplicates. GetDefinitions already
+            // orders by index, so only assert here rather than re-sorting a very large sequence.
+            MemoryStream nameMap = new MemoryStream();
+            int count = 0;
+            int previousIndex = -1;
+            foreach (WasmSymbol symbol in functionSymbols)
+            {
+                Debug.Assert(symbol.Index > previousIndex, "Function name map must be sorted by index and duplicate-free");
+                previousIndex = symbol.Index;
+
+                WriteULEB128(nameMap, (ulong)symbol.Index);
+                WriteName(nameMap, symbol.Name.AsSpan());
+                count++;
+            }
+
+            FunctionCount = count;
+
+            MemoryStream subsection = new MemoryStream();
+            WriteULEB128(subsection, (ulong)count);
+            nameMap.Position = 0;
+            nameMap.CopyTo(subsection);
+
+            MemoryStream payload = new MemoryStream();
+            WriteName(payload, SectionName);
+            payload.WriteByte(FunctionNameSubsectionId);
+            WriteULEB128(payload, (ulong)subsection.Length);
+            subsection.Position = 0;
+            subsection.CopyTo(payload);
+
+            return payload.ToArray();
+        }
+
+        private static void WriteName(Stream stream, ReadOnlySpan<byte> utf8Name)
+        {
+            WriteULEB128(stream, (ulong)utf8Name.Length);
+            stream.Write(utf8Name);
+        }
+
+        private static void WriteULEB128(Stream stream, ulong value)
+        {
+            Span<byte> buffer = stackalloc byte[(int)DwarfHelper.SizeOfULEB128(value)];
+            int written = DwarfHelper.WriteULEB128(buffer, value);
+            stream.Write(buffer.Slice(0, written));
+        }
+
+        public int EncodeSize() =>
+            1 + (int)DwarfHelper.SizeOfULEB128((ulong)_payload.Length) + _payload.Length;
+
+        public int EmitToStream(Stream outputFileStream)
+        {
+            outputFileStream.WriteByte((byte)WasmSectionType.Custom);
+            WriteULEB128(outputFileStream, (ulong)_payload.Length);
+            outputFileStream.Write(_payload);
+
+            return EncodeSize();
+        }
+    }
+}

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -54,6 +54,8 @@ namespace ILCompiler.ObjectWriter
         ];
 
         private protected readonly Dictionary<string, WasmGlobal> _definedGlobals = new();
+        /// <summary>Names of the writer-inserted stub functions, which are the only exported functions.</summary>
+        private protected readonly List<Utf8String> _wasmStubNames = new();
         private protected readonly WasmSections _sections = new();
         private protected readonly WasmSymbolManager _wasmSymbolManager = new();
         /// <summary>
@@ -349,6 +351,7 @@ namespace ILCompiler.ObjectWriter
 
             RegisterFunctionSymbol(name);
             RegisterStubIndexAndSignature(body.Signature);
+            _wasmStubNames.Add(name);
         }
 
         private protected int RegisterSignature(WasmFuncType signature)

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
@@ -463,6 +463,12 @@ namespace ILCompiler.ObjectWriter
             dataSection.EmitToStream(outputFileStream);
 #endif
 
+            // The name section goes last, after the data section, as tooling expects. It is the only
+            // record of function names now that they are no longer carried by the export table, and
+            // wasm-merge -g synthesizes the merged module's names from it.
+            WasmNameSection nameSection = new WasmNameSection(_wasmSymbolManager.GetDefinitions(WasmIndexSpace.Function));
+            nameSection.EmitToStream(outputFileStream);
+
             if (_outputInfoBuilder is not null)
             {
                 // Populate the output section layout so OutputInfoBuilder.EnumerateMethods can resolve each
@@ -996,13 +1002,15 @@ namespace ILCompiler.ObjectWriter
             Debug.Assert(_definedGlobals.ContainsKey("webcilVersion"));
             WriteGlobalExport("webcilVersion", _definedGlobals["webcilVersion"].Index);
 
-            // TODO-WASM: Handle exports better (e.g., only export public methods, etc.)
-            IEnumerable<WasmSymbol> functionSymbols = _wasmSymbolManager.GetDefinitions(
-                WasmIndexSpace.Function,
-                Comparer<WasmSymbol>.Create(static (x, y) => x.Name.CompareTo(y.Name)));
-            foreach (WasmSymbol symbol in functionSymbols)
+            // Export only the stubs the host actually calls. Exporting every compiled function does
+            // not scale: exports count towards the engine's effective-type-size limit, and a
+            // framework-sized composite exceeds it, producing a module no conforming engine loads.
+            // Nothing needs them - the element segment, not the export table, is what makes a
+            // function reachable - and the names they used to carry now live in the name section.
+            foreach (Utf8String stubName in _wasmStubNames)
             {
-                WriteFunctionExport(symbol.Name.ToString(), symbol.Index);
+                WasmSymbol stubSymbol = _wasmSymbolManager.GetSymbol(stubName);
+                WriteFunctionExport(stubName.ToString(), stubSymbol.Index);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
@@ -247,15 +247,21 @@ internal static class WasmR2RAssert
             uint index = ReadWasmUleb32(image, ref offset, subsectionEnd);
             string name = ReadWasmName(image, ref offset, subsectionEnd);
 
-            if (index <= previousIndex)
+            // Names must cover the defined-function range exactly. Checking only the ordering and
+            // the lower bound would accept a uniformly shifted map, which is precisely the
+            // off-by-one this section has to be trusted not to have.
+            uint expectedIndex = importedFunctionCount + i;
+            if (index != expectedIndex)
             {
-                failures.Add($"Name section entries are not sorted and unique by index ({index} follows {previousIndex}).");
+                failures.Add(
+                    $"Name section entry {i} names function index {index}; expected {expectedIndex} " +
+                    $"after {importedFunctionCount} function imports.");
                 return;
             }
 
-            if (index < importedFunctionCount)
+            if (index <= previousIndex)
             {
-                failures.Add($"Name section names imported function index {index}; only defined functions are named.");
+                failures.Add($"Name section entries are not sorted and unique by index ({index} follows {previousIndex}).");
                 return;
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
@@ -117,9 +117,10 @@ internal static class WasmR2RAssert
         // webcilVersion is the first global defined in the module (not imported), so it's index should be the count of imported globals
         CheckWasmExport(exports, "webcilVersion", WasmImportKind.Global, importedGlobalCount, failures);
         CheckFunctionExports(exports, importedFunctionCount, definedFunctionCount, failures);
+        CheckFunctionNames(reader, importedFunctionCount, definedFunctionCount, failures);
 
         diagnostic = failures.Count == 0
-            ? "WASM imports, definitions, exports, and instruction references use the expected per-kind indices."
+            ? "WASM imports, definitions, exports, names, and instruction references use the expected per-kind indices."
             : string.Join(Environment.NewLine, failures);
         return failures.Count == 0;
     }
@@ -183,30 +184,145 @@ internal static class WasmR2RAssert
         uint definedFunctionCount,
         List<string> failures)
     {
-        List<uint> functionIndices = exports.Values
-            .Where(export => export.Kind == WasmImportKind.Function)
-            .Select(export => export.Index)
-            .Order()
+        // Only the host-called stubs are exported. Exporting every compiled function counts towards
+        // the engine's effective-type-size limit and makes a framework-sized composite unloadable;
+        // function names live in the name section instead, which CheckFunctionNames verifies.
+        // A self-installing image needs two stubs; a host-installed component stub needs three.
+        List<string> exportedFunctions = exports
+            .Where(export => export.Value.Kind == WasmImportKind.Function)
+            .Select(export => export.Key)
+            .Order(StringComparer.Ordinal)
             .ToList();
 
-        if (functionIndices.Count != definedFunctionCount)
+        string[] selfInstalling = ["getWebcilSize", "patchWebcilHeader"];
+        string[] hostInstalled = ["fillWebcilTable", "getWebcilPayload", "getWebcilSize"];
+        if (!exportedFunctions.SequenceEqual(selfInstalling, StringComparer.Ordinal) &&
+            !exportedFunctions.SequenceEqual(hostInstalled, StringComparer.Ordinal))
         {
             failures.Add(
-                $"Found {functionIndices.Count} function exports for {definedFunctionCount} " +
-                "function-section entries.");
+                $"Expected exactly the stub function exports [{string.Join(", ", selfInstalling)}] " +
+                $"or [{string.Join(", ", hostInstalled)}]; found [{string.Join(", ", exportedFunctions)}].");
             return;
         }
 
-        for (int i = 0; i < functionIndices.Count; i++)
+        foreach (string name in exportedFunctions)
         {
-            uint expectedIndex = importedFunctionCount + (uint)i;
-            if (functionIndices[i] != expectedIndex)
+            uint index = exports[name].Index;
+            if (index < importedFunctionCount || index >= importedFunctionCount + definedFunctionCount)
             {
                 failures.Add(
-                    $"Function export index {functionIndices[i]} at sorted position {i}; " +
-                    $"expected {expectedIndex} after {importedFunctionCount} function imports.");
+                    $"Function export '{name}' has index {index}, outside the defined-function range " +
+                    $"[{importedFunctionCount}, {importedFunctionCount + definedFunctionCount}).");
             }
         }
+    }
+
+    /// <summary>
+    /// Verifies the <c>name</c> custom section names every defined function, since it is the only
+    /// record of function names once they are no longer carried by the export table.
+    /// </summary>
+    private static void CheckFunctionNames(
+        WebcilImageReader reader,
+        uint importedFunctionCount,
+        uint definedFunctionCount,
+        List<string> failures)
+    {
+        ReadOnlySpan<byte> image = reader.GetEntireImage().AsSpan();
+        if (!TryGetWasmFunctionNameSubsection(image, out int offset, out int subsectionEnd))
+        {
+            failures.Add("WASM image does not contain a 'name' custom section with a function-name subsection.");
+            return;
+        }
+
+        uint count = ReadWasmUleb32(image, ref offset, subsectionEnd);
+        if (count != definedFunctionCount)
+        {
+            failures.Add($"Name section names {count} functions for {definedFunctionCount} function-section entries.");
+            return;
+        }
+
+        long previousIndex = -1;
+        for (uint i = 0; i < count; i++)
+        {
+            uint index = ReadWasmUleb32(image, ref offset, subsectionEnd);
+            string name = ReadWasmName(image, ref offset, subsectionEnd);
+
+            if (index <= previousIndex)
+            {
+                failures.Add($"Name section entries are not sorted and unique by index ({index} follows {previousIndex}).");
+                return;
+            }
+
+            if (index < importedFunctionCount)
+            {
+                failures.Add($"Name section names imported function index {index}; only defined functions are named.");
+                return;
+            }
+
+            if (name.Length == 0)
+            {
+                failures.Add($"Name section entry for function index {index} has an empty name.");
+                return;
+            }
+
+            previousIndex = index;
+        }
+
+        if (offset != subsectionEnd)
+        {
+            failures.Add("WASM name section function subsection contains trailing data.");
+        }
+    }
+
+    private static bool TryGetWasmFunctionNameSubsection(
+        ReadOnlySpan<byte> image,
+        out int subsectionOffset,
+        out int subsectionEnd)
+    {
+        subsectionOffset = 0;
+        subsectionEnd = 0;
+
+        if (image.Length < 8)
+            throw new BadImageFormatException("WASM image is shorter than its magic and version header.");
+
+        int offset = 8;
+        while (offset < image.Length)
+        {
+            byte sectionId = ReadWasmByte(image, ref offset, image.Length);
+            uint sectionSize = ReadWasmUleb32(image, ref offset, image.Length);
+            if (sectionSize > int.MaxValue || sectionSize > image.Length - offset)
+                throw new BadImageFormatException($"WASM section {sectionId} extends beyond the image boundary.");
+
+            int sectionEnd = offset + (int)sectionSize;
+            if (sectionId == 0) // custom
+            {
+                int cursor = offset;
+                if (ReadWasmName(image, ref cursor, sectionEnd) == "name")
+                {
+                    // Subsections are ordered by id; the function-name subsection is id 1.
+                    while (cursor < sectionEnd)
+                    {
+                        byte subsectionId = ReadWasmByte(image, ref cursor, sectionEnd);
+                        uint subsectionSize = ReadWasmUleb32(image, ref cursor, sectionEnd);
+                        if (subsectionSize > sectionEnd - cursor)
+                            throw new BadImageFormatException("WASM name subsection extends beyond its section.");
+
+                        if (subsectionId == 1)
+                        {
+                            subsectionOffset = cursor;
+                            subsectionEnd = cursor + (int)subsectionSize;
+                            return true;
+                        }
+
+                        cursor += (int)subsectionSize;
+                    }
+                }
+            }
+
+            offset = sectionEnd;
+        }
+
+        return false;
     }
 
     private static Dictionary<(string Module, string Name), WasmImportIndex> ReadWasmImports(WebcilImageReader reader)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -198,6 +198,7 @@
     <Compile Include="..\..\Common\Compiler\ObjectWriter\TypeString.cs" Link="Compiler\ObjectWriter\TypeString.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\Wasm\WasmDataSection.cs" Link="Compiler\ObjectWriter\Wasm\WasmDataSection.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\Wasm\WasmDataSegment.cs" Link="Compiler\ObjectWriter\Wasm\WasmDataSegment.cs" />
+    <Compile Include="..\..\Common\Compiler\ObjectWriter\Wasm\WasmNameSection.cs" Link="Compiler\ObjectWriter\Wasm\WasmNameSection.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\Wasm\WasmSection.cs" Link="Compiler\ObjectWriter\Wasm\WasmSection.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\Wasm\WasmSections.cs" Link="Compiler\ObjectWriter\Wasm\WasmSections.cs" />
     <Compile Include="..\..\Common\Compiler\ObjectWriter\Wasm\WebcilSection.cs" Link="Compiler\ObjectWriter\Wasm\WebcilSection.cs" />


### PR DESCRIPTION
Fixes #132905.

`WebCilObjectWriter.WriteExports` exported every defined function. At framework scale that produces a module no conforming engine will load, because exports count towards the engine's effective-type-size limit.

Measured over the full wasi-wasm framework closure (181 assemblies + corelib), with function count identical either side so the export section is the only variable:

| | functions | exports | export section | `wasm-tools validate` |
|---|---|---|---|---|
| before | 232,673 | 232,675 | 29.0 MB | ❌ `effective type size exceeds the limit of 1000000` |
| after | 232,673 | **4** | **65 bytes** | ✅ valid |

`wasmtime` rejects the "before" image identically — both use `wasmparser` underneath. The limit is reached somewhere around 160,000 exported functions, so a small composite is unaffected and only framework-sized ones fail.

## Why the exports were there, and why nothing needs them

The V0 writer exported bodies "so that the resulting module can be loaded and method bodies can be called by an external loader" (#122111). But `WriteElements()` — immediately below `WriteExports()` — already emits an element segment over all function indices, and that, not the export table, is what makes a function reachable. There was a `TODO-WASM: Handle exports better` sitting above the loop.

### Exports do not participate in call resolution

Worth stating explicitly, since it is the obvious objection:

- A direct `call` takes a **function index**, not a name, so intra-module calls are unaffected by the export table.
- A cross-module call appears as a function **import** in the calling module, resolved against the *provider's* exports. Neither a composite nor a single-assembly image has any function imports — both carry the same seven: four globals, a table, a tag, and memory. There is nothing to pair.
- Exports matter only when something outside looks a function up by name: a host at instantiation, or `wasm-merge` pairing an import to an export. The stubs that serve that purpose are kept.

Cross-module linkage is the **shared table**, not imports. Every image is instantiated against the host's single table with its own `tableBase`, its functions are installed into that slice, and a cross-assembly call resolves through an R2R fixup cell to an absolute table index dispatched by `call_indirect`. That mechanism is identical in composite and non-composite builds; only the number of modules sharing the table differs.

The one mechanism by which removing exports *could* invalidate a module is `ref.func`, which requires its target to be "declared" — via an export, a global initializer, or an element segment. That is not in play on two independent counts: these images contain no `ref.func` at all, and the element segment already declares every function regardless.

For reference, R2R wasm today emits no direct calls whatsoever. A census over decoded WAT finds 0 `call` and 202,143 `call_indirect` in a 56,790-function composite, and 0 `call` in single-assembly images as well. That is context rather than a dependency: the reasoning above holds either way.

Also verified that neither JS loader reads per-function exports (`fillWebcilTable` is `table.init` over the *element segment*), nor does `WebcilImageReader` or r2rdump.

## The catch, and the reason this is not just a deletion

crossgen2 emits no custom sections, so the export names were the **only** record of function names — `wasm-merge -g` synthesizes a merged module's name section from them. Simply dropping the exports would leave every composite frame anonymous in a debugger.

So this emits a `name` custom section instead. It is ignored by engines, counts towards no limit, and can be stripped when size matters — which is the only arrangement that gets loadable-at-scale, named, and small at the same time.

Only the stubs the host actually calls are exported now. Stub names are recorded at `InsertWasmStub`, so the export set is derived rather than hardcoded.

## Effect by image kind

| image | functions | exports | name section |
|---|---|---|---|
| composite | 52,693 | 4 | 4.8 MB |
| component stub | 3 | 5 — unchanged | 53 B |
| single-assembly | 31 | 4 | 2 KB |

Component stubs are unaffected, since all of their functions *are* stubs.

## Validation

- Reproduced the failure before fixing it, so the pass distinguishes something.
- Name section verified index-sorted, duplicate-free, contiguous over the defined-function range, no trailing bytes, by three independent parsers (`wasm-tools validate`, `wasm-tools print` resolving `$getWebcilSize`, and a standalone scanner).
- Browser end-to-end in **both composite and non-composite** modes, each against a control with R2R disabled and, for composite, a stale-stub control. R2R-active runs at 5 ms against 112–119 ms interpreted, with identical program output. A passing run alone would not have shown R2R was used — a stale stub still logs `Ready to Run initialized successfully` while running fully interpreted — so the timing separation is what carries it.
- The non-composite run is the sharpest evidence that exports are not the linkage mechanism: `System.Private.CoreLib` goes from 52,454 functions to 5 exports, and the other images still call into it. Its per-module R2R log is byte-identical to the pre-change baseline.
- `ILCompiler.ReadyToRun.Tests`: 55/0 for `TargetOS=browser`, 85/0 for the default target.

The second commit addresses review feedback: the payload was built through chained `MemoryStream`s and a final `ToArray()`, so it is now sized in one pass and streamed to the output. **The emitted bytes are unchanged** — the name section is byte-identical before and after the rewrite, confirmed by sha256 over the 28 MB framework-scale section. No memory measurement is claimed: peak RSS at framework scale is dominated by crossgen2's ~2.7 GiB compilation working set, and run-to-run spread there is wider than the effect, so RSS is the wrong instrument.

## Test change

`CheckFunctionExports` asserted that exports cover every defined function — the invariant being removed. It is replaced by a stronger one: the name section must name every defined function, and index `i` must equal `importedFunctionCount + i`.

The exact-index requirement is deliberate. Count, ordering, uniqueness and a lower bound are all *relational* properties that a uniformly shifted map satisfies, so only an absolute anchor excludes an off-by-one — which is exactly the failure mode a name section has to be trusted not to have. Confirmed by negative controls: suppressing the name section, and emitting `Index + 1`, each fail the test with a specific diagnostic.

> [!NOTE]
> This pull request description was generated by GitHub Copilot.