### PR TITLE
[GC] Preserve workstation GC diagnostic data in heap dumps

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2890,7 +2890,8 @@ ClrDataAccess::GetGCHeapStaticData(struct DacpGcHeapDetails *detailsData)
 
     detailsData->alloc_allocated = (CLRDATA_ADDRESS)*g_gcDacGlobals->alloc_allocated;
     detailsData->ephemeral_heap_segment = (CLRDATA_ADDRESS)*g_gcDacGlobals->ephemeral_heap_segment;
-    if (g_gcDacGlobals->minor_version_number >= 9)
+    if (g_gcDacGlobals->minor_version_number >= 9 &&
+        g_gcDacGlobals->card_table.IsValid())
     {
         detailsData->card_table = (CLRDATA_ADDRESS)*g_gcDacGlobals->card_table;
     }

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -4010,7 +4010,8 @@ ClrDataAccess::EnumWksGlobalMemoryRegions(CLRDataEnumMemoryFlags flags)
 
     Dereference(g_gcDacGlobals->ephemeral_heap_segment).EnumMem();
     g_gcDacGlobals->alloc_allocated.EnumMem();
-    if (g_gcDacGlobals->minor_version_number >= 9)
+    if (g_gcDacGlobals->minor_version_number >= 9 &&
+        g_gcDacGlobals->card_table.IsValid())
     {
         g_gcDacGlobals->card_table.EnumMem();
     }

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2890,7 +2890,14 @@ ClrDataAccess::GetGCHeapStaticData(struct DacpGcHeapDetails *detailsData)
 
     detailsData->alloc_allocated = (CLRDATA_ADDRESS)*g_gcDacGlobals->alloc_allocated;
     detailsData->ephemeral_heap_segment = (CLRDATA_ADDRESS)*g_gcDacGlobals->ephemeral_heap_segment;
-    detailsData->card_table = PTR_CDADDR(g_card_table);
+    if (g_gcDacGlobals->minor_version_number >= 9)
+    {
+        detailsData->card_table = (CLRDATA_ADDRESS)*g_gcDacGlobals->card_table;
+    }
+    else
+    {
+        detailsData->card_table = PTR_CDADDR(g_card_table);
+    }
 
     if (IsRegionGCEnabled())
     {
@@ -4002,6 +4009,10 @@ ClrDataAccess::EnumWksGlobalMemoryRegions(CLRDataEnumMemoryFlags flags)
 
     Dereference(g_gcDacGlobals->ephemeral_heap_segment).EnumMem();
     g_gcDacGlobals->alloc_allocated.EnumMem();
+    if (g_gcDacGlobals->minor_version_number >= 9)
+    {
+        g_gcDacGlobals->card_table.EnumMem();
+    }
     g_gcDacGlobals->gc_structures_invalid_cnt.EnumMem();
     Dereference(g_gcDacGlobals->finalize_queue).EnumMem();
 

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -4013,6 +4013,10 @@ ClrDataAccess::EnumWksGlobalMemoryRegions(CLRDataEnumMemoryFlags flags)
     {
         g_gcDacGlobals->card_table.EnumMem();
     }
+    DacEnumMemoryRegion(g_gcDacGlobals->interesting_data_per_heap.GetAddr(), sizeof(size_t) * NUM_GC_DATA_POINTS);
+    DacEnumMemoryRegion(g_gcDacGlobals->compact_reasons_per_heap.GetAddr(), sizeof(size_t) * MAX_COMPACT_REASONS_COUNT);
+    DacEnumMemoryRegion(g_gcDacGlobals->expand_mechanisms_per_heap.GetAddr(), sizeof(size_t) * MAX_EXPAND_MECHANISMS_COUNT);
+    DacEnumMemoryRegion(g_gcDacGlobals->interesting_mechanism_bits_per_heap.GetAddr(), sizeof(size_t) * MAX_GC_MECHANISM_BITS_COUNT);
     g_gcDacGlobals->gc_structures_invalid_cnt.EnumMem();
     Dereference(g_gcDacGlobals->finalize_queue).EnumMem();
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -4495,6 +4495,7 @@ void PopulateDacVars(GcDacVars *gcDacVars)
     bool v4 = gcDacVars->minor_version_number >= 4;
     bool v6 = gcDacVars->minor_version_number >= 6;
     bool v8 = gcDacVars->minor_version_number >= 8;
+    bool v9 = gcDacVars->minor_version_number >= 9;
 
 #define DEFINE_FIELD(field_name, field_type) offsetof(CLASS_NAME, field_name),
 #define DEFINE_DPTR_FIELD(field_name, field_type) offsetof(CLASS_NAME, field_name),
@@ -4526,7 +4527,7 @@ void PopulateDacVars(GcDacVars *gcDacVars)
     // work differently than .Net SOS.  When making breaking changes here you may need to
     // find NativeAOT's equivalent of SOS_BREAKING_CHANGE_VERSION and increment it.
     gcDacVars->major_version_number = 2;
-    gcDacVars->minor_version_number = 8;
+    gcDacVars->minor_version_number = 9;
     if (v2)
     {
         gcDacVars->total_bookkeeping_elements = total_bookkeeping_elements;
@@ -4646,6 +4647,12 @@ void PopulateDacVars(GcDacVars *gcDacVars)
     {
 #ifdef MULTIPLE_HEAPS
         gcDacVars->g_totalCpuCount = &::g_totalCpuCount;
+#endif // MULTIPLE_HEAPS
+    }
+    if (v9)
+    {
+#ifndef MULTIPLE_HEAPS
+        gcDacVars->card_table = &gc_heap::card_table;
 #endif // MULTIPLE_HEAPS
     }
 }

--- a/src/coreclr/gc/gcinterface.dacvars.def
+++ b/src/coreclr/gc/gcinterface.dacvars.def
@@ -97,6 +97,9 @@ GC_DAC_VAL        (void*,                 gc_descriptor)
 // Here is where v5.8 fields start
 GC_DAC_VAR    (uint32_t,              g_totalCpuCount)
 
+// Here is where v5.9 fields start
+GC_DAC_PTR_VAR(uint32_t,              card_table)
+
 #undef GC_DAC_VAR
 #undef GC_DAC_ARRAY_VAR
 #undef GC_DAC_PTR_VAR

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -11,7 +11,7 @@
 // The minor version of the IGCHeap interface. Non-breaking changes are required
 // to bump the minor version number. GCs and EEs with minor version number
 // mismatches can still interoperate correctly, with some care.
-#define GC_INTERFACE_MINOR_VERSION 8
+#define GC_INTERFACE_MINOR_VERSION 9
 
 // The major version of the IGCToCLR interface. Breaking changes to this interface
 // require bumps in the major version number.


### PR DESCRIPTION
## Summary
- Append the workstation `card_table` pointer to `GcDacVars` at GC interface minor version 9.
- Use the versioned GC-DAC variable when returning workstation heap details, retaining the VM-global fallback when the field is unavailable.
- Explicitly enumerate the workstation card-table pointer storage.
- Preserve the complete workstation `interesting_data_per_heap`, `compact_reasons_per_heap`, `expand_mechanisms_per_heap`, and `interesting_mechanism_bits_per_heap` arrays.

Before this change, CDB `/mw` heap dumps did not preserve the workstation card-table pointer storage and preserved only the first element of each GC diagnostics array. After the card-table read was fixed, legacy DAC `!dumpgcdata` could load the dump and print global GC mechanisms, but failed when requesting per-heap interesting information:

```text
[info per heap]
Error requesting interesting GC info
```

cDAC's GC contract also eagerly reads these complete arrays while constructing `GCHeapData`, so it encountered the same missing-memory problem. Explicitly preserving the card-table pointer and complete diagnostic-array ranges makes this data available to both the legacy DAC API used by `!dumpgcdata` and the cDAC GC heap reader.

## Testing
- `./build.cmd clr -rc checked`
- `./build.cmd clr+libs -rc release`
- `./build.cmd clr+libs+host -rc release`
- `src/tests/build.cmd -GenerateLayoutOnly x64 Release`
- Generated a CDB `/mw` dump from a workstation GC process after GC initialization.
- Verified the pre-change dump reports `Error requesting interesting GC info` from `!dumpgcdata`.
- Verified the post-change dump prints all 9 interesting-data points, 11 compacting reasons, 6 expansion mechanisms, and 2 mechanism bits through legacy DAC `!dumpgcdata`.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.