### PR TITLE
Rewind trailing 0x1F byte in GZipStream on seekable leaveOpen streams

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -332,7 +332,15 @@ namespace System.IO.Compression
                         // - Inflation is not finished yet.
                         // - Provided input wasn't completely empty
                         // In such case, we are dealing with a truncated input stream.
-                        if (s_useStrictValidation && !buffer.IsEmpty && !_inflater.Finished() && _inflater.NonEmptyInput())
+                        if (_inflater.HasUnconfirmedGZipProbe && _stream.CanSeek)
+                        {
+                            // A lone trailing GZip ID1 (0x1F) byte was speculatively consumed as a
+                            // possible concatenated member, but no further data followed. It was actually
+                            // trailing content: mark the inflater finished so the byte is rewound below and
+                            // not re-read on subsequent calls.
+                            _inflater.MarkEndOfStream();
+                        }
+                        else if (s_useStrictValidation && !buffer.IsEmpty && !_inflater.Finished() && _inflater.NonEmptyInput())
                         {
                             ThrowTruncatedInvalidData();
                         }
@@ -376,8 +384,10 @@ namespace System.IO.Compression
             // 1. DeflateStream => return
             // 2. GZipStream that is finished but may have an additional GZipStream appended => feed more input
             // 3. GZipStream that is finished and appended with garbage => return
-            _inflater!.Finished() &&
-            (!_inflater.IsGzipStream() || !_inflater.NeedsInput());
+            (_inflater!.Finished() &&
+            (!_inflater.IsGzipStream() || !_inflater.NeedsInput()))
+            // 4. GZipStream whose lone trailing 0x1F probe has been resolved as end-of-stream => return
+            || _inflater.EndOfStreamReached;
 
         private void EnsureNotDisposed()
         {
@@ -484,7 +494,15 @@ namespace System.IO.Compression
                                 // - Inflation is not finished yet.
                                 // - Provided input wasn't completely empty
                                 // In such case, we are dealing with a truncated input stream.
-                                if (s_useStrictValidation && !_inflater.Finished() && _inflater.NonEmptyInput() && !buffer.IsEmpty)
+                                if (_inflater.HasUnconfirmedGZipProbe && _stream.CanSeek)
+                                {
+                                    // A lone trailing GZip ID1 (0x1F) byte was speculatively consumed as a
+                                    // possible concatenated member, but no further data followed. It was
+                                    // actually trailing content: mark the inflater finished so the byte is
+                                    // rewound below and not re-read on subsequent calls.
+                                    _inflater.MarkEndOfStream();
+                                }
+                                else if (s_useStrictValidation && !_inflater.Finished() && _inflater.NonEmptyInput() && !buffer.IsEmpty)
                                 {
                                     ThrowTruncatedInvalidData();
                                 }
@@ -691,8 +709,10 @@ namespace System.IO.Compression
             Debug.Assert(stream.CanSeek);
             Debug.Assert(_inflater != null);
 
-            // Check if there are unconsumed bytes in the inflater's input buffer
-            int unconsumedBytes = _inflater.GetAvailableInput();
+            // Check if there are unconsumed bytes in the inflater's input buffer, plus any lone GZip ID1
+            // (0x1F) byte that was speculatively consumed as an unconfirmed concatenated-member probe but
+            // turned out to be trailing data.
+            int unconsumedBytes = _inflater.GetAvailableInput() + _inflater.UnconfirmedGZipProbeBytes;
             if (unconsumedBytes > 0)
             {
                 try
@@ -961,14 +981,20 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(false);
-                    if (s_useStrictValidation && !_deflateStream._inflater.Finished())
+                    if (s_useStrictValidation && !_deflateStream._inflater.Finished() && !_deflateStream._inflater.HasUnconfirmedGZipProbe)
                     {
                         ThrowTruncatedInvalidData();
                     }
 
-                    // Rewind the stream if decompression has finished and the stream supports seeking
-                    if (_deflateStream._inflater.Finished() && !_deflateStream._decompressionFinished && _deflateStream._stream.CanSeek)
+                    // Rewind the stream if decompression has finished and the stream supports seeking. A lone
+                    // trailing GZip ID1 (0x1F) byte that was speculatively consumed as a possible concatenated
+                    // member also counts as finished here: it was actually trailing data.
+                    if ((_deflateStream._inflater.Finished() || _deflateStream._inflater.HasUnconfirmedGZipProbe) && !_deflateStream._decompressionFinished && _deflateStream._stream.CanSeek)
                     {
+                        if (_deflateStream._inflater.HasUnconfirmedGZipProbe)
+                        {
+                            _deflateStream._inflater.MarkEndOfStream();
+                        }
                         _deflateStream.TryRewindStream(_deflateStream._stream);
                         _deflateStream._decompressionFinished = true;
                     }
@@ -1004,14 +1030,20 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     _deflateStream._stream.CopyTo(this, _arrayPoolBuffer.Length);
-                    if (s_useStrictValidation && !_deflateStream._inflater.Finished())
+                    if (s_useStrictValidation && !_deflateStream._inflater.Finished() && !_deflateStream._inflater.HasUnconfirmedGZipProbe)
                     {
                         ThrowTruncatedInvalidData();
                     }
 
-                    // Rewind the stream if decompression has finished and the stream supports seeking
-                    if (_deflateStream._inflater.Finished() && !_deflateStream._decompressionFinished && _deflateStream._stream.CanSeek)
+                    // Rewind the stream if decompression has finished and the stream supports seeking. A lone
+                    // trailing GZip ID1 (0x1F) byte that was speculatively consumed as a possible concatenated
+                    // member also counts as finished here: it was actually trailing data.
+                    if ((_deflateStream._inflater.Finished() || _deflateStream._inflater.HasUnconfirmedGZipProbe) && !_deflateStream._decompressionFinished && _deflateStream._stream.CanSeek)
                     {
+                        if (_deflateStream._inflater.HasUnconfirmedGZipProbe)
+                        {
+                            _deflateStream._inflater.MarkEndOfStream();
+                        }
                         _deflateStream.TryRewindStream(_deflateStream._stream);
                         _deflateStream._decompressionFinished = true;
                     }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -981,7 +981,11 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(false);
-                    if (s_useStrictValidation && !_deflateStream._inflater.Finished() && !_deflateStream._inflater.HasUnconfirmedGZipProbe)
+                    // A lone trailing GZip ID1 (0x1F) probe only suppresses the truncated-data error when the
+                    // base stream is seekable, since only then can the byte be rewound below. On non-seekable
+                    // streams strict validation still throws, preserving the existing behavior.
+                    if (s_useStrictValidation && !_deflateStream._inflater.Finished() &&
+                        !(_deflateStream._inflater.HasUnconfirmedGZipProbe && _deflateStream._stream.CanSeek))
                     {
                         ThrowTruncatedInvalidData();
                     }
@@ -1030,7 +1034,11 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     _deflateStream._stream.CopyTo(this, _arrayPoolBuffer.Length);
-                    if (s_useStrictValidation && !_deflateStream._inflater.Finished() && !_deflateStream._inflater.HasUnconfirmedGZipProbe)
+                    // A lone trailing GZip ID1 (0x1F) probe only suppresses the truncated-data error when the
+                    // base stream is seekable, since only then can the byte be rewound below. On non-seekable
+                    // streams strict validation still throws, preserving the existing behavior.
+                    if (s_useStrictValidation && !_deflateStream._inflater.Finished() &&
+                        !(_deflateStream._inflater.HasUnconfirmedGZipProbe && _deflateStream._stream.CanSeek))
                     {
                         ThrowTruncatedInvalidData();
                     }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -964,6 +964,16 @@ namespace System.IO.Compression
                 try
                 {
                     Debug.Assert(_deflateStream._inflater != null);
+
+                    // If a lone trailing GZip ID1 (0x1F) probe was already resolved as end-of-stream and the
+                    // base stream rewound, the inflater is terminally finished. A subsequent CopyToAsync would
+                    // otherwise re-read the rewound byte from the base stream and spin (the inflater returns 0
+                    // without consuming input while NeedsInput stays false), so return without re-reading.
+                    if (_deflateStream._inflater.EndOfStreamReached)
+                    {
+                        return;
+                    }
+
                     // Flush any existing data in the inflater to the destination stream.
                     while (!_deflateStream._inflater.Finished())
                     {
@@ -1017,6 +1027,16 @@ namespace System.IO.Compression
                 try
                 {
                     Debug.Assert(_deflateStream._inflater != null);
+
+                    // If a lone trailing GZip ID1 (0x1F) probe was already resolved as end-of-stream and the
+                    // base stream rewound, the inflater is terminally finished. A subsequent CopyTo would
+                    // otherwise re-read the rewound byte from the base stream and spin (the inflater returns 0
+                    // without consuming input while NeedsInput stays false), so return without re-reading.
+                    if (_deflateStream._inflater.EndOfStreamReached)
+                    {
+                        return;
+                    }
+
                     // Flush any existing data in the inflater to the destination stream.
                     while (!_deflateStream._inflater.Finished())
                     {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -23,6 +23,8 @@ namespace System.IO.Compression
         private MemoryHandle _inputBufferHandle;                    // The handle to the buffer that provides input to _zlibStream
         private readonly long _uncompressedSize;
         private long _currentInflatedCount;
+        private int _gzipConcatProbeBytes;                          // Count of leftover bytes speculatively consumed as a possible concatenated GZip member that hasn't been confirmed (only ever 0 or 1, the lone GZip ID1 byte)
+        private bool _endOfStream;                                  // Set once an unconfirmed GZip concatenation probe has been resolved as trailing data at the end of the stream
 
         private object SyncLock => this;                    // Used to make writing to unmanaged structures atomic
 
@@ -80,6 +82,14 @@ namespace System.IO.Compression
 
         public unsafe int InflateVerified(byte* bufPtr, int length)
         {
+            // Once a lone GZip ID1 (0x1F) probe has been confirmed as trailing data at the end of the
+            // stream, the inflater is terminally finished. Returning 0 here prevents DeflateStream from
+            // re-reading (and re-consuming) the byte that was already rewound in the base stream.
+            if (_endOfStream)
+            {
+                return 0;
+            }
+
             // State is valid; attempt inflation
             try
             {
@@ -143,6 +153,9 @@ namespace System.IO.Compression
 
             lock (SyncLock)
             {
+                // Re-evaluating the leftover input supersedes any previously recorded probe.
+                _gzipConcatProbeBytes = 0;
+
                 byte* nextInPointer = (byte*)_zlibStream.NextIn;
                 uint nextAvailIn = _zlibStream.AvailIn;
 
@@ -151,6 +164,13 @@ namespace System.IO.Compression
                 {
                     return true;
                 }
+
+                // A single leftover 0x1F (GZip ID1) is ambiguous: it may be the first byte of a
+                // concatenated member whose ID2 byte hasn't been read yet, or it may be trailing content
+                // after the member. We optimistically treat it as the start of a concatenated member
+                // (resetting below), but remember it as an unconfirmed probe so that DeflateStream can
+                // rewind it if the base stream turns out to have no further data.
+                _gzipConcatProbeBytes = nextAvailIn == 1 ? 1 : 0;
 
                 // Reset our existing zstream.
                 _zlibStream.InflateReset2_(_windowBits);
@@ -168,6 +188,30 @@ namespace System.IO.Compression
         public bool NonEmptyInput() => _nonEmptyInput;
 
         internal int GetAvailableInput() => (int)_zlibStream.AvailIn;
+
+        /// <summary>
+        /// Number of bytes that were speculatively consumed as a possible concatenated GZip member
+        /// header but haven't been confirmed as such (either 0, or 1 for a lone trailing GZip ID1 byte).
+        /// </summary>
+        internal int UnconfirmedGZipProbeBytes => _gzipConcatProbeBytes;
+
+        /// <summary>
+        /// Whether the inflater consumed a lone GZip ID1 (0x1F) byte as an unconfirmed concatenated
+        /// member probe. If the base stream has no further data, that byte was actually trailing
+        /// content and should be rewound.
+        /// </summary>
+        internal bool HasUnconfirmedGZipProbe => _gzipConcatProbeBytes > 0;
+
+        /// <summary>
+        /// Whether an unconfirmed GZip concatenation probe has been resolved as trailing data at the end of the stream.
+        /// </summary>
+        internal bool EndOfStreamReached => _endOfStream;
+
+        /// <summary>
+        /// Marks the inflater as terminally finished after an unconfirmed GZip concatenation probe has
+        /// been rewound, so that subsequent reads don't re-consume the rewound byte from the base stream.
+        /// </summary>
+        internal void MarkEndOfStream() => _endOfStream = true;
 
         public void SetInput(byte[] inputBuffer, int startIndex, int count)
         {
@@ -194,6 +238,9 @@ namespace System.IO.Compression
                 _zlibStream.AvailIn = (uint)inputBuffer.Length;
                 _finished = false;
                 _nonEmptyInput = true;
+
+                // Feeding new input resolves any pending lone-0x1F probe: the byte wasn't trailing data.
+                _gzipConcatProbeBytes = 0;
             }
         }
 

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -211,6 +211,93 @@ namespace System.IO.Compression
             Assert.Equal(-1, stream.ReadByte());
         }
 
+        [InlineData(TestScenario.Read)]
+        [InlineData(TestScenario.ReadAsync)]
+        [InlineData(TestScenario.Copy)]
+        [InlineData(TestScenario.CopyAsync)]
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void TrailingLoneGZipId1_StrictValidation_RewindsWhenSeekableThrowsWhenNot(TestScenario testScenario)
+        {
+            // Guards the intentional strict-validation behavior change for a trailing lone GZip ID1 (0x1F).
+            // The switch is read once into a static readonly field, so it must be set before the type loads;
+            // RemoteExecutor gives each case a fresh process to avoid global switch contamination.
+            RemoteExecutor.Invoke(async (testScenario) =>
+            {
+                TestScenario scenario = Enum.Parse<TestScenario>(testScenario);
+
+                AppContext.SetSwitch("System.IO.Compression.UseStrictValidation", true);
+
+                byte[] payload = "hello"u8.ToArray();
+                byte[] gzip;
+                using (var ms = new MemoryStream())
+                {
+                    using (var gz = new GZipStream(ms, CompressionLevel.SmallestSize, leaveOpen: true))
+                    {
+                        gz.Write(payload);
+                    }
+                    gzip = ms.ToArray();
+                }
+
+                // A single trailing GZip ID1 (0x1F) byte: speculatively consumed as a possible concatenated
+                // member, but it is actually trailing data.
+                byte[] combined = new byte[gzip.Length + 1];
+                gzip.CopyTo(combined, 0);
+                combined[^1] = 0x1F;
+
+                static async Task<byte[]> DecompressAsync(Stream source, TestScenario scenario)
+                {
+                    using var gz = new GZipStream(source, CompressionMode.Decompress, leaveOpen: true);
+                    using var output = new MemoryStream();
+                    switch (scenario)
+                    {
+                        case TestScenario.Copy:
+                            gz.CopyTo(output);
+                            break;
+                        case TestScenario.CopyAsync:
+                            await gz.CopyToAsync(output);
+                            break;
+                        case TestScenario.Read:
+                        {
+                            byte[] buffer = new byte[64];
+                            int n;
+                            while ((n = gz.Read(buffer, 0, buffer.Length)) > 0)
+                            {
+                                output.Write(buffer, 0, n);
+                            }
+                            break;
+                        }
+                        case TestScenario.ReadAsync:
+                        {
+                            byte[] buffer = new byte[64];
+                            int n;
+                            while ((n = await gz.ReadAsync(buffer)) > 0)
+                            {
+                                output.Write(buffer, 0, n);
+                            }
+                            break;
+                        }
+                    }
+                    return output.ToArray();
+                }
+
+                // Seekable: even under strict validation the trailing 0x1F is rewound and preserved, not thrown on.
+                var seekable = new LocalMemoryStream();
+                seekable.Write(combined, 0, combined.Length);
+                seekable.Position = 0;
+                byte[] decompressed = await DecompressAsync(seekable, scenario);
+                Assert.Equal(payload, decompressed);
+                Assert.Equal(gzip.Length, seekable.Position);
+                Assert.Equal(0x1F, seekable.ReadByte());
+
+                // Non-seekable: the probe byte cannot be rewound, so strict validation must still throw.
+                var nonSeekable = new LocalMemoryStream();
+                nonSeekable.Write(combined, 0, combined.Length);
+                nonSeekable.Position = 0;
+                nonSeekable.SetCanSeek(false);
+                await Assert.ThrowsAsync<InvalidDataException>(() => DecompressAsync(nonSeekable, scenario));
+            }, testScenario.ToString()).Dispose();
+        }
+
         [Theory]
         [InlineData(1000, TestScenario.Read, 1000, 1)]
         [InlineData(1000, TestScenario.ReadByte, 0, 1)]

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -211,6 +211,85 @@ namespace System.IO.Compression
             Assert.Equal(-1, stream.ReadByte());
         }
 
+        [Theory]
+        [InlineData(TestScenario.Read)]
+        [InlineData(TestScenario.ReadAsync)]
+        [InlineData(TestScenario.Copy)]
+        [InlineData(TestScenario.CopyAsync)]
+        public async Task TrailingLoneGZipId1_SecondConsume_IsNoOpAndDoesNotHang(TestScenario scenario)
+        {
+            // After a lone trailing GZip ID1 (0x1F) is rewound on a seekable stream, the inflater is
+            // terminally finished. A second decompression pass on the same GZipStream must be a no-op: it must
+            // not re-read and re-feed the rewound byte from the base stream. The copy paths previously spun
+            // forever in that case (the inflater returns 0 without consuming input while NeedsInput stays false).
+            byte[] payload = "hello"u8.ToArray();
+
+            byte[] gzip;
+            using (var ms = new MemoryStream())
+            {
+                using (var gz = new GZipStream(ms, CompressionLevel.SmallestSize, leaveOpen: true))
+                {
+                    gz.Write(payload);
+                }
+                gzip = ms.ToArray();
+            }
+
+            byte[] combined = new byte[gzip.Length + 1];
+            gzip.CopyTo(combined, 0);
+            combined[^1] = 0x1F;
+
+            static async Task<byte[]> DecompressOnce(GZipStream gzipStream, TestScenario scenario)
+            {
+                using var output = new MemoryStream();
+                switch (scenario)
+                {
+                    case TestScenario.Copy:
+                        gzipStream.CopyTo(output);
+                        break;
+                    case TestScenario.CopyAsync:
+                        await gzipStream.CopyToAsync(output);
+                        break;
+                    case TestScenario.Read:
+                    {
+                        byte[] buffer = new byte[64];
+                        int n;
+                        while ((n = gzipStream.Read(buffer, 0, buffer.Length)) > 0)
+                        {
+                            output.Write(buffer, 0, n);
+                        }
+                        break;
+                    }
+                    case TestScenario.ReadAsync:
+                    {
+                        byte[] buffer = new byte[64];
+                        int n;
+                        while ((n = await gzipStream.ReadAsync(buffer)) > 0)
+                        {
+                            output.Write(buffer, 0, n);
+                        }
+                        break;
+                    }
+                }
+                return output.ToArray();
+            }
+
+            using var stream = new MemoryStream(combined);
+            using var decompressor = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
+
+            byte[] first = await DecompressOnce(decompressor, scenario);
+            Assert.Equal(payload, first);
+            Assert.Equal(gzip.Length, stream.Position);
+
+            // Second pass must produce no data and must not hang re-reading the rewound 0x1F.
+            byte[] second = await DecompressOnce(decompressor, scenario);
+            Assert.Empty(second);
+
+            // The trailing byte is still available to the caller after both passes.
+            Assert.Equal(gzip.Length, stream.Position);
+            Assert.Equal(0x1F, stream.ReadByte());
+            Assert.Equal(-1, stream.ReadByte());
+        }
+
         [InlineData(TestScenario.Read)]
         [InlineData(TestScenario.ReadAsync)]
         [InlineData(TestScenario.Copy)]

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -116,6 +116,102 @@ namespace System.IO.Compression
         }
 
         [Theory]
+        [InlineData(0x00, TestScenario.Read)]
+        [InlineData(0x00, TestScenario.ReadByte)]
+        [InlineData(0x00, TestScenario.ReadAsync)]
+        [InlineData(0x00, TestScenario.Copy)]
+        [InlineData(0x00, TestScenario.CopyAsync)]
+        [InlineData(0x1F, TestScenario.Read)]
+        [InlineData(0x1F, TestScenario.ReadByte)]
+        [InlineData(0x1F, TestScenario.ReadAsync)]
+        [InlineData(0x1F, TestScenario.Copy)]
+        [InlineData(0x1F, TestScenario.CopyAsync)]
+        [InlineData(0x8B, TestScenario.Read)]
+        [InlineData(0x8B, TestScenario.ReadAsync)]
+        [InlineData(0x8B, TestScenario.Copy)]
+        [InlineData(0xFF, TestScenario.Read)]
+        [InlineData(0xFF, TestScenario.ReadAsync)]
+        [InlineData(0xFF, TestScenario.Copy)]
+        public async Task TrailingByteAfterGzipMember_IsRewound(byte footer, TestScenario scenario)
+        {
+            // Regression coverage for a seekable leaveOpen:true stream shaped as [header][gzip][1-byte footer].
+            // The decompressor must rewind the base stream to the first footer byte so the caller can read it,
+            // even when the footer byte is the lone GZip ID1 value (0x1F) that the inflater speculatively treats
+            // as the start of a concatenated member.
+            byte[] header = "HEADER"u8.ToArray();
+            byte[] payload = "hello"u8.ToArray();
+
+            byte[] gzip;
+            using (var ms = new MemoryStream())
+            {
+                using (var gz = new GZipStream(ms, CompressionLevel.SmallestSize, leaveOpen: true))
+                {
+                    gz.Write(payload);
+                }
+                gzip = ms.ToArray();
+            }
+
+            byte[] combined = new byte[header.Length + gzip.Length + 1];
+            header.CopyTo(combined, 0);
+            gzip.CopyTo(combined, header.Length);
+            combined[^1] = footer;
+
+            using var stream = new MemoryStream(combined);
+            stream.Position = header.Length;
+
+            byte[] decompressed;
+            using (var gz = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true))
+            using (var output = new MemoryStream())
+            {
+                switch (scenario)
+                {
+                    case TestScenario.Copy:
+                        gz.CopyTo(output);
+                        break;
+                    case TestScenario.CopyAsync:
+                        await gz.CopyToAsync(output);
+                        break;
+                    case TestScenario.ReadByte:
+                        int b;
+                        while ((b = gz.ReadByte()) != -1)
+                        {
+                            output.WriteByte((byte)b);
+                        }
+                        break;
+                    case TestScenario.Read:
+                    {
+                        byte[] buffer = new byte[64];
+                        int n;
+                        while ((n = gz.Read(buffer, 0, buffer.Length)) > 0)
+                        {
+                            output.Write(buffer, 0, n);
+                        }
+                        break;
+                    }
+                    case TestScenario.ReadAsync:
+                    {
+                        byte[] buffer = new byte[64];
+                        int n;
+                        while ((n = await gz.ReadAsync(buffer)) > 0)
+                        {
+                            output.Write(buffer, 0, n);
+                        }
+                        break;
+                    }
+                }
+
+                decompressed = output.ToArray();
+            }
+
+            Assert.Equal(payload, decompressed);
+
+            // The base stream should be rewound to exactly the footer byte, and reading it should return it.
+            Assert.Equal(header.Length + gzip.Length, stream.Position);
+            Assert.Equal(footer, stream.ReadByte());
+            Assert.Equal(-1, stream.ReadByte());
+        }
+
+        [Theory]
         [InlineData(1000, TestScenario.Read, 1000, 1)]
         [InlineData(1000, TestScenario.ReadByte, 0, 1)]
         [InlineData(1000, TestScenario.ReadAsync, 1000, 1)]


### PR DESCRIPTION
## Why

When you decompress a gzip member from a **seekable** base stream opened with `leaveOpen: true`, and a single stray `0x1F` byte (gzip's ID1 magic byte) follows the member, `GZipStream` consumed that byte but never rewound it. The base stream was left positioned one byte past the member, so the trailing `0x1F` was silently lost to whoever read the base stream next.

## Root cause

After a member finishes, `Inflater.ResetStreamForLeftoverInput()` tries to detect a concatenated member by peeking at the leftover input for the 2-byte magic `1F 8B`. It cannot verify that magic from a *single* leftover byte, so with exactly one leftover `0x1F` it optimistically resets zlib. The next `Inflate()` then consumes the `0x1F` as the start of a would-be header, `GetAvailableInput()` drops to 0, and `TryRewindStream` has nothing left to rewind.

## Approach

`Inflater` now records an "unconfirmed lone-`0x1F` probe" — but only when *exactly one* leftover `0x1F` byte triggered the optimistic reset. The probe never fires for a genuine multi-byte concatenation (`1F 8B ...`), and it is cleared as soon as new input arrives or a real concatenation header is seen, so it can never coexist with actual decompressed output.

When the base stream then hits EOF on a seekable stream, `DeflateStream` recognizes the pending probe, rewinds the byte, and marks the inflater terminally finished. `InflateVerified` short-circuits once end-of-stream is confirmed so subsequent reads don't re-advance the base stream (avoiding a re-read that would undo the rewind). This is wired at all four decompression sites: sync `ReadCore`, async `Core`, and sync/async `CopyFromSourceToDestination`.

## Notable points for review

- **Intentional behavioral change under strict validation** (the default-off internal `s_useStrictValidation` AppContext switch): a trailing `0x1F` on a seekable stream now rewinds instead of throwing `InvalidDataException`, making it consistent with the existing trailing-`0xFF` behavior. The non-seekable strict path is unchanged and still throws.
- **Out of scope:** the "separate-chunk" variant, where the finished member and the lone `0x1F` arrive in *separate* `Read`/`Write` chunks, does not set the probe and is not addressed here (it requires a base stream that fragments reads exactly at the member boundary; the reported repro is same-chunk).

## Tests

Adds a regression `[Theory] TrailingByteAfterGzipMember_IsRewound` covering footers `0x00`/`0x1F`/`0x8B`/`0xFF` across `Read`/`ReadByte`/`ReadAsync`/`Copy`/`CopyAsync` (16 cases). Verified the test fails on the `0x1F` cases without the fix and passes with it; the full `System.IO.Compression.Tests` suite passes (2628 tests, 0 failures).

Fixes: #132946

> [!NOTE]
> This pull request was authored with GitHub Copilot.