### PR TITLE
[S.T.J] Fix PropertyRef.Equals 

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PropertyRef.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PropertyRef.cs
@@ -41,8 +41,10 @@ namespace System.Text.Json.Serialization.Metadata
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ReadOnlySpan<byte> propertyName, ulong key)
         {
-            // If the property name is less than 8 bytes, it is embedded in the key so no further comparison is necessary.
-            return key == Key && (propertyName.Length <= PropertyNameKeyLength || propertyName.SequenceEqual(Utf8PropertyName));
+            // If both property names are less than 8 bytes, they are embedded in the key so no further comparison is necessary.
+            return key == Key &&
+                ((propertyName.Length <= PropertyNameKeyLength && Utf8PropertyName.Length <= PropertyNameKeyLength)
+                    || propertyName.SequenceEqual(Utf8PropertyName));
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
@@ -165,6 +165,47 @@ namespace System.Text.Json.Serialization.Tests
             JsonSerializer.Deserialize<SimpleTestClass>(json, options);
         }
 
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        public static void PropertyCache_NamesWithSameKeyButDifferentLength_AreDistinct(int shortNameLength)
+        {
+            string shortName = new('a', shortNameLength);
+            string longName =
+                shortName +
+                new string('\0', 7 - shortNameLength) +
+                new string('b', 249 + shortNameLength);
+
+            Assert.Equal(256, longName.Length - shortName.Length);
+
+            var resolver = new DefaultJsonTypeInfoResolver();
+            resolver.Modifiers.Add(typeInfo =>
+            {
+                if (typeInfo.Type == typeof(PropertyKeyLengthPoco))
+                {
+                    typeInfo.Properties[0].Name = shortName;
+                }
+            });
+
+            var options = new JsonSerializerOptions { TypeInfoResolver = resolver };
+
+            string json = JsonSerializer.Serialize(new Dictionary<string, string> { [longName] = "42" });
+            Assert.Null(JsonSerializer.Deserialize<PropertyKeyLengthPoco>(json, options).Value);
+
+            json = JsonSerializer.Serialize(new Dictionary<string, string> { [shortName] = "42" });
+            Assert.Equal("42", JsonSerializer.Deserialize<PropertyKeyLengthPoco>(json, options).Value);
+        }
+
+        private class PropertyKeyLengthPoco
+        {
+            public string Value { get; set; }
+        }
+
         // Use a common options instance to encourage additional metadata collisions across types. Also since
         // this options is not the default options instance the tests will not use previously cached metadata.
         private static JsonSerializerOptions s_options = new JsonSerializerOptions { IncludeFields = true };

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
@@ -166,6 +166,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Theory]
+        [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
@@ -183,16 +184,23 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Equal(256, longName.Length - shortName.Length);
 
-            var resolver = new DefaultJsonTypeInfoResolver();
-            resolver.Modifiers.Add(typeInfo =>
+            var options = new JsonSerializerOptions
             {
-                if (typeInfo.Type == typeof(PropertyKeyLengthPoco))
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
                 {
-                    typeInfo.Properties[0].Name = shortName;
+                    Modifiers =
+                    {
+                        // Customize the name so the theory can exercise every length with one POCO type.
+                        typeInfo =>
+                        {
+                            if (typeInfo.Type == typeof(PropertyKeyLengthPoco))
+                            {
+                                typeInfo.Properties[0].Name = shortName;
+                            }
+                        }
+                    }
                 }
-            });
-
-            var options = new JsonSerializerOptions { TypeInfoResolver = resolver };
+            };
 
             string json = JsonSerializer.Serialize(new Dictionary<string, string> { [longName] = "42" });
             Assert.Null(JsonSerializer.Deserialize<PropertyKeyLengthPoco>(json, options).Value);
@@ -203,6 +211,7 @@ namespace System.Text.Json.Serialization.Tests
 
         private class PropertyKeyLengthPoco
         {
+            // The declared name is irrelevant because the resolver replaces it.
             public string Value { get; set; }
         }
 


### PR DESCRIPTION
To compare name if `this.Utf8PropertyName` is also > `PropertyNameKeyLength`.