### PR TITLE
[release/10.0] Fix internal Helix queue selection

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -84,9 +84,11 @@ jobs:
       - OSX.15.Amd64.Open
 
     # Android
-    # Always use the Ubuntu-based Android queue for internal validation as there is no internal equivalent of
-    # the Windows.11.Amd64.Android.Open queue.
-    - ${{ if or(eq(variables['System.TeamProject'], 'internal'), in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64')) }}:
+    # Use the Ubuntu-based Android queue for x86/x64/bionic_x64 on all projects,
+    # and also for arm/arm64/bionic_arm/bionic_arm64 on non-public projects (no internal Windows Android queue).
+    - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
+      - Ubuntu.2204.Amd64.Android.29.Open
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Ubuntu.2204.Amd64.Android.29.Open
     - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Windows.11.Amd64.Android.Open


### PR DESCRIPTION
Internal builds fail with 2k~ errors in 10.0.

Restrict the Ubuntu Android queue to Android and Bionic platforms so internal validation does not run every libraries work item on an Android agent.

This was made in release/11.0 in https://github.com/dotnet/runtime/pull/125548/changes#diff-cbc8f55c9e8b4fc53ff194be8f6e99b461bbb888220a8ede2e5edb53b947b287.