### PR TITLE
[System.Text.Json] Use root-level patterns for generated unions

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -738,8 +738,7 @@ namespace System.Text.Json.SourceGeneration
                     writer.WriteLine("},");
 
                     // The deconstructor switch has no `_` arm — it relies on the union's
-                    // declared case set being exhaustively covered by its arms. The `Value`
-                    // property patterns below still count towards that coverage, so adding a
+                    // declared case set being exhaustively covered by its arms. Adding a
                     // `_` arm would make it unreachable (CS8510).
                     writer.WriteLine($"UnionDeconstructor = static ({genericArg} value) =>");
                     writer.WriteLine('{');
@@ -787,15 +786,7 @@ namespace System.Text.Json.SourceGeneration
                         string patternTypeFQN = caseSpec.PatternType.FullyQualifiedName;
                         string caseTypeFQN = caseSpec.CaseType.FullyQualifiedName;
 
-                        // Always match on Value rather than writing a bare type pattern. C# union
-                        // matching tests a type pattern against the union instance before falling
-                        // back to the union's value, so whenever the instance can itself match the
-                        // case type the bare form binds the incoming union instead of its payload —
-                        // silently where the conversion is implicit, and as CS8780 where it is not.
-                        // The union shape guarantees a public object Value holding the payload, so
-                        // the property pattern is unconditionally correct and does not depend on
-                        // predicting which types the compiler considers instance-compatible.
-                        writer.WriteLine($"{{ Value: {patternTypeFQN} caseValue{deconArmIndex} }} => (typeof({caseTypeFQN}), (object?)caseValue{deconArmIndex}),");
+                        writer.WriteLine($"{patternTypeFQN} caseValue{deconArmIndex} => (typeof({caseTypeFQN}), (object?)caseValue{deconArmIndex}),");
                         deconArmIndex++;
                     }
 

--- a/src/libraries/System.Text.Json/tests/Common/UnionTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/UnionTests.cs
@@ -1792,9 +1792,8 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         // The self-referential case is nullable, which makes it the union's null case as well:
-        // the generated null arm reports typeof(NullableNat?) while the payload arm still has
-        // to dispatch off Value. Covers the interaction between Nullable<T> case unwrapping
-        // and union-instance matching, since both apply to the same case here.
+        // the generated null arm reports typeof(NullableNat?) while the non-null arm matches
+        // the unwrapped NullableNat payload.
         public union NullableNat(bool, NullableNat?);
 
         [Theory]
@@ -1836,8 +1835,8 @@ namespace System.Text.Json.Serialization.Tests
         #region Class unions with subtype cases
 
         // A [Union] class is not sealed, so a case type can derive from the union itself.
-        // The union instance is then pattern compatible with the case type, exactly as it is
-        // for a self-referential case, but by the opposite subtyping direction.
+        // Root-level union type patterns still target the payload, even when an ordinary type
+        // pattern could match the union instance through that inheritance.
         //
         // Value is [JsonIgnore]d because CircleShape inherits it, and would otherwise carry it
         // into its own JSON object. That has no bearing on union recognition: ShapeUnion is
@@ -1914,18 +1913,14 @@ namespace System.Text.Json.Serialization.Tests
 
         #endregion
 
-        #region Class unions matched by their own case types
+        #region Class unions overlapping their own case types
 
         // ShapeUnion above covers a case type deriving from the union. This region covers the
         // opposite subtyping direction: the union derives from, or implements, one of its own
         // case types.
         //
-        // Both directions make the union instance pattern compatible with the case type, but the
-        // language treats them very differently. An explicit reference conversion (case derives
-        // from union) puts the compiler into Try-Both mode, which it reports. An implicit one
-        // (union derives from case) suppresses union matching altogether, so a bare type pattern
-        // binds the union instance rather than the payload, silently and with no diagnostic.
-        // These tests pin the payload as the observable result in that silent direction.
+        // In both directions, an ordinary type pattern could match the union instance. Union type
+        // patterns instead target the payload; these tests pin the payload as the observable result.
 
         [JsonConverter(typeof(JsonWritableConverter))]
         public interface IJsonWritable
@@ -1950,8 +1945,8 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         // The union implements the same interface it declares as a case. Because the converter is
-        // attached to the interface, a deconstructor that bound the union instance instead of the
-        // payload would still serialize successfully — through the union's own WriteTo — and
+        // attached to the interface, a root-level pattern that bound the union instance instead of
+        // the payload would still serialize successfully — through the union's own WriteTo — and
         // produce "union" instead of the payload's label. The union itself is unaffected by the
         // converter and continues to use built-in union serialization.
 #pragma warning disable SYSLIB1227
@@ -2034,8 +2029,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("payload", poco.Label);
         }
 
-        // The [Union] class equivalent: the union derives from one of its own case types, so the
-        // conversion from the union to the case is an implicit reference conversion.
+        // The [Union] class equivalent: the union derives from one of its own case types, so an
+        // ordinary type pattern could match the union instance through an implicit conversion.
         public class NodeCase
         {
             public string? Label { get; set; }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/RecursiveNullableUnionType/net462/MyContext.Nat.g.cs.txt
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/RecursiveNullableUnionType/net462/MyContext.Nat.g.cs.txt
@@ -41,8 +41,8 @@ namespace TestApp
                         return value switch
                         {
                             null => (typeof(global::TestApp.Nat?), (object?)null),
-                            { Value: bool caseValue0 } => (typeof(bool), (object?)caseValue0),
-                            { Value: global::TestApp.Nat caseValue1 } => (typeof(global::TestApp.Nat?), (object?)caseValue1),
+                            bool caseValue0 => (typeof(bool), (object?)caseValue0),
+                            global::TestApp.Nat caseValue1 => (typeof(global::TestApp.Nat?), (object?)caseValue1),
                         };
                     },
                     TypeClassifier = null,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/RecursiveNullableUnionType/netcoreapp/MyContext.Nat.g.cs.txt
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/RecursiveNullableUnionType/netcoreapp/MyContext.Nat.g.cs.txt
@@ -41,8 +41,8 @@ namespace TestApp
                         return value switch
                         {
                             null => (typeof(global::TestApp.Nat?), (object?)null),
-                            { Value: bool caseValue0 } => (typeof(bool), (object?)caseValue0),
-                            { Value: global::TestApp.Nat caseValue1 } => (typeof(global::TestApp.Nat?), (object?)caseValue1),
+                            bool caseValue0 => (typeof(bool), (object?)caseValue0),
+                            global::TestApp.Nat caseValue1 => (typeof(global::TestApp.Nat?), (object?)caseValue1),
                         };
                     },
                     TypeClassifier = null,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/RecursiveUnionType/net462/MyContext.Nat.g.cs.txt
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/RecursiveUnionType/net462/MyContext.Nat.g.cs.txt
@@ -40,8 +40,8 @@ namespace TestApp
                         return value switch
                         {
                             null => ((global::System.Type?)null, (object?)null),
-                            { Value: bool caseValue0 } => (typeof(bool), (object?)caseValue0),
-                            { Value: global::TestApp.Nat caseValue1 } => (typeof(global::TestApp.Nat), (object?)caseValue1),
+                            bool caseValue0 => (typeof(bool), (object?)caseValue0),
+                            global::TestApp.Nat caseValue1 => (typeof(global::TestApp.Nat), (object?)caseValue1),
                         };
                     },
                     TypeClassifier = null,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/RecursiveUnionType/netcoreapp/MyContext.Nat.g.cs.txt
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/RecursiveUnionType/netcoreapp/MyContext.Nat.g.cs.txt
@@ -40,8 +40,8 @@ namespace TestApp
                         return value switch
                         {
                             null => ((global::System.Type?)null, (object?)null),
-                            { Value: bool caseValue0 } => (typeof(bool), (object?)caseValue0),
-                            { Value: global::TestApp.Nat caseValue1 } => (typeof(global::TestApp.Nat), (object?)caseValue1),
+                            bool caseValue0 => (typeof(bool), (object?)caseValue0),
+                            global::TestApp.Nat caseValue1 => (typeof(global::TestApp.Nat), (object?)caseValue1),
                         };
                     },
                     TypeClassifier = null,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/SubclassCaseUnionType/net462/MyContext.Shape.g.cs.txt
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/SubclassCaseUnionType/net462/MyContext.Shape.g.cs.txt
@@ -46,8 +46,8 @@ namespace TestApp
                         return value switch
                         {
                             null => (typeof(global::TestApp.Circle), (object?)null),
-                            { Value: int caseValue0 } => (typeof(int), (object?)caseValue0),
-                            { Value: global::TestApp.Circle caseValue1 } => (typeof(global::TestApp.Circle), (object?)caseValue1),
+                            int caseValue0 => (typeof(int), (object?)caseValue0),
+                            global::TestApp.Circle caseValue1 => (typeof(global::TestApp.Circle), (object?)caseValue1),
                         };
                     },
                     TypeClassifier = null,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/SubclassCaseUnionType/netcoreapp/MyContext.Shape.g.cs.txt
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/Baselines/SubclassCaseUnionType/netcoreapp/MyContext.Shape.g.cs.txt
@@ -46,8 +46,8 @@ namespace TestApp
                         return value switch
                         {
                             null => (typeof(global::TestApp.Circle), (object?)null),
-                            { Value: int caseValue0 } => (typeof(int), (object?)caseValue0),
-                            { Value: global::TestApp.Circle caseValue1 } => (typeof(global::TestApp.Circle), (object?)caseValue1),
+                            int caseValue0 => (typeof(int), (object?)caseValue0),
+                            global::TestApp.Circle caseValue1 => (typeof(global::TestApp.Circle), (object?)caseValue1),
                         };
                     },
                     TypeClassifier = null,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorOutputTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorOutputTests.cs
@@ -150,9 +150,9 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             // recognizes a union by the attribute plus a public object-typed Value property,
             // and derives its cases from the public single-parameter constructors.
             //
-            // Diagnostic validation is off because the same version has no union pattern
-            // matching either, so it rejects the emitted `bool` arm against a Nat operand.
-            VerifyAgainstBaseline("""
+            // These test projects run against Roslyn versions that predate union pattern matching.
+            // Pin the resulting generated-code diagnostics instead of ignoring them entirely.
+            JsonSourceGeneratorResult result = VerifyAgainstBaseline("""
                 using System.Runtime.CompilerServices;
                 using System.Text.Json.Serialization;
                 namespace TestApp
@@ -169,6 +169,8 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                     }
                 }
                 """, nameof(RecursiveUnionType), disableDiagnosticValidation: true);
+
+            AssertLegacyCompilerDiagnostics(result, "CS0037", "CS8121");
         }
 
         [Fact]
@@ -177,7 +179,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             // Same as RecursiveUnionType, but the self-referential case is nullable, so it is
             // also the union's null case. The emitted root-level arm has to pattern match the
             // unwrapped Nat while still reporting typeof(Nat?) as the case type.
-            VerifyAgainstBaseline("""
+            JsonSourceGeneratorResult result = VerifyAgainstBaseline("""
                 using System.Runtime.CompilerServices;
                 using System.Text.Json.Serialization;
                 namespace TestApp
@@ -194,6 +196,8 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                     }
                 }
                 """, nameof(RecursiveNullableUnionType), disableDiagnosticValidation: true);
+
+            AssertLegacyCompilerDiagnostics(result, "CS0037", "CS8121");
         }
 
         [Fact]
@@ -201,7 +205,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         {
             // A class union is not sealed, so a case type can derive from the union itself.
             // The root-level union pattern must match its payload rather than the union instance.
-            VerifyAgainstBaseline("""
+            JsonSourceGeneratorResult result = VerifyAgainstBaseline("""
                 using System.Runtime.CompilerServices;
                 using System.Text.Json.Serialization;
                 namespace TestApp
@@ -226,6 +230,8 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                     }
                 }
                 """, nameof(SubclassCaseUnionType), disableDiagnosticValidation: true);
+
+            AssertLegacyCompilerDiagnostics(result, "CS8121");
         }
 
         [Fact]
@@ -440,7 +446,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         /// generated file matches the corresponding baseline in
         /// <c>Baselines/{testId}/{tfm}/{hintName}.cs.txt</c>.
         /// </summary>
-        private void VerifyAgainstBaseline(string source, string testId, bool disableDiagnosticValidation = false, CSharpParseOptions? parseOptions = null)
+        private JsonSourceGeneratorResult VerifyAgainstBaseline(string source, string testId, bool disableDiagnosticValidation = false, CSharpParseOptions? parseOptions = null)
         {
             Compilation compilation = CompilationHelper.CreateCompilation(source, parseOptions: parseOptions);
             JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, disableDiagnosticValidation: disableDiagnosticValidation, logger: logger);
@@ -490,7 +496,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                     IO.File.WriteAllText(absPath, generatedSourceText.ToString());
                 }
 
-                return;
+                return result;
             }
 #else
             // Collect expected baseline files from disk.
@@ -522,6 +528,23 @@ namespace System.Text.Json.SourceGeneration.UnitTests
                 bool matches = RoslynTestUtils.CompareLines(expectedLines, generatedSourceText, out string errorMessage);
                 Assert.True(matches, $"Baseline mismatch for {baselineFileName}.\n{errorMessage}");
             }
+
+            return result;
+#endif
+        }
+
+        private static void AssertLegacyCompilerDiagnostics(JsonSourceGeneratorResult result, params string[] expectedIds)
+        {
+#if NET
+            string[] actualIds = result.NewCompilation.GetDiagnostics()
+                .Where(diagnostic =>
+                    diagnostic.Severity is DiagnosticSeverity.Error &&
+                    diagnostic.Location.SourceTree?.FilePath.EndsWith(".g.cs", StringComparison.Ordinal) is true)
+                .Select(diagnostic => diagnostic.Id)
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(expectedIds.OrderBy(id => id, StringComparer.Ordinal), actualIds);
 #endif
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorOutputTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorOutputTests.cs
@@ -175,8 +175,8 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         public void RecursiveNullableUnionType()
         {
             // Same as RecursiveUnionType, but the self-referential case is nullable, so it is
-            // also the union's null case. The emitted arm has to pattern match the unwrapped
-            // Nat while still reporting typeof(Nat?) as the case type.
+            // also the union's null case. The emitted root-level arm has to pattern match the
+            // unwrapped Nat while still reporting typeof(Nat?) as the case type.
             VerifyAgainstBaseline("""
                 using System.Runtime.CompilerServices;
                 using System.Text.Json.Serialization;
@@ -200,8 +200,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         public void SubclassCaseUnionType()
         {
             // A class union is not sealed, so a case type can derive from the union itself.
-            // The union instance is pattern compatible with Circle by the opposite subtyping
-            // direction to a self-referential case, and needs the same property-pattern arm.
+            // The root-level union pattern must match its payload rather than the union instance.
             VerifyAgainstBaseline("""
                 using System.Runtime.CompilerServices;
                 using System.Text.Json.Serialization;


### PR DESCRIPTION
Uses root-level type patterns for source-generated union deconstructors. Candidate for .NET 11 backport.

> [!NOTE]
> This pull request was created with GitHub Copilot.