### PR TITLE
Avoid duplicate ValueTask checks in transparent awaits

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -435,64 +435,30 @@ namespace System.Runtime.CompilerServices
             return default!;
         }
 
-        /// <summary>
-        /// Used by internal thunks that implement awaiting on ValueTask.
-        /// A ValueTask may wrap:
-        /// - Completed result   (we never await this)
-        /// - Task
-        /// - ValueTaskSource
-        /// Therefore, when we are awaiting a ValueTask completion we are really
-        /// awaiting a completion of an underlying Task or ValueTaskSource.
-        /// </summary>
-        /// <param name="valueTask">ValueTask whose completion we are awaiting.</param>
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
-        private static unsafe void TransparentSuspend(ValueTask valueTask)
+        private static unsafe void TransparentSuspend(IValueTaskSource source, short token)
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
             Continuation? sentinelContinuation = state.SentinelContinuation ??= new Continuation();
 
-            Continuation nextCont;
-            object? obj = valueTask._obj;
-            if (obj is Task t)
+            ValueTaskSourceContinuation? vtsCont = state.CachedValueTaskSourceContinuation;
+            if (vtsCont != null)
             {
-                RuntimeAsyncTaskContinuation? taskCont = state.CachedTaskContinuation;
-                if (taskCont != null)
-                {
-                    state.CachedTaskContinuation = null;
-                }
-                else
-                {
-                    taskCont = new RuntimeAsyncTaskContinuation();
-                }
-
-                taskCont.Initialize(t);
-                state.StackState->TaskContinuation = taskCont;
-                nextCont = taskCont;
+                state.CachedValueTaskSourceContinuation = null;
             }
             else
             {
-                ValueTaskSourceContinuation? vtsCont = state.CachedValueTaskSourceContinuation;
-                if (vtsCont != null)
-                {
-                    state.CachedValueTaskSourceContinuation = null;
-                }
-                else
-                {
-                    vtsCont = new ValueTaskSourceContinuation();
-                }
-
-                Debug.Assert(obj is IValueTaskSource);
-                vtsCont.Initialize(Unsafe.As<object, IValueTaskSource>(ref obj), valueTask._token);
-                state.StackState->ValueTaskSourceContinuation = vtsCont;
-                nextCont = vtsCont;
+                vtsCont = new ValueTaskSourceContinuation();
             }
 
-            sentinelContinuation.Next = nextCont;
+            vtsCont.Initialize(source, token);
 
+            sentinelContinuation.Next = vtsCont;
+            state.StackState->ValueTaskSourceContinuation = vtsCont;
             state.CaptureContexts();
-            AsyncSuspend(nextCont);
+            AsyncSuspend(vtsCont);
         }
 
         [Intrinsic]
@@ -536,50 +502,27 @@ namespace System.Runtime.CompilerServices
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
-        private static unsafe T TransparentSuspend<T>(ValueTask<T> valueTask)
+        private static unsafe T TransparentSuspend<T>(IValueTaskSource<T> source, short token)
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
             Continuation? sentinelContinuation = state.SentinelContinuation ??= new Continuation();
 
-            Continuation nextCont;
-            object? obj = valueTask._obj;
-            if (obj is Task<T> t)
+            ValueTaskSourceContinuation? vtsCont = state.CachedValueTaskSourceContinuation;
+            if (vtsCont != null)
             {
-                RuntimeAsyncTaskContinuation? taskCont = state.CachedTaskContinuation;
-                if (taskCont != null)
-                {
-                    state.CachedTaskContinuation = null;
-                }
-                else
-                {
-                    taskCont = new RuntimeAsyncTaskContinuation();
-                }
-
-                taskCont.Initialize<T>(t);
-                state.StackState->TaskContinuation = taskCont;
-                nextCont = taskCont;
+                state.CachedValueTaskSourceContinuation = null;
             }
             else
             {
-                ValueTaskSourceContinuation? vtsCont = state.CachedValueTaskSourceContinuation;
-                if (vtsCont != null)
-                {
-                    state.CachedValueTaskSourceContinuation = null;
-                }
-                else
-                {
-                    vtsCont = new ValueTaskSourceContinuation();
-                }
-
-                Debug.Assert(obj is IValueTaskSource<T>);
-                vtsCont.Initialize<T>(Unsafe.As<object, IValueTaskSource<T>>(ref obj), valueTask._token);
-                state.StackState->ValueTaskSourceContinuation = vtsCont;
-                nextCont = vtsCont;
+                vtsCont = new ValueTaskSourceContinuation();
             }
 
-            sentinelContinuation.Next = nextCont;
+            vtsCont.Initialize<T>(source, token);
+
+            sentinelContinuation.Next = vtsCont;
+            state.StackState->ValueTaskSourceContinuation = vtsCont;
             state.CaptureContexts();
-            AsyncSuspend(nextCont);
+            AsyncSuspend(vtsCont);
             return default!;
         }
 
@@ -706,14 +649,35 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.Async)]
         private static void TransparentAwait(ValueTask task)
         {
-            if (!task.IsCompleted)
+            object? obj = task._obj;
+            if (obj == null)
             {
-                TailAwait();
-                TransparentSuspend(task);
                 return;
             }
 
-            task.ThrowIfCompletedUnsuccessfully();
+            if (obj is Task t)
+            {
+                if (!t.IsCompleted)
+                {
+                    TailAwait();
+                    TransparentSuspend(t);
+                    return;
+                }
+
+                TaskAwaiter.ValidateEnd(t);
+                return;
+            }
+
+            Debug.Assert(obj is IValueTaskSource);
+            IValueTaskSource vts = Unsafe.As<object, IValueTaskSource>(ref obj);
+            if (vts.GetStatus(task._token) == ValueTaskSourceStatus.Pending)
+            {
+                TailAwait();
+                TransparentSuspend(vts, task._token);
+                return;
+            }
+
+            vts.GetResult(task._token);
         }
 
         [BypassReadyToRun]
@@ -734,13 +698,33 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.Async)]
         private static T TransparentAwait<T>(ValueTask<T> task)
         {
-            if (!task.IsCompleted)
+            object? obj = task._obj;
+            if (obj == null)
             {
-                TailAwait();
-                return TransparentSuspend(task);
+                return task._result!;
             }
 
-            return task.Result;
+            if (obj is Task<T> t)
+            {
+                if (!t.IsCompleted)
+                {
+                    TailAwait();
+                    return TransparentSuspend(t);
+                }
+
+                TaskAwaiter.ValidateEnd(t);
+                return t.ResultOnSuccess;
+            }
+
+            Debug.Assert(obj is IValueTaskSource<T>);
+            IValueTaskSource<T> vts = Unsafe.As<object, IValueTaskSource<T>>(ref obj);
+            if (vts.GetStatus(task._token) == ValueTaskSourceStatus.Pending)
+            {
+                TailAwait();
+                return TransparentSuspend(vts, task._token);
+            }
+
+            return vts.GetResult(task._token);
         }
 
         // Represents execution of a chain of suspended and resuming runtime


### PR DESCRIPTION
Classify ValueTask backing objects once in TransparentAwait and pass typed Task or IValueTaskSource instances to the suspend helpers. This mirrors the existing AsyncHelpers.Await implementation and removes repeated type checks and temporary ValueTask materialization from runtime-async tail awaits.

This is about 2% RPS improvement on the TechEmpower Arm64 JSON benchmarks. That benchmark was spending a not insignificant time in `CastHelpers.IsInstanceOfClass` invoked by the duplicated `is Task<T>` check that was inside AsyncHelpers.TransparentSuspend. The primary source of that comes from `SocketReceiver.WaitForDataAsync`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>