### PR TITLE
Allow constrained. call and ldftn for static virtual interface methods in ILVerify

### DIFF
--- a/src/coreclr/tools/ILVerification.Tests/ILTests/PrefixTests.il
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/PrefixTests.il
@@ -80,6 +80,46 @@
         ret
     }
 
+    .method static public hidebysig void ConstrainedLdftn.StaticAbstractOnConstrainedTypeParam_Valid<(IStaticInterface) T>() cil managed
+    {
+        constrained. !!T
+        ldftn  void IStaticInterface::StaticAbstractMethod()
+        pop
+        ret
+    }
+
+    .method static public hidebysig void ConstrainedLdftn.StaticAbstractOnImplStruct_Valid() cil managed
+    {
+        constrained. ImplStruct
+        ldftn  void IStaticInterface::StaticAbstractMethod()
+        pop
+        ret
+    }
+
+    .method static public hidebysig void ConstrainedLdftn.UnconstrainedTypeParam_Invalid_ConstrainedTypeNoInterfaceImpl<T>() cil managed
+    {
+        constrained. !!T
+        ldftn  void IStaticInterface::StaticAbstractMethod()
+        pop
+        ret
+    }
+
+    .method static public hidebysig void ConstrainedLdftn.NonImplStruct_Invalid_ConstrainedTypeNoInterfaceImpl() cil managed
+    {
+        constrained. NonImplStruct
+        ldftn  void IStaticInterface::StaticAbstractMethod()
+        pop
+        ret
+    }
+
+    .method static public hidebysig void ConstrainedLdftn.NonVirtualStaticMethod_Invalid_Constrained<(IStaticInterface) T>() cil managed
+    {
+        constrained. !!T
+        ldftn  void PrefixTestsType::StaticMethod()
+        pop
+        ret
+    }
+
     .method static public hidebysig void Readonly.Ldelema_Valid() cil managed 
     {
         .locals init (int32[] V_0)

--- a/src/coreclr/tools/ILVerification.Tests/ILTests/PrefixTests.il
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/PrefixTests.il
@@ -9,11 +9,74 @@
 {
 }
 
+.class interface public auto ansi abstract IStaticInterface
+{
+    .method public hidebysig newslot abstract virtual static void StaticAbstractMethod() cil managed
+    {
+    }
+}
+
+.class public sequential ansi sealed beforefieldinit ImplStruct
+       extends [System.Runtime]System.ValueType
+       implements IStaticInterface
+{
+    .pack 0
+    .size 1
+
+    .method public hidebysig static void StaticAbstractMethod() cil managed
+    {
+        .override method void IStaticInterface::StaticAbstractMethod()
+        ret
+    }
+}
+
+.class public sequential ansi sealed beforefieldinit NonImplStruct
+       extends [System.Runtime]System.ValueType
+{
+    .pack 0
+    .size 1
+}
+
 .class public auto ansi beforefieldinit PrefixTestsType
        extends [System.Runtime]System.Object
 {
-    .method static public hidebysig void StaticMethod() cil managed 
+    .method static public hidebysig void StaticMethod() cil managed
     {
+        ret
+    }
+
+    .method static public hidebysig void ConstrainedCall.StaticAbstractOnConstrainedTypeParam_Valid<(IStaticInterface) T>() cil managed
+    {
+        constrained. !!T
+        call    void IStaticInterface::StaticAbstractMethod()
+        ret
+    }
+
+    .method static public hidebysig void ConstrainedCall.StaticAbstractOnImplStruct_Valid() cil managed
+    {
+        constrained. ImplStruct
+        call    void IStaticInterface::StaticAbstractMethod()
+        ret
+    }
+
+    .method static public hidebysig void ConstrainedCall.UnconstrainedTypeParam_Invalid_ConstrainedTypeNoInterfaceImpl<T>() cil managed
+    {
+        constrained. !!T
+        call    void IStaticInterface::StaticAbstractMethod()
+        ret
+    }
+
+    .method static public hidebysig void ConstrainedCall.NonImplStruct_Invalid_ConstrainedTypeNoInterfaceImpl() cil managed
+    {
+        constrained. NonImplStruct
+        call    void IStaticInterface::StaticAbstractMethod()
+        ret
+    }
+
+    .method static public hidebysig void ConstrainedCall.NonVirtualStaticMethod_Invalid_Constrained<(IStaticInterface) T>() cil managed
+    {
+        constrained. !!T
+        call    void PrefixTestsType::StaticMethod()
         ret
     }
 

--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -1553,12 +1553,27 @@ namespace Internal.IL
             TypeDesc constrained = null;
             bool tailCall = false;
 
+            MethodDesc method = ResolveMethodToken(token);
+            MethodSignature sig = method.Signature;
+
             if (opcode != ILOpcode.newobj)
             {
-                if (HasPendingPrefix(Prefix.Constrained) && opcode == ILOpcode.callvirt)
+                if (HasPendingPrefix(Prefix.Constrained))
                 {
-                    ClearPendingPrefix(Prefix.Constrained);
-                    constrained = _constrained;
+                    if (opcode == ILOpcode.callvirt)
+                    {
+                        ClearPendingPrefix(Prefix.Constrained);
+                        constrained = _constrained;
+                    }
+                    else if (opcode == ILOpcode.call && method.IsVirtual && sig.IsStatic && method.OwningType.IsInterface)
+                    {
+                        ClearPendingPrefix(Prefix.Constrained);
+                        constrained = _constrained;
+
+                        // The constrained type must implement the interface declaring the static virtual method
+                        if (!constrained.CanCastTo(method.OwningType))
+                            VerificationError(VerifierError.ConstrainedTypeNoInterfaceImpl, constrained, method.OwningType);
+                    }
                 }
 
                 if (HasPendingPrefix(Prefix.Tail))
@@ -1572,10 +1587,6 @@ namespace Internal.IL
             // if (sig.isVarArg())
             //      eeGetCallSiteSig(memberRef, getCurrentModuleHandle(), getCurrentContext(), &sig, false);
 
-            MethodDesc method = ResolveMethodToken(token);
-
-            MethodSignature sig = method.Signature;
-
             TypeDesc methodType = sig.IsStatic ? null : method.OwningType;
 
             if (opcode == ILOpcode.callvirt)
@@ -1587,7 +1598,9 @@ namespace Internal.IL
             {
                 EcmaMethod ecmaMethod = method.GetTypicalMethodDefinition() as EcmaMethod;
                 if (ecmaMethod != null)
-                    Check(!ecmaMethod.IsAbstract, VerifierError.CallAbstract);
+                {
+                    Check(!ecmaMethod.IsAbstract || (method.OwningType.IsInterface && constrained != null), VerifierError.CallAbstract);
+                }
             }
 
             if (opcode == ILOpcode.newobj && methodType.IsDelegate)

--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -1833,6 +1833,14 @@ namespace Internal.IL
                 _delegateCreateStart = _currentInstructionOffset;
 
                 instance = null;
+
+                if (HasPendingPrefix(Prefix.Constrained) && method.IsVirtual &&
+                    method.Signature.IsStatic && method.OwningType.IsInterface)
+                {
+                    ClearPendingPrefix(Prefix.Constrained);
+                    if (!_constrained.CanCastTo(method.OwningType))
+                        VerificationError(VerifierError.ConstrainedTypeNoInterfaceImpl, _constrained, method.OwningType);
+                }
             }
             else if (opCode == ILOpcode.ldvirtftn)
             {

--- a/src/coreclr/tools/ILVerification/Strings.resx
+++ b/src/coreclr/tools/ILVerification/Strings.resx
@@ -183,6 +183,9 @@
   <data name="ConstrainedCallWithNonByRefThis" xml:space="preserve">
     <value>The 'this' argument to a constrained call must have ByRef type.</value>
   </data>
+  <data name="ConstrainedTypeNoInterfaceImpl" xml:space="preserve">
+    <value>The type operand of the constrained prefix must implement the interface declaring the static virtual method.</value>
+  </data>
   <data name="CtorExpected" xml:space="preserve">
     <value>.ctor expected.</value>
   </data>

--- a/src/coreclr/tools/ILVerification/VerifierError.cs
+++ b/src/coreclr/tools/ILVerification/VerifierError.cs
@@ -192,5 +192,6 @@ namespace ILVerify
         LocallocStackNotEmpty, // localloc requires that stack must be empty, except for 'size' argument
         InvalidBaseType, // Type has an invalid base type.
         BadTypeSpec, // Invalid TypeSpec metadata.
+        ConstrainedTypeNoInterfaceImpl, // The type operand of the constrained prefix must implement the interface declaring the static virtual method.
     }
 }


### PR DESCRIPTION
Fixes #132820

ILVerify predates static virtual interface methods, so the IL Roslyn emits for `T.M()` (`constrained. !!T` followed by `call`) gets flagged with bogus `Constrained` and `CallAbstract` errors.

Consume the `constrained.` prefix on `call` when the target is a static virtual method on an interface, and check that the constrained type actually implements that interface (new `ConstrainedTypeNoInterfaceImpl` error). 

Tests added to PrefixTests.il.