### PR TITLE
Handle StreamBuffer disposal race in SslStream test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamDisposeTest.cs
@@ -149,7 +149,10 @@ namespace System.Net.Security.Tests
                 {
                     await task;
                 }
-                catch (InvalidOperationException ex) when (ex.StackTrace?.Contains("System.IO.ConnectedStreams") ?? true)
+                catch (InvalidOperationException ex) when (ex.StackTrace is null ||
+                    ex.StackTrace.Contains("System.IO.ConnectedStreams") ||
+                    ex.StackTrace.Contains("System.IO.StreamBuffer.TryWriteToBuffer") ||
+                    ex.StackTrace.Contains("System.IO.StreamBuffer.WriteAsync"))
                 {
                     // Writing to a disposed ConnectedStream (test only, does not happen with NetworkStream)
                     return;


### PR DESCRIPTION
`Dispose_ParallelWithHandshake_ThrowsODE` can surface the expected disposal race through `StreamBuffer.TryWriteToBuffer` on Alpine, where the `ConnectedStreams` frame is absent from the stack trace. This caused the test to fail after #132748 narrowed the exception filter to `ConnectedStreams`.

Accept the two specific `StreamBuffer` write methods in addition to `ConnectedStreams`. Matching the methods rather than the entire type avoids hiding unrelated `InvalidOperationException` failures from `StreamBuffer`.

Testing: the targeted outer-loop test passed. The full System.Net.Security functional suite ran 5,369 tests; this test passed, with one unrelated failure in `TlsSessionTests.ClientSession_ExternalCertificateValidation_AcceptWithDefaultValidation_FailsOnUntrustedCert` on the local Windows environment.

> [!NOTE]
> This pull request description was created by GitHub Copilot.