### PR TITLE
[release/11.0-rc1] Force runtime discovery for TypeMap entries when unable to encode a type in crossgen2's precomputed TypeMap

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunExternalTypeMapNode.cs
@@ -11,7 +11,12 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.ReadyToRun
 {
-    internal class ReadyToRunExternalTypeMapNode(ModuleDesc triggeringModule, TypeDesc group, TypeMapMetadata.IExternalTypeMap map, ImportReferenceProvider importProvider) : SortableDependencyNode, IExternalTypeMapNode
+    internal class ReadyToRunExternalTypeMapNode(
+        ModuleDesc triggeringModule,
+        TypeDesc group,
+        TypeMapMetadata.IExternalTypeMap map,
+        ImportReferenceProvider importProvider,
+        bool requiresRuntimeProcessing) : SortableDependencyNode, IExternalTypeMapNode
     {
         public TypeDesc TypeMapGroup => group;
 
@@ -40,7 +45,7 @@ namespace ILCompiler.ReadyToRun
         public Vertex CreateTypeMap(NodeFactory factory, NativeWriter writer, Section section, INativeFormatTypeReferenceProvider externalReferences)
         {
             Vertex typeMapGroupVertex = externalReferences.EncodeReferenceToType(writer, TypeMapGroup, TriggeringModule);
-            if (map.ThrowingMethodStub is not null)
+            if (map.ThrowingMethodStub is not null || requiresRuntimeProcessing)
             {
                 // We don't write out the throwing method stub for R2R
                 // as emitting loose methods is not supported/very expensive.
@@ -71,7 +76,7 @@ namespace ILCompiler.ReadyToRun
         {
             yield return new DependencyListEntry(importProvider.GetImportToType(TypeMapGroup, TriggeringModule), $"Type map '{TypeMapGroup}' key type");
 
-            if (map.ThrowingMethodStub is not null)
+            if (map.ThrowingMethodStub is not null || requiresRuntimeProcessing)
             {
                 yield break;
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunProxyTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunProxyTypeMapNode.cs
@@ -9,7 +9,12 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.ReadyToRun
 {
-    internal class ReadyToRunProxyTypeMapNode(ModuleDesc triggeringModule, TypeDesc group, TypeMapMetadata.IProxyTypeMap map, ImportReferenceProvider importProvider) : SortableDependencyNode, IProxyTypeMapNode
+    internal class ReadyToRunProxyTypeMapNode(
+        ModuleDesc triggeringModule,
+        TypeDesc group,
+        TypeMapMetadata.IProxyTypeMap map,
+        ImportReferenceProvider importProvider,
+        bool requiresRuntimeProcessing) : SortableDependencyNode, IProxyTypeMapNode
     {
         public TypeDesc TypeMapGroup => group;
 
@@ -38,7 +43,7 @@ namespace ILCompiler.ReadyToRun
         public Vertex CreateTypeMap(NodeFactory factory, NativeWriter writer, Section section, INativeFormatTypeReferenceProvider ProxyReferences)
         {
             Vertex typeMapGroupVertex = ProxyReferences.EncodeReferenceToType(writer, TypeMapGroup, TriggeringModule);
-            if (map.ThrowingMethodStub is not null)
+            if (map.ThrowingMethodStub is not null || requiresRuntimeProcessing)
             {
                 // We don't write out the throwing method stub for R2R
                 // as emitting loose methods is not supported/very expensive.
@@ -71,7 +76,7 @@ namespace ILCompiler.ReadyToRun
         {
             yield return new DependencyListEntry(importProvider.GetImportToType(TypeMapGroup, TriggeringModule), $"Type map '{TypeMapGroup}' key type");
 
-            if (map.ThrowingMethodStub is not null)
+            if (map.ThrowingMethodStub is not null || requiresRuntimeProcessing)
             {
                 yield break;
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunTypeMapManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunTypeMapManager.cs
@@ -2,22 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
 using ILCompiler.DependencyAnalysisFramework;
+using ILCompiler.ReadyToRun.TypeSystem;
 using Internal.Runtime;
 using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.ReadyToRun
 {
     public sealed class ReadyToRunTypeMapManager(ModuleDesc triggeringModule, TypeMapMetadata assemblyTypeMaps) : TypeMapManager
     {
         private ImportReferenceProvider _importReferenceProvider;
+        private readonly HashSet<TypeDesc> _externalTypeMapsRequiringRuntimeProcessing = [];
+        private readonly HashSet<TypeDesc> _proxyTypeMapsRequiringRuntimeProcessing = [];
 
         public override ModuleDesc AssociatedModule => triggeringModule;
 
         public override void AttachToDependencyGraph(DependencyAnalyzerBase<NodeFactory> graph)
         {
+            if (IsEmpty)
+                return;
+
             base.AttachToDependencyGraph(graph);
             foreach (var map in GetExternalTypeMaps())
             {
@@ -39,7 +47,12 @@ namespace ILCompiler.ReadyToRun
         {
             foreach (var map in assemblyTypeMaps.Maps)
             {
-                yield return new ReadyToRunExternalTypeMapNode(triggeringModule, map.Key, map.Value, _importReferenceProvider);
+                yield return new ReadyToRunExternalTypeMapNode(
+                    triggeringModule,
+                    map.Key,
+                    map.Value,
+                    _importReferenceProvider,
+                    _externalTypeMapsRequiringRuntimeProcessing.Contains(map.Key));
             }
         }
 
@@ -47,7 +60,12 @@ namespace ILCompiler.ReadyToRun
         {
             foreach (var map in assemblyTypeMaps.Maps)
             {
-                yield return new ReadyToRunProxyTypeMapNode(triggeringModule, map.Key, map.Value, _importReferenceProvider);
+                yield return new ReadyToRunProxyTypeMapNode(
+                    triggeringModule,
+                    map.Key,
+                    map.Value,
+                    _importReferenceProvider,
+                    _proxyTypeMapsRequiringRuntimeProcessing.Contains(map.Key));
             }
         }
 
@@ -58,9 +76,108 @@ namespace ILCompiler.ReadyToRun
             if (IsEmpty)
                 return;
 
+            PrepareTypeMapsForEncoding(nodeFactory);
+
             header.Add(ReadyToRunSectionType.ExternalTypeMaps, new ExternalTypeMapObjectNode(this, importReferenceProvider));
             header.Add(ReadyToRunSectionType.ProxyTypeMaps, new ProxyTypeMapObjectNode(this, importReferenceProvider));
             header.Add(ReadyToRunSectionType.TypeMapAssemblyTargets, new TypeMapAssemblyTargetsNode(assemblyTypeMaps, importReferenceProvider));
+        }
+
+        // Some types referenced by TypeMap attributes may not have an existing TypeRef/AssemblyRef relationship to the
+        // module that declared the attribute. Mark just the affected (TypeMapGroup, ProxyOrExternalMap) entry for
+        // runtime attribute processing.
+        private void PrepareTypeMapsForEncoding(NodeFactory nodeFactory)
+        {
+            foreach (var mapEntry in assemblyTypeMaps.Maps)
+            {
+                TypeMapMetadata.Map map = mapEntry.Value;
+
+                // The generic TypeMap attribute TypeSpec necessarily provides an encodable metadata
+                // reference to its group type.
+                Debug.Assert(CanEncodeReferenceToType(mapEntry.Key));
+
+                TypeMapMetadata.IExternalTypeMap externalTypeMap = map;
+                if (externalTypeMap.ThrowingMethodStub is null)
+                {
+                    foreach ((TypeDesc type, _) in externalTypeMap.TypeMap.Values)
+                    {
+                        if (!CanEncodeReferenceToType(type))
+                        {
+                            _externalTypeMapsRequiringRuntimeProcessing.Add(mapEntry.Key);
+                            break;
+                        }
+                    }
+                }
+
+                TypeMapMetadata.IProxyTypeMap proxyTypeMap = map;
+                if (proxyTypeMap.ThrowingMethodStub is null)
+                {
+                    foreach (KeyValuePair<TypeDesc, TypeDesc> typeMapEntry in proxyTypeMap.TypeMap)
+                    {
+                        if (!CanEncodeReferenceToType(typeMapEntry.Key) ||
+                            !CanEncodeReferenceToType(typeMapEntry.Value))
+                        {
+                            _proxyTypeMapsRequiringRuntimeProcessing.Add(mapEntry.Key);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            bool CanEncodeReferenceToType(TypeDesc type)
+            {
+                if (nodeFactory.CompilationModuleGroup.VersionsWithTypeReference(type))
+                    return true;
+
+                if (type is EcmaType ecmaType)
+                {
+                    return MutableModule.CanCreateReferenceToType(
+                        triggeringModule,
+                        ecmaType,
+                        (ReadyToRunCompilationModuleGroupBase)nodeFactory.CompilationModuleGroup);
+                }
+
+                if (type.IsParameterizedType)
+                {
+                    return CanEncodeReferenceToType(((ParameterizedType)type).ParameterType);
+                }
+
+                if (type.IsFunctionPointer)
+                {
+                    MethodSignature signature = ((FunctionPointerType)type).Signature;
+
+                    if (!CanEncodeReferenceToType(signature.ReturnType))
+                        return false;
+
+                    for (int i = 0; i < signature.Length; i++)
+                    {
+                        if (!CanEncodeReferenceToType(signature[i]))
+                            return false;
+                    }
+
+                    return true;
+                }
+
+                if (type.HasInstantiation)
+                {
+                    if (!CanEncodeReferenceToType(type.GetTypeDefinition()))
+                        return false;
+
+                    foreach (TypeDesc instantiationArgument in type.Instantiation)
+                    {
+                        if (!CanEncodeReferenceToType(instantiationArgument))
+                            return false;
+                    }
+
+                    return true;
+                }
+
+                // Generic parameters (encoded as ELEMENT_TYPE_VAR/MVAR) and other simple type
+                // shapes that don't reference any other type by name always encode safely.
+                // Anything else reaching here is an unexpected TypeDesc shape for a TypeMap
+                // key or value; treat it as unencodable rather than assuming successful encoding.
+                return type.IsSignatureVariable;
+            }
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -124,15 +124,25 @@ namespace Internal.TypeSystem.Ecma
                 return result;
             }
 
-            static string GetNameOfAssemblyRefWhichResolvesToType(ModuleDesc module, MetadataType type)
+            // Looks up the AssemblyRef name used by an existing TypeRef in `moduleToSearch` that
+            // resolves to `referencedType` (potentially through a type-forwarder).
+            internal static bool TryGetAssemblyReferenceNameForTypeReference(
+                ModuleDesc moduleToSearch,
+                MetadataType referencedType,
+                out string assemblyReferenceName)
             {
-                if (!s_assemblyNameFromTypeLookups.TryGetValue(module, out var lookupTable))
+                if (!s_assemblyNameFromTypeLookups.TryGetValue(moduleToSearch, out var lookupTable))
                 {
-                    lookupTable = ComputeTypeLookupTable(module);
-                    s_assemblyNameFromTypeLookups.AddOrUpdate(module, lookupTable);
+                    lookupTable = ComputeTypeLookupTable(moduleToSearch);
+                    s_assemblyNameFromTypeLookups.AddOrUpdate(moduleToSearch, lookupTable);
                 }
 
-                if (lookupTable.TryGetValue(type, out string assemblyName))
+                return lookupTable.TryGetValue(referencedType, out assemblyReferenceName);
+            }
+
+            static string GetNameOfAssemblyRefWhichResolvesToType(ModuleDesc module, MetadataType type)
+            {
+                if (TryGetAssemblyReferenceNameForTypeReference(module, type, out string assemblyName))
                 {
                     return assemblyName;
                 }
@@ -147,6 +157,48 @@ namespace Internal.TypeSystem.Ecma
 
                 throw new KeyNotFoundException($"Unable to resolve an assembly reference from module '{module}' to type '{type}'.");
             }
+        }
+
+        internal static bool CanCreateReferenceToType(ModuleDesc sourceModule, MetadataType type, ReadyToRunCompilationModuleGroupBase compilationGroup)
+        {
+            ModuleDesc targetModule = type.Module;
+            if (targetModule == type.Context.SystemModule ||
+                compilationGroup.CrossModuleInlineableModule(targetModule) ||
+                compilationGroup.VersionsWithModule(targetModule))
+            {
+                return true;
+            }
+
+            if (sourceModule is not EcmaModule sourceEcmaModule || targetModule is not EcmaModule targetEcmaModule)
+            {
+                return false;
+            }
+
+            // An existing TypeRef in the source module (potentially resolving to `type` through a
+            // type-forwarder) already proves a matching AssemblyRef exists.
+            if (ManagedBinaryEmitterForInternalUse.TryGetAssemblyReferenceNameForTypeReference(sourceEcmaModule, type, out _))
+            {
+                return true;
+            }
+
+            // Otherwise falls back to the type's defining assembly name, ensuring the
+            // source module has an AssemblyRef to it.
+            string targetAssemblyName = targetEcmaModule.Assembly.GetName().Name;
+            return HasAssemblyReference(sourceEcmaModule, targetAssemblyName);
+        }
+
+        private static bool HasAssemblyReference(EcmaModule module, string assemblyName)
+        {
+            foreach (AssemblyReferenceHandle assemblyReferenceHandle in module.MetadataReader.AssemblyReferences)
+            {
+                AssemblyReference assemblyReference = module.MetadataReader.GetAssemblyReference(assemblyReferenceHandle);
+                if (module.MetadataReader.StringComparer.Equals(assemblyReference.Name, assemblyName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         class Cache


### PR DESCRIPTION
PR #131610 enabled Crossgen2 to precompute TypeMap entries for types referenced only by type name strings in custom-attribute blobs. These references in attributes do not inherently require corresponding `TypeRef` or `AssemblyRef` metadata rows. Roslyn generally emits full assembly identities for external types and may also introduce metadata references, but other valid producers may emit only the serialized name.

Crossgen2 successfully resolves that string to a `TypeDesc`. It therefore knows the target module and full assembly identity. The problem occurs when translating that result into a ReadyToRun type fixup.

The mutable manifest currently represents an out-of-bubble reference using:

```
#<assembly-simple-name>:<source-module-index>

```

At runtime this means:
1. Resolve the source module by index.
2. Find an `AssemblyRef` with that simple name in the source module.
3. Bind that `AssemblyRef`.
4. Resolve the synthetic `TypeRef`.

PR #131610 supplied the target assembly’s simple name even but step 2 was impossible because the source module had no corresponding `AssemblyRef`. The resulting fixup is well-formed, but cannot be resolved.

See https://github.com/dotnet/runtime/issues/132811 for additional info.

To workaround the issue, we emit the (TypeMapGroup, ProxyOrExternalMap) entry with a `0` state, which tells the runtime to build the map from attributes instead of using the precomputed map. This was done previously for maps that are expected to throw a type system exception. This allows some parts of the type map to still be encoded if a single entry is unencodable.

The fix going into main is https://github.com/dotnet/runtime/pull/133038, which is more involved, modifies the R2R format, and bumps the R2R version. Since there are workarounds for the mobile team, we can do this less risky change for the backport. 

## Customer Impact

Found internally. Crossgenned apps with a valid precomputed type map can throw at runtime.

## Regression

Yes. The original TypeMap implementation would create the map only at runtime. The TypeMap precomputation PR introduced issue https://github.com/dotnet/runtime/issues/131527. The fix for that introduced issue https://github.com/dotnet/runtime/issues/132811, the one this fixes.

## Testing

The existing test suite caught the issue but wasn't run in the PRs because crossgen tests aren't a part the default 'runtime' pipeline. The crossgen2 pipelines catch this issue and will be green if the issue is fixed.

## Risk

Low. The fix doesn't introduce new features or a change to the TypeMap section format. It utilizes existing functionality to force runtime computation of the map. There is a risk that we haven't caught all possible edge cases.