### PR TITLE
Add BigInteger.ModInverse and BigInteger.LeastCommonMultiple

### DIFF
--- a/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
+++ b/src/libraries/System.Runtime.Numerics/ref/System.Runtime.Numerics.cs
@@ -66,6 +66,7 @@ namespace System.Numerics
         public static bool IsPositive(System.Numerics.BigInteger value) { throw null; }
         public static bool IsPow2(System.Numerics.BigInteger value) { throw null; }
         public static System.Numerics.BigInteger LeadingZeroCount(System.Numerics.BigInteger value) { throw null; }
+        public static System.Numerics.BigInteger LeastCommonMultiple(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         public static double Log(System.Numerics.BigInteger value) { throw null; }
         public static double Log(System.Numerics.BigInteger value, double baseValue) { throw null; }
         public static double Log10(System.Numerics.BigInteger value) { throw null; }
@@ -74,6 +75,7 @@ namespace System.Numerics
         public static System.Numerics.BigInteger MaxMagnitude(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
         public static System.Numerics.BigInteger Min(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         public static System.Numerics.BigInteger MinMagnitude(System.Numerics.BigInteger x, System.Numerics.BigInteger y) { throw null; }
+        public static System.Numerics.BigInteger ModInverse(System.Numerics.BigInteger value, System.Numerics.BigInteger modulus) { throw null; }
         public static System.Numerics.BigInteger ModPow(System.Numerics.BigInteger value, System.Numerics.BigInteger exponent, System.Numerics.BigInteger modulus) { throw null; }
         public static System.Numerics.BigInteger Multiply(System.Numerics.BigInteger left, System.Numerics.BigInteger right) { throw null; }
         public static System.Numerics.BigInteger Negate(System.Numerics.BigInteger value) { throw null; }

--- a/src/libraries/System.Runtime.Numerics/src/Resources/Strings.resx
+++ b/src/libraries/System.Runtime.Numerics/src/Resources/Strings.resx
@@ -78,6 +78,9 @@
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>
+  <data name="Arithmetic_ModInverseDoesNotExist" xml:space="preserve">
+    <value>The value and the modulus are not coprime, so no modular inverse exists.</value>
+  </data>
   <data name="Format_TooLarge" xml:space="preserve">
     <value>The value is too large to be represented by this format specifier.</value>
   </data>

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1176,6 +1176,25 @@ namespace System.Numerics
             return result;
         }
 
+        /// <summary>Finds the least common multiple of two <see cref="BigInteger" /> values.</summary>
+        /// <param name="left">The first value.</param>
+        /// <param name="right">The second value.</param>
+        /// <returns>The smallest non-negative integer that is a multiple of both <paramref name="left" /> and <paramref name="right" />.</returns>
+        /// <remarks>
+        ///   <para>
+        ///     The result is always non-negative, because the sign of either operand does not affect the
+        ///     set of their common multiples.
+        ///   </para>
+        ///   <para>
+        ///     Zero is a multiple of every integer, so the result is <see cref="Zero" /> when either
+        ///     <paramref name="left" /> or <paramref name="right" /> is <see cref="Zero" />.
+        ///   </para>
+        /// </remarks>
+        public static BigInteger LeastCommonMultiple(BigInteger left, BigInteger right)
+        {
+            throw new NotImplementedException();
+        }
+
         public static BigInteger Max(BigInteger left, BigInteger right)
         {
             return left.CompareTo(right) < 0 ? right : left;
@@ -1297,6 +1316,36 @@ namespace System.Numerics
                     bits[digitShift + length] = carry;
                 }
             }
+        }
+
+        /// <summary>Finds the modular multiplicative inverse of a <see cref="BigInteger" /> value.</summary>
+        /// <param name="value">The value to invert.</param>
+        /// <param name="modulus">The modulus.</param>
+        /// <returns>
+        ///   The least non-negative integer <c>x</c> in the range <c>[0, modulus)</c> that satisfies
+        ///   <c>value * x == 1 (mod modulus)</c>, or <see cref="Zero" /> when <paramref name="modulus" /> is one.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="modulus" /> is less than or equal to zero.</exception>
+        /// <exception cref="ArithmeticException"><paramref name="value" /> and <paramref name="modulus" /> are not coprime, so no inverse exists.</exception>
+        /// <remarks>
+        ///   <para>
+        ///     <paramref name="value" /> is first reduced to its canonical representative in the range
+        ///     <c>[0, modulus)</c>, so a negative <paramref name="value" /> is inverted as though the
+        ///     appropriate multiple of <paramref name="modulus" /> had been added to it.
+        ///   </para>
+        ///   <para>
+        ///     Every integer is congruent to zero modulo one, so the result is <see cref="Zero" /> for any
+        ///     <paramref name="value" /> when <paramref name="modulus" /> is one.
+        ///   </para>
+        ///   <para>
+        ///     An inverse exists only when <paramref name="value" /> and <paramref name="modulus" /> are
+        ///     coprime. This excludes the case where <paramref name="value" /> is congruent to zero modulo
+        ///     <paramref name="modulus" />, including when <paramref name="value" /> is itself <see cref="Zero" />.
+        ///   </para>
+        /// </remarks>
+        public static BigInteger ModInverse(BigInteger value, BigInteger modulus)
+        {
+            throw new NotImplementedException();
         }
 
         public static BigInteger ModPow(BigInteger value, BigInteger exponent, BigInteger modulus)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1381,19 +1381,59 @@ namespace System.Numerics
                 throw new ArithmeticException(SR.Arithmetic_ModInverseDoesNotExist);
             }
 
-            nuint reducedLimb = 0;
+            BigInteger result = TryGetPowerOfTwoExponent(modulus, out int modulusExponent)
+                ? ModInversePowerOfTwo(reduced, modulusExponent)
+                : ModInverseGeneral(reduced, modulus);
+
+            Debug.Assert(result == ModInverseSchoolbook(reduced, modulus));
+
+            return result;
+        }
+
+        private static BigInteger ModInversePowerOfTwo(BigInteger value, int exponent)
+        {
+            Debug.Assert(exponent >= 1);
+            Debug.Assert(value.Sign > 0);
+
+            if (value.IsEven)
+            {
+                // The value and the modulus share the factor two.
+                throw new ArithmeticException(SR.Arithmetic_ModInverseDoesNotExist);
+            }
+
+            nuint valueLimb = 0;
+            ReadOnlySpan<nuint> valueBits = value._bits is null
+                ? CreateSingleLimb(ref valueLimb, NumericsHelpers.Abs(value._sign))
+                : value._bits;
+
+            // The inverse is reduced modulo 2^exponent, which needs one fewer limb than the
+            // modulus itself whenever the modulus is an exact multiple of the limb width.
+            int size = (exponent + BigIntegerCalculator.BitsPerLimb - 1) / BigIntegerCalculator.BitsPerLimb;
+            Span<nuint> bits = RentedBuffer.Create(size, out RentedBuffer bitsBuffer);
+
+            BigIntegerCalculator.ModInversePowerOfTwo(valueBits, exponent, bits);
+
+            BigInteger result = new BigInteger(bits, negative: false);
+            bitsBuffer.Dispose();
+
+            return result;
+        }
+
+        private static BigInteger ModInverseGeneral(BigInteger value, BigInteger modulus)
+        {
+            nuint valueLimb = 0;
             nuint modulusLimb = 0;
 
-            ReadOnlySpan<nuint> reducedBits = reduced._bits is null
-                ? CreateSingleLimb(ref reducedLimb, NumericsHelpers.Abs(reduced._sign))
-                : reduced._bits;
+            ReadOnlySpan<nuint> valueBits = value._bits is null
+                ? CreateSingleLimb(ref valueLimb, NumericsHelpers.Abs(value._sign))
+                : value._bits;
             ReadOnlySpan<nuint> modulusBits = modulus._bits is null
                 ? CreateSingleLimb(ref modulusLimb, NumericsHelpers.Abs(modulus._sign))
                 : modulus._bits;
 
             Span<nuint> bits = RentedBuffer.Create(modulusBits.Length, out RentedBuffer bitsBuffer);
 
-            if (!BigIntegerCalculator.ModInverse(reducedBits, modulusBits, bits))
+            if (!BigIntegerCalculator.ModInverse(valueBits, modulusBits, bits))
             {
                 bitsBuffer.Dispose();
                 throw new ArithmeticException(SR.Arithmetic_ModInverseDoesNotExist);
@@ -1401,8 +1441,6 @@ namespace System.Numerics
 
             BigInteger result = new BigInteger(bits, negative: false);
             bitsBuffer.Dispose();
-
-            Debug.Assert(result == ModInverseSchoolbook(reduced, modulus));
 
             return result;
         }

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1381,13 +1381,9 @@ namespace System.Numerics
                 throw new ArithmeticException(SR.Arithmetic_ModInverseDoesNotExist);
             }
 
-            BigInteger result = TryGetPowerOfTwoExponent(modulus, out int modulusExponent)
+            return TryGetPowerOfTwoExponent(modulus, out int modulusExponent)
                 ? ModInversePowerOfTwo(reduced, modulusExponent)
                 : ModInverseGeneral(reduced, modulus);
-
-            Debug.Assert(result == ModInverseSchoolbook(reduced, modulus));
-
-            return result;
         }
 
         private static BigInteger ModInversePowerOfTwo(BigInteger value, int exponent)
@@ -1449,38 +1445,6 @@ namespace System.Numerics
         {
             storage = value;
             return new ReadOnlySpan<nuint>(in storage);
-        }
-
-        private static BigInteger ModInverseSchoolbook(BigInteger value, BigInteger modulus)
-        {
-            Debug.Assert(value.Sign >= 0 && value < modulus);
-            Debug.Assert(modulus > s_one);
-
-            // Executes the extended Euclidean algorithm, carrying the cofactor of value
-            // alongside the remainder sequence. On termination the last non-zero remainder
-            // is the greatest common divisor and its cofactor is the inverse.
-            // https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
-
-            BigInteger previousRemainder = modulus, remainder = value;
-            BigInteger previousCofactor = s_zero, cofactor = s_one;
-
-            while (!remainder.IsZero)
-            {
-                BigInteger quotient = DivRem(previousRemainder, remainder, out BigInteger nextRemainder);
-
-                (previousRemainder, remainder) = (remainder, nextRemainder);
-                (previousCofactor, cofactor) = (cofactor, previousCofactor - (quotient * cofactor));
-            }
-
-            if (!previousRemainder.IsOne)
-            {
-                // The greatest common divisor is not one, so value is not invertible.
-                // This covers the case where value is congruent to zero modulo the modulus.
-                throw new ArithmeticException(SR.Arithmetic_ModInverseDoesNotExist);
-            }
-
-            // The cofactor is bounded in magnitude by the modulus, but may be negative.
-            return previousCofactor.Sign < 0 ? previousCofactor + modulus : previousCofactor;
         }
 
         public static BigInteger ModPow(BigInteger value, BigInteger exponent, BigInteger modulus)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1192,7 +1192,21 @@ namespace System.Numerics
         /// </remarks>
         public static BigInteger LeastCommonMultiple(BigInteger left, BigInteger right)
         {
-            throw new NotImplementedException();
+            if (left.IsZero || right.IsZero)
+            {
+                return s_zero;
+            }
+
+            if (TryGetPowerOfTwoExponent(left, out int leftExponent)
+                && TryGetPowerOfTwoExponent(right, out int rightExponent))
+            {
+                return CreatePowerOfTwo(Math.Max(leftExponent, rightExponent), negative: false);
+            }
+
+            // Divide before multiplying so the intermediate never exceeds the result.
+            // The greatest common divisor always divides left exactly, so the quotient is exact.
+            BigInteger greatestCommonDivisor = GreatestCommonDivisor(left, right);
+            return Abs(left / greatestCommonDivisor) * Abs(right);
         }
 
         public static BigInteger Max(BigInteger left, BigInteger right)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1375,10 +1375,45 @@ namespace System.Numerics
                 reduced += modulus;
             }
 
-            return ModInverseCore(reduced, modulus);
+            if (reduced.IsZero)
+            {
+                // The greatest common divisor is the modulus, which is greater than one.
+                throw new ArithmeticException(SR.Arithmetic_ModInverseDoesNotExist);
+            }
+
+            nuint reducedLimb = 0;
+            nuint modulusLimb = 0;
+
+            ReadOnlySpan<nuint> reducedBits = reduced._bits is null
+                ? CreateSingleLimb(ref reducedLimb, NumericsHelpers.Abs(reduced._sign))
+                : reduced._bits;
+            ReadOnlySpan<nuint> modulusBits = modulus._bits is null
+                ? CreateSingleLimb(ref modulusLimb, NumericsHelpers.Abs(modulus._sign))
+                : modulus._bits;
+
+            Span<nuint> bits = RentedBuffer.Create(modulusBits.Length, out RentedBuffer bitsBuffer);
+
+            if (!BigIntegerCalculator.ModInverse(reducedBits, modulusBits, bits))
+            {
+                bitsBuffer.Dispose();
+                throw new ArithmeticException(SR.Arithmetic_ModInverseDoesNotExist);
+            }
+
+            BigInteger result = new BigInteger(bits, negative: false);
+            bitsBuffer.Dispose();
+
+            Debug.Assert(result == ModInverseSchoolbook(reduced, modulus));
+
+            return result;
         }
 
-        private static BigInteger ModInverseCore(BigInteger value, BigInteger modulus)
+        private static ReadOnlySpan<nuint> CreateSingleLimb(ref nuint storage, nuint value)
+        {
+            storage = value;
+            return new ReadOnlySpan<nuint>(in storage);
+        }
+
+        private static BigInteger ModInverseSchoolbook(BigInteger value, BigInteger modulus)
         {
             Debug.Assert(value.Sign >= 0 && value < modulus);
             Debug.Assert(modulus > s_one);

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1359,7 +1359,55 @@ namespace System.Numerics
         /// </remarks>
         public static BigInteger ModInverse(BigInteger value, BigInteger modulus)
         {
-            throw new NotImplementedException();
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(modulus.Sign, nameof(modulus));
+
+            if (modulus.IsOne)
+            {
+                // Every integer is congruent to zero modulo one.
+                return s_zero;
+            }
+
+            // Reduce to the canonical representative in [0, modulus) so that a negative
+            // value is inverted as though a multiple of the modulus had been added to it.
+            BigInteger reduced = value % modulus;
+            if (reduced.Sign < 0)
+            {
+                reduced += modulus;
+            }
+
+            return ModInverseCore(reduced, modulus);
+        }
+
+        private static BigInteger ModInverseCore(BigInteger value, BigInteger modulus)
+        {
+            Debug.Assert(value.Sign >= 0 && value < modulus);
+            Debug.Assert(modulus > s_one);
+
+            // Executes the extended Euclidean algorithm, carrying the cofactor of value
+            // alongside the remainder sequence. On termination the last non-zero remainder
+            // is the greatest common divisor and its cofactor is the inverse.
+            // https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
+
+            BigInteger previousRemainder = modulus, remainder = value;
+            BigInteger previousCofactor = s_zero, cofactor = s_one;
+
+            while (!remainder.IsZero)
+            {
+                BigInteger quotient = DivRem(previousRemainder, remainder, out BigInteger nextRemainder);
+
+                (previousRemainder, remainder) = (remainder, nextRemainder);
+                (previousCofactor, cofactor) = (cofactor, previousCofactor - (quotient * cofactor));
+            }
+
+            if (!previousRemainder.IsOne)
+            {
+                // The greatest common divisor is not one, so value is not invertible.
+                // This covers the case where value is congruent to zero modulo the modulus.
+                throw new ArithmeticException(SR.Arithmetic_ModInverseDoesNotExist);
+            }
+
+            // The cofactor is bounded in magnitude by the modulus, but may be negative.
+            return previousCofactor.Sign < 0 ? previousCofactor + modulus : previousCofactor;
         }
 
         public static BigInteger ModPow(BigInteger value, BigInteger exponent, BigInteger modulus)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.GcdInv.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.GcdInv.cs
@@ -262,6 +262,307 @@ namespace System.Numerics
             left.CopyTo(result);
         }
 
+        public static bool ModInverse(ReadOnlySpan<nuint> value, ReadOnlySpan<nuint> modulus, Span<nuint> result)
+        {
+            Debug.Assert(value.Length >= 1);
+            Debug.Assert(modulus.Length >= 1);
+            Debug.Assert(ActualLength(value) >= 1);
+            Debug.Assert(CompareActual(value, modulus) < 0);
+            Debug.Assert(result.Length == modulus.Length);
+
+            // Executes the extended Euclidean algorithm, reusing the Lehmer guessing step
+            // and Jebelean termination condition from Gcd to advance several Euclid steps
+            // at a time.
+            //
+            // Alongside the remainder sequence r[0] = modulus, r[1] = value this carries a
+            // sequence of cofactor magnitudes
+            //
+            //     t[0] = 0, t[1] = 1, t[i+1] = t[i-1] + q[i] * t[i]
+            //
+            // which satisfies the invariant
+            //
+            //     r[i] == (-1)^(i+1) * t[i] * value   (mod modulus)
+            //
+            // Every t[i] is non-negative and the recurrence only ever adds, so cofactors
+            // stay unsigned like the rest of the calculator and the alternating sign is
+            // carried as the parity of i alone. The companion identity
+            //
+            //     t[i] * r[i-1] + t[i-1] * r[i] == modulus
+            //
+            // bounds every cofactor by the modulus, so one limb beyond the modulus is
+            // always enough to hold one, including while it is being accumulated.
+
+            int limbCount = modulus.Length;
+            int cofactorLength = limbCount + 1;
+
+            Span<nuint> x = BigInteger.RentedBuffer.Create(limbCount, out BigInteger.RentedBuffer xBuffer);
+            Span<nuint> y = BigInteger.RentedBuffer.Create(limbCount, out BigInteger.RentedBuffer yBuffer);
+            Span<nuint> u = BigInteger.RentedBuffer.Create(cofactorLength, out BigInteger.RentedBuffer uBuffer);
+            Span<nuint> v = BigInteger.RentedBuffer.Create(cofactorLength, out BigInteger.RentedBuffer vBuffer);
+            Span<nuint> cofactorLow = BigInteger.RentedBuffer.Create(cofactorLength, out BigInteger.RentedBuffer cofactorLowBuffer);
+            Span<nuint> cofactorHigh = BigInteger.RentedBuffer.Create(cofactorLength, out BigInteger.RentedBuffer cofactorHighBuffer);
+            Span<nuint> quotient = BigInteger.RentedBuffer.Create(limbCount, out BigInteger.RentedBuffer quotientBuffer);
+            Span<nuint> remainder = BigInteger.RentedBuffer.Create(limbCount, out BigInteger.RentedBuffer remainderBuffer);
+            Span<nuint> product = BigInteger.RentedBuffer.Create(limbCount + cofactorLength, out BigInteger.RentedBuffer productBuffer);
+
+            modulus.CopyTo(x);
+            value.CopyTo(y.Slice(0, value.Length));
+
+            int xLength = ActualLength(x);
+            int yLength = ActualLength(y);
+
+            v[0] = 1;
+
+            // Parity of i, the index of x within the remainder sequence. x starts as
+            // r[0] = modulus, so the index starts even.
+            bool oddIndex = false;
+
+            // Lehmer's guess needs the leading limbs that ExtractDigits reads.
+            int lehmerMinimum = nint.Size == 4 ? 3 : 2;
+
+            while (yLength > 0)
+            {
+                if (xLength >= lehmerMinimum && yLength >= lehmerMinimum)
+                {
+                    ExtractDigits(x.Slice(0, xLength), y.Slice(0, yLength), out ulong xDigits, out ulong yDigits);
+
+                    uint a = 1U, b = 0U;
+                    uint c = 0U, d = 1U;
+
+                    int iteration = 0;
+
+                    // Lehmer's guessing: use top digits to compute a 2x2 matrix (a,b,c,d)
+                    // that approximates several GCD steps. Stop when the quotient or
+                    // matrix entries would overflow, or when the Jebelean termination
+                    // condition (t < s || t + r > y - c) indicates the guess may be wrong.
+                    while (yDigits != 0)
+                    {
+                        ulong q, r, s, t;
+
+                        // Odd iteration
+                        q = xDigits / yDigits;
+
+                        if (q > 0xFFFFFFFF)
+                        {
+                            break;
+                        }
+
+                        r = a + q * c;
+                        s = b + q * d;
+                        t = xDigits - q * yDigits;
+
+                        if (r > 0x7FFFFFFF || s > 0x7FFFFFFF || t < s || t + r > yDigits - c)
+                        {
+                            break;
+                        }
+
+                        a = (uint)r;
+                        b = (uint)s;
+                        xDigits = t;
+
+                        ++iteration;
+                        if (xDigits == b)
+                        {
+                            break;
+                        }
+
+                        // Even iteration
+                        q = yDigits / xDigits;
+
+                        if (q > 0xFFFFFFFF)
+                        {
+                            break;
+                        }
+
+                        r = d + q * b;
+                        s = c + q * a;
+                        t = yDigits - q * xDigits;
+
+                        if (r > 0x7FFFFFFF || s > 0x7FFFFFFF || t < s || t + r > xDigits - b)
+                        {
+                            break;
+                        }
+
+                        d = (uint)r;
+                        c = (uint)s;
+                        yDigits = t;
+
+                        ++iteration;
+                        if (yDigits == c)
+                        {
+                            break;
+                        }
+                    }
+
+                    if (b != 0)
+                    {
+                        // Lehmer's step. The remainders take the signed matrix, so the
+                        // cofactor magnitudes take the same matrix with the signs dropped:
+                        // the alternating signs of the two cofactors cancel the two
+                        // subtractions exactly.
+                        int count = LehmerCore(x.Slice(0, xLength), y.Slice(0, yLength), a, b, c, d);
+                        xLength = Refresh(x.Slice(0, xLength), count);
+                        yLength = Refresh(y.Slice(0, yLength), count);
+
+                        CombineCofactors(u, v, a, b, cofactorLow);
+                        CombineCofactors(u, v, c, d, cofactorHigh);
+                        cofactorLow.CopyTo(u);
+                        cofactorHigh.CopyTo(v);
+
+                        if ((iteration & 1) != 0)
+                        {
+                            // The transformation advanced the index by an odd number of
+                            // steps, so x now holds the later remainder. Swapping restores
+                            // the ordering and flips the parity in lockstep.
+                            Span<nuint> swapRemainder = x;
+                            x = y;
+                            y = swapRemainder;
+
+                            Span<nuint> swapCofactor = u;
+                            u = v;
+                            v = swapCofactor;
+
+                            (xLength, yLength) = (yLength, xLength);
+                            oddIndex = !oddIndex;
+                        }
+
+                        continue;
+                    }
+                }
+
+                // Euclid's step, also used whenever the operands are too short for
+                // Lehmer's guess to read the leading limbs it needs.
+                Span<nuint> stepQuotient = quotient.Slice(0, xLength - yLength + 1);
+                Span<nuint> stepRemainder = remainder.Slice(0, xLength);
+
+                Divide(x.Slice(0, xLength), y.Slice(0, yLength), stepQuotient, stepRemainder);
+
+                int quotientLength = ActualLength(stepQuotient);
+                Debug.Assert(quotientLength >= 1, "x >= y, so the quotient is at least one.");
+
+                // v' = u + q * v, computed before the buffers are rotated.
+                if (quotientLength == 1)
+                {
+                    AddScaled(u, v, stepQuotient[0], cofactorLow);
+                }
+                else
+                {
+                    product.Clear();
+                    Multiply(stepQuotient.Slice(0, quotientLength), v, product);
+                    AddSelf(product, u);
+
+                    Debug.Assert(!product.Slice(cofactorLength).ContainsAnyExcept((nuint)0));
+                    product.Slice(0, cofactorLength).CopyTo(cofactorLow);
+                }
+
+                // (x, y) <- (y, x mod y) and (u, v) <- (v, u + q * v)
+                stepRemainder.Slice(0, yLength).CopyTo(x);
+                x.Slice(yLength).Clear();
+                xLength = yLength;
+
+                Span<nuint> stepTemp = x;
+                x = y;
+                y = stepTemp;
+
+                (xLength, yLength) = (yLength, xLength);
+                xLength = ActualLength(x.Slice(0, xLength));
+                yLength = ActualLength(y.Slice(0, yLength));
+
+                v.CopyTo(u);
+                cofactorLow.CopyTo(v);
+
+                oddIndex = !oddIndex;
+            }
+
+            // The last non-zero remainder is the greatest common divisor.
+            bool coprime = xLength == 1 && x[0] == 1;
+
+            if (coprime)
+            {
+                // r[k] == 1 == (-1)^(k+1) * t[k] * value, so the inverse is t[k] when k is
+                // odd and modulus - t[k] when k is even.
+                int cofactorActualLength = ActualLength(u);
+                Debug.Assert(cofactorActualLength >= 1 && cofactorActualLength <= limbCount);
+
+                if (oddIndex)
+                {
+                    u.Slice(0, cofactorActualLength).CopyTo(result);
+                    result.Slice(cofactorActualLength).Clear();
+                }
+                else
+                {
+                    modulus.CopyTo(result);
+                    SubtractSelf(result, u.Slice(0, cofactorActualLength));
+                }
+            }
+
+            productBuffer.Dispose();
+            remainderBuffer.Dispose();
+            quotientBuffer.Dispose();
+            cofactorHighBuffer.Dispose();
+            cofactorLowBuffer.Dispose();
+            vBuffer.Dispose();
+            uBuffer.Dispose();
+            yBuffer.Dispose();
+            xBuffer.Dispose();
+
+            return coprime;
+        }
+
+        private static void CombineCofactors(ReadOnlySpan<nuint> left, ReadOnlySpan<nuint> right,
+                                             nuint leftMultiplier, nuint rightMultiplier,
+                                             Span<nuint> destination)
+        {
+            Debug.Assert(left.Length == right.Length);
+            Debug.Assert(destination.Length == left.Length);
+            Debug.Assert(leftMultiplier <= 0x7FFFFFFF);
+            Debug.Assert(rightMultiplier <= 0x7FFFFFFF);
+
+            // Computes leftMultiplier * left + rightMultiplier * right. Both multipliers
+            // are at most 31 bits, but a limb is 32 bits wide on a 32-bit process, so the
+            // accumulator has to be wider than a limb on either architecture. With both
+            // multipliers below 2^31 the running carry stays below 2^32, so no term ever
+            // approaches the top of the accumulator.
+
+            UInt128 carry = 0;
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                UInt128 digit = ((UInt128)leftMultiplier * left[i]) + ((UInt128)rightMultiplier * right[i]) + carry;
+                destination[i] = (nuint)digit;
+                carry = digit >> BitsPerLimb;
+            }
+
+            // The result is another cofactor, so it is bounded by the modulus and cannot
+            // overflow the spare limb the destination carries.
+            Debug.Assert(carry == 0);
+        }
+
+        private static void AddScaled(ReadOnlySpan<nuint> addend, ReadOnlySpan<nuint> left,
+                                      nuint multiplier, Span<nuint> destination)
+        {
+            Debug.Assert(addend.Length == left.Length);
+            Debug.Assert(destination.Length == left.Length);
+
+            // Computes addend + multiplier * left for a full-width multiplier. Writing L
+            // for the limb radix, every accumulator term is bounded by
+            // (L-1) + (L-1)^2 + (L-1) == L^2 - 1, so a carry stays below L and the
+            // accumulator stays within twice the width of a limb. A second full-width
+            // multiplier would not fit, which is why the two-multiplier form above is
+            // restricted to the 31-bit entries Lehmer's guess produces.
+
+            UInt128 carry = 0;
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                UInt128 digit = addend[i] + ((UInt128)multiplier * left[i]) + carry;
+                destination[i] = (nuint)digit;
+                carry = digit >> BitsPerLimb;
+            }
+
+            Debug.Assert(carry == 0);
+        }
+
         private static int Overwrite(Span<nuint> buffer, ulong value)
         {
             if (nint.Size == 4)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.GcdInv.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.GcdInv.cs
@@ -509,6 +509,121 @@ namespace System.Numerics
             return coprime;
         }
 
+        public static void ModInversePowerOfTwo(ReadOnlySpan<nuint> value, int exponent, Span<nuint> result)
+        {
+            Debug.Assert(value.Length >= 1);
+            Debug.Assert((value[0] & 1) != 0);
+            Debug.Assert(exponent >= 1);
+            Debug.Assert(result.Length == (exponent + BitsPerLimb - 1) / BitsPerLimb);
+            Debug.Assert(ActualLength(value) <= result.Length);
+
+            // Executes Hensel lifting, in the Newton iteration form, on the 2-adic inverse.
+            //
+            // If value * x == 1 (mod 2^m), then x' = x * (2 - value * x) satisfies
+            // value * x' == 1 (mod 2^2m): writing value * x = 1 + e * 2^m gives
+            //
+            //     value * x' = (1 + e * 2^m) * (1 - e * 2^m) = 1 - e^2 * 2^2m
+            //
+            // so each step doubles the number of correct bits. Only odd values are
+            // invertible modulo a power of two, which the caller has already established.
+
+            int limbCount = result.Length;
+
+            result.Clear();
+
+            // Seed with the inverse modulo a single limb. ComputeMontgomeryInverse runs the
+            // same iteration to full limb width, but returns the negated inverse because
+            // that is what Montgomery reduction consumes; negating it back recovers the
+            // plain 2-adic inverse of the low limb.
+            result[0] = (nuint)0 - ComputeMontgomeryInverse(value[0]);
+
+            if (limbCount > 1)
+            {
+                Span<nuint> factor = BigInteger.RentedBuffer.Create(limbCount, out BigInteger.RentedBuffer factorBuffer);
+                Span<nuint> product = BigInteger.RentedBuffer.Create(limbCount * 2, out BigInteger.RentedBuffer productBuffer);
+
+                int valueLength = ActualLength(value);
+
+                // The seed is correct to one whole limb, and the iteration doubles that
+                // until it covers the modulus, so this terminates after exactly
+                // ceil(log2(limbCount)) steps with correctLimbs == limbCount.
+                int correctLimbs = 1;
+
+                while (correctLimbs < limbCount)
+                {
+                    int nextLimbs = Math.Min(correctLimbs * 2, limbCount);
+                    int resultLength = ActualLength(result.Slice(0, correctLimbs));
+                    int valueFactorLength = Math.Min(valueLength, nextLimbs);
+
+                    // factor = 2 - value * result, modulo the limb radix to nextLimbs.
+                    // Dropping limbs above nextLimbs from either operand is exactly the
+                    // truncation the modular reduction asks for. Multiply wants a
+                    // destination of exactly the product width, so each call gets its own
+                    // slice; a product narrower than nextLimbs simply leaves the cleared
+                    // high limbs of the destination alone.
+                    int lowWidth = valueFactorLength + resultLength;
+                    Span<nuint> lowProduct = product.Slice(0, lowWidth);
+                    lowProduct.Clear();
+
+                    Multiply(value.Slice(0, valueFactorLength), result.Slice(0, resultLength), lowProduct);
+
+                    factor.Slice(0, nextLimbs).Clear();
+                    lowProduct.Slice(0, Math.Min(lowWidth, nextLimbs)).CopyTo(factor);
+                    SubtractFromTwo(factor.Slice(0, nextLimbs));
+
+                    // result = result * factor, again modulo the limb radix to nextLimbs.
+                    int highWidth = nextLimbs + resultLength;
+                    Span<nuint> highProduct = product.Slice(0, highWidth);
+                    highProduct.Clear();
+
+                    Multiply(factor.Slice(0, nextLimbs), result.Slice(0, resultLength), highProduct);
+
+                    Debug.Assert(highWidth >= nextLimbs);
+                    highProduct.Slice(0, nextLimbs).CopyTo(result);
+
+                    correctLimbs = nextLimbs;
+                }
+
+                Debug.Assert(correctLimbs == limbCount);
+
+                productBuffer.Dispose();
+                factorBuffer.Dispose();
+            }
+
+            // The lift works to whole limbs, so trim the top limb back to the bits the
+            // modulus actually spans. Reducing the inverse modulo 2^exponent leaves the
+            // congruence intact because 2^exponent divides the limb radix to limbCount.
+            int topBits = exponent - ((limbCount - 1) * BitsPerLimb);
+            Debug.Assert(topBits >= 1 && topBits <= BitsPerLimb);
+
+            if (topBits < BitsPerLimb)
+            {
+                result[limbCount - 1] &= ((nuint)1 << topBits) - 1;
+            }
+
+            // The inverse of an odd value is odd, so it is never zero.
+            Debug.Assert((result[0] & 1) != 0);
+        }
+
+        private static void SubtractFromTwo(Span<nuint> bits)
+        {
+            // Computes 2 - bits modulo the limb radix to bits.Length. The two's complement
+            // of t is ~t + 1, so 2 - t is ~t + 3, with the carry out of the top limb
+            // dropped because that is the modular reduction.
+
+            nuint carry = 3;
+
+            for (int i = 0; i < bits.Length; i++)
+            {
+                nuint complement = ~bits[i];
+                nuint digit = complement + carry;
+
+                // Unsigned addition wrapped exactly when the sum fell below an addend.
+                carry = digit < complement ? 1U : 0U;
+                bits[i] = digit;
+            }
+        }
+
         private static void CombineCofactors(ReadOnlySpan<nuint> left, ReadOnlySpan<nuint> right,
                                              nuint leftMultiplier, nuint rightMultiplier,
                                              Span<nuint> destination)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/leastcommonmultiple.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/leastcommonmultiple.cs
@@ -1,0 +1,316 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Numerics.Tests
+{
+    public class LeastCommonMultipleTests
+    {
+        private const int Samples = 16;
+
+        private static readonly Random s_random = new Random(100);
+
+        [Theory]
+        [InlineData(4, 6, 12)]
+        [InlineData(6, 4, 12)]
+        [InlineData(21, 6, 42)]
+        [InlineData(12, 18, 36)]
+        [InlineData(3, 7, 21)]              // coprime: product
+        [InlineData(4, 8, 8)]               // one divides the other
+        [InlineData(8, 4, 8)]
+        [InlineData(5, 5, 5)]
+        [InlineData(1, 7, 7)]
+        [InlineData(7, 1, 7)]
+        [InlineData(-4, 6, 12)]             // result is always non-negative
+        [InlineData(4, -6, 12)]
+        [InlineData(-4, -6, 12)]
+        [InlineData(-2147483648, 1, 2147483648)]
+        [InlineData(-2147483648, -2147483648, 2147483648)]
+        public static void SmallValues(long left, long right, long expected)
+        {
+            Assert.Equal((BigInteger)expected, BigInteger.LeastCommonMultiple(left, right));
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0, 5)]
+        [InlineData(5, 0)]
+        [InlineData(0, -5)]
+        [InlineData(-5, 0)]
+        [InlineData(0, long.MaxValue)]
+        [InlineData(0, long.MinValue)]
+        public static void ZeroOperand_ReturnsZero(long left, long right)
+        {
+            Assert.Equal(BigInteger.Zero, BigInteger.LeastCommonMultiple(left, right));
+        }
+
+        [Fact]
+        public static void ResultIsNeverNegative()
+        {
+            foreach ((BigInteger left, BigInteger right) in Pairs())
+            {
+                BigInteger result = BigInteger.LeastCommonMultiple(left, right);
+
+                Assert.True(result.Sign >= 0, $"Result was negative for left={left}, right={right}.");
+            }
+        }
+
+        [Fact]
+        public static void IsCommutative()
+        {
+            foreach ((BigInteger left, BigInteger right) in Pairs())
+            {
+                Assert.Equal(
+                    BigInteger.LeastCommonMultiple(left, right),
+                    BigInteger.LeastCommonMultiple(right, left));
+            }
+        }
+
+        [Fact]
+        public static void SignOfOperandsDoesNotAffectResult()
+        {
+            foreach ((BigInteger left, BigInteger right) in Pairs())
+            {
+                BigInteger expected = BigInteger.LeastCommonMultiple(left, right);
+
+                Assert.Equal(expected, BigInteger.LeastCommonMultiple(-left, right));
+                Assert.Equal(expected, BigInteger.LeastCommonMultiple(left, -right));
+                Assert.Equal(expected, BigInteger.LeastCommonMultiple(-left, -right));
+            }
+        }
+
+        [Fact]
+        public static void ResultIsAMultipleOfBothOperands()
+        {
+            foreach ((BigInteger left, BigInteger right) in Pairs())
+            {
+                BigInteger result = BigInteger.LeastCommonMultiple(left, right);
+
+                if (result.IsZero)
+                {
+                    Assert.True(left.IsZero || right.IsZero);
+                    continue;
+                }
+
+                Assert.Equal(BigInteger.Zero, result % left);
+                Assert.Equal(BigInteger.Zero, result % right);
+            }
+        }
+
+        [Fact]
+        public static void ProductOfLcmAndGcdEqualsProductOfMagnitudes()
+        {
+            // lcm(a, b) * gcd(a, b) == |a * b| for all a, b (including zero, where both sides are zero).
+            foreach ((BigInteger left, BigInteger right) in Pairs())
+            {
+                BigInteger lcm = BigInteger.LeastCommonMultiple(left, right);
+                BigInteger gcd = BigInteger.GreatestCommonDivisor(left, right);
+
+                Assert.Equal(BigInteger.Abs(left * right), lcm * gcd);
+            }
+        }
+
+        [Fact]
+        public static void IsTheLeastCommonMultiple()
+        {
+            // No proper divisor of the result that is still a common multiple should exist;
+            // equivalently, result / |left| and result / |right| must be coprime cofactors.
+            foreach ((BigInteger left, BigInteger right) in Pairs())
+            {
+                if (left.IsZero || right.IsZero)
+                {
+                    continue;
+                }
+
+                BigInteger result = BigInteger.LeastCommonMultiple(left, right);
+
+                BigInteger leftCofactor = result / BigInteger.Abs(left);
+                BigInteger rightCofactor = result / BigInteger.Abs(right);
+
+                Assert.Equal(BigInteger.One, BigInteger.GreatestCommonDivisor(leftCofactor, rightCofactor));
+            }
+        }
+
+        [Fact]
+        public static void IsIdempotent()
+        {
+            foreach ((BigInteger left, BigInteger _) in Pairs())
+            {
+                Assert.Equal(BigInteger.Abs(left), BigInteger.LeastCommonMultiple(left, left));
+            }
+        }
+
+        [Fact]
+        public static void OneIsTheIdentity()
+        {
+            foreach ((BigInteger left, BigInteger _) in Pairs())
+            {
+                Assert.Equal(BigInteger.Abs(left), BigInteger.LeastCommonMultiple(left, BigInteger.One));
+                Assert.Equal(BigInteger.Abs(left), BigInteger.LeastCommonMultiple(BigInteger.One, left));
+            }
+        }
+
+        [Fact]
+        public static void IsAssociative()
+        {
+            BigInteger[] values = new BigInteger[]
+            {
+                6,
+                10,
+                15,
+                BigInteger.Pow(2, 61) - 1,
+                BigInteger.Pow(3, 40),
+                RandomNonNegative(32),
+            };
+
+            foreach (BigInteger x in values)
+            {
+                foreach (BigInteger y in values)
+                {
+                    foreach (BigInteger z in values)
+                    {
+                        Assert.Equal(
+                            BigInteger.LeastCommonMultiple(BigInteger.LeastCommonMultiple(x, y), z),
+                            BigInteger.LeastCommonMultiple(x, BigInteger.LeastCommonMultiple(y, z)));
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public static void PowersOfTwo()
+        {
+            for (int i = 0; i < 256; i += 17)
+            {
+                for (int j = 0; j < 256; j += 23)
+                {
+                    BigInteger left = BigInteger.One << i;
+                    BigInteger right = BigInteger.One << j;
+
+                    Assert.Equal(BigInteger.One << Math.Max(i, j), BigInteger.LeastCommonMultiple(left, right));
+                    Assert.Equal(BigInteger.One << Math.Max(i, j), BigInteger.LeastCommonMultiple(-left, right));
+                }
+            }
+        }
+
+        [Fact]
+        public static void SharedTrailingZeroLimbs()
+        {
+            // Both operands are shifted by whole limb counts, which exercises the common
+            // limb offset handling shared with GreatestCommonDivisor.
+            foreach (int shift in new int[] { 32, 64, 96, 128, 256 })
+            {
+                BigInteger left = RandomPositive(16) << shift;
+                BigInteger right = RandomPositive(16) << shift;
+
+                BigInteger lcm = BigInteger.LeastCommonMultiple(left, right);
+                BigInteger gcd = BigInteger.GreatestCommonDivisor(left, right);
+
+                Assert.Equal(BigInteger.Abs(left * right), lcm * gcd);
+                Assert.Equal(BigInteger.Zero, lcm % left);
+                Assert.Equal(BigInteger.Zero, lcm % right);
+            }
+        }
+
+        [Fact]
+        public static void LargeOperands()
+        {
+            foreach (int byteCount in new int[] { 8, 9, 16, 17, 32, 64, 128, 256, 512 })
+            {
+                for (int i = 0; i < 4; i++)
+                {
+                    BigInteger left = RandomPositive(byteCount);
+                    BigInteger right = RandomPositive(byteCount);
+
+                    if ((i & 1) != 0)
+                    {
+                        left = -left;
+                    }
+
+                    BigInteger lcm = BigInteger.LeastCommonMultiple(left, right);
+
+                    Assert.True(lcm.Sign > 0);
+                    Assert.Equal(BigInteger.Zero, lcm % left);
+                    Assert.Equal(BigInteger.Zero, lcm % right);
+                    Assert.Equal(
+                        BigInteger.Abs(left * right),
+                        lcm * BigInteger.GreatestCommonDivisor(left, right));
+                }
+            }
+        }
+
+        [Fact]
+        public static void CarmichaelFunctionUsage()
+        {
+            // The motivating scenario from the API proposal: lambda(n) = lcm(p - 1, q - 1).
+            BigInteger p = BigInteger.Parse("32416190071");
+            BigInteger q = BigInteger.Parse("32416187567");
+
+            BigInteger lambda = BigInteger.LeastCommonMultiple(p - 1, q - 1);
+
+            Assert.Equal(BigInteger.Zero, lambda % (p - 1));
+            Assert.Equal(BigInteger.Zero, lambda % (q - 1));
+            Assert.Equal(
+                BigInteger.Abs((p - 1) * (q - 1)),
+                lambda * BigInteger.GreatestCommonDivisor(p - 1, q - 1));
+
+            BigInteger e = 65537;
+            BigInteger d = BigInteger.ModInverse(e, lambda);
+
+            Assert.Equal(BigInteger.One, (e * d) % lambda);
+        }
+
+        private static IEnumerable<(BigInteger Left, BigInteger Right)> Pairs()
+        {
+            yield return (0, 0);
+            yield return (0, 7);
+            yield return (7, 0);
+            yield return (1, 1);
+            yield return (4, 6);
+            yield return (-4, 6);
+            yield return (long.MaxValue, long.MaxValue);
+            yield return (BigInteger.Pow(2, 127) - 1, BigInteger.Pow(2, 89) - 1);
+            yield return (BigInteger.Pow(2, 128), BigInteger.Pow(2, 64));
+
+            for (int i = 0; i < Samples; i++)
+            {
+                foreach (int byteCount in new int[] { 1, 2, 4, 8, 16, 48, 100 })
+                {
+                    BigInteger left = RandomPositive(byteCount);
+                    BigInteger right = RandomPositive(byteCount);
+
+                    if ((i & 1) != 0)
+                    {
+                        left = -left;
+                    }
+
+                    if ((i & 2) != 0)
+                    {
+                        right = -right;
+                    }
+
+                    yield return (left, right);
+                }
+            }
+        }
+
+        private static BigInteger RandomNonNegative(int byteCount)
+        {
+            byte[] bytes = new byte[byteCount + 1];
+            s_random.NextBytes(bytes);
+
+            // Clear the most significant byte so the two's complement value is non-negative.
+            bytes[byteCount] = 0;
+
+            return new BigInteger(bytes);
+        }
+
+        private static BigInteger RandomPositive(int byteCount)
+        {
+            BigInteger result = RandomNonNegative(byteCount);
+            return result.IsZero ? BigInteger.One : result;
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/modinverse.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/modinverse.cs
@@ -1,0 +1,327 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Numerics.Tests
+{
+    public class ModInverseTests
+    {
+        private const int Samples = 16;
+
+        private static readonly Random s_random = new Random(100);
+
+        // Mersenne exponents: 2^p - 1 is prime for each of these. Used to cross-check
+        // against ModPow via Fermat's little theorem, and to cover a range of limb counts.
+        private static readonly int[] s_mersenneExponents = new int[] { 31, 61, 89, 127, 521, 607, 1279 };
+
+        [Theory]
+        [InlineData(3, 7, 5)]
+        [InlineData(2, 7, 4)]
+        [InlineData(6, 7, 6)]
+        [InlineData(1, 7, 1)]
+        [InlineData(10, 7, 5)]          // |value| > modulus
+        [InlineData(-3, 7, 2)]          // negative value is reduced first
+        [InlineData(-1, 7, 6)]
+        [InlineData(-11, 13, 7)]
+        [InlineData(7, 26, 15)]
+        [InlineData(2, 9, 5)]
+        [InlineData(5, 12, 5)]
+        [InlineData(17, 3120, 2753)]    // textbook RSA exponent
+        [InlineData(65537, 1000000007, 743534192)]
+        [InlineData(-2147483648, 3, 1)] // int.MinValue: negation must not overflow
+        [InlineData(1, 2, 1)]           // smallest non-degenerate modulus
+        public static void SmallValues(long value, long modulus, long expected)
+        {
+            Assert.Equal((BigInteger)expected, BigInteger.ModInverse(value, modulus));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        [InlineData(5)]
+        [InlineData(-5)]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MinValue)]
+        public static void ModulusOne_ReturnsZero(long value)
+        {
+            Assert.Equal(BigInteger.Zero, BigInteger.ModInverse(value, BigInteger.One));
+        }
+
+        [Theory]
+        [InlineData(6, 9)]      // gcd == 3
+        [InlineData(0, 5)]      // gcd == 5
+        [InlineData(5, 5)]      // value == modulus
+        [InlineData(-5, 5)]
+        [InlineData(10, 5)]     // value is a multiple of modulus
+        [InlineData(4, 8)]
+        [InlineData(0, 2)]
+        [InlineData(2, 2)]
+        public static void NotCoprime_ThrowsArithmeticException(long value, long modulus)
+        {
+            Assert.Throws<ArithmeticException>(() => BigInteger.ModInverse(value, modulus));
+        }
+
+        [Theory]
+        [InlineData(3, 0)]
+        [InlineData(3, -1)]
+        [InlineData(3, -7)]
+        [InlineData(0, 0)]
+        [InlineData(0, -1)]
+        [InlineData(-3, long.MinValue)]
+        public static void NonPositiveModulus_ThrowsArgumentOutOfRangeException(long value, long modulus)
+        {
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
+                () => BigInteger.ModInverse(value, modulus));
+
+            Assert.Equal("modulus", exception.ParamName);
+        }
+
+        [Fact]
+        public static void KnownIdentities()
+        {
+            foreach (BigInteger modulus in new BigInteger[] { 2, 3, 7, 26, 3120, 1000000007, BigInteger.Pow(2, 521) - 1 })
+            {
+                // 1 is always its own inverse.
+                Assert.Equal(BigInteger.One, BigInteger.ModInverse(BigInteger.One, modulus));
+
+                // (modulus - 1)^2 == modulus^2 - 2*modulus + 1 == 1 (mod modulus)
+                Assert.Equal(modulus - 1, BigInteger.ModInverse(modulus - 1, modulus));
+
+                // -1 reduces to modulus - 1.
+                Assert.Equal(modulus - 1, BigInteger.ModInverse(BigInteger.MinusOne, modulus));
+            }
+        }
+
+        [Fact]
+        public static void ResultIsCanonicalRepresentative()
+        {
+            foreach ((BigInteger value, BigInteger modulus) in CoprimePairs())
+            {
+                BigInteger inverse = BigInteger.ModInverse(value, modulus);
+
+                Assert.True(inverse.Sign >= 0, $"Inverse was negative for value={value}, modulus={modulus}.");
+                Assert.True(inverse < modulus, $"Inverse was not below the modulus for value={value}, modulus={modulus}.");
+            }
+        }
+
+        [Fact]
+        public static void SatisfiesDefiningCongruence()
+        {
+            foreach ((BigInteger value, BigInteger modulus) in CoprimePairs())
+            {
+                BigInteger inverse = BigInteger.ModInverse(value, modulus);
+
+                Assert.Equal(BigInteger.One % modulus, Mod(value * inverse, modulus));
+            }
+        }
+
+        [Fact]
+        public static void InverseOfInverseIsReducedValue()
+        {
+            foreach ((BigInteger value, BigInteger modulus) in CoprimePairs())
+            {
+                if (modulus.IsOne)
+                {
+                    continue;
+                }
+
+                BigInteger inverse = BigInteger.ModInverse(value, modulus);
+
+                Assert.Equal(Mod(value, modulus), BigInteger.ModInverse(inverse, modulus));
+            }
+        }
+
+        [Fact]
+        public static void ValueIsReducedModuloTheModulus()
+        {
+            foreach ((BigInteger value, BigInteger modulus) in CoprimePairs())
+            {
+                BigInteger expected = BigInteger.ModInverse(value, modulus);
+
+                // Adding or subtracting any multiple of the modulus leaves the inverse unchanged.
+                Assert.Equal(expected, BigInteger.ModInverse(value + modulus, modulus));
+                Assert.Equal(expected, BigInteger.ModInverse(value - modulus, modulus));
+                Assert.Equal(expected, BigInteger.ModInverse(value + (modulus * 1000), modulus));
+
+                // Negating the value negates the inverse.
+                Assert.Equal(Mod(-expected, modulus), BigInteger.ModInverse(-value, modulus));
+            }
+        }
+
+        [Fact]
+        public static void MatchesModPowForPrimeModulus()
+        {
+            // For prime p and value not divisible by p, Fermat's little theorem gives
+            // value^(p-2) == value^-1 (mod p).
+            foreach (int exponent in s_mersenneExponents)
+            {
+                BigInteger prime = BigInteger.Pow(2, exponent) - 1;
+
+                foreach (BigInteger value in new BigInteger[] { 2, 3, 65537, prime - 2, RandomNonNegative((exponent / 8) + 1) })
+                {
+                    BigInteger reduced = Mod(value, prime);
+                    if (reduced.IsZero)
+                    {
+                        continue;
+                    }
+
+                    Assert.Equal(
+                        BigInteger.ModPow(reduced, prime - 2, prime),
+                        BigInteger.ModInverse(value, prime));
+                }
+            }
+        }
+
+        [Fact]
+        public static void PowerOfTwoModulus()
+        {
+            // Exercises the power-of-two fast path. Only odd values are invertible mod 2^k.
+            foreach (int bitLength in new int[] { 1, 2, 8, 31, 32, 33, 63, 64, 65, 127, 128, 255, 1024, 2048 })
+            {
+                BigInteger modulus = BigInteger.One << bitLength;
+
+                for (int i = 0; i < 4; i++)
+                {
+                    BigInteger value = RandomNonNegative((bitLength / 8) + 2) | BigInteger.One;
+
+                    BigInteger inverse = BigInteger.ModInverse(value, modulus);
+
+                    Assert.True(inverse.Sign >= 0 && inverse < modulus);
+                    Assert.Equal(BigInteger.One, Mod(value * inverse, modulus));
+
+                    // The negated value must invert to the negated inverse.
+                    Assert.Equal(Mod(-inverse, modulus), BigInteger.ModInverse(-value, modulus));
+                }
+
+                // Even values share the factor 2 with the modulus, so no inverse exists.
+                Assert.Throws<ArithmeticException>(
+                    () => BigInteger.ModInverse((RandomNonNegative(4) | BigInteger.One) << 1, modulus));
+            }
+        }
+
+        [Fact]
+        public static void LargeOperands()
+        {
+            // Sizes chosen to straddle the small/large thresholds inside BigIntegerCalculator
+            // and to cover realistic cryptographic operand widths.
+            foreach (int byteCount in new int[] { 8, 9, 16, 17, 32, 64, 128, 256, 512 })
+            {
+                for (int i = 0; i < 4; i++)
+                {
+                    BigInteger modulus = RandomNonNegative(byteCount) | BigInteger.One;
+                    if (modulus <= BigInteger.One)
+                    {
+                        continue;
+                    }
+
+                    BigInteger value = RandomNonNegative(byteCount);
+                    if (!BigInteger.GreatestCommonDivisor(value, modulus).IsOne)
+                    {
+                        continue;
+                    }
+
+                    BigInteger inverse = BigInteger.ModInverse(value, modulus);
+
+                    Assert.True(inverse.Sign >= 0 && inverse < modulus);
+                    Assert.Equal(BigInteger.One, Mod(value * inverse, modulus));
+
+                    // The same must hold when the value is presented in negative form.
+                    BigInteger negativeInverse = BigInteger.ModInverse(-value, modulus);
+                    Assert.Equal(BigInteger.One, Mod(-value * negativeInverse, modulus));
+                }
+            }
+        }
+
+        [Fact]
+        public static void AsymmetricOperandSizes()
+        {
+            // A small value against a large modulus and the reverse exercise different
+            // short-circuit paths in the calculator.
+            BigInteger largeModulus = BigInteger.Pow(2, 1279) - 1;
+
+            Assert.Equal(BigInteger.One, Mod(3 * BigInteger.ModInverse(3, largeModulus), largeModulus));
+            Assert.Equal(BigInteger.One, Mod(65537 * BigInteger.ModInverse(65537, largeModulus), largeModulus));
+
+            // 2^1024 + 1 == 2 (mod 65537), so the two are coprime.
+            BigInteger largeValue = BigInteger.Pow(2, 1024) + 1;
+            Assert.Equal(BigInteger.One, Mod(largeValue * BigInteger.ModInverse(largeValue, 65537), 65537));
+        }
+
+        [Fact]
+        public static void NonCoprimeLargeOperands()
+        {
+            BigInteger shared = BigInteger.Pow(2, 521) - 1;
+
+            Assert.Throws<ArithmeticException>(() => BigInteger.ModInverse(shared * 3, shared * 5));
+            Assert.Throws<ArithmeticException>(() => BigInteger.ModInverse(-shared * 3, shared * 5));
+            Assert.Throws<ArithmeticException>(() => BigInteger.ModInverse(BigInteger.Zero, shared));
+        }
+
+        [Fact]
+        public static void ChineseRemainderTheoremReconstruction()
+        {
+            // x == r1 (mod m1), x == r2 (mod m2), with m1 and m2 coprime.
+            BigInteger m1 = 3, m2 = 5, r1 = 2, r2 = 3;
+            BigInteger product = m1 * m2;
+
+            BigInteger x = Mod(r1 + (m1 * Mod(BigInteger.ModInverse(m1, m2) * (r2 - r1), m2)), product);
+
+            Assert.Equal((BigInteger)8, x);
+            Assert.Equal(r1, Mod(x, m1));
+            Assert.Equal(r2, Mod(x, m2));
+        }
+
+        private static IEnumerable<(BigInteger Value, BigInteger Modulus)> CoprimePairs()
+        {
+            yield return (3, 7);
+            yield return (-3, 7);
+            yield return (1, 1);
+            yield return (0, 1);
+            yield return (65537, 1000000007);
+            yield return (BigInteger.Pow(2, 127) - 1, BigInteger.Pow(2, 89) - 1);
+
+            for (int i = 0; i < Samples; i++)
+            {
+                foreach (int byteCount in new int[] { 1, 2, 4, 8, 16, 48, 100 })
+                {
+                    BigInteger modulus = RandomNonNegative(byteCount);
+                    if (modulus <= BigInteger.One)
+                    {
+                        continue;
+                    }
+
+                    BigInteger value = RandomNonNegative(byteCount);
+                    if ((i & 1) != 0)
+                    {
+                        value = -value;
+                    }
+
+                    if (BigInteger.GreatestCommonDivisor(value, modulus).IsOne)
+                    {
+                        yield return (value, modulus);
+                    }
+                }
+            }
+        }
+
+        private static BigInteger RandomNonNegative(int byteCount)
+        {
+            byte[] bytes = new byte[byteCount + 1];
+            s_random.NextBytes(bytes);
+
+            // Clear the most significant byte so the two's complement value is non-negative.
+            bytes[byteCount] = 0;
+
+            return new BigInteger(bytes);
+        }
+
+        private static BigInteger Mod(BigInteger value, BigInteger modulus)
+        {
+            BigInteger remainder = value % modulus;
+            return remainder.Sign < 0 ? remainder + modulus : remainder;
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/modinverse.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/modinverse.cs
@@ -203,6 +203,77 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public static void PowerOfTwoModulusExhaustiveBitLengths()
+        {
+            // Every bit length through 300, plus the neighbourhoods of the larger whole-limb
+            // multiples, so the power-of-two fast path is covered at, just below and just
+            // above each limb boundary on both 32-bit and 64-bit limb layouts.
+            List<int> bitLengths = new List<int>();
+
+            for (int bitLength = 1; bitLength <= 300; bitLength++)
+            {
+                bitLengths.Add(bitLength);
+            }
+
+            foreach (int bitLength in new int[] { 511, 512, 513, 1023, 1024, 1025, 2047, 2048, 2049, 4096 })
+            {
+                bitLengths.Add(bitLength);
+            }
+
+            foreach (int bitLength in bitLengths)
+            {
+                BigInteger modulus = BigInteger.One << bitLength;
+
+                // Small odd values stress the low limbs the lifting starts from, and
+                // modulus - 1 is its own inverse for every power-of-two modulus.
+                foreach (BigInteger candidate in new BigInteger[] { 1, 3, 5, 7, modulus - 1 })
+                {
+                    BigInteger value = candidate | BigInteger.One;
+
+                    Assert.Equal(BigInteger.One, Mod(value * BigInteger.ModInverse(value, modulus), modulus));
+                    Assert.Equal(BigInteger.One, Mod(-value * BigInteger.ModInverse(-value, modulus), modulus));
+                }
+
+                for (int i = 0; i < 4; i++)
+                {
+                    BigInteger value = RandomNonNegative((bitLength / 8) + 2) | BigInteger.One;
+
+                    BigInteger inverse = BigInteger.ModInverse(value, modulus);
+
+                    Assert.True(inverse.Sign > 0 && inverse < modulus);
+                    Assert.Equal(BigInteger.One, Mod(value * inverse, modulus));
+
+                    // Even values share the factor 2 with the modulus, so no inverse exists.
+                    Assert.Throws<ArithmeticException>(() => BigInteger.ModInverse(value << 1, modulus));
+                }
+            }
+        }
+
+        [Fact]
+        public static void PowerOfTwoModulusResultIsUniqueAndOdd()
+        {
+            // The inverse modulo a power of two is the unique representative in
+            // [0, 2^bitLength), is always odd because the value it inverts is, and inverting
+            // it again returns the reduced value.
+            foreach (int bitLength in new int[] { 1, 2, 3, 7, 8, 16, 31, 32, 33, 64, 65, 127, 128, 129, 192, 256, 320, 512, 1024, 2048 })
+            {
+                BigInteger modulus = BigInteger.One << bitLength;
+
+                for (int i = 0; i < Samples; i++)
+                {
+                    BigInteger value = RandomNonNegative((bitLength / 8) + 3) | BigInteger.One;
+
+                    BigInteger inverse = BigInteger.ModInverse(value, modulus);
+
+                    Assert.True(inverse.Sign > 0 && inverse < modulus);
+                    Assert.False(inverse.IsEven);
+                    Assert.Equal(BigInteger.One, Mod(value * inverse, modulus));
+                    Assert.Equal(Mod(value, modulus), BigInteger.ModInverse(inverse, modulus));
+                }
+            }
+        }
+
+        [Fact]
         public static void LargeOperands()
         {
             // Sizes chosen to straddle the small/large thresholds inside BigIntegerCalculator

--- a/src/libraries/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
+++ b/src/libraries/System.Runtime.Numerics/tests/System.Runtime.Numerics.Tests.csproj
@@ -28,11 +28,13 @@
     <Compile Include="BigInteger\IsOne.cs" />
     <Compile Include="BigInteger\IsPowerOfTwo.cs" />
     <Compile Include="BigInteger\IsZero.cs" />
+    <Compile Include="BigInteger\leastcommonmultiple.cs" />
     <Compile Include="BigInteger\log.cs" />
     <Compile Include="BigInteger\log02.cs" />
     <Compile Include="BigInteger\log10.cs" />
     <Compile Include="BigInteger\max.cs" />
     <Compile Include="BigInteger\min.cs" />
+    <Compile Include="BigInteger\modinverse.cs" />
     <Compile Include="BigInteger\modpow.cs" />
     <Compile Include="BigInteger\multiply.cs" />
     <Compile Include="BigInteger\MyBigInt.cs" />


### PR DESCRIPTION
# Add BigInteger.ModInverse and BigInteger.LeastCommonMultiple

Implements the two APIs approved in #130021:

```csharp
public static BigInteger ModInverse(BigInteger value, BigInteger modulus);
public static BigInteger LeastCommonMultiple(BigInteger left, BigInteger right);
```

Both match the shape signed off by @bartonjs in API review. Nothing outside the approved
surface is added — in particular there is no `ExtendedEuclidian` and no `TryModInverse`.

## Semantics

### `ModInverse(value, modulus)`

- Returns the least non-negative `x` in `[0, modulus)` with `value * x == 1 (mod modulus)`.
- `value` may be negative; it is reduced to its canonical representative first.
- Returns `Zero` when `modulus` is `1`, for any `value` including `0`.
- Throws `ArgumentOutOfRangeException` when `modulus <= 0`, with `ParamName` `"modulus"`.
- Throws `ArithmeticException` when `value` and `modulus` are not coprime, which includes
  the case where `value` is congruent to zero modulo `modulus`.

### `LeastCommonMultiple(left, right)`

The proposal did not pin down the edge cases, so these were posted on the issue and drew
no objection before implementation started:

- The result is always non-negative. The sign of either operand does not change the set of
  their common multiples.
- The result is `Zero` when either operand is zero, including `(0, 0)`. Zero is a multiple
  of every integer, so it is the least common multiple in that case rather than an error.
- The method never throws.

It is computed as `Abs(left / gcd) * Abs(right)`, dividing before multiplying so the
intermediate value never exceeds the result.

## Documentation wording

The `<returns>` text on `ModInverse` states the contract as a congruence:

> the least non-negative integer `x` in the range `[0, modulus)` that satisfies
> `value * x == 1 (mod modulus)`

rather than the `(value * x) % modulus == 1` phrasing used in the original proposal text.
That phrasing is wrong. C#'s `%` truncates toward zero, so for negative `value` the
remainder is negative and the stated equality does not hold even when the returned `x` is
correct. `ModInverse(-3, 7)` is `2`, and `(-3 * 2) % 7` is `-6`, not `1`. The congruence
form is true for every input the method accepts.

## Implementation

The work landed in five reviewable steps, one commit each.

**Schoolbook baseline first.** `ModInverse` was first implemented as a plain extended
Euclidean algorithm over `BigInteger` operations, purely to establish correctness. It was
then retained temporarily as a debug-only differential oracle — a `Debug.Assert` comparing
every result computed by the real implementation against the schoolbook one — while the
optimized paths were developed. The final commit removes both the oracle and the second
implementation, so this is development scaffolding that does not ship.

**Lehmer-based extended GCD.** The general path is `BigIntegerCalculator.ModInverse` in
`BigIntegerCalculator.GcdInv.cs`, reusing the existing Lehmer guessing step and Jebelean
termination condition from `Gcd`. The Bézout cofactor is carried alongside the remainder
sequence using the recurrence

```
t[0] = 0, t[1] = 1, t[i+1] = t[i-1] + q[i] * t[i]
```

which satisfies `r[i] == (-1)^(i+1) * t[i] * value (mod modulus)`. Every cofactor is
non-negative and the recurrence only ever adds, so the cofactors stay unsigned like the
rest of the calculator and the alternating sign is carried as the parity of the remainder
index alone.

This falls out especially cleanly for the Lehmer step. `LehmerCore` applies
`x' = a*x - b*y`, `y' = d*y - c*x` to the remainders. Cofactors take the same linear map,
and substituting the alternating signs cancels both subtractions exactly, leaving
`u' = a*u + b*v`, `v' = c*u + d*v` on magnitudes — the same matrix with the signs dropped,
not its transpose. The existing odd-iteration swap that restores remainder ordering
doubles as the parity flip, so no separate sign bookkeeping is needed.

Buffer sizing comes from the identity `t[i] * r[i-1] + t[i-1] * r[i] == modulus`, which
bounds every cofactor by the modulus, including while one is being accumulated. Cofactor
buffers therefore carry exactly one spare limb.

**Hensel lifting for power-of-two moduli.** Inverting modulo `2^k` does not need the
Lehmer path. `ModInversePowerOfTwo` runs Newton iteration on the 2-adic inverse: if
`value * x == 1 (mod 2^m)` then `x * (2 - value * x)` is correct modulo `2^2m`, because
writing `value * x = 1 + e * 2^m` gives `(1 + e*2^m) * (1 - e*2^m) = 1 - e^2 * 2^2m`. Each
step doubles the number of correct bits, so the lift terminates after
`ceil(log2(limbCount))` steps.

The seed is the inverse modulo a single limb, taken from the existing
`ComputeMontgomeryInverse` in `BigIntegerCalculator.PowMod.cs`. That helper returns the
*negated* inverse, because that is what Montgomery reduction consumes, so the sign is
corrected before use. The lift works in whole limbs and the top limb is then masked back
to the bits the modulus spans, which is sound because `2^k` divides the limb radix raised
to the limb count.

## Note for future contributors to this file

`BigIntegerCalculator.Multiply` requires a destination of **exactly** `left.Length +
right.Length` limbs, not merely one that is large enough. The documented assert only says
`bits.Length >= left.Length + right.Length`, but the Karatsuba path splits the destination
as `bits[..2n]` / `bits[2n..]` and asserts `bitsLow.Length >= bitsHigh.Length`, which fails
for an oversized destination. Reusing one generously sized scratch buffer across several
multiplies of differing widths — the obvious thing to do — trips this. It is worth knowing
before writing new code against that API.

## 32-bit

One branch in this change is architecture-conditional and was **never executed locally**,
because this was developed and tested on arm64:

- `BigIntegerCalculator.GcdInv.cs:321` — `int lehmerMinimum = nint.Size == 4 ? 3 : 2;`

This is the minimum operand length before Lehmer's guess can be attempted, mirroring
`ExtractDigits`' own asserts (`>= 3` limbs on 32-bit, `>= 2` on 64-bit). Too low and
`ExtractDigits` reads past the operand; too high only costs performance. It deserves
attention from 32-bit CI legs.

The surface was deliberately kept this small. The cofactor combination helpers use a
`UInt128` accumulator with `BitsPerLimb` shifts and so are architecture-neutral, and the
Euclid step was written as a fully general fallback used whenever operands are too short
for Lehmer, rather than as a separate terminal path that only 32-bit would reach. The
power-of-two fast path introduces no architecture-conditional branch at all.

## Testing

Two new test files, `modinverse.cs` and `leastcommonmultiple.cs`, add 84 tests. The full
`System.Runtime.Numerics` suite is **8718 tests, 0 failures**, up from a baseline of 8634.

The tests verify the defining mathematical identities directly rather than diffing against
a reference implementation: the congruence `value * x == 1 (mod modulus)`, canonicality of
the representative, `ModInverse` being an involution, agreement with `ModPow` via Fermat's
little theorem for Mersenne prime moduli, `lcm(a,b) * gcd(a,b) == |a*b|`, coprimality of
the LCM cofactors, associativity, commutativity, and identity. This means they remain
meaningful independently of how the implementation is written.

Coverage includes exhaustive power-of-two bit lengths — every length through 300 plus the
larger limb boundaries — operand widths from 1 to 512 bytes, asymmetric operand sizes,
Mersenne and shifted-limb structured operands, and the non-coprime and non-positive-modulus
error paths.

Mutation testing was used to check the tests are actually sensitive to the errors most
likely to occur here, since a green suite alone says little about a sign convention:

- Inverting the final parity: 10+ failures.
- Removing the parity flip only on the Lehmer odd-iteration path, keeping the swap — a bug
  reachable only on large operands: 6 failures, including `LargeOperands` and
  `InverseOfInverseIsReducedValue`.
- Dropping the `ComputeMontgomeryInverse` sign correction: caught.

Separately, during development an out-of-tree stress harness exercised roughly 480,000
exhaustive small cases, 300 consecutive Fibonacci pairs (the worst case for Euclid step
counts, and so for parity churn), and randomized operands across 26 widths, with every call
cross-checked against the schoolbook oracle described above.

## Performance

Measured on a **Release** build of `clr+libs`. The harness prints the resolved
`System.Runtime.Numerics` location and its `DebuggableAttribute` optimizer status before
running, and refuses to present numbers from a Debug assembly — this code carries per-limb
`Debug.Assert`s, including an O(n) buffer scan, that would otherwise dominate.

```
BenchmarkDotNet v0.15.2, macOS 26.6 (25G72) [Darwin 25.6.0]
Apple M4, 1 CPU, 10 logical and 10 physical cores
  [Host] : .NET 11.0.0 (42.42.42.42424), Arm64 RyuJIT AdvSIMD
Toolchain=InProcessEmitToolchain
```

| Method                   | Bits | Mean        | Error    | StdDev   | Ratio | Gen0   | Allocated |
|------------------------- |----- |------------:|---------:|---------:|------:|-------:|----------:|
| GreatestCommonDivisor    | 256  |    809.2 ns |  4.64 ns |  4.34 ns |  1.00 |      - |         - |
| ModInverse               | 256  |  1,679.4 ns |  2.06 ns |  1.93 ns |  2.08 | 0.0134 |     112 B |
| ModInverse (2^k modulus) | 256  |    122.1 ns |  1.26 ns |  1.17 ns |  0.15 | 0.0067 |      56 B |
| LeastCommonMultiple      | 256  |    955.0 ns |  1.62 ns |  1.52 ns |  1.18 | 0.0172 |     144 B |
| GreatestCommonDivisor    | 2048 |  8,083.4 ns | 13.68 ns | 12.13 ns |  1.00 |      - |         - |
| ModInverse               | 2048 | 16,547.0 ns | 18.55 ns | 17.35 ns |  2.05 | 0.0610 |     560 B |
| ModInverse (2^k modulus) | 2048 |  1,435.1 ns |  4.60 ns |  4.08 ns |  0.18 | 0.0324 |     280 B |
| LeastCommonMultiple      | 2048 |  9,199.4 ns | 24.11 ns | 20.13 ns |  1.14 | 0.0916 |     816 B |
| GreatestCommonDivisor    | 4096 | 18,974.7 ns | 30.60 ns | 28.62 ns |  1.00 |      - |         - |
| ModInverse               | 4096 | 50,605.2 ns | 26.36 ns | 24.66 ns |  2.67 | 0.1221 |   1,072 B |
| ModInverse (2^k modulus) | 4096 |  4,237.6 ns |  5.56 ns |  5.20 ns |  0.22 | 0.0610 |     536 B |
| LeastCommonMultiple      | 4096 | 22,211.7 ns | 20.16 ns | 15.74 ns |  1.17 | 0.1831 |   1,584 B |

Takeaways:

- **Cofactor tracking costs about 2x plain GCD** — 2.08x, 2.05x, 2.67x at 256, 2048 and
  4096 bits. `GreatestCommonDivisor` is the baseline precisely so this overhead is visible;
  it is the price of the extended algorithm over the plain one on the shared Lehmer path.
  The rise to 2.67x at 4096 bits is outside the noise: cofactors grow toward modulus width
  while remainders shrink, so cofactor updates become a larger share of each Lehmer block
  as operands grow.
- **The power-of-two fast path is 12-14x faster than the general path**, at 0.15-0.22x the
  cost of a GCD. That is Hensel lifting's `O(M(n) log n)` against Lehmer's `O(n^2)`.
- **`LeastCommonMultiple` costs GCD plus about 15%**, consistently — one exact division and
  one multiplication on top of the GCD it has to compute anyway.

The `GreatestCommonDivisor` baseline shows zero allocation because its operands are coprime
by construction, as they must be for an inverse to exist, so it returns `1`, which
`BigInteger` represents inline. The work is a full-length Lehmer run either way; only the
allocation column is asymmetric.