### PR TITLE
Disable failing COM dynamic test on CoreCLR

### DIFF
--- a/src/tests/Interop/COM/Dynamic/Program.cs
+++ b/src/tests/Interop/COM/Dynamic/Program.cs
@@ -11,6 +11,7 @@ namespace Dynamic
     public class Program
     {
         [SkipOnCoreClr("This test is very slow under some GC stress variations, especially with DOTNET_HeapVerify=1, and can time out in CI. See https://github.com/dotnet/runtime/issues/39584.", RuntimeTestModes.AnyGCStress)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/132947", TestRuntimes.CoreCLR)]
         [Fact]
         [Xunit.SkipOnCoreClrAttribute("Depends on COM behavior that is not correct in interpreter", RuntimeTestModes.InterpreterActive)]
         public static int TestEntryPoint()


### PR DESCRIPTION
The COM dynamic test is currently failing frequently in Checked CoreCLR runs on `Windows.Amd64.Open.rt`. Disable it on CoreCLR while #132947 tracks the cleanup fix.

The skip remains scoped to CoreCLR so other applicable runtime coverage is preserved.

Validation:
- `git diff --check`
- `src/tests/build.sh -Test Interop/COM/Dynamic/Dynamic.csproj x64 checked`

> [!NOTE]
> This pull request description was generated with GitHub Copilot assistance.