### PR TITLE
Restore current task tracking for runtime async dispatch

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -957,6 +957,7 @@ namespace System.Runtime.CompilerServices
                 AsyncDispatcherInfo asyncDispatcherInfo;
                 asyncDispatcherInfo.Next = refDispatcherInfo;
                 asyncDispatcherInfo.NextContinuation = MoveContinuationState();
+                asyncDispatcherInfo.CurrentTask = this;
                 refDispatcherInfo = &asyncDispatcherInfo;
 
                 while (true)


### PR DESCRIPTION
## Summary

- Restore `AsyncDispatcherInfo.CurrentTask` on the standard, non-instrumented `DispatchContinuations` path.
- Make the current runtime async task available while its continuation chain is being dispatched.

This assignment was present before the instrumented and non-instrumented dispatch paths were separated in #126091.

## Reasoning

Without this link, diagnostics tools cannot deterministically find the parent Task for a runtime async continuation chain in non-instrumented scenarios like crash dumps. While it is possible to use heuristics to link the tasks (trying to find the 'this' parameter of the `DispatchContinuations` caller) these do not work in all scenarios.

Given the very low overhead of writing this field, I believe it is valuable enough to re-add to the normal path.

## Performance

Measured on Windows x64 under Hyper-V using BenchmarkDotNet with tiered compilation disabled. The benchmark performs 10,000 runtime-async suspensions and resumptions per invocation and compares separate baseline and changed Release testhosts.

Across 10 paired runs:

| Runtime | Mean |
| --- | ---: |
| Baseline | 65.857 ns |
| Changed | 64.652 ns |

The changed runtime measured 1.83% faster overall. The eight additional runs measured 1.24% faster, with the changed runtime faster in all eight. Because the change adds a store and shifts generated code layout, the apparent improvement should be treated as layout or environmental noise rather than a causal speedup. No performance regression was detected.

ReadyToRun code size for `RuntimeAsyncTask<int>.DispatchContinuations` increased by 7 bytes, from 1,488 to 1,495 bytes.

## Testing

- Release CoreCLR and libraries build
- `System.Runtime.Tests`: 77,810 total, 0 failed, 88 skipped

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
