### PR TITLE
Avoid shared-file races in parallel CoreCLR builds

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -299,9 +299,15 @@ set __IntermediatesEventingDir=%__ArtifactsIntermediatesDir%\Eventing\%__TargetA
 
 REM Find python and set it to the variable PYTHON
 set _C=-c "import sys; sys.stdout.write(sys.executable)"
-(py -3 %_C% || py -2 %_C% || python3 %_C% || python2 %_C% || python %_C%) > "%TEMP%\pythonlocation.txt" 2> NUL
+set __PythonLocation=
+for /f "delims=" %%i in ('py -3 %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if NOT DEFINED __PythonLocation for /f "delims=" %%i in ('py -2 %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if NOT DEFINED __PythonLocation for /f "delims=" %%i in ('python3 %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if NOT DEFINED __PythonLocation for /f "delims=" %%i in ('python2 %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if NOT DEFINED __PythonLocation for /f "delims=" %%i in ('python %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if DEFINED __PythonLocation set "PYTHON=!__PythonLocation!"
+set __PythonLocation=
 set _C=
-set /p PYTHON=<"%TEMP%\pythonlocation.txt"
 
 if NOT DEFINED PYTHON (
     echo %__ErrMsgPrefix%%__MsgPrefix%Error: Could not find a Python installation.

--- a/src/coreclr/pgosupport.cmake
+++ b/src/coreclr/pgosupport.cmake
@@ -32,24 +32,26 @@ function(add_pgo TargetName)
             set(ProfileFileName "coreclr.profdata")
         endif(CLR_CMAKE_HOST_WIN32)
 
-        file(TO_NATIVE_PATH
-            "${CLR_CMAKE_OPTDATA_PATH}/data/${ProfileFileName}"
-            ProfilePath
-        )
+        set(ProfileSourcePath "${CLR_CMAKE_OPTDATA_PATH}/data/${ProfileFileName}")
 
         # If we don't have profile data available, gracefully fall back to a non-PGO opt build
-        if(NOT EXISTS ${ProfilePath})
-            message("PGO data file NOT found: ${ProfilePath}")
+        if(NOT EXISTS "${ProfileSourcePath}")
+            message("PGO data file NOT found: ${ProfileSourcePath}")
         elseif(CMAKE_GENERATOR MATCHES "Visual Studio")
             # MSVC is sensitive to exactly the options passed during PGO optimization and Ninja and
             # MSBuild differ slightly (but not meaningfully for runtime behavior)
             message("Cannot use PGO optimization built with Ninja from MSBuild. Re-run build with Ninja to apply PGO information")
-        else(NOT EXISTS ${ProfilePath})
+        else()
             if(CLR_CMAKE_HOST_WIN32)
+                # link.exe opens PGO databases without file sharing, so use a build-local copy.
+                set(ProfilePath "${CMAKE_CURRENT_BINARY_DIR}/${ProfileFileName}")
+                configure_file("${ProfileSourcePath}" "${ProfilePath}" COPYONLY)
+                file(TO_NATIVE_PATH "${ProfilePath}" ProfilePath)
                 set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELEASE        " /LTCG /USEPROFILE:PGD=\"${ProfilePath}\"")
                 set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELWITHDEBINFO " /LTCG /USEPROFILE:PGD=\"${ProfilePath}\"")
                 add_compile_definitions(WITH_NATIVE_PGO)
             else(CLR_CMAKE_HOST_WIN32)
+                file(TO_NATIVE_PATH "${ProfileSourcePath}" ProfilePath)
                 if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELWITHDEBINFO)
                     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
                         check_have_lto_and_pgodata_supported(${ProfilePath})
@@ -64,7 +66,7 @@ function(add_pgo TargetName)
                     endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
                 endif(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELWITHDEBINFO)
             endif(CLR_CMAKE_HOST_WIN32)
-        endif(NOT EXISTS ${ProfilePath})
+        endif()
     endif(CLR_CMAKE_PGO_INSTRUMENT)
 endfunction(add_pgo)
 

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -212,9 +212,15 @@ if defined __TreeSubtree (
 
 REM Find python and set it to the variable PYTHON
 set _C=-c "import sys; sys.stdout.write(sys.executable)"
-(py -3 %_C% || py -2 %_C% || python3 %_C% || python2 %_C% || python %_C%) > %TEMP%\pythonlocation.txt 2> NUL
+set __PythonLocation=
+for /f "delims=" %%i in ('py -3 %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if NOT DEFINED __PythonLocation for /f "delims=" %%i in ('py -2 %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if NOT DEFINED __PythonLocation for /f "delims=" %%i in ('python3 %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if NOT DEFINED __PythonLocation for /f "delims=" %%i in ('python2 %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if NOT DEFINED __PythonLocation for /f "delims=" %%i in ('python %_C% 2^>NUL') do set "__PythonLocation=%%i"
+if DEFINED __PythonLocation set "PYTHON=!__PythonLocation!"
+set __PythonLocation=
 set _C=
-set /p PYTHON=<%TEMP%\pythonlocation.txt
 
 if NOT DEFINED PYTHON (
     echo %__MsgPrefix%Error: Could not find a Python installation.


### PR DESCRIPTION
When I build multiple dotnet/runtime repos on the same windows machine at the same time I quite often run into build failures.

Avoid cross-checkout file contention in Windows CoreCLR builds:
- capture Python discovery output without `%TEMP%\pythonlocation.txt`
- copy MSVC PGO databases into each build tree before linking

Validated with a Release `clr.runtime` build and two concurrent isolated Release JIT builds.

Addresses #45423 and #46018.

> [!NOTE]
> This PR description was generated by GitHub Copilot.