### PR TITLE
Avoid slow parallel connect failures in SocketAsyncEventArgs test

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -1129,27 +1129,12 @@ namespace System.Net.Sockets.Tests
         [SkipOnPlatform(TestPlatforms.Wasi, "Wasi doesn't support DualMode")]
         public void Connect_Parallel_Fails()
         {
-            using PortBlocker portBlocker = new PortBlocker(() =>
-            {
-                Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-                socket.DualMode = false;
-                socket.BindToAnonymousPort(IPAddress.IPv6Loopback);
-                return socket;
-            });
-            Socket a = portBlocker.MainSocket;
-            // the port blocker did not call Socket.Bind so we called bind() but we did not update properties on Socket
-            Socket b = new Socket(portBlocker.SecondarySocket.SafeHandle);
-
-            // do NOT a.Listen(1);
-            // do NOT b.Listen(1);
-            // Do NOT a.AcceptAsync();
-            // Do NOT b.AcceptAsync();
-
             var mres = new ManualResetEventSlim();
             SocketAsyncEventArgs saea = new SocketAsyncEventArgs();
-            saea.RemoteEndPoint = new DnsEndPoint("localhost", portBlocker.Port);
+            // A bound but non-listening port can time out instead of refusing connections on macOS.
+            saea.RemoteEndPoint = new DnsEndPoint("localhost", DualModeBase.UnusedPort);
             saea.Completed += (_, _) => mres.Set();
-            if (Socket.ConnectAsync(a.SocketType, a.ProtocolType, saea, ConnectAlgorithm.Parallel))
+            if (Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, saea, ConnectAlgorithm.Parallel))
             {
                 Assert.True(mres.Wait(TestSettings.PassingTestLongTimeout), "Completed did not get called in time");
             }


### PR DESCRIPTION
Fixes #132059

## Summary

`SocketAsyncEventArgsTest.Connect_Parallel_Fails` used IPv4 and IPv6 sockets that were bound but not listening. On macOS, connecting to such sockets can remain pending rather than fail promptly, causing the test to exceed its 30-second timeout.

Use the test suite's reserved unused port instead. This still exercises parallel IPv4 and IPv6 connection failures while avoiding OS-dependent behavior for bound, non-listening ports.

## Validation

- Required `clr+libs` baseline build passed.
- `Connect_Parallel_Fails` passed 50 consecutive local runs.
- All 2,500 `System.Net.Sockets` functional tests passed locally.
- Repeated on `osx.26.arm64.open` Helix using the same macOS runtime payload:
  - [Original assembly, first run](https://helix.dot.net/api/jobs/44725cdd-cf9b-4bfd-8a5a-dbbea5544543/details?api-version=2019-06-17): 50/50 passed, taking approximately 7.85-7.94 seconds per test.
  - [Updated assembly, first run](https://helix.dot.net/api/jobs/b27a7401-e1a0-41f4-a356-37779905771c/details?api-version=2019-06-17): 50/50 passed, taking approximately 45-101 milliseconds per test.
  - [Original assembly, second run](https://helix.dot.net/api/jobs/9350550b-306a-4ed6-a90e-324530a34ac0/details?api-version=2019-06-17): completed tests took approximately 19.26 seconds each; the 15-minute work item timed out during iteration 46 after 45 passes.
  - [Updated assembly, second run](https://helix.dot.net/api/jobs/1dc80a33-4028-4c2d-898b-062e0f9a57f0/details?api-version=2019-06-17): 50/50 passed, taking approximately 43-87 milliseconds per test and completing the work item in 32 seconds.

Across two macOS ARM64 machines per version, the original setup varied from approximately 8 to 19 seconds per completed test, while the updated test consistently completed in under 101 milliseconds. This confirms that the original setup has substantial OS-dependent latency and that using the reserved unused port removes it.

> [!NOTE]
> This description was drafted with GitHub Copilot.