### PR TITLE
Preserve side effects in SIMD classification helpers

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -25772,7 +25772,7 @@ GenTree* Compiler::gtNewSimdIsFiniteNode(var_types type, GenTree* op1, var_types
     }
 
     assert(varTypeIsIntegral(simdBaseType));
-    return gtNewAllBitsSetConNode(type);
+    return gtWrapWithSideEffects(gtNewAllBitsSetConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -25802,7 +25802,7 @@ GenTree* Compiler::gtNewSimdIsInfinityNode(var_types type, GenTree* op1, var_typ
         op1 = gtNewSimdAbsNode(type, op1, simdBaseType, simdSize);
         return gtNewSimdIsPositiveInfinityNode(type, op1, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -25841,7 +25841,7 @@ GenTree* Compiler::gtNewSimdIsIntegerNode(var_types type, GenTree* op1, var_type
     }
 
     assert(varTypeIsIntegral(simdBaseType));
-    return gtNewAllBitsSetConNode(type);
+    return gtWrapWithSideEffects(gtNewAllBitsSetConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -25871,7 +25871,7 @@ GenTree* Compiler::gtNewSimdIsNaNNode(var_types type, GenTree* op1, var_types si
         GenTree* op1Dup = fgMakeMultiUse(&op1);
         return gtNewSimdCmpOpNode(GT_NE, type, op1, op1Dup, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -25907,7 +25907,7 @@ GenTree* Compiler::gtNewSimdIsNegativeNode(var_types type, GenTree* op1, var_typ
 
     if (varTypeIsUnsigned(simdBaseType))
     {
-        return gtNewZeroConNode(type);
+        return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
     }
     return gtNewSimdCmpOpNode(GT_LT, type, op1, gtNewZeroConNode(type), simdBaseType, simdSize);
 }
@@ -25957,7 +25957,7 @@ GenTree* Compiler::gtNewSimdIsNegativeInfinityNode(var_types type,
 
         return gtNewSimdCmpOpNode(GT_EQ, type, op1, cnsNode, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -26076,7 +26076,7 @@ GenTree* Compiler::gtNewSimdIsPositiveNode(var_types type, GenTree* op1, var_typ
 
     if (varTypeIsUnsigned(simdBaseType))
     {
-        return gtNewAllBitsSetConNode(type);
+        return gtWrapWithSideEffects(gtNewAllBitsSetConNode(type), op1, GTF_ALL_EFFECT);
     }
     return gtNewSimdCmpOpNode(GT_GE, type, op1, gtNewZeroConNode(type), simdBaseType, simdSize);
 }
@@ -26126,7 +26126,7 @@ GenTree* Compiler::gtNewSimdIsPositiveInfinityNode(var_types type,
 
         return gtNewSimdCmpOpNode(GT_EQ, type, op1, cnsNode, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -26180,7 +26180,7 @@ GenTree* Compiler::gtNewSimdIsSubnormalNode(var_types type, GenTree* op1, var_ty
 
         return gtNewSimdCmpOpNode(GT_LT, type, op1, cnsNode2, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/src/tests/JIT/Regression/JitBlue/Runtime_132902/Runtime_132902.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_132902/Runtime_132902.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+namespace Runtime_132902;
+
+public class Runtime_132902
+{
+    public enum Classification
+    {
+        IsFinite,
+        IsInfinity,
+        IsInteger,
+        IsNaN,
+        IsNegative,
+        IsNegativeInfinity,
+        IsPositive,
+        IsPositiveInfinity,
+        IsSubnormal,
+    }
+
+    [Theory]
+    [InlineData(Classification.IsFinite)]
+    [InlineData(Classification.IsInfinity)]
+    [InlineData(Classification.IsInteger)]
+    [InlineData(Classification.IsNaN)]
+    [InlineData(Classification.IsNegative)]
+    [InlineData(Classification.IsNegativeInfinity)]
+    [InlineData(Classification.IsPositive)]
+    [InlineData(Classification.IsPositiveInfinity)]
+    [InlineData(Classification.IsSubnormal)]
+    public static void TestEntryPoint(Classification classification)
+    {
+        Action action = classification switch
+        {
+            Classification.IsFinite => () => IsFinite(Vector128<int>.Count),
+            Classification.IsInfinity => () => IsInfinity(Vector128<int>.Count),
+            Classification.IsInteger => () => IsInteger(Vector128<int>.Count),
+            Classification.IsNaN => () => IsNaN(Vector128<int>.Count),
+            Classification.IsNegative => () => IsNegative(Vector128<uint>.Count),
+            Classification.IsNegativeInfinity => () => IsNegativeInfinity(Vector128<int>.Count),
+            Classification.IsPositive => () => IsPositive(Vector128<uint>.Count),
+            Classification.IsPositiveInfinity => () => IsPositiveInfinity(Vector128<int>.Count),
+            Classification.IsSubnormal => () => IsSubnormal(Vector128<int>.Count),
+            _ => throw new ArgumentOutOfRangeException(nameof(classification)),
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(action);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsFinite(int index) =>
+        Vector128.IsFinite(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsInfinity(int index) =>
+        Vector128.IsInfinity(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsInteger(int index) =>
+        Vector128.IsInteger(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsNaN(int index) =>
+        Vector128.IsNaN(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<uint> IsNegative(int index) =>
+        Vector128.IsNegative(Vector128.WithElement(Vector128<uint>.Zero, index, 0u));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsNegativeInfinity(int index) =>
+        Vector128.IsNegativeInfinity(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<uint> IsPositive(int index) =>
+        Vector128.IsPositive(Vector128.WithElement(Vector128<uint>.Zero, index, 0u));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsPositiveInfinity(int index) =>
+        Vector128.IsPositiveInfinity(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsSubnormal(int index) =>
+        Vector128.IsSubnormal(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -133,6 +133,7 @@
     <Compile Include="JitBlue\Runtime_132243\Runtime_132243.cs" />
     <Compile Include="JitBlue\Runtime_132784\Runtime_132784.cs" />
     <Compile Include="JitBlue\Runtime_132785\Runtime_132785.cs" />
+    <Compile Include="JitBlue\Runtime_132902\Runtime_132902.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Fixes #132902

SIMD classification helpers that produce constant results now preserve side effects from their operands. This covers all nine affected classification operations rather than only the reported `IsInfinity` case.

Adds regression coverage using an exception-bearing `Vector128.WithElement` operand, which exercises the shared x64 and WASM import shape.

> [!NOTE]
> This pull request was created with GitHub Copilot.