### PR TITLE
[mono][llvm] Properly link endfinally to leave targets

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -694,8 +694,13 @@ compute_bb_regions (MonoCompile *cfg)
 }
 
 
-static gboolean
-ip_in_finally_clause (MonoCompile *cfg, int offset)
+/*
+ * Return the index of the innermost finally/fault clause whose handler contains
+ * OFFSET, or -1 if there is none. The clauses are ordered from inner to outer,
+ * so the first match is the innermost one.
+ */
+static int
+ip_get_finally_clause_index (MonoCompile *cfg, int offset)
 {
 	MonoMethodHeader *header = cfg->header;
 	MonoExceptionClause *clause;
@@ -706,9 +711,9 @@ ip_in_finally_clause (MonoCompile *cfg, int offset)
 			continue;
 
 		if (MONO_OFFSET_IN_HANDLER (clause, GINT_TO_UINT32(offset)))
-			return TRUE;
+			return GUINT_TO_INT (i);
 	}
-	return FALSE;
+	return -1;
 }
 
 /* Find clauses between ip and target, from inner to outer */
@@ -6456,6 +6461,12 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	MonoBasicBlock *tblock = NULL;
 	MonoBasicBlock *init_localsbb = NULL, *init_localsbb2 = NULL;
 	MonoSimpleBasicBlock *bb = NULL, *original_bb = NULL;
+	/*
+	 * For each finally clause, the bblocks containing its ENDFINALLY instructions and the
+	 * targets of the LEAVE instructions which invoke it. Only used by the LLVM backend.
+	 */
+	GSList **clause_endfinally_bbs = NULL;
+	GSList **clause_leave_target_bbs = NULL;
 	MonoMethod *method_definition;
 	MonoInst **arg_array;
 	MonoMethodHeader *header;
@@ -6658,6 +6669,11 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		if (header->num_clauses) {
 			cfg->spvars = g_hash_table_new (NULL, NULL);
 			cfg->exvars = g_hash_table_new (NULL, NULL);
+
+			if (COMPILE_LLVM (cfg)) {
+				clause_endfinally_bbs = mono_mempool_alloc0 (cfg->mempool, sizeof (GSList*) * header->num_clauses);
+				clause_leave_target_bbs = mono_mempool_alloc0 (cfg->mempool, sizeof (GSList*) * header->num_clauses);
+			}
 		}
 		cfg->clause_is_dead = mono_mempool_alloc0 (cfg->mempool, sizeof (gboolean) * header->num_clauses);
 
@@ -11224,14 +11240,20 @@ field_access_end:
 			if (COMPILE_LLVM (cfg))
 				INLINE_FAILURE ("throw");
 			break;
-		case MONO_CEE_ENDFINALLY:
-			if (!ip_in_finally_clause (cfg, GPTRDIFF_TO_INT (ip - header->code)))
+		case MONO_CEE_ENDFINALLY: {
+			int clause_index = ip_get_finally_clause_index (cfg, GPTRDIFF_TO_INT (ip - header->code));
+
+			if (clause_index < 0)
 				UNVERIFIED;
 			/* mono_save_seq_point_info () depends on this */
 			if (sp != stack_start)
 				emit_seq_point (cfg, method, ip, FALSE, FALSE);
 			MONO_INST_NEW (cfg, ins, OP_ENDFINALLY);
 			MONO_ADD_INS (cfg->cbb, ins);
+
+			if (clause_endfinally_bbs)
+				clause_endfinally_bbs [clause_index] = g_slist_prepend_mempool (cfg->mempool, clause_endfinally_bbs [clause_index], cfg->cbb);
+
 			start_new_bblock = 1;
 			ins_has_side_effect = FALSE;
 
@@ -11243,6 +11265,7 @@ field_access_end:
 				sp--;
 			}
 			break;
+		}
 		case MONO_CEE_LEAVE:
 		case MONO_CEE_LEAVE_S: {
 			GList *handlers;
@@ -11344,16 +11367,10 @@ field_access_end:
 					MONO_START_BB (cfg, dont_throw);
 					cfg->cbb->clause_holes = tmp;
 
-					if (COMPILE_LLVM (cfg)) {
+					if (clause_leave_target_bbs) {
 						MonoBasicBlock *target_bb;
-
-						/*
-						 * Link the finally bblock with the target, since it will
-						 * conceptually branch there.
-						 */
-						GET_BBLOCK (cfg, tblock, cfg->cil_start + clause->handler_offset + clause->handler_len - 1);
 						GET_BBLOCK (cfg, target_bb, target);
-						link_bblock (cfg, tblock, target_bb);
+						clause_leave_target_bbs [leave->index] = g_slist_prepend_mempool (cfg->mempool, clause_leave_target_bbs [leave->index], target_bb);
 					}
 				}
 			}
@@ -12547,6 +12564,19 @@ all_bbs_done:
 
 				NEW_SEQ_POINT (cfg, seq_point_ins, i, FALSE);
 				mono_add_seq_point (cfg, NULL, seq_point_ins, SEQ_POINT_NATIVE_OFFSET_DEAD_CODE);
+			}
+		}
+	}
+
+	/*
+	 * Link the finally bblock with the target, since it will
+	 * conceptually branch there.
+	 */
+	if (clause_endfinally_bbs) {
+		for (guint i = 0; i < header->num_clauses; ++i) {
+			for (GSList *l = clause_endfinally_bbs [i]; l; l = l->next) {
+				for (GSList *l2 = clause_leave_target_bbs [i]; l2; l2 = l2->next)
+					link_bblock (cfg, (MonoBasicBlock*)l->data, (MonoBasicBlock*)l2->data);
 			}
 		}
 	}

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -6465,8 +6465,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	 * For each finally clause, the bblocks containing its ENDFINALLY instructions and the
 	 * targets of the LEAVE instructions which invoke it. Only used by the LLVM backend.
 	 */
-	GSList **clause_endfinally_bbs = NULL;
-	GSList **clause_leave_target_bbs = NULL;
+	GSList **llvm_clause_endfinally_bbs = NULL;
+	GSList **llvm_clause_leave_target_bbs = NULL;
 	MonoMethod *method_definition;
 	MonoInst **arg_array;
 	MonoMethodHeader *header;
@@ -6671,8 +6671,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			cfg->exvars = g_hash_table_new (NULL, NULL);
 
 			if (COMPILE_LLVM (cfg)) {
-				clause_endfinally_bbs = mono_mempool_alloc0 (cfg->mempool, sizeof (GSList*) * header->num_clauses);
-				clause_leave_target_bbs = mono_mempool_alloc0 (cfg->mempool, sizeof (GSList*) * header->num_clauses);
+				llvm_clause_endfinally_bbs = mono_mempool_alloc0 (cfg->mempool, sizeof (GSList*) * header->num_clauses);
+				llvm_clause_leave_target_bbs = mono_mempool_alloc0 (cfg->mempool, sizeof (GSList*) * header->num_clauses);
 			}
 		}
 		cfg->clause_is_dead = mono_mempool_alloc0 (cfg->mempool, sizeof (gboolean) * header->num_clauses);
@@ -11251,8 +11251,8 @@ field_access_end:
 			MONO_INST_NEW (cfg, ins, OP_ENDFINALLY);
 			MONO_ADD_INS (cfg->cbb, ins);
 
-			if (clause_endfinally_bbs)
-				clause_endfinally_bbs [clause_index] = g_slist_prepend_mempool (cfg->mempool, clause_endfinally_bbs [clause_index], cfg->cbb);
+			if (llvm_clause_endfinally_bbs)
+				llvm_clause_endfinally_bbs [clause_index] = g_slist_prepend_mempool (cfg->mempool, llvm_clause_endfinally_bbs [clause_index], cfg->cbb);
 
 			start_new_bblock = 1;
 			ins_has_side_effect = FALSE;
@@ -11367,10 +11367,10 @@ field_access_end:
 					MONO_START_BB (cfg, dont_throw);
 					cfg->cbb->clause_holes = tmp;
 
-					if (clause_leave_target_bbs) {
+					if (llvm_clause_leave_target_bbs) {
 						MonoBasicBlock *target_bb;
 						GET_BBLOCK (cfg, target_bb, target);
-						clause_leave_target_bbs [leave->index] = g_slist_prepend_mempool (cfg->mempool, clause_leave_target_bbs [leave->index], target_bb);
+						llvm_clause_leave_target_bbs [leave->index] = g_slist_prepend_mempool (cfg->mempool, llvm_clause_leave_target_bbs [leave->index], target_bb);
 					}
 				}
 			}
@@ -12572,10 +12572,10 @@ all_bbs_done:
 	 * Link the finally bblock with the target, since it will
 	 * conceptually branch there.
 	 */
-	if (clause_endfinally_bbs) {
+	if (llvm_clause_endfinally_bbs) {
 		for (guint i = 0; i < header->num_clauses; ++i) {
-			for (GSList *l = clause_endfinally_bbs [i]; l; l = l->next) {
-				for (GSList *l2 = clause_leave_target_bbs [i]; l2; l2 = l2->next)
+			for (GSList *l = llvm_clause_endfinally_bbs [i]; l; l = l->next) {
+				for (GSList *l2 = llvm_clause_leave_target_bbs [i]; l2; l2 = l2->next)
 					link_bblock (cfg, (MonoBasicBlock*)l->data, (MonoBasicBlock*)l2->data);
 			}
 		}

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -12821,7 +12821,13 @@ MONO_RESTORE_WARNING
 		return;
 
 	if (!has_terminator && bb->next_bb && bb != cfg->bb_exit && (bb == cfg->bb_entry || bb->in_count > 0)) {
-		LLVMBuildBr (builder, get_bb (ctx, bb->next_bb));
+		MonoBasicBlock *next_bb = bb->next_bb;
+
+		while (next_bb && next_bb->in_count == 0)
+			next_bb = next_bb->next_bb;
+
+		if (next_bb)
+			LLVMBuildBr (builder, get_bb (ctx, next_bb));
 	}
 
 	if (bb == cfg->bb_exit && sig->ret->type == MONO_TYPE_VOID) {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_132936/Runtime_132936.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_132936/Runtime_132936.il
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// The finally handler below does not end with its endfinally instruction, it ends with a
+// branch back to it. Mono used to assume that the last byte of a finally handler is the
+// endfinally opcode when linking the handler with the target of the leave instruction,
+// which created a bogus cfg edge from a bblock which was never emitted. That left an
+// unfilled phi argument behind, which the array bounds check removal pass then followed.
+// The dead code inside the handler is what pushes the endfinally away from the end.
+
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
+.assembly extern xunit.core { }
+.assembly Runtime_132936 { }
+
+.class public sequential ansi sealed beforefieldinit Scope
+       extends [System.Runtime]System.ValueType
+{
+  .field private int32 _dummy
+
+  .method public hidebysig instance void Close() cil managed
+  {
+    .maxstack 8
+    ret
+  }
+}
+
+.class public auto ansi sealed beforefieldinit Runtime_132936
+       extends [System.Runtime]System.Object
+{
+  .method public static int32 Main()
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    .maxstack 2
+
+    ldc.i4.4
+    call int32 Runtime_132936::Test(int32)
+    ldc.i4.4
+    bne.un.s FAIL
+
+    ldc.i4.4
+    call int32 Runtime_132936::TestDeadCodeAfterEndFinally(int32)
+    ldc.i4.4
+    bne.un.s FAIL
+
+    ldc.i4.s 100
+    ret
+
+  FAIL:
+    ldc.i4.s 101
+    ret
+  }
+
+  // Returns the number of elements it walked over, i.e. len.
+  .method private static int32 Test(int32 len) cil managed
+  {
+    .maxstack 4
+    .locals init (int32[] V_0, valuetype Scope V_1, int32 V_2)
+
+    .try
+    {
+              ldarg.0
+              newarr    [System.Runtime]System.Int32
+              ldc.i4.7
+              brtrue.s  STORE
+              pop
+    MID:      nop
+              leave.s   AFTER
+
+    STORE:    stloc.0
+              br.s      MID
+    }
+    finally
+    {
+              ldloca.s  V_1
+              ldc.i4.3
+              brtrue.s  CLOSE
+              pop
+    EF:       endfinally
+
+    CLOSE:    call      instance void Scope::Close()
+              br.s      EF
+    }
+
+  AFTER:      ldc.i4.0
+              stloc.2
+              br.s      COND
+
+  LOOP:       ldloc.0
+              ldloc.2
+              ldelem.i4
+              pop
+              ldloc.2
+              ldc.i4.1
+              add
+              stloc.2
+
+  COND:       ldloc.2
+              ldloc.0
+              ldlen
+              conv.i4
+              blt.s     LOOP
+
+              ldloc.2
+              ret
+  }
+
+  // Same problem, but here the block following the endfinally is unreachable. Mono terminates
+  // the llvm basic block of the handler with an implicit branch to the next bblock, which is
+  // never emitted because it is unreachable, leaving a block without a terminator behind.
+  //
+  // Returns the number of elements it walked over, i.e. len.
+  .method private static int32 TestDeadCodeAfterEndFinally(int32 len) cil managed
+  {
+    .maxstack 4
+    .locals init (int32[] V_0, int32 V_1)
+
+    .try
+    {
+              ldarg.0
+              newarr    [System.Runtime]System.Int32
+              stloc.0
+              leave.s   AFTER
+    }
+    finally
+    {
+    EF:       endfinally
+              br.s      EF
+    }
+
+  AFTER:      ldc.i4.0
+              stloc.1
+              br.s      COND
+
+  LOOP:       ldloc.0
+              ldloc.1
+              ldelem.i4
+              pop
+              ldloc.1
+              ldc.i4.1
+              add
+              stloc.1
+
+  COND:       ldloc.1
+              ldloc.0
+              ldlen
+              conv.i4
+              blt.s     LOOP
+
+              ldloc.1
+              ret
+  }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_132936/Runtime_132936.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_132936/Runtime_132936.ilproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When emitting a leave instruction, we need to find all finally blocks so that we call all those handlers beforehand. LLVM chooses to link the finally block with the leave targets so it does it and this point. It does it however in a wrong way, by linking the bblock containing the last instruction to the leave target. This is incorrect because a finally block can have multiple endfinally opcodes and the last opcode doesn't necessarily need to be an endfinally in the first place. This invalid CFG generation could trigger asserts in later optimization passes.

As a fix, whenever we compile a leave and obtain all the protecting finally handlers, we store them in a per-finally handler list. Then, once the code gen is finished, we iterate over all instructions of bblocks in those finally blocks and, whenever we encounter an endfinally, we link that bblock to the leave target. This fixes the invalid linking of bblocks as well as properly handling the scenario of having multiple endfinally blocks.

Fixes https://github.com/dotnet/runtime/issues/132936