### PR TITLE
JIT: Fix Crossgen2 assertion for non-inlineable tail-call GDV

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -9141,14 +9141,9 @@ bool Compiler::canKeepNonInlineableGdvCandidate(GenTreeCall* call)
         return false;
     }
 
-    // An explicit tail call has to stay a tail call, so don't perturb its shape.
+    // Don't keep non-inlineable GDV candidates for tail calls.
     //
-    // Implicit ones are fine: fgMorphPotentialTailCall can tail call out of the
-    // BBJ_ALWAYS blocks the expansion produces. That includes recursive ones -
-    // the tail-recursion-to-loop transform requires a non-virtual callee, so
-    // devirtualizing here is what makes it possible in the first place.
-    //
-    if (call->IsTailPrefixedCall())
+    if (call->CanTailCall())
     {
         return false;
     }


### PR DESCRIPTION
Main is currently broken in Checked CoreCLR builds while crossgenning `System.Private.CoreLib`:

```
Assertion failed 'block->HasFlag(BBF_RECURSIVE_TAILCALL)' in 'System.Type:GetTypeCodeImpl():int:this' during 'Morph - Inlining'
```

#132375 began retaining non-inlineable GDV candidates for implicit recursive tail calls after [this review discussion](https://github.com/dotnet/runtime/pull/132375#discussion_r3797398249). GDV expansion then moves the residual recursive call into a new block without its recursive-tailcall block marker, triggering the assertion.

Conservatively avoid retaining non-inlineable GDV candidates for all tail calls. Inlineable implicit-tail-call GDV remains unchanged. We can be less conservative, but that requires changes in the GDV expansion code (at very least - mark blocks as containing a tail call, ensure its shape is correct).

Validation:
- `build.cmd Clr.Jit -c Checked`
- Re-ran the failing Crossgen2 command
- SuperPMI replay of `benchmarks.run.` (56,322 contexts)