### PR TITLE
Lazily allocate object writer section state

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/CoffObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/CoffObjectWriter.cs
@@ -47,7 +47,22 @@ namespace ILCompiler.ObjectWriter
     /// </remarks>
     internal partial class CoffObjectWriter : ObjectWriter
     {
-        protected sealed record SectionDefinition(CoffSectionHeader Header, Stream Stream, List<CoffRelocation> Relocations, Utf8String ComdatName, Utf8String SymbolName);
+        protected sealed class SectionDefinition
+        {
+            public SectionDefinition(CoffSectionHeader header, Stream stream, Utf8String comdatName, Utf8String symbolName)
+            {
+                Header = header;
+                Stream = stream;
+                ComdatName = comdatName;
+                SymbolName = symbolName;
+            }
+
+            public CoffSectionHeader Header { get; }
+            public Stream Stream { get; }
+            public List<CoffRelocation> Relocations { get; set; }
+            public Utf8String ComdatName { get; }
+            public Utf8String SymbolName { get; }
+        }
 
         protected readonly Machine _machine;
         protected readonly List<SectionDefinition> _sections = new();
@@ -156,7 +171,7 @@ namespace ILCompiler.ObjectWriter
                 }
             }
 
-            _sections.Add(new SectionDefinition(sectionHeader, sectionStream, new List<CoffRelocation>(), comdatName, symbolName));
+            _sections.Add(new SectionDefinition(sectionHeader, sectionStream, comdatName, symbolName));
         }
 
         protected internal override void UpdateSectionAlignment(int sectionIndex, int alignment)
@@ -278,10 +293,17 @@ namespace ILCompiler.ObjectWriter
 
         private protected override void EmitRelocations(int sectionIndex, List<SymbolicRelocation> relocationList)
         {
-            CoffSectionHeader sectionHeader = _sections[sectionIndex].Header;
-            List<CoffRelocation> coffRelocations = _sections[sectionIndex].Relocations;
+            SectionDefinition section = _sections[sectionIndex];
+            CoffSectionHeader sectionHeader = section.Header;
             if (relocationList.Count > 0)
             {
+                List<CoffRelocation> coffRelocations = section.Relocations;
+                if (coffRelocations is null)
+                {
+                    coffRelocations = new List<CoffRelocation>();
+                    section.Relocations = coffRelocations;
+                }
+
                 if (relocationList.Count <= ushort.MaxValue)
                 {
                     sectionHeader.NumberOfRelocations = (ushort)relocationList.Count;
@@ -402,8 +424,9 @@ namespace ILCompiler.ObjectWriter
                 }
 
                 // Section relocations
-                section.Header.PointerToRelocations = section.Relocations.Count > 0 ? dataOffset : 0;
-                dataOffset += (uint)(section.Relocations.Count * CoffRelocation.Size);
+                int relocationCount = section.Relocations?.Count ?? 0;
+                section.Header.PointerToRelocations = relocationCount > 0 ? dataOffset : 0;
+                dataOffset += (uint)(relocationCount * CoffRelocation.Size);
 
                 // Record the section layout
                 _outputSectionLayout.Add(new OutputSection(section.Header.Name, section.Header.PointerToRawData, section.Header.VirtualAddress, section.Header.SizeOfRawData));
@@ -449,9 +472,9 @@ namespace ILCompiler.ObjectWriter
                     section.Stream.CopyTo(outputFileStream);
                 }
 
-                if (section.Relocations.Count > 0)
+                if (section.Relocations is List<CoffRelocation> relocations)
                 {
-                    foreach (ref readonly CoffRelocation relocation in CollectionsMarshal.AsSpan(section.Relocations))
+                    foreach (ref readonly CoffRelocation relocation in CollectionsMarshal.AsSpan(relocations))
                     {
                         relocation.Write(outputFileStream);
                     }

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
@@ -111,7 +111,7 @@ namespace ILCompiler.ObjectWriter
                 sectionIndex = _sectionIndexToData.Count;
                 CreateSection(section, comdatName, symbolName, sectionIndex, sectionData.GetReadStream());
                 _sectionIndexToData.Add(sectionData);
-                _sectionIndexToRelocations.Add(new());
+                _sectionIndexToRelocations.Add(null);
                 if (comdatName.IsNull)
                 {
                     _sectionNameToSectionIndex.Add(section.Name, sectionIndex);
@@ -234,12 +234,19 @@ namespace ILCompiler.ObjectWriter
             Utf8String symbolName,
             long addend)
         {
-            _sectionIndexToRelocations[sectionIndex].Add(new SymbolicRelocation(offset, relocType, symbolName, addend));
+            List<SymbolicRelocation> relocations = _sectionIndexToRelocations[sectionIndex];
+            if (relocations is null)
+            {
+                relocations = new List<SymbolicRelocation>();
+                _sectionIndexToRelocations[sectionIndex] = relocations;
+            }
+
+            relocations.Add(new SymbolicRelocation(offset, relocType, symbolName, addend));
         }
 
         private protected bool SectionHasRelocations(int sectionIndex)
         {
-            return _sectionIndexToRelocations[sectionIndex].Count > 0;
+            return _sectionIndexToRelocations[sectionIndex]?.Count > 0;
         }
 
         private protected virtual void EmitReferencedMethod(Utf8String symbolName) { }
@@ -310,6 +317,11 @@ namespace ILCompiler.ObjectWriter
             SortedSet<Utf8String> undefinedSymbolSet = new SortedSet<Utf8String>();
             foreach (var relocationList in _sectionIndexToRelocations)
             {
+                if (relocationList is null)
+                {
+                    continue;
+                }
+
                 foreach (var symbolicRelocation in relocationList)
                 {
                     if (!_definedSymbols.ContainsKey(symbolicRelocation.SymbolName))
@@ -597,7 +609,11 @@ namespace ILCompiler.ObjectWriter
             int relocSectionIndex = 0;
             foreach (List<SymbolicRelocation> relocationList in _sectionIndexToRelocations)
             {
-                EmitRelocations(relocSectionIndex, relocationList);
+                if (relocationList is not null)
+                {
+                    EmitRelocations(relocSectionIndex, relocationList);
+                }
+
                 relocSectionIndex++;
             }
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/SectionData.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/SectionData.cs
@@ -16,36 +16,57 @@ namespace ILCompiler.ObjectWriter
     /// Optimized append-only structure for writing sections.
     /// </summary>
     /// <remarks>
-    /// The section data are kept in memory as a list of buffers. It supports
-    /// appending existing read-only buffers without copying (such as buffer
-    /// from ObjectNode.ObjectData).
+    /// The section data are kept in memory as a sequence of buffers, with the
+    /// first buffer stored directly and a list allocated only when needed. It
+    /// supports appending existing read-only buffers without copying (such as
+    /// buffer from ObjectNode.ObjectData).
     /// </remarks>
     internal sealed class SectionData
     {
-        private readonly ArrayBufferWriter<byte> _appendBuffer = new();
-        private readonly List<ReadOnlyMemory<byte>> _buffers = new();
+        private const int PaddingBufferSize = 16;
+        private const byte NopPaddingByte = 0x90;
+
+        private static readonly byte[] s_zeroPadding = new byte[PaddingBufferSize];
+        private static readonly byte[] s_nopPadding = CreatePadding(NopPaddingByte);
+
+        private ArrayBufferWriter<byte> _appendBuffer;
+        private List<ReadOnlyMemory<byte>> _buffers;
+        private ReadOnlyMemory<byte> _firstBuffer;
+        private int _bufferCount;
         private long _length;
-        private readonly byte[] _padding = new byte[16];
+        private readonly byte[] _padding;
 
         public SectionData(byte paddingByte = 0)
         {
-            _padding.AsSpan().Fill(paddingByte);
+            _padding = paddingByte switch
+            {
+                0 => s_zeroPadding,
+                NopPaddingByte => s_nopPadding,
+                _ => CreatePadding(paddingByte),
+            };
+        }
+
+        private static byte[] CreatePadding(byte value)
+        {
+            byte[] result = new byte[PaddingBufferSize];
+            result.AsSpan().Fill(value);
+            return result;
         }
 
         private void FlushAppendBuffer()
         {
-            if (_appendBuffer.WrittenCount > 0)
+            if (_appendBuffer is { WrittenCount: > 0 } appendBuffer)
             {
-                _buffers.Add(_appendBuffer.WrittenSpan.ToArray());
-                _length += _appendBuffer.WrittenCount;
-                _appendBuffer.Clear();
+                AddBuffer(appendBuffer.WrittenSpan.ToArray());
+                _length += appendBuffer.WrittenCount;
+                appendBuffer.Clear();
             }
         }
 
         public void AppendData(ReadOnlyMemory<byte> data)
         {
             FlushAppendBuffer();
-            _buffers.Add(data);
+            AddBuffer(data);
             _length += data.Length;
         }
 
@@ -53,10 +74,11 @@ namespace ILCompiler.ObjectWriter
         {
             if (paddingLength > 0)
             {
-                if (_appendBuffer.WrittenCount > 0 || paddingLength > _padding.Length)
+                if ((_appendBuffer?.WrittenCount ?? 0) > 0 || paddingLength > _padding.Length)
                 {
-                    _appendBuffer.GetSpan(paddingLength).Slice(0, paddingLength).Fill(_padding[0]);
-                    _appendBuffer.Advance(paddingLength);
+                    ArrayBufferWriter<byte> appendBuffer = GetAppendBuffer();
+                    appendBuffer.GetSpan(paddingLength).Slice(0, paddingLength).Fill(_padding[0]);
+                    appendBuffer.Advance(paddingLength);
                 }
                 else
                 {
@@ -65,14 +87,47 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        public IBufferWriter<byte> BufferWriter => _appendBuffer;
+        public IBufferWriter<byte> BufferWriter => GetAppendBuffer();
 
-        public long Length => _length + _appendBuffer.WrittenCount;
+        public long Length => _length + (_appendBuffer?.WrittenCount ?? 0);
 
         /// <summary>
         /// Gets a read-only stream accessing the section data.
         /// </summary>
         public Stream GetReadStream() => new ReadStream(this);
+
+        private ArrayBufferWriter<byte> GetAppendBuffer()
+        {
+            return _appendBuffer ??= new ArrayBufferWriter<byte>();
+        }
+
+        private void AddBuffer(ReadOnlyMemory<byte> data)
+        {
+            if (_bufferCount == 0)
+            {
+                _firstBuffer = data;
+            }
+            else
+            {
+                if (_buffers is null)
+                {
+                    _buffers = new List<ReadOnlyMemory<byte>>();
+                    _buffers.Add(_firstBuffer);
+                }
+
+                _buffers.Add(data);
+            }
+
+            _bufferCount++;
+        }
+
+        private int BufferCount => _bufferCount;
+
+        private ReadOnlyMemory<byte> GetBuffer(int index)
+        {
+            Debug.Assert((uint)index < (uint)_bufferCount);
+            return _buffers is null ? _firstBuffer : _buffers[index];
+        }
 
         private sealed class ReadStream : Stream
         {
@@ -98,11 +153,12 @@ namespace ILCompiler.ObjectWriter
                     _position = 0;
                     _bufferIndex = 0;
                     _bufferPosition = 0;
-                    while (_position < value && _bufferIndex < _sectionData._buffers.Count)
+                    while (_position < value && _bufferIndex < _sectionData.BufferCount)
                     {
-                        if (_sectionData._buffers[_bufferIndex].Length < value - _position)
+                        ReadOnlyMemory<byte> currentBuffer = _sectionData.GetBuffer(_bufferIndex);
+                        if (currentBuffer.Length < value - _position)
                         {
-                            _position += _sectionData._buffers[_bufferIndex].Length;
+                            _position += currentBuffer.Length;
                             _bufferIndex++;
                         }
                         else
@@ -136,9 +192,9 @@ namespace ILCompiler.ObjectWriter
 
                 // _bufferIndex and _bufferPosition is only valid after seeking when
                 // _position < _length
-                while (_position < _sectionData._length && _bufferIndex < _sectionData._buffers.Count)
+                while (_position < _sectionData._length && _bufferIndex < _sectionData.BufferCount)
                 {
-                    ReadOnlySpan<byte> currentBuffer = _sectionData._buffers[_bufferIndex].Span.Slice(_bufferPosition);
+                    ReadOnlySpan<byte> currentBuffer = _sectionData.GetBuffer(_bufferIndex).Span.Slice(_bufferPosition);
 
                     if (currentBuffer.Length >= buffer.Length)
                     {


### PR DESCRIPTION
# Proposed body## Summary- Allocate symbolic and COFF relocation lists only when a section emits its first relocation.- Store the first section-data fragment directly, allocate overflow storage only for subsequent fragments, and create append buffers only when needed.- Share immutable zero and x86/x64 NOP padding buffers instead of allocating one padding array per section.These changes form one cohesive optimization on current main: all three allocations are per-section state created by the shared object-writer layer, and all can be deferred for the common section shape without changing object layout.## Motivation`ObjectWriter` currently creates empty symbolic and format-specific relocation lists for every section. `SectionData` also eagerly creates an `ArrayBufferWriter<byte>`, a buffer list, and a padding array even when a section has no buffered writes and only one data fragment.That fixed cost is material for NativeAOT workloads with very large section counts, especially when most sections have no relocations and only one fragment.## Implementation`ObjectWriter` now uses `null` to represent a section with no symbolic relocations and creates the existing `List<SymbolicRelocation>` on the first add. Undefined-symbol discovery and format-specific relocation conversion skip this zero-relocation state. Non-empty lists remain ordinary mutable lists, preserving insertion order and platform-specific behavior such as Mach-O's existing in-place reversal.The COFF writer similarly creates `List<CoffRelocation>` only when symbolic relocations are converted. `SectionDefinition` becomes a class so this lazily initialized property can be updated without replacing the section record. COFF relocation counts, overflow records, ordering, and emitted bytes are unchanged.`SectionData` now:- creates its `ArrayBufferWriter<byte>` on first buffered write;- stores its first `ReadOnlyMemory<byte>` directly;- moves to the existing list representation on the second fragment;- shares immutable 16-byte zero and NOP padding buffers;- retains existing no-copy `ReadOnlyMemory<byte>` ownership and live stream behavior.Object emission remains single-threaded; this does not change its thread-safety contract. No collection capacity planning, compact relocation representation, experiment gate, or profiling infrastructure is included.## Validation- Clean current-main baseline before the first rebase at `c210d82dbc1ab432b9369604a1caef9a0ab763d2`  - The initial long-path `.\build.cmd clr+libs+host` attempt stopped before native compilation because the inherited Windows environment exceeded `cmd.exe`'s command-line limit (`The input line is too long`).  - The same unchanged commit built successfully from a short `N:` mapping with a sanitized PATH: 0 warnings, 0 errors.- `.\build.cmd clr.aot+libs -rc Release -lc Release`  - Final uninstrumented toolchain build succeeded: 0 warnings, 0 errors.- `.\build.cmd clr.aot+libs -rc Checked -lc Release`  - Succeeded: 0 warnings, 0 errors.- `.\src\tests\build.cmd nativeaot Release tree nativeaot`  - Succeeded with the suite's 9 expected trim/AOT-analysis warnings and 0 errors.- `.\src\tests\run.cmd runnativeaottests Release`  - 28 passed, 0 failed or skipped.  - The NativeAOT determinism test produced matching 11,021,593-byte outputs.- Current-main rebase at `0fd08c887c1317055025965cbe829b732fbe942d`  - From a short `U:` mapping with a sanitized PATH, `.\dotnet.cmd build src\coreclr\tools\aot\ILCompiler.Compiler\ILCompiler.Compiler.csproj -c Release -p:Platform=x64` succeeded: 0 warnings, 0 errors.  - `.\dotnet.cmd build src\coreclr\tools\aot\ILCompiler.ReadyToRun\ILCompiler.ReadyToRun.csproj -c Release -p:Platform=x64` succeeded: 0 warnings, 0 errors.  - Current main intentionally deleted `ILCompiler.Compiler.Tests`; this rebase drops the test-only friend assembly and the former focused unit tests in accordance with that upstream test-architecture change.- Targeted `dotnet format --verify-no-changes` checks and `git diff --check` passed.- Two independent model-family reviews and a post-rebase source review checked every object-writer relocation override and the stream/storage lifetime rules.## Current-main benchmarkThe authoritative current-main benchmark uses the repository's net11 toolchain rather than forcing the retained net10 RDM response through an incompatible compiler/framework contract.An ignored local runner generated 10,000 worker/marker type pairs, compiled them with current-main ILC in multifile mode, and produced 220,076 COFF sections. Baseline and changed compilers were built from the same current-main commit with identical temporary measurement probes. One warmup per variant preceded five measured interleaved A/B pairs.| Metric (median of 5) | Baseline | Changed | Change || --- | ---: | ---: | ---: || Wall time | 4.554 s | 4.350 s | -4.48% || CPU time | 12.750 s | 12.516 s | -1.84% || Object emission | 1.726 s | 1.580 s | -8.44% || Node materialization | 0.739 s | 0.700 s | -5.30% || Object-phase allocation | 833.61 MiB | 795.89 MiB | -37.72 MiB (-4.52%) || Total managed allocation | 1,344.63 MiB | 1,306.27 MiB | -38.36 MiB (-2.85%) || Peak private memory | 776.33 MiB | 719.42 MiB | -56.91 MiB (-7.33%) || Peak working set | 700.89 MiB | 637.96 MiB | -62.93 MiB (-8.98%) |Object-phase allocation fell in every pair by 37.65-37.83 MiB. Timing and peak process metrics remain sensitive to shared-machine scheduling and GC timing: one object-emission pair regressed 1.6%, while the other four improved. The repeated allocation reduction is the primary current-main signal; timing is directional.Every measured baseline and changed run emitted the same 49,921,241-byte object with SHA-256 `2BDC559EBE496FC9A7237FA938EFB3278429BA0D23D97B4B2146A5E970BA3A32`.## Retained .NET 10 RDM evidenceThe retained production profile used the matching v10.0.11 compiler/framework contract, not current main. That workload emitted a 3,744,336,196-byte COFF BigObj with 3,526,007 sections, 18,258,125 symbols, and tens of millions of relocation records.For the accepted `lazy-relocation-lists;compact-section-data` mechanism:- repeated full-RDM runs reduced managed allocation by 1.13-1.21 GiB;- the confirming pair reduced object emission by about 5.6%, while the first pair was near-neutral;- a smaller EntryModel screen attributed 15.9 MB of allocation and about 4.4% object-phase improvement to lazy relocation lists, followed by another 4.9 MB allocation reduction from compact section data with timing near noise;- generated objects were byte-identical.Those net10 results establish the large-scale motivation. The net11 stress workload above is the authoritative validation that the mechanism still applies to current main.## Limitations and risk- Local end-to-end measurements are Windows x64. The symbolic relocation and section-data changes are shared by COFF, ELF, Mach-O, PE, Wasm, and ReadyToRun; all overrides were reviewed and the ReadyToRun consumer was built, but non-Windows end-to-end coverage is left to CI.- Allocation savings scale with section count, so ordinary applications should see a smaller absolute effect than the stress and RDM workloads.- No whole-compiler wall-time guarantee is claimed because short-run controls and the retained production runs both showed substantial environmental variance.- This is an internal representation change with no public API or intended output change.> [!NOTE]> This PR description was drafted with GitHub Copilot.