### PR TITLE
Avoid boxing NativeAOT dependency enumerators

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNode.cs
@@ -55,6 +55,18 @@ namespace ILCompiler.DependencyAnalysis
 
         public sealed override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
+            DependencyList dependencies = GetStaticDependencyList(factory);
+            return dependencies is not null ? dependencies : Array.Empty<DependencyListEntry>();
+        }
+
+        internal sealed override bool TryGetStaticDependencyList(NodeFactory factory, out DependencyList dependencies)
+        {
+            dependencies = GetStaticDependencyList(factory);
+            return true;
+        }
+
+        private DependencyList GetStaticDependencyList(NodeFactory factory)
+        {
             DependencyList dependencies = ComputeNonRelocationBasedDependencies(factory);
             Relocation[] relocs = GetData(factory, true).Relocs;
 
@@ -76,10 +88,7 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies.Add(wasmTypeNode, "Wasm Method Code Nodes Require Signature");
             }
 
-            if (dependencies == null)
-                return Array.Empty<DependencyListEntry>();
-            else
-                return dependencies;
+            return dependencies;
         }
 
         protected virtual DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -62,6 +62,17 @@ namespace ILCompiler.DependencyAnalysis
 #if !READYTORUN
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
+            return GetStaticDependencyList(factory);
+        }
+
+        internal override bool TryGetStaticDependencyList(NodeFactory factory, out DependencyList dependencies)
+        {
+            dependencies = GetStaticDependencyList(factory);
+            return true;
+        }
+
+        private DependencyList GetStaticDependencyList(NodeFactory factory)
+        {
             DependencyList dependencies = new DependencyList();
 
             MethodDesc canonDecl = _decl.GetCanonMethodTarget(CanonicalFormKind.Specific);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/DependencyAnalyzerTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/DependencyAnalyzerTests.cs
@@ -74,10 +74,8 @@ namespace ILCompiler.Compiler.Tests
         {
             TestNode[] dependencyNodes = CreateNodes("dependency", count);
             DependencyListEntry[] entries = CreateStaticEntries(dependencyNodes);
-            var root = new TestNode("root")
-            {
-                StaticDependencies = CreateStaticDependencies(collectionKind, entries),
-            };
+            var root = new TestNode("root");
+            SetStaticDependencies(root, collectionKind, entries);
             DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
 
             analyzer.AddRoot(root, "root");
@@ -87,6 +85,7 @@ namespace ILCompiler.Compiler.Tests
             expected[0] = root;
             CopyExpectedNodes(expected, 1, dependencyNodes, collectionKind);
             Assert.Equal(expected, analyzer.MarkedNodeList);
+            Assert.Equal(collectionKind == DependencyCollectionKind.DependencyList ? 0 : 1, root.StaticEnumerableAccessCount);
         }
 
         [Theory]
@@ -96,10 +95,8 @@ namespace ILCompiler.Compiler.Tests
             var condition = new TestNode("condition");
             TestNode[] dependencyNodes = CreateNodes("dependency", count);
             CombinedDependencyListEntry[] entries = CreateConditionalEntries(dependencyNodes, condition);
-            var root = new TestNode("root")
-            {
-                ConditionalDependencies = CreateConditionalDependencies(collectionKind, entries),
-            };
+            var root = new TestNode("root");
+            SetConditionalDependencies(root, collectionKind, entries);
             DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
 
             analyzer.AddRoot(condition, "condition");
@@ -111,6 +108,7 @@ namespace ILCompiler.Compiler.Tests
             expected[1] = root;
             CopyExpectedNodes(expected, 2, dependencyNodes, collectionKind);
             Assert.Equal(expected, analyzer.MarkedNodeList);
+            Assert.Equal(collectionKind == DependencyCollectionKind.List ? 0 : 1, root.ConditionalEnumerableAccessCount);
         }
 
         [Theory]
@@ -122,10 +120,8 @@ namespace ILCompiler.Compiler.Tests
             [
                 new CombinedDependencyListEntry(dependency, null, "unconditional"),
             ];
-            var root = new TestNode("root")
-            {
-                ConditionalDependencies = CreateConditionalDependencies(collectionKind, entries),
-            };
+            var root = new TestNode("root");
+            SetConditionalDependencies(root, collectionKind, entries);
             DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
 
             analyzer.AddRoot(root, "root");
@@ -140,22 +136,20 @@ namespace ILCompiler.Compiler.Tests
         {
             var condition = new TestNode("condition");
             TestNode[] dependencyNodes = CreateNodes("dependency", count);
-            var conditionProvider = new TestNode("condition provider")
-            {
-                StaticDependencies =
+            var conditionProvider = new TestNode("condition provider");
+            conditionProvider.SetStaticDependencies(
+                (IEnumerable<DependencyListEntry>)
                 [
                     new DependencyListEntry(condition, "condition"),
-                ],
-            };
+                ]);
             CombinedDependencyListEntry[] entries = CreateConditionalEntries(dependencyNodes, condition);
-            var root = new TestNode("root")
-            {
-                StaticDependencies =
+            var root = new TestNode("root");
+            root.SetStaticDependencies(
+                (IEnumerable<DependencyListEntry>)
                 [
                     new DependencyListEntry(conditionProvider, "condition provider"),
-                ],
-                ConditionalDependencies = CreateConditionalDependencies(collectionKind, entries),
-            };
+                ]);
+            SetConditionalDependencies(root, collectionKind, entries);
             DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
 
             analyzer.AddRoot(root, "root");
@@ -184,10 +178,15 @@ namespace ILCompiler.Compiler.Tests
                 "dependency",
                 () => dependencies.Add(new DependencyListEntry(addedDependency, "added dependency")));
             dependencies.Add(new DependencyListEntry(dependency, "dependency"));
-            var root = new TestNode("root")
+            var root = new TestNode("root");
+            if (dependencies is DependencyList dependencyList)
             {
-                StaticDependencies = dependencies,
-            };
+                root.SetStaticDependencies(dependencyList);
+            }
+            else
+            {
+                root.SetStaticDependencies((IEnumerable<DependencyListEntry>)dependencies);
+            }
             DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
             analyzer.AddRoot(root, "root");
 
@@ -204,15 +203,29 @@ namespace ILCompiler.Compiler.Tests
                 "dependency",
                 () => dependencies.Add(new CombinedDependencyListEntry(addedDependency, condition, "added dependency")));
             dependencies.Add(new CombinedDependencyListEntry(dependency, condition, "dependency"));
-            var root = new TestNode("root")
-            {
-                ConditionalDependencies = dependencies,
-            };
+            var root = new TestNode("root");
+            root.SetConditionalDependencies(dependencies);
             DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
             analyzer.AddRoot(condition, "condition");
             analyzer.AddRoot(root, "root");
 
             Assert.Throws<InvalidOperationException>(analyzer.ComputeMarkedNodes);
+        }
+
+        [Fact]
+        public void NullConcreteDependencyListsDoNotUseEnumerableFallback()
+        {
+            var root = new TestNode("root");
+            root.SetNullStaticDependencyList();
+            root.SetNullConditionalDependencyList();
+            DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
+
+            analyzer.AddRoot(root, "root");
+            analyzer.ComputeMarkedNodes();
+
+            Assert.Equal(new DependencyNodeCore<object>[] { root }, analyzer.MarkedNodeList);
+            Assert.Equal(0, root.StaticEnumerableAccessCount);
+            Assert.Equal(0, root.ConditionalEnumerableAccessCount);
         }
 
         private static DependencyAnalyzer<NoLogStrategy<object>, object> CreateAnalyzer()
@@ -282,6 +295,21 @@ namespace ILCompiler.Compiler.Tests
             };
         }
 
+        private static void SetStaticDependencies(
+            TestNode node,
+            DependencyCollectionKind collectionKind,
+            DependencyListEntry[] entries)
+        {
+            if (collectionKind == DependencyCollectionKind.DependencyList)
+            {
+                node.SetStaticDependencies(new DependencyList(entries));
+            }
+            else
+            {
+                node.SetStaticDependencies(CreateStaticDependencies(collectionKind, entries));
+            }
+        }
+
         private static IEnumerable<CombinedDependencyListEntry> CreateConditionalDependencies(
             DependencyCollectionKind collectionKind,
             CombinedDependencyListEntry[] entries)
@@ -294,6 +322,21 @@ namespace ILCompiler.Compiler.Tests
                 DependencyCollectionKind.ReimplementedList => new ReimplementedEnumerableList<CombinedDependencyListEntry>(entries),
                 _ => throw new UnreachableException(),
             };
+        }
+
+        private static void SetConditionalDependencies(
+            TestNode node,
+            DependencyCollectionKind collectionKind,
+            CombinedDependencyListEntry[] entries)
+        {
+            if (collectionKind == DependencyCollectionKind.List)
+            {
+                node.SetConditionalDependencies(new List<CombinedDependencyListEntry>(entries));
+            }
+            else
+            {
+                node.SetConditionalDependencies(CreateConditionalDependencies(collectionKind, entries));
+            }
         }
 
         private static IEnumerable<T> Enumerate<T>(T[] items)
@@ -351,6 +394,16 @@ namespace ILCompiler.Compiler.Tests
         {
             private readonly string _name;
             private readonly Action _onMarked;
+            private IEnumerable<DependencyListEntry> _staticDependencies = Array.Empty<DependencyListEntry>();
+            private IEnumerable<CombinedDependencyListEntry> _conditionalDependencies;
+            private DependencyList _staticDependencyList;
+            private List<CombinedDependencyListEntry> _conditionalDependencyList;
+            private bool _providesStaticDependencyList;
+            private bool _providesConditionalDependencyList;
+
+            public int StaticEnumerableAccessCount { get; private set; }
+
+            public int ConditionalEnumerableAccessCount { get; private set; }
 
             public TestNode(string name, Action onMarked = null)
             {
@@ -358,26 +411,73 @@ namespace ILCompiler.Compiler.Tests
                 _onMarked = onMarked;
             }
 
-            public IEnumerable<DependencyListEntry> StaticDependencies { get; set; } = Array.Empty<DependencyListEntry>();
-
-            public IEnumerable<CombinedDependencyListEntry> ConditionalDependencies { get; set; }
-
             public override bool InterestingForDynamicDependencyAnalysis => false;
 
             public override bool HasDynamicDependencies => false;
 
-            public override bool HasConditionalStaticDependencies => ConditionalDependencies is not null;
+            public override bool HasConditionalStaticDependencies =>
+                _providesConditionalDependencyList || _conditionalDependencies is not null;
 
             public override bool StaticDependenciesAreComputed => true;
 
+            public void SetStaticDependencies(IEnumerable<DependencyListEntry> dependencies)
+            {
+                _staticDependencies = dependencies;
+            }
+
+            public void SetStaticDependencies(DependencyList dependencies)
+            {
+                _staticDependencies = dependencies;
+                _staticDependencyList = dependencies;
+                _providesStaticDependencyList = true;
+            }
+
+            public void SetConditionalDependencies(IEnumerable<CombinedDependencyListEntry> dependencies)
+            {
+                _conditionalDependencies = dependencies;
+            }
+
+            public void SetConditionalDependencies(List<CombinedDependencyListEntry> dependencies)
+            {
+                _conditionalDependencies = dependencies;
+                _conditionalDependencyList = dependencies;
+                _providesConditionalDependencyList = true;
+            }
+
+            public void SetNullStaticDependencyList()
+            {
+                _providesStaticDependencyList = true;
+            }
+
+            public void SetNullConditionalDependencyList()
+            {
+                _providesConditionalDependencyList = true;
+            }
+
             public override IEnumerable<DependencyListEntry> GetStaticDependencies(object context)
             {
-                return StaticDependencies;
+                StaticEnumerableAccessCount++;
+                return _staticDependencies;
             }
 
             public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(object context)
             {
-                return ConditionalDependencies;
+                ConditionalEnumerableAccessCount++;
+                return _conditionalDependencies;
+            }
+
+            internal override bool TryGetStaticDependencyList(object context, out DependencyList dependencies)
+            {
+                dependencies = _staticDependencyList;
+                return _providesStaticDependencyList;
+            }
+
+            internal override bool TryGetConditionalStaticDependencyList(
+                object context,
+                out List<CombinedDependencyListEntry> dependencies)
+            {
+                dependencies = _conditionalDependencyList;
+                return _providesConditionalDependencyList;
             }
 
             public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/DependencyAnalyzerTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/DependencyAnalyzerTests.cs
@@ -1,0 +1,402 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Xunit;
+
+using CombinedDependencyListEntry = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<object>.CombinedDependencyListEntry;
+using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<object>.DependencyList;
+using DependencyListEntry = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<object>.DependencyListEntry;
+
+namespace ILCompiler.Compiler.Tests
+{
+    public class DependencyAnalyzerTests
+    {
+        public enum DependencyCollectionKind
+        {
+            Array,
+            DependencyList,
+            Enumerable,
+            List,
+            ReimplementedList,
+        }
+
+        public static IEnumerable<object[]> StaticDependencyData()
+        {
+            DependencyCollectionKind[] collectionKinds =
+            [
+                DependencyCollectionKind.Array,
+                DependencyCollectionKind.DependencyList,
+                DependencyCollectionKind.Enumerable,
+                DependencyCollectionKind.List,
+                DependencyCollectionKind.ReimplementedList,
+            ];
+
+            return CreateDependencyData(collectionKinds);
+        }
+
+        public static IEnumerable<object[]> ConditionalDependencyData()
+        {
+            DependencyCollectionKind[] collectionKinds =
+            [
+                DependencyCollectionKind.Array,
+                DependencyCollectionKind.Enumerable,
+                DependencyCollectionKind.List,
+                DependencyCollectionKind.ReimplementedList,
+            ];
+
+            return CreateDependencyData(collectionKinds);
+        }
+
+        public static IEnumerable<object[]> ConditionalDependencyCollectionKinds()
+        {
+            yield return new object[] { DependencyCollectionKind.Array };
+            yield return new object[] { DependencyCollectionKind.Enumerable };
+            yield return new object[] { DependencyCollectionKind.List };
+            yield return new object[] { DependencyCollectionKind.ReimplementedList };
+        }
+
+        public static IEnumerable<object[]> MutableStaticDependencyLists()
+        {
+            yield return new object[] { DependencyCollectionKind.DependencyList };
+            yield return new object[] { DependencyCollectionKind.List };
+        }
+
+        [Theory]
+        [MemberData(nameof(StaticDependencyData))]
+        public void StaticDependenciesPreserveOrder(DependencyCollectionKind collectionKind, int count)
+        {
+            TestNode[] dependencyNodes = CreateNodes("dependency", count);
+            DependencyListEntry[] entries = CreateStaticEntries(dependencyNodes);
+            var root = new TestNode("root")
+            {
+                StaticDependencies = CreateStaticDependencies(collectionKind, entries),
+            };
+            DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
+
+            analyzer.AddRoot(root, "root");
+            analyzer.ComputeMarkedNodes();
+
+            DependencyNodeCore<object>[] expected = new DependencyNodeCore<object>[count + 1];
+            expected[0] = root;
+            CopyExpectedNodes(expected, 1, dependencyNodes, collectionKind);
+            Assert.Equal(expected, analyzer.MarkedNodeList);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConditionalDependencyData))]
+        public void ConditionalDependenciesPreserveOrder(DependencyCollectionKind collectionKind, int count)
+        {
+            var condition = new TestNode("condition");
+            TestNode[] dependencyNodes = CreateNodes("dependency", count);
+            CombinedDependencyListEntry[] entries = CreateConditionalEntries(dependencyNodes, condition);
+            var root = new TestNode("root")
+            {
+                ConditionalDependencies = CreateConditionalDependencies(collectionKind, entries),
+            };
+            DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
+
+            analyzer.AddRoot(condition, "condition");
+            analyzer.AddRoot(root, "root");
+            analyzer.ComputeMarkedNodes();
+
+            DependencyNodeCore<object>[] expected = new DependencyNodeCore<object>[count + 2];
+            expected[0] = condition;
+            expected[1] = root;
+            CopyExpectedNodes(expected, 2, dependencyNodes, collectionKind);
+            Assert.Equal(expected, analyzer.MarkedNodeList);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConditionalDependencyCollectionKinds))]
+        public void NullConditionalDependencyIsUnconditional(DependencyCollectionKind collectionKind)
+        {
+            var dependency = new TestNode("dependency");
+            CombinedDependencyListEntry[] entries =
+            [
+                new CombinedDependencyListEntry(dependency, null, "unconditional"),
+            ];
+            var root = new TestNode("root")
+            {
+                ConditionalDependencies = CreateConditionalDependencies(collectionKind, entries),
+            };
+            DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
+
+            analyzer.AddRoot(root, "root");
+            analyzer.ComputeMarkedNodes();
+
+            Assert.Equal(new DependencyNodeCore<object>[] { root, dependency }, analyzer.MarkedNodeList);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConditionalDependencyData))]
+        public void ConditionalDependenciesAreMarkedWhenConditionAppears(DependencyCollectionKind collectionKind, int count)
+        {
+            var condition = new TestNode("condition");
+            TestNode[] dependencyNodes = CreateNodes("dependency", count);
+            var conditionProvider = new TestNode("condition provider")
+            {
+                StaticDependencies =
+                [
+                    new DependencyListEntry(condition, "condition"),
+                ],
+            };
+            CombinedDependencyListEntry[] entries = CreateConditionalEntries(dependencyNodes, condition);
+            var root = new TestNode("root")
+            {
+                StaticDependencies =
+                [
+                    new DependencyListEntry(conditionProvider, "condition provider"),
+                ],
+                ConditionalDependencies = CreateConditionalDependencies(collectionKind, entries),
+            };
+            DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
+
+            analyzer.AddRoot(root, "root");
+            analyzer.ComputeMarkedNodes();
+
+            DependencyNodeCore<object>[] expected = new DependencyNodeCore<object>[count + 3];
+            expected[0] = root;
+            expected[1] = conditionProvider;
+            expected[2] = condition;
+            CopyExpectedNodes(expected, 3, dependencyNodes, collectionKind);
+            Assert.Equal(expected, analyzer.MarkedNodeList);
+        }
+
+        [Theory]
+        [MemberData(nameof(MutableStaticDependencyLists))]
+        public void StaticDependencyListMutationIsDetected(DependencyCollectionKind collectionKind)
+        {
+            List<DependencyListEntry> dependencies = collectionKind switch
+            {
+                DependencyCollectionKind.DependencyList => new DependencyList(),
+                DependencyCollectionKind.List => new List<DependencyListEntry>(),
+                _ => throw new UnreachableException(),
+            };
+            var addedDependency = new TestNode("added dependency");
+            var dependency = new TestNode(
+                "dependency",
+                () => dependencies.Add(new DependencyListEntry(addedDependency, "added dependency")));
+            dependencies.Add(new DependencyListEntry(dependency, "dependency"));
+            var root = new TestNode("root")
+            {
+                StaticDependencies = dependencies,
+            };
+            DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
+            analyzer.AddRoot(root, "root");
+
+            Assert.Throws<InvalidOperationException>(analyzer.ComputeMarkedNodes);
+        }
+
+        [Fact]
+        public void ConditionalDependencyListMutationIsDetected()
+        {
+            var condition = new TestNode("condition");
+            var addedDependency = new TestNode("added dependency");
+            var dependencies = new List<CombinedDependencyListEntry>();
+            var dependency = new TestNode(
+                "dependency",
+                () => dependencies.Add(new CombinedDependencyListEntry(addedDependency, condition, "added dependency")));
+            dependencies.Add(new CombinedDependencyListEntry(dependency, condition, "dependency"));
+            var root = new TestNode("root")
+            {
+                ConditionalDependencies = dependencies,
+            };
+            DependencyAnalyzer<NoLogStrategy<object>, object> analyzer = CreateAnalyzer();
+            analyzer.AddRoot(condition, "condition");
+            analyzer.AddRoot(root, "root");
+
+            Assert.Throws<InvalidOperationException>(analyzer.ComputeMarkedNodes);
+        }
+
+        private static DependencyAnalyzer<NoLogStrategy<object>, object> CreateAnalyzer()
+        {
+            return new DependencyAnalyzer<NoLogStrategy<object>, object>(new object(), resultSorter: null);
+        }
+
+        private static IEnumerable<object[]> CreateDependencyData(DependencyCollectionKind[] collectionKinds)
+        {
+            int[] counts = [0, 1, 3];
+            foreach (DependencyCollectionKind collectionKind in collectionKinds)
+            {
+                foreach (int count in counts)
+                {
+                    yield return new object[] { collectionKind, count };
+                }
+            }
+        }
+
+        private static TestNode[] CreateNodes(string namePrefix, int count)
+        {
+            var nodes = new TestNode[count];
+            for (int i = 0; i < nodes.Length; i++)
+            {
+                nodes[i] = new TestNode($"{namePrefix} {i}");
+            }
+
+            return nodes;
+        }
+
+        private static DependencyListEntry[] CreateStaticEntries(TestNode[] dependencyNodes)
+        {
+            var entries = new DependencyListEntry[dependencyNodes.Length];
+            for (int i = 0; i < entries.Length; i++)
+            {
+                entries[i] = new DependencyListEntry(dependencyNodes[i], $"dependency {i}");
+            }
+
+            return entries;
+        }
+
+        private static CombinedDependencyListEntry[] CreateConditionalEntries(
+            TestNode[] dependencyNodes,
+            TestNode condition)
+        {
+            var entries = new CombinedDependencyListEntry[dependencyNodes.Length];
+            for (int i = 0; i < entries.Length; i++)
+            {
+                entries[i] = new CombinedDependencyListEntry(dependencyNodes[i], condition, $"dependency {i}");
+            }
+
+            return entries;
+        }
+
+        private static IEnumerable<DependencyListEntry> CreateStaticDependencies(
+            DependencyCollectionKind collectionKind,
+            DependencyListEntry[] entries)
+        {
+            return collectionKind switch
+            {
+                DependencyCollectionKind.Array => entries,
+                DependencyCollectionKind.DependencyList => new DependencyList(entries),
+                DependencyCollectionKind.Enumerable => Enumerate(entries),
+                DependencyCollectionKind.List => new List<DependencyListEntry>(entries),
+                DependencyCollectionKind.ReimplementedList => new ReimplementedEnumerableList<DependencyListEntry>(entries),
+                _ => throw new UnreachableException(),
+            };
+        }
+
+        private static IEnumerable<CombinedDependencyListEntry> CreateConditionalDependencies(
+            DependencyCollectionKind collectionKind,
+            CombinedDependencyListEntry[] entries)
+        {
+            return collectionKind switch
+            {
+                DependencyCollectionKind.Array => entries,
+                DependencyCollectionKind.Enumerable => Enumerate(entries),
+                DependencyCollectionKind.List => new List<CombinedDependencyListEntry>(entries),
+                DependencyCollectionKind.ReimplementedList => new ReimplementedEnumerableList<CombinedDependencyListEntry>(entries),
+                _ => throw new UnreachableException(),
+            };
+        }
+
+        private static IEnumerable<T> Enumerate<T>(T[] items)
+        {
+            foreach (T item in items)
+            {
+                yield return item;
+            }
+        }
+
+        private static void CopyExpectedNodes(
+            DependencyNodeCore<object>[] destination,
+            int destinationIndex,
+            TestNode[] nodes,
+            DependencyCollectionKind collectionKind)
+        {
+            if (collectionKind == DependencyCollectionKind.ReimplementedList)
+            {
+                for (int i = nodes.Length - 1; i >= 0; i--)
+                {
+                    destination[destinationIndex++] = nodes[i];
+                }
+            }
+            else
+            {
+                for (int i = 0; i < nodes.Length; i++)
+                {
+                    destination[destinationIndex++] = nodes[i];
+                }
+            }
+        }
+
+        private sealed class ReimplementedEnumerableList<T> : List<T>, IEnumerable<T>, IEnumerable
+        {
+            public ReimplementedEnumerableList(IEnumerable<T> items)
+                : base(items)
+            {
+            }
+
+            IEnumerator<T> IEnumerable<T>.GetEnumerator()
+            {
+                for (int i = Count - 1; i >= 0; i--)
+                {
+                    yield return this[i];
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return ((IEnumerable<T>)this).GetEnumerator();
+            }
+        }
+
+        private sealed class TestNode : DependencyNodeCore<object>
+        {
+            private readonly string _name;
+            private readonly Action _onMarked;
+
+            public TestNode(string name, Action onMarked = null)
+            {
+                _name = name;
+                _onMarked = onMarked;
+            }
+
+            public IEnumerable<DependencyListEntry> StaticDependencies { get; set; } = Array.Empty<DependencyListEntry>();
+
+            public IEnumerable<CombinedDependencyListEntry> ConditionalDependencies { get; set; }
+
+            public override bool InterestingForDynamicDependencyAnalysis => false;
+
+            public override bool HasDynamicDependencies => false;
+
+            public override bool HasConditionalStaticDependencies => ConditionalDependencies is not null;
+
+            public override bool StaticDependenciesAreComputed => true;
+
+            public override IEnumerable<DependencyListEntry> GetStaticDependencies(object context)
+            {
+                return StaticDependencies;
+            }
+
+            public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(object context)
+            {
+                return ConditionalDependencies;
+            }
+
+            public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
+                List<DependencyNodeCore<object>> markedNodes,
+                int firstNode,
+                object context)
+            {
+                return Array.Empty<CombinedDependencyListEntry>();
+            }
+
+            protected override void OnMarked(object context)
+            {
+                _onMarked?.Invoke();
+            }
+
+            protected override string GetName(object context)
+            {
+                return _name;
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="DependencyAnalyzerTests.cs" />
     <Compile Include="DependencyGraphTests.cs" />
     <Compile Include="DevirtualizationTests.cs" />
     <Compile Include="SwiftLoweringTests.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -314,6 +314,19 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
+            return GetConditionalStaticDependencyList(factory);
+        }
+
+        internal override bool TryGetConditionalStaticDependencyList(
+            NodeFactory factory,
+            out List<CombinedDependencyListEntry> dependencies)
+        {
+            dependencies = GetConditionalStaticDependencyList(factory);
+            return true;
+        }
+
+        private List<CombinedDependencyListEntry> GetConditionalStaticDependencyList(NodeFactory factory)
+        {
             List<CombinedDependencyListEntry> result = new List<CombinedDependencyListEntry>();
 
             if (IsReflectionVisible)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ScannedMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ScannedMethodNode.cs
@@ -82,7 +82,22 @@ namespace ILCompiler.DependencyAnalysis
             return _dependencies;
         }
 
+        internal override bool TryGetStaticDependencyList(NodeFactory factory, out DependencyList dependencies)
+        {
+            Debug.Assert(_dependencies != null);
+            dependencies = _dependencies;
+            return true;
+        }
+
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => _conditionalDependencies;
+
+        internal override bool TryGetConditionalStaticDependencyList(
+            NodeFactory factory,
+            out List<CombinedDependencyListEntry> dependencies)
+        {
+            dependencies = _conditionalDependencies;
+            return true;
+        }
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
@@ -183,34 +183,81 @@ namespace ILCompiler.DependencyAnalysisFramework
             IEnumerable<DependencyNodeCore<DependencyContextType>.DependencyListEntry> staticDependencies = node.GetStaticDependencies(_dependencyContext);
             if (staticDependencies != null)
             {
-                foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in staticDependencies)
+                // Preserve custom enumeration behavior on List<T> subclasses by only fast-pathing known exact types.
+                if (staticDependencies is List<DependencyNodeCore<DependencyContextType>.DependencyListEntry> dependencyList &&
+                    (dependencyList.GetType() == typeof(DependencyNodeCore<DependencyContextType>.DependencyList) ||
+                     dependencyList.GetType() == typeof(List<DependencyNodeCore<DependencyContextType>.DependencyListEntry>)))
                 {
-                    AddToMarkStack(dependency.Node, dependency.Reason, node, null);
+                    foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in dependencyList)
+                    {
+                        AddToMarkStack(dependency.Node, dependency.Reason, node, null);
+                    }
+                }
+                else if (staticDependencies is DependencyNodeCore<DependencyContextType>.DependencyListEntry[] dependencyArray)
+                {
+                    foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in dependencyArray)
+                    {
+                        AddToMarkStack(dependency.Node, dependency.Reason, node, null);
+                    }
+                }
+                else
+                {
+                    foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in staticDependencies)
+                    {
+                        AddToMarkStack(dependency.Node, dependency.Reason, node, null);
+                    }
                 }
             }
 
             if (node.HasConditionalStaticDependencies)
             {
-                foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in node.GetConditionalStaticDependencies(_dependencyContext))
+                IEnumerable<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> conditionalDependencies =
+                    node.GetConditionalStaticDependencies(_dependencyContext);
+                if (conditionalDependencies is List<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> dependencyList &&
+                    conditionalDependencies.GetType() == typeof(List<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry>))
                 {
-                    if (dependency.OtherReasonNode is null || dependency.OtherReasonNode.Marked)
+                    foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in dependencyList)
                     {
-                        AddToMarkStack(dependency.Node, dependency.Reason, node, dependency.OtherReasonNode);
-                    }
-                    else
-                    {
-                        HashSet<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> storedDependencySet;
-                        if (!_conditional_dependency_store.TryGetValue(dependency.OtherReasonNode, out storedDependencySet))
-                        {
-                            storedDependencySet = new HashSet<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry>();
-                            _conditional_dependency_store.Add(dependency.OtherReasonNode, storedDependencySet);
-                        }
-                        // Swap out other reason node as we're storing that as the dictionary key
-                        DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry conditionalDependencyStoreEntry =
-                            new DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry(dependency.Node, node, dependency.Reason);
-                        storedDependencySet.Add(conditionalDependencyStoreEntry);
+                        ProcessConditionalDependency(node, dependency);
                     }
                 }
+                else if (conditionalDependencies is DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry[] dependencyArray)
+                {
+                    foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in dependencyArray)
+                    {
+                        ProcessConditionalDependency(node, dependency);
+                    }
+                }
+                else
+                {
+                    foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in conditionalDependencies)
+                    {
+                        ProcessConditionalDependency(node, dependency);
+                    }
+                }
+            }
+        }
+
+        private void ProcessConditionalDependency(
+            DependencyNodeCore<DependencyContextType> node,
+            in DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency)
+        {
+            if (dependency.OtherReasonNode is null || dependency.OtherReasonNode.Marked)
+            {
+                AddToMarkStack(dependency.Node, dependency.Reason, node, dependency.OtherReasonNode);
+            }
+            else
+            {
+                HashSet<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> storedDependencySet;
+                if (!_conditional_dependency_store.TryGetValue(dependency.OtherReasonNode, out storedDependencySet))
+                {
+                    storedDependencySet = new HashSet<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry>();
+                    _conditional_dependency_store.Add(dependency.OtherReasonNode, storedDependencySet);
+                }
+                // Swap out other reason node as we're storing that as the dictionary key
+                DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry conditionalDependencyStoreEntry =
+                    new DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry(dependency.Node, node, dependency.Reason);
+                storedDependencySet.Add(conditionalDependencyStoreEntry);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
@@ -180,29 +180,23 @@ namespace ILCompiler.DependencyAnalysisFramework
         // Internal details
         private void GetStaticDependenciesImpl(DependencyNodeCore<DependencyContextType> node)
         {
-            IEnumerable<DependencyNodeCore<DependencyContextType>.DependencyListEntry> staticDependencies = node.GetStaticDependencies(_dependencyContext);
-            if (staticDependencies != null)
+            if (node.TryGetStaticDependencyList(_dependencyContext, out DependencyNodeCore<DependencyContextType>.DependencyList staticDependencies))
             {
-                // Preserve custom enumeration behavior on List<T> subclasses by only fast-pathing known exact types.
-                if (staticDependencies is List<DependencyNodeCore<DependencyContextType>.DependencyListEntry> dependencyList &&
-                    (dependencyList.GetType() == typeof(DependencyNodeCore<DependencyContextType>.DependencyList) ||
-                     dependencyList.GetType() == typeof(List<DependencyNodeCore<DependencyContextType>.DependencyListEntry>)))
-                {
-                    foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in dependencyList)
-                    {
-                        AddToMarkStack(dependency.Node, dependency.Reason, node, null);
-                    }
-                }
-                else if (staticDependencies is DependencyNodeCore<DependencyContextType>.DependencyListEntry[] dependencyArray)
-                {
-                    foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in dependencyArray)
-                    {
-                        AddToMarkStack(dependency.Node, dependency.Reason, node, null);
-                    }
-                }
-                else
+                if (staticDependencies != null)
                 {
                     foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in staticDependencies)
+                    {
+                        AddToMarkStack(dependency.Node, dependency.Reason, node, null);
+                    }
+                }
+            }
+            else
+            {
+                IEnumerable<DependencyNodeCore<DependencyContextType>.DependencyListEntry> enumerableDependencies =
+                    node.GetStaticDependencies(_dependencyContext);
+                if (enumerableDependencies != null)
+                {
+                    foreach (DependencyNodeCore<DependencyContextType>.DependencyListEntry dependency in enumerableDependencies)
                     {
                         AddToMarkStack(dependency.Node, dependency.Reason, node, null);
                     }
@@ -211,26 +205,23 @@ namespace ILCompiler.DependencyAnalysisFramework
 
             if (node.HasConditionalStaticDependencies)
             {
-                IEnumerable<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> conditionalDependencies =
-                    node.GetConditionalStaticDependencies(_dependencyContext);
-                if (conditionalDependencies is List<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> dependencyList &&
-                    conditionalDependencies.GetType() == typeof(List<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry>))
+                if (node.TryGetConditionalStaticDependencyList(
+                    _dependencyContext,
+                    out List<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> conditionalDependencies))
                 {
-                    foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in dependencyList)
+                    if (conditionalDependencies != null)
                     {
-                        ProcessConditionalDependency(node, dependency);
-                    }
-                }
-                else if (conditionalDependencies is DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry[] dependencyArray)
-                {
-                    foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in dependencyArray)
-                    {
-                        ProcessConditionalDependency(node, dependency);
+                        foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in conditionalDependencies)
+                        {
+                            ProcessConditionalDependency(node, dependency);
+                        }
                     }
                 }
                 else
                 {
-                    foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in conditionalDependencies)
+                    IEnumerable<DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry> enumerableDependencies =
+                        node.GetConditionalStaticDependencies(_dependencyContext);
+                    foreach (DependencyNodeCore<DependencyContextType>.CombinedDependencyListEntry dependency in enumerableDependencies)
                     {
                         ProcessConditionalDependency(node, dependency);
                     }

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyNodeCore.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyNodeCore.cs
@@ -127,6 +127,26 @@ namespace ILCompiler.DependencyAnalysisFramework
 
         public abstract IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(DependencyContextType context);
 
+        // Allows nodes that naturally produce a concrete list to avoid exposing it as IEnumerable<T>
+        // to the dependency analyzer. A true result means the list was provided, including when it is null.
+        internal virtual bool TryGetStaticDependencyList(
+            DependencyContextType context,
+            out DependencyList dependencies)
+        {
+            dependencies = null;
+            return false;
+        }
+
+        // Allows nodes that naturally produce a concrete list to avoid exposing it as IEnumerable<T>
+        // to the dependency analyzer. A true result means the list was provided, including when it is null.
+        internal virtual bool TryGetConditionalStaticDependencyList(
+            DependencyContextType context,
+            out List<CombinedDependencyListEntry> dependencies)
+        {
+            dependencies = null;
+            return false;
+        }
+
         public abstract IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<DependencyContextType>> markedNodes, int firstNode, DependencyContextType context);
 
         internal void CallOnMarked(DependencyContextType context)

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
@@ -16,6 +16,12 @@
     <Configurations>Debug;Release;Checked</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="ILCompiler.Compiler" />
+    <InternalsVisibleTo Include="ILCompiler.Compiler.Tests" />
+    <InternalsVisibleTo Include="ILCompiler.ReadyToRun" />
+    <InternalsVisibleTo Include="ILCompiler.RyuJit" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="ComputedStaticDependencyNode.cs" />
     <Compile Include="DependencyAnalyzer.cs" />
     <Compile Include="DependencyAnalyzerBase.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -68,9 +68,23 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
+            CombinedDependencyList dependencies = GetConditionalStaticDependencyList(factory);
+            return dependencies is not null ? dependencies : Array.Empty<CombinedDependencyListEntry>();
+        }
+
+        internal override bool TryGetConditionalStaticDependencyList(
+            NodeFactory factory,
+            out List<CombinedDependencyListEntry> dependencies)
+        {
+            dependencies = GetConditionalStaticDependencyList(factory);
+            return true;
+        }
+
+        private CombinedDependencyList GetConditionalStaticDependencyList(NodeFactory factory)
+        {
             CombinedDependencyList dependencies = null;
             CodeBasedDependencyAlgorithm.AddConditionalDependenciesDueToMethodCodePresence(ref dependencies, factory, _method);
-            return dependencies ?? (IEnumerable<CombinedDependencyListEntry>)Array.Empty<CombinedDependencyListEntry>();
+            return dependencies;
         }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)


### PR DESCRIPTION
## Summary

- Let hot dependency producers explicitly expose their existing concrete lists to the dependency analyzer.
- Enumerate those lists with their struct enumerators, avoiding boxed `IEnumerable<T>` enumeration without runtime type tests in the analyzer.
- Preserve the existing `IEnumerable<T>` contract and fallback for all other nodes.

## Motivation

Dependency analysis exposes dependencies as `IEnumerable<T>`, but hot NativeAOT nodes commonly build `DependencyList` or `List<CombinedDependencyListEntry>`. Enumerating those values through the interface boxes collection enumerators.

The original profiling experiment observed 28.536 million static concrete-list visits covering 96.861 million entries and 6.715 million conditional-list visits covering 73.188 million entries. A general prototype established the optimization ceiling: graph and mark time each improved by about 7.3 seconds, managed allocation fell by 1.35-1.39 GiB, and output was byte-identical.

## Implementation

`DependencyNodeCore` now has internal opt-in methods for nodes that naturally own a concrete static or conditional dependency list. `ObjectNode`, `VirtualMethodUseNode`, `ScannedMethodNode`, `MethodCodeNode`, and `EETypeNode` implement those paths. `DependencyAnalyzer` asks each producer for its concrete representation and otherwise uses the unchanged enumerable fallback.

This keeps representation knowledge with the producer: the analyzer contains no collection casts or runtime type checks. The public `IEnumerable<T>` APIs remain unchanged for existing consumers and source-included implementations.

The concrete paths use normal `List<T>.Enumerator` values, retaining ordering and version checks if an `OnMarked` callback mutates a list during enumeration. Null, already-marked, and deferred conditional dependencies retain their previous behavior.

## Validation

- `.\dotnet.cmd test src\coreclr\tools\aot\ILCompiler.Compiler.Tests\ILCompiler.Compiler.Tests.csproj -c Release -p:Platform=x64 -p:UseSharedCompilation=false`
  - 69 passed, 0 failed
  - Covers concrete-list and enumerable fallback selection, ordering, empty/single/multiple entries, custom enumerable behavior, null concrete lists, immediate/deferred/null conditions, and mutation detection
- Built `ILCompiler` Release x64: 0 warnings, 0 errors
- Built `ILCompiler.ReadyToRun` Release x64: 0 warnings, 0 errors
- `.\src\tests\build.cmd nativeaot Release tree nativeaot /p:UseSharedCompilation=false`
- `.\src\tests\run.cmd runnativeaottests Release`
  - 28 passed, 0 failed

## Current-main benchmark

The retained RDM response is pinned to `net10.0`, WindowsDesktop 10.0.11, and the matching .NET 10 framework closure, while current main builds a `net11.0` compiler and framework. Mixing those contracts would not be a valid comparison.

Instead, an ignored local runner generated a current-main `net11.0` workload with 10,000 worker/marker type pairs and ran five interleaved baseline/changed pairs after warmup. Both compilers contained identical temporary measurement probes; no probes or experiment gates are in this change.

| Metric | Baseline median | Changed median | Change |
| --- | ---: | ---: | ---: |
| Wall time | 5.257 s | 5.383 s | +2.41% |
| CPU time | 13.484 s | 13.156 s | -2.43% |
| Graph time | 3.110 s | 3.113 s | +0.07% |
| Mark time | 1.396 s | 1.429 s | +2.40% |
| Graph allocation | 846.06 MiB | 831.21 MiB | -14.84 MiB (-1.75%) |
| Peak private memory | 714.26 MiB | 713.40 MiB | -0.86 MiB |

Short-run wall and phase measurements are within machine noise; the repeatable local signal is lower graph allocation. Every baseline/changed run produced the same 39,922,359-byte object with SHA-256 `CE5C81C91A3774A8324455A306F9AE6AE06C30331E7A14D762F94AEEA27CC919`.

> [!NOTE]
> This PR description was drafted with GitHub Copilot.