### PR TITLE
[release/10.0] Fix nested exception handler reachability in ILLink

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -1160,7 +1160,23 @@ namespace Mono.Linker.Steps
                 var reachable = new BitArray(FoldedInstructions.Count);
 
                 Stack<int>? condBranches = null;
-                bool exceptionHandlersChecked = !Body.HasExceptionHandlers;
+                BitArray? reachableExceptionHandlers = null;
+                (int Start, int End)[]? exceptionHandlerRanges = null;
+                if (Body.HasExceptionHandlers)
+                {
+                    int handlerCount = ExceptionHandlers.Count;
+                    reachableExceptionHandlers = new BitArray(handlerCount);
+                    exceptionHandlerRanges = new (int Start, int End)[handlerCount];
+
+                    // Fixed-point discovery can scan handlers multiple times, but instruction positions do not change here.
+                    Collection<Instruction> instructions = Instructions;
+                    for (int handlerIndex = 0; handlerIndex < handlerCount; handlerIndex++)
+                    {
+                        ExceptionHandler handler = ExceptionHandlers[handlerIndex];
+                        exceptionHandlerRanges[handlerIndex] = (instructions.IndexOf(handler.TryStart), instructions.IndexOf(handler.TryEnd) - 1);
+                    }
+                }
+
                 Instruction target;
                 int i = 0;
                 while (true)
@@ -1218,23 +1234,23 @@ namespace Mono.Linker.Steps
                         continue;
                     }
 
-                    if (!exceptionHandlersChecked)
+                    if (reachableExceptionHandlers != null)
                     {
-                        exceptionHandlersChecked = true;
+                        Debug.Assert(exceptionHandlerRanges is not null);
 
-                        var instrs = Instructions;
-                        foreach (var handler in ExceptionHandlers)
+                        // Newly reachable handlers can contain protected regions for nested handlers.
+                        for (int handlerIndex = 0; handlerIndex < ExceptionHandlers.Count; handlerIndex++)
                         {
-                            int start = instrs.IndexOf(handler.TryStart);
-                            int end = instrs.IndexOf(handler.TryEnd) - 1;
-
-                            if (!HasAnyBitSet(reachable, start, end))
-                            {
-                                unreachableHandlers ??= new List<ExceptionHandler>();
-
-                                unreachableHandlers.Add(handler);
+                            if (reachableExceptionHandlers[handlerIndex])
                                 continue;
-                            }
+
+                            var handler = ExceptionHandlers[handlerIndex];
+                            (int Start, int End) range = exceptionHandlerRanges[handlerIndex];
+
+                            if (!HasAnyBitSet(reachable, range.Start, range.End))
+                                continue;
+
+                            reachableExceptionHandlers[handlerIndex] = true;
 
                             condBranches ??= new Stack<int>();
 
@@ -1261,6 +1277,15 @@ namespace Mono.Linker.Steps
                         {
                             i = condBranches.Pop();
                             continue;
+                        }
+
+                        for (int handlerIndex = 0; handlerIndex < ExceptionHandlers.Count; handlerIndex++)
+                        {
+                            if (reachableExceptionHandlers[handlerIndex])
+                                continue;
+
+                            unreachableHandlers ??= new List<ExceptionHandler>();
+                            unreachableHandlers.Add(ExceptionHandlers[handlerIndex]);
                         }
                     }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/NestedFinallyInFinallyHandler.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/NestedFinallyInFinallyHandler.cs
@@ -1,0 +1,57 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.UnreachableBlock
+{
+    [SetupCompileArgument("/optimize+")]
+    [SetupLinkerArgument("--enable-opt", "ipconstprop")]
+    public class NestedFinallyInFinallyHandler
+    {
+        public static void Main()
+        {
+            Test();
+        }
+
+        [Kept]
+        [ExpectBodyModified]
+        static void Test()
+        {
+            try
+            {
+                if (AlwaysFalse)
+                    Unreachable();
+            }
+            finally
+            {
+                try
+                {
+                    Reached();
+                }
+                finally
+                {
+                    try
+                    {
+                        Cleanup();
+                    }
+                    finally
+                    {
+                        NestedCleanup();
+                    }
+                }
+            }
+        }
+
+        static bool AlwaysFalse => false;
+
+        static void Unreachable() { }
+
+        [Kept]
+        static void Reached() { }
+
+        [Kept]
+        static void Cleanup() { }
+
+        [Kept]
+        static void NestedCleanup() { }
+    }
+}


### PR DESCRIPTION
Backport of #131236 to `release/10.0`.

The `ILTrimExpectedFailures.txt` entry from the source PR was omitted because the ILTrim test harness is not present on this branch. The regression test fails against the pre-fix optimizer and all 22 `UnreachableBlock` tests pass with the fix.

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Reported in https://github.com/dotnet/runtime/issues/131088. ILLink removed reachable code in nested exception handlers, causing incorrect app behavior (for example due to remove cleanup code).

## Regression

- [ ] Yes
- [x] No

## Testing

Confirmed it fixes the customer-reported issue, and added test coverage. Existing tests and framework trimming validate it doesn't regress other scenarios as usual.

## Risk

Low: fixes a correctness issue in reachability analysis and does not introduce any other changes. This could lead to increased app size in cases where nested handlers were previously incorrectly trimmed.