### PR TITLE
[release/11.0] Preserve side effects in SIMD classification helpers

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -25840,7 +25840,7 @@ GenTree* Compiler::gtNewSimdIsFiniteNode(var_types type, GenTree* op1, var_types
     }
 
     assert(varTypeIsIntegral(simdBaseType));
-    return gtNewAllBitsSetConNode(type);
+    return gtWrapWithSideEffects(gtNewAllBitsSetConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -25870,7 +25870,7 @@ GenTree* Compiler::gtNewSimdIsInfinityNode(var_types type, GenTree* op1, var_typ
         op1 = gtNewSimdAbsNode(type, op1, simdBaseType, simdSize);
         return gtNewSimdIsPositiveInfinityNode(type, op1, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -25909,7 +25909,7 @@ GenTree* Compiler::gtNewSimdIsIntegerNode(var_types type, GenTree* op1, var_type
     }
 
     assert(varTypeIsIntegral(simdBaseType));
-    return gtNewAllBitsSetConNode(type);
+    return gtWrapWithSideEffects(gtNewAllBitsSetConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -25939,7 +25939,7 @@ GenTree* Compiler::gtNewSimdIsNaNNode(var_types type, GenTree* op1, var_types si
         GenTree* op1Dup = fgMakeMultiUse(&op1);
         return gtNewSimdCmpOpNode(GT_NE, type, op1, op1Dup, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -25975,7 +25975,7 @@ GenTree* Compiler::gtNewSimdIsNegativeNode(var_types type, GenTree* op1, var_typ
 
     if (varTypeIsUnsigned(simdBaseType))
     {
-        return gtNewZeroConNode(type);
+        return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
     }
     return gtNewSimdCmpOpNode(GT_LT, type, op1, gtNewZeroConNode(type), simdBaseType, simdSize);
 }
@@ -26025,7 +26025,7 @@ GenTree* Compiler::gtNewSimdIsNegativeInfinityNode(var_types type,
 
         return gtNewSimdCmpOpNode(GT_EQ, type, op1, cnsNode, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -26144,7 +26144,7 @@ GenTree* Compiler::gtNewSimdIsPositiveNode(var_types type, GenTree* op1, var_typ
 
     if (varTypeIsUnsigned(simdBaseType))
     {
-        return gtNewAllBitsSetConNode(type);
+        return gtWrapWithSideEffects(gtNewAllBitsSetConNode(type), op1, GTF_ALL_EFFECT);
     }
     return gtNewSimdCmpOpNode(GT_GE, type, op1, gtNewZeroConNode(type), simdBaseType, simdSize);
 }
@@ -26194,7 +26194,7 @@ GenTree* Compiler::gtNewSimdIsPositiveInfinityNode(var_types type,
 
         return gtNewSimdCmpOpNode(GT_EQ, type, op1, cnsNode, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -26248,7 +26248,7 @@ GenTree* Compiler::gtNewSimdIsSubnormalNode(var_types type, GenTree* op1, var_ty
 
         return gtNewSimdCmpOpNode(GT_LT, type, op1, cnsNode2, simdBaseType, simdSize);
     }
-    return gtNewZeroConNode(type);
+    return gtWrapWithSideEffects(gtNewZeroConNode(type), op1, GTF_ALL_EFFECT);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/src/tests/JIT/Regression/JitBlue/Runtime_132902/Runtime_132902.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_132902/Runtime_132902.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+namespace Runtime_132902;
+
+public class Runtime_132902
+{
+    public enum Classification
+    {
+        IsFinite,
+        IsInfinity,
+        IsInteger,
+        IsNaN,
+        IsNegative,
+        IsNegativeInfinity,
+        IsPositive,
+        IsPositiveInfinity,
+        IsSubnormal,
+    }
+
+    [Theory]
+    [InlineData(Classification.IsFinite)]
+    [InlineData(Classification.IsInfinity)]
+    [InlineData(Classification.IsInteger)]
+    [InlineData(Classification.IsNaN)]
+    [InlineData(Classification.IsNegative)]
+    [InlineData(Classification.IsNegativeInfinity)]
+    [InlineData(Classification.IsPositive)]
+    [InlineData(Classification.IsPositiveInfinity)]
+    [InlineData(Classification.IsSubnormal)]
+    public static void TestEntryPoint(Classification classification)
+    {
+        Action action = classification switch
+        {
+            Classification.IsFinite => () => IsFinite(Vector128<int>.Count),
+            Classification.IsInfinity => () => IsInfinity(Vector128<int>.Count),
+            Classification.IsInteger => () => IsInteger(Vector128<int>.Count),
+            Classification.IsNaN => () => IsNaN(Vector128<int>.Count),
+            Classification.IsNegative => () => IsNegative(Vector128<uint>.Count),
+            Classification.IsNegativeInfinity => () => IsNegativeInfinity(Vector128<int>.Count),
+            Classification.IsPositive => () => IsPositive(Vector128<uint>.Count),
+            Classification.IsPositiveInfinity => () => IsPositiveInfinity(Vector128<int>.Count),
+            Classification.IsSubnormal => () => IsSubnormal(Vector128<int>.Count),
+            _ => throw new ArgumentOutOfRangeException(nameof(classification)),
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(action);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsFinite(int index) =>
+        Vector128.IsFinite(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsInfinity(int index) =>
+        Vector128.IsInfinity(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsInteger(int index) =>
+        Vector128.IsInteger(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsNaN(int index) =>
+        Vector128.IsNaN(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<uint> IsNegative(int index) =>
+        Vector128.IsNegative(Vector128.WithElement(Vector128<uint>.Zero, index, 0u));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsNegativeInfinity(int index) =>
+        Vector128.IsNegativeInfinity(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<uint> IsPositive(int index) =>
+        Vector128.IsPositive(Vector128.WithElement(Vector128<uint>.Zero, index, 0u));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsPositiveInfinity(int index) =>
+        Vector128.IsPositiveInfinity(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<int> IsSubnormal(int index) =>
+        Vector128.IsSubnormal(Vector128.WithElement(Vector128<int>.Zero, index, 0));
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -129,6 +129,7 @@
     <Compile Include="JitBlue\Runtime_122237\Runtime_122237.cs" />
     <Compile Include="JitBlue\Runtime_131716\Runtime_131716.cs" />
     <Compile Include="JitBlue\Runtime_132268\Runtime_132268.cs" />
+    <Compile Include="JitBlue\Runtime_132902\Runtime_132902.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Fixes #132902

main PR https://github.com/dotnet/runtime/pull/132921

# Description

Backports the fix that preserves operand side effects when SIMD classification helpers fold to constant results. This covers all nine affected classification operations.

# Customer Impact

Without this fix, the JIT can remove observable side effects, including exceptions, from operands passed to SIMD classification APIs. Behavior can differ depending on the compilation tier.

# Regression

No known regression in .NET 11.

# Testing

Built the checked CoreCLR runtime and the priority-1 `Regression_ro_2` project. The checked consolidated regression shard passed, including all nine `Runtime_132902` cases. `jit-format` completed successfully for Windows x64.

# Risk

Low. The change is limited to preserving side effects on existing constant-folding paths by using the established `gtWrapWithSideEffects` helper. Regression coverage exercises every affected classification operation.

# Package authoring no longer needed in .NET 9

IMPORTANT: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
