### PR TITLE
Emit TaskWaitBegin and TaskWaitEnd for RuntimeAsync suspensions

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -907,8 +907,19 @@ namespace System.Runtime.CompilerServices
                 if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                 {
                     Continuation? nextContinuation = state.SentinelContinuation!.Next;
+                    Task? awaitedTask = (nextContinuation as RuntimeAsyncTaskContinuation)?.Task;
 
                     AsyncDebugger.HandleSuspended(nextContinuation);
+
+                    if (awaitedTask is not null)
+                    {
+                        TplEventSource.Log.TaskWaitBegin(
+                            m_taskScheduler?.Id ?? TaskScheduler.Default.Id,
+                            Id,
+                            awaitedTask.Id,
+                            TplEventSource.TaskWaitBehavior.Asynchronous,
+                            Id);
+                    }
 
                     if (!HandleSuspended(ref state))
                     {

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Tracing;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -912,7 +913,8 @@ namespace System.Runtime.CompilerServices
                     AsyncDebugger.HandleSuspended(nextContinuation);
 
                     TplEventSource log = TplEventSource.Log;
-                    if (awaitedTask is not null && log.IsEnabled())
+                    if (awaitedTask is not null &&
+                        log.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.TaskTransfer | TplEventSource.Keywords.Tasks))
                     {
                         log.TaskWaitBegin(
                             m_taskScheduler?.Id ?? TaskScheduler.Default.Id,

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -911,9 +911,10 @@ namespace System.Runtime.CompilerServices
 
                     AsyncDebugger.HandleSuspended(nextContinuation);
 
-                    if (awaitedTask is not null)
+                    TplEventSource log = TplEventSource.Log;
+                    if (awaitedTask is not null && log.IsEnabled())
                     {
-                        TplEventSource.Log.TaskWaitBegin(
+                        log.TaskWaitBegin(
                             m_taskScheduler?.Id ?? TaskScheduler.Default.Id,
                             Id,
                             awaitedTask.Id,

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -908,21 +908,7 @@ namespace System.Runtime.CompilerServices
                 if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                 {
                     Continuation? nextContinuation = state.SentinelContinuation!.Next;
-                    Task? awaitedTask = (nextContinuation as RuntimeAsyncTaskContinuation)?.Task;
-
-                    AsyncDebugger.HandleSuspended(nextContinuation);
-
-                    TplEventSource log = TplEventSource.Log;
-                    if (awaitedTask is not null &&
-                        log.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.TaskTransfer | TplEventSource.Keywords.Tasks))
-                    {
-                        log.TaskWaitBegin(
-                            m_taskScheduler?.Id ?? TaskScheduler.Default.Id,
-                            Id,
-                            awaitedTask.Id,
-                            TplEventSource.TaskWaitBehavior.Asynchronous,
-                            Id);
-                    }
+                    AsyncDebugger.HandleSuspended(this, nextContinuation);
 
                     if (!HandleSuspended(ref state))
                     {
@@ -1092,7 +1078,7 @@ namespace System.Runtime.CompilerServices
                 asyncDispatcherInfo.NextContinuation = MoveContinuationState();
                 refDispatcherInfo = &asyncDispatcherInfo;
 
-                RuntimeAsyncInstrumentationHelpers.ResumeRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags);
+                RuntimeAsyncInstrumentationHelpers.ResumeRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags, asyncDispatcherInfo.NextContinuation);
 
                 while (true)
                 {
@@ -1792,7 +1778,7 @@ namespace System.Runtime.CompilerServices
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static void ResumeRuntimeAsyncContext(Task task, ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
+            public static void ResumeRuntimeAsyncContext(Task task, ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Continuation? continuation)
             {
                 info.CurrentTask = task;
                 AsyncProfiler.InitInfo(ref info.AsyncProfilerInfo);
@@ -1808,7 +1794,7 @@ namespace System.Runtime.CompilerServices
 
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        AsyncDebugger.ResumeAsyncContext(task);
+                        AsyncDebugger.ResumeAsyncContext(task, continuation);
                     }
                 }
             }
@@ -1965,8 +1951,9 @@ namespace System.Runtime.CompilerServices
                 TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
             }
 
-            public static void ResumeAsyncContext(Task task)
+            public static void ResumeAsyncContext(Task task, Continuation? continuation)
             {
+                OutputTaskWaitEnd(task, continuation);
                 TplEventSource.Log.TraceSynchronousWorkBegin(task.Id, CausalitySynchronousWork.Execution);
             }
 
@@ -2019,16 +2006,32 @@ namespace System.Runtime.CompilerServices
                 Task.RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
             }
 
-            public static void HandleSuspended(Continuation? nextContinuation)
+            public static void HandleSuspended(Task task, Continuation? nextContinuation)
             {
                 if (nextContinuation != null)
                 {
                     Task.TryAddRuntimeAsyncContinuationChainTimestamps(nextContinuation);
                 }
+
+                if (nextContinuation is RuntimeAsyncTaskContinuation { Task: Task awaitedTask })
+                {
+                    TplEventSource log = TplEventSource.Log;
+                    if (log.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.TaskTransfer | TplEventSource.Keywords.Tasks))
+                    {
+                        log.TaskWaitBegin(
+                            task.m_taskScheduler?.Id ?? TaskScheduler.Default.Id,
+                            task.Id,
+                            awaitedTask.Id,
+                            TplEventSource.TaskWaitBehavior.Asynchronous,
+                            task.Id);
+                    }
+                }
             }
 
             public static void HandleSuspendedFailed(Task task, Continuation? nextContinuation)
             {
+                OutputTaskWaitEnd(task, nextContinuation);
+
                 if (nextContinuation != null)
                 {
                     Task.RemoveRuntimeAsyncTask(task, nextContinuation);
@@ -2036,6 +2039,21 @@ namespace System.Runtime.CompilerServices
                 else
                 {
                     Task.RemoveRuntimeAsyncTask(task);
+                }
+            }
+
+            private static void OutputTaskWaitEnd(Task task, Continuation? continuation)
+            {
+                if (continuation is RuntimeAsyncTaskContinuation { Task: Task awaitedTask })
+                {
+                    TplEventSource log = TplEventSource.Log;
+                    if (log.IsEnabled(EventLevel.Verbose, TplEventSource.Keywords.Tasks))
+                    {
+                        log.TaskWaitEnd(
+                            task.m_taskScheduler?.Id ?? TaskScheduler.Default.Id,
+                            task.Id,
+                            awaitedTask.Id);
+                    }
                 }
             }
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -2013,7 +2013,12 @@ namespace System.Runtime.CompilerServices
                     Task.TryAddRuntimeAsyncContinuationChainTimestamps(nextContinuation);
                 }
 
-                if (nextContinuation is RuntimeAsyncTaskContinuation { Task: Task awaitedTask })
+                OutputTaskWaitBegin(task, nextContinuation);
+            }
+
+            private static void OutputTaskWaitBegin(Task task, Continuation? continuation)
+            {
+                if (continuation is RuntimeAsyncTaskContinuation { Task: Task awaitedTask })
                 {
                     TplEventSource log = TplEventSource.Log;
                     if (log.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.TaskTransfer | TplEventSource.Keywords.Tasks))

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
@@ -153,6 +153,18 @@ namespace System.Runtime.CompilerServices
             private static Continuation? ResumeTaskContinuation(Continuation cont, ref byte result)
             {
                 var taskCont = (RuntimeAsyncTaskContinuation)cont;
+
+                TplEventSource log = TplEventSource.Log;
+                if (Task.s_asyncDebuggingEnabled && log.IsEnabled())
+                {
+                    Task awaitedTask = taskCont.Task!;
+                    Task runtimeAsyncTask = taskCont.RuntimeAsyncTask!;
+                    log.TaskWaitEnd(
+                        runtimeAsyncTask.m_taskScheduler?.Id ?? TaskScheduler.Default.Id,
+                        runtimeAsyncTask.Id,
+                        awaitedTask.Id);
+                }
+
                 taskCont.Next = null;
                 taskCont.RuntimeAsyncTask = null;
                 taskCont.ContinuationContext = null;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -155,7 +156,8 @@ namespace System.Runtime.CompilerServices
                 var taskCont = (RuntimeAsyncTaskContinuation)cont;
 
                 TplEventSource log = TplEventSource.Log;
-                if (Task.s_asyncDebuggingEnabled && log.IsEnabled())
+                if (Task.s_asyncDebuggingEnabled &&
+                    log.IsEnabled(EventLevel.Verbose, TplEventSource.Keywords.Tasks))
                 {
                     Task awaitedTask = taskCont.Task!;
                     Task runtimeAsyncTask = taskCont.RuntimeAsyncTask!;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -154,7 +153,6 @@ namespace System.Runtime.CompilerServices
             private static Continuation? ResumeTaskContinuation(Continuation cont, ref byte result)
             {
                 var taskCont = (RuntimeAsyncTaskContinuation)cont;
-
                 taskCont.Next = null;
                 taskCont.RuntimeAsyncTask = null;
                 taskCont.ContinuationContext = null;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeAsyncTaskContinuation.cs
@@ -155,18 +155,6 @@ namespace System.Runtime.CompilerServices
             {
                 var taskCont = (RuntimeAsyncTaskContinuation)cont;
 
-                TplEventSource log = TplEventSource.Log;
-                if (Task.s_asyncDebuggingEnabled &&
-                    log.IsEnabled(EventLevel.Verbose, TplEventSource.Keywords.Tasks))
-                {
-                    Task awaitedTask = taskCont.Task!;
-                    Task runtimeAsyncTask = taskCont.RuntimeAsyncTask!;
-                    log.TaskWaitEnd(
-                        runtimeAsyncTask.m_taskScheduler?.Id ?? TaskScheduler.Default.Id,
-                        runtimeAsyncTask.Id,
-                        awaitedTask.Id);
-                }
-
                 taskCont.Next = null;
                 taskCont.RuntimeAsyncTask = null;
                 taskCont.ContinuationContext = null;

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -517,8 +517,8 @@ namespace System.Threading.Tasks.Tests
             RemoteExecutor.Invoke(async () =>
             {
                 // Start a multi-await task WITHOUT instrumentation enabled.
-                var tcs1 = new TaskCompletionSource();
-                var tcs2 = new TaskCompletionSource();
+                var tcs1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 Task inflight = FuncThatWaitsTwice(tcs1, tcs2);
 
                 // Task is now suspended at first await with no instrumentation.

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -517,8 +517,8 @@ namespace System.Threading.Tasks.Tests
             RemoteExecutor.Invoke(async () =>
             {
                 // Start a multi-await task WITHOUT instrumentation enabled.
-                var tcs1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                var tcs2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs1 = new TaskCompletionSource();
+                var tcs2 = new TaskCompletionSource();
                 Task inflight = FuncThatWaitsTwice(tcs1, tcs2);
 
                 // Task is now suspended at first await with no instrumentation.
@@ -609,8 +609,8 @@ namespace System.Threading.Tasks.Tests
                 {
                     listener.RunWithCallback(events.Enqueue, () =>
                     {
-                        var tcs1 = new TaskCompletionSource();
-                        var tcs2 = new TaskCompletionSource();
+                        var tcs1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                        var tcs2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                         Task runtimeAsyncTask = FuncThatWaitsTwice(tcs1, tcs2);
                         int runtimeAsyncTaskId = runtimeAsyncTask.Id;
                         int firstAwaitedTaskId = tcs1.Task.Id;

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -623,6 +623,7 @@ namespace System.Threading.Tasks.Tests
                             (int)e.Payload[4]! == runtimeAsyncTaskId);
                         Assert.DoesNotContain(events, e =>
                             e.EventId == TaskWaitEndId &&
+                            (int)e.Payload![1]! == runtimeAsyncTaskId &&
                             (int)e.Payload![2]! == firstAwaitedTaskId);
 
                         tcs1.SetResult();
@@ -646,6 +647,7 @@ namespace System.Threading.Tasks.Tests
                             (int)e.Payload[4]! == runtimeAsyncTaskId);
                         Assert.DoesNotContain(events, e =>
                             e.EventId == TaskWaitEndId &&
+                            (int)e.Payload![1]! == runtimeAsyncTaskId &&
                             (int)e.Payload![2]! == secondAwaitedTaskId);
 
                         tcs2.SetResult();

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -21,6 +21,7 @@ namespace System.Threading.Tasks.Tests
         private static readonly FieldInfo s_continuationTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncContinuationTimestamps");
         private static readonly FieldInfo s_activeTasksField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_currentActiveTasks");
         private static readonly FieldInfo s_activeFlagsField = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "s_activeFlags");
+        private static readonly FieldInfo s_taskIdField = typeof(Task).GetField("m_taskId", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         private static readonly object s_debuggerLock = new object();
 
@@ -576,6 +577,87 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        public void RuntimeAsync_TaskWaitEvents()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                const int TaskWaitBeginId = 10;
+                const int TaskWaitEndId = 11;
+
+                AttachDebugger();
+
+                var events = new ConcurrentQueue<EventWrittenEventArgs>();
+                using (var listener = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose))
+                {
+                    listener.RunWithCallback(events.Enqueue, () =>
+                    {
+                        var tcs1 = new TaskCompletionSource();
+                        var tcs2 = new TaskCompletionSource();
+                        Task runtimeAsyncTask = FuncThatWaitsTwice(tcs1, tcs2);
+                        int runtimeAsyncTaskId = runtimeAsyncTask.Id;
+                        int firstAwaitedTaskId = tcs1.Task.Id;
+                        int secondAwaitedTaskId = tcs2.Task.Id;
+
+                        Assert.Contains(events, e =>
+                            e.EventId == TaskWaitBeginId &&
+                            (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                            (int)e.Payload[2]! == firstAwaitedTaskId &&
+                            (int)e.Payload[4]! == runtimeAsyncTaskId);
+                        Assert.DoesNotContain(events, e =>
+                            e.EventId == TaskWaitEndId &&
+                            (int)e.Payload![2]! == firstAwaitedTaskId);
+
+                        tcs1.SetResult();
+
+                        Assert.Contains(events, e =>
+                            e.EventId == TaskWaitEndId &&
+                            (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                            (int)e.Payload[2]! == firstAwaitedTaskId);
+                        Assert.Contains(events, e =>
+                            e.EventId == TaskWaitBeginId &&
+                            (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                            (int)e.Payload[2]! == secondAwaitedTaskId &&
+                            (int)e.Payload[4]! == runtimeAsyncTaskId);
+                        Assert.DoesNotContain(events, e =>
+                            e.EventId == TaskWaitEndId &&
+                            (int)e.Payload![2]! == secondAwaitedTaskId);
+
+                        tcs2.SetResult();
+                        runtimeAsyncTask.GetAwaiter().GetResult();
+
+                        Assert.Contains(events, e =>
+                            e.EventId == TaskWaitEndId &&
+                            (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                            (int)e.Payload[2]! == secondAwaitedTaskId);
+                    });
+                }
+
+                DetachDebugger();
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        public void RuntimeAsync_TaskWaitEventsArePayForPlay()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                AttachDebugger();
+
+                var tcs1 = new TaskCompletionSource();
+                var tcs2 = new TaskCompletionSource();
+                Task runtimeAsyncTask = FuncThatWaitsTwice(tcs1, tcs2);
+
+                Assert.Equal(0, (int)s_taskIdField.GetValue(tcs1.Task)!);
+
+                tcs1.SetResult();
+                tcs2.SetResult();
+                runtimeAsyncTask.GetAwaiter().GetResult();
+
+                DetachDebugger();
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
         public void RuntimeAsync_SuspensionTimestampsAreDistinct()
         {
             RemoteExecutor.Invoke(async () =>
@@ -601,6 +683,8 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
+                const int TaskWaitBeginId = 10;
+                const int TaskWaitEndId = 11;
                 const int TraceOperationBeginId = 14;
                 const string RuntimeAsyncTaskOperationName = "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask";
 
@@ -608,6 +692,9 @@ namespace System.Threading.Tasks.Tests
                 // The AsyncDebugger guard should prevent the V2 async instrumentation
                 // from emitting any TPL causality events.
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
+                int runtimeAsyncTaskId = 0;
+                int firstAwaitedTaskId = 0;
+                int secondAwaitedTaskId = 0;
                 using (var listener = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose))
                 {
                     listener.RunWithCallback(events.Enqueue, () =>
@@ -616,8 +703,27 @@ namespace System.Threading.Tasks.Tests
                         {
                             Func().GetAwaiter().GetResult();
                         }
+
+                        var tcs1 = new TaskCompletionSource();
+                        var tcs2 = new TaskCompletionSource();
+                        Task runtimeAsyncTask = FuncThatWaitsTwice(tcs1, tcs2);
+                        runtimeAsyncTaskId = runtimeAsyncTask.Id;
+                        firstAwaitedTaskId = tcs1.Task.Id;
+                        secondAwaitedTaskId = tcs2.Task.Id;
+                        tcs1.SetResult();
+                        tcs2.SetResult();
+                        runtimeAsyncTask.GetAwaiter().GetResult();
                     });
                 }
+
+                Assert.DoesNotContain(events, e =>
+                    e.EventId == TaskWaitBeginId &&
+                    (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                    ((int)e.Payload[2]! == firstAwaitedTaskId || (int)e.Payload[2]! == secondAwaitedTaskId));
+                Assert.DoesNotContain(events, e =>
+                    e.EventId == TaskWaitEndId &&
+                    (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                    ((int)e.Payload[2]! == firstAwaitedTaskId || (int)e.Payload[2]! == secondAwaitedTaskId));
 
                 // TraceOperationBegin with the RuntimeAsyncTask operation name is uniquely
                 // emitted by V2 async instrumentation. It must not appear without a debugger.

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
@@ -21,7 +22,7 @@ namespace System.Threading.Tasks.Tests
         private static readonly FieldInfo s_continuationTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncContinuationTimestamps");
         private static readonly FieldInfo s_activeTasksField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_currentActiveTasks");
         private static readonly FieldInfo s_activeFlagsField = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "s_activeFlags");
-        private static readonly FieldInfo s_taskIdField = typeof(Task).GetField("m_taskId", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        private static readonly FieldInfo s_taskIdField = GetCorLibClassInstanceField("System.Threading.Tasks.Task", "m_taskId");
 
         private static readonly object s_debuggerLock = new object();
 
@@ -89,6 +90,23 @@ namespace System.Threading.Tasks.Tests
             if (field == null)
             {
                 throw new InvalidOperationException($"Expected static field '{fieldName}' to exist on type '{className}'.");
+            }
+
+            return field;
+        }
+
+        private static FieldInfo GetCorLibClassInstanceField(string className, string fieldName)
+        {
+            Type? classType = typeof(object).Assembly.GetType(className);
+            if (classType == null)
+            {
+                throw new InvalidOperationException($"Type '{className}' doesn't exist in System.Private.CoreLib.");
+            }
+
+            FieldInfo? field = classType.GetField(fieldName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field == null)
+            {
+                throw new InvalidOperationException($"Expected instance field '{fieldName}' to exist on type '{className}'.");
             }
 
             return field;
@@ -406,8 +424,8 @@ namespace System.Threading.Tasks.Tests
             {
                 AttachDebugger();
 
-                var tcs1 = new TaskCompletionSource();
-                var tcs2 = new TaskCompletionSource();
+                var tcs1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 Task inflight = FuncThatWaitsTwice(tcs1, tcs2);
 
                 // Task is suspended on tcs1 — should be in active tasks
@@ -609,6 +627,14 @@ namespace System.Threading.Tasks.Tests
 
                         tcs1.SetResult();
 
+                        Assert.True(
+                            SpinWait.SpinUntil(
+                                () => events.Any(e =>
+                                    e.EventId == TaskWaitBeginId &&
+                                    (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                                    (int)e.Payload[2]! == secondAwaitedTaskId),
+                                TimeSpan.FromSeconds(30)),
+                            "Expected the RuntimeAsync task to suspend on the second task.");
                         Assert.Contains(events, e =>
                             e.EventId == TaskWaitEndId &&
                             (int)e.Payload![1]! == runtimeAsyncTaskId &&
@@ -625,6 +651,14 @@ namespace System.Threading.Tasks.Tests
                         tcs2.SetResult();
                         runtimeAsyncTask.GetAwaiter().GetResult();
 
+                        Assert.True(
+                            SpinWait.SpinUntil(
+                                () => events.Any(e =>
+                                    e.EventId == TaskWaitEndId &&
+                                    (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                                    (int)e.Payload[2]! == secondAwaitedTaskId),
+                                TimeSpan.FromSeconds(30)),
+                            "Expected the RuntimeAsync task to finish waiting on the second task.");
                         Assert.Contains(events, e =>
                             e.EventId == TaskWaitEndId &&
                             (int)e.Payload![1]! == runtimeAsyncTaskId &&
@@ -650,6 +684,8 @@ namespace System.Threading.Tasks.Tests
                 Assert.Equal(0, (int)s_taskIdField.GetValue(tcs1.Task)!);
 
                 tcs1.SetResult();
+                Assert.Equal(0, (int)s_taskIdField.GetValue(tcs2.Task)!);
+
                 tcs2.SetResult();
                 runtimeAsyncTask.GetAwaiter().GetResult();
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -191,6 +191,12 @@ namespace System.Threading.Tasks.Tests
         }
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task FuncThatWaitsOnce(Task task)
+        {
+            await task;
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         static async Task FuncThatInspectsContinuationTimestamps(TaskCompletionSource tcs, Action callback)
         {
             await tcs.Task;
@@ -616,11 +622,15 @@ namespace System.Threading.Tasks.Tests
                         int firstAwaitedTaskId = tcs1.Task.Id;
                         int secondAwaitedTaskId = tcs2.Task.Id;
 
-                        Assert.Contains(events, e =>
-                            e.EventId == TaskWaitBeginId &&
-                            (int)e.Payload![1]! == runtimeAsyncTaskId &&
-                            (int)e.Payload[2]! == firstAwaitedTaskId &&
-                            (int)e.Payload[4]! == runtimeAsyncTaskId);
+                        Assert.True(
+                            SpinWait.SpinUntil(
+                                () => events.Any(e =>
+                                    e.EventId == TaskWaitBeginId &&
+                                    (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                                    (int)e.Payload[2]! == firstAwaitedTaskId &&
+                                    (int)e.Payload[4]! == runtimeAsyncTaskId),
+                                TimeSpan.FromSeconds(30)),
+                            "Expected the RuntimeAsync task to suspend on the first task.");
                         Assert.DoesNotContain(events, e =>
                             e.EventId == TaskWaitEndId &&
                             (int)e.Payload![1]! == runtimeAsyncTaskId &&
@@ -665,6 +675,64 @@ namespace System.Threading.Tasks.Tests
                             e.EventId == TaskWaitEndId &&
                             (int)e.Payload![1]! == runtimeAsyncTaskId &&
                             (int)e.Payload[2]! == secondAwaitedTaskId);
+                    });
+                }
+
+                DetachDebugger();
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        public void RuntimeAsync_TaskWaitEndEventsForFaultedAndCanceledTasks()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                const int TaskWaitBeginId = 10;
+                const int TaskWaitEndId = 11;
+
+                AttachDebugger();
+
+                var events = new ConcurrentQueue<EventWrittenEventArgs>();
+                using (var listener = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose))
+                {
+                    listener.RunWithCallback(events.Enqueue, () =>
+                    {
+                        foreach (bool cancel in new[] { false, true })
+                        {
+                            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                            Task runtimeAsyncTask = FuncThatWaitsOnce(tcs.Task);
+                            int runtimeAsyncTaskId = runtimeAsyncTask.Id;
+                            int awaitedTaskId = tcs.Task.Id;
+
+                            Assert.True(
+                                SpinWait.SpinUntil(
+                                    () => events.Any(e =>
+                                        e.EventId == TaskWaitBeginId &&
+                                        (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                                        (int)e.Payload[2]! == awaitedTaskId),
+                                    TimeSpan.FromSeconds(30)),
+                                $"Expected a wait-begin event for the {(cancel ? "canceled" : "faulted")} task.");
+
+                            if (cancel)
+                            {
+                                tcs.SetCanceled();
+                                Assert.ThrowsAny<OperationCanceledException>(() => runtimeAsyncTask.GetAwaiter().GetResult());
+                            }
+                            else
+                            {
+                                tcs.SetException(new InvalidOperationException());
+                                Assert.Throws<InvalidOperationException>(() => runtimeAsyncTask.GetAwaiter().GetResult());
+                            }
+
+                            Assert.True(
+                                SpinWait.SpinUntil(
+                                    () => events.Any(e =>
+                                        e.EventId == TaskWaitEndId &&
+                                        (int)e.Payload![1]! == runtimeAsyncTaskId &&
+                                        (int)e.Payload[2]! == awaitedTaskId),
+                                    TimeSpan.FromSeconds(30)),
+                                $"Expected a wait-end event for the {(cancel ? "canceled" : "faulted")} task.");
+                        }
                     });
                 }
 


### PR DESCRIPTION
Expose the existing awaited-task relationship to debugger ETW consumers without walking or enumerating Task objects.