### PR TITLE
Document that PhysicalFilesWatcher can watch paths that don't exist

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.FileProviders
         /// <summary>
         /// Initializes a new instance of the <see cref="PhysicalFileProvider"/> class at the given root directory.
         /// </summary>
-        /// <param name="root">The root directory. This should be an absolute path.</param>
+        /// <param name="root">The root directory. This should be an absolute path. The directory isn't required to exist.</param>
         public PhysicalFileProvider(string root)
             : this(root, ExclusionFilters.Sensitive)
         {
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.FileProviders
         /// <summary>
         /// Initializes a new instance of the <see cref="PhysicalFileProvider"/> class at the given root directory.
         /// </summary>
-        /// <param name="root">The root directory. This should be an absolute path.</param>
+        /// <param name="root">The root directory. This should be an absolute path. The directory isn't required to exist.</param>
         /// <param name="filters">A bitwise combination of the enumeration values that specifies which files or directories are excluded.</param>
         public PhysicalFileProvider(string root, ExclusionFilters filters)
         {
@@ -337,8 +337,8 @@ namespace Microsoft.Extensions.FileProviders
         ///     <para>Globbing patterns are interpreted by <see cref="Microsoft.Extensions.FileSystemGlobbing.Matcher" />.</para>
         /// </summary>
         /// <param name="filter">
-        /// Filter string used to determine what files or directories to monitor. Example: **/*.cs, *.*,
-        /// subDirectory/**/*.cshtml.
+        /// A filter string used to determine what files or directories to monitor. Examples: <c>**/*.cs</c>, <c>*.*</c>,
+        /// and <c>subDirectory/**/*.cshtml</c>. The files or directories aren't required to exist when this method is called.
         /// </param>
         /// <returns>
         /// An <see cref="IChangeToken" /> that is notified when a file or directory matching <paramref name="filter" /> is added,

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// <summary>
         /// Initializes a new instance of the <see cref="PhysicalFilesWatcher"/> class that watches files in <paramref name="root"/>.
         /// </summary>
-        /// <param name="root">The root directory for the watcher.</param>
+        /// <param name="root">The root directory for the watcher. The directory isn't required to exist.</param>
         /// <param name="fileSystemWatcher">The wrapped watcher that's watching <paramref name="root"/>.</param>
         /// <param name="pollForChanges">
         /// <see langword="true"/> for the poller to use polling to trigger instances of
@@ -83,7 +83,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// <summary>
         /// Initializes a new instance of the <see cref="PhysicalFilesWatcher"/> class that watches files in <paramref name="root"/>.
         /// </summary>
-        /// <param name="root">The root directory for the watcher.</param>
+        /// <param name="root">The root directory for the watcher. The directory isn't required to exist.</param>
         /// <param name="fileSystemWatcher">The wrapped watcher that is watching <paramref name="root"/>.</param>
         /// <param name="pollForChanges">
         /// <see langword="true"/> for the poller to use polling to trigger instances of
@@ -160,7 +160,9 @@ namespace Microsoft.Extensions.FileProviders.Physical
         /// Creates an instance of <see cref="IChangeToken" /> for all files and directories that match the
         /// <paramref name="filter" />.
         /// </summary>
-        /// <param name="filter">A globbing pattern for files and directories to watch.</param>
+        /// <param name="filter">
+        /// A globbing pattern for files and directories to watch. The files or directories aren't required to exist when this method is called.
+        /// </param>
         /// <returns>A change token for all files and directories that match the filter.</returns>
         /// <remarks>
         /// Globbing patterns are relative to the root directory given in the constructor


### PR DESCRIPTION
Also fixes formatting of `PhysicalFilesProvider.Watch()` parameter:

<img width="919" height="142" alt="image" src="https://github.com/user-attachments/assets/92200835-f44d-4771-b16b-6522632b3252" />
