### PR TITLE
Restore chaos65204782cs as a standalone JIT test

### DIFF
--- a/src/tests/JIT/Generics/Coverage/chaos65204782cs.csproj
+++ b/src/tests/JIT/Generics/Coverage/chaos65204782cs.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <DebugType>PdbOnly</DebugType>
+    <!-- https://github.com/dotnet/runtime/issues/132942 -->
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+    <!-- Needed for MonoAotIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="chaos65204782cs.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Generics/JIT.Generics.csproj
+++ b/src/tests/JIT/Generics/JIT.Generics.csproj
@@ -4,6 +4,9 @@
     <HasMergedInTests>true</HasMergedInTests>
   </PropertyGroup>
   <ItemGroup>
+    <MergedWrapperProjectReference Include="Coverage\chaos65204782cs.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="Arrays\ConstructedTypes\MultiDim\class01.cs" />
     <Compile Include="Arrays\ConstructedTypes\MultiDim\class01_Instance.cs" />
     <Compile Include="Arrays\ConstructedTypes\MultiDim\class01_static.cs" />
@@ -32,7 +35,6 @@
     <Compile Include="Conversions\Reference\NonGenToGen03.cs" />
     <Compile Include="Coverage\chaos55915408cs.cs" />
     <Compile Include="Coverage\chaos56200037cs.cs" />
-    <Compile Include="Coverage\chaos65204782cs.cs" />
     <Compile Include="Exceptions\general_class_instance01.cs" />
     <Compile Include="Exceptions\general_class_static01.cs" />
     <Compile Include="Exceptions\general_struct_instance01.cs" />

--- a/src/tests/JIT/Generics/JIT.Generics_ro.csproj
+++ b/src/tests/JIT/Generics/JIT.Generics_ro.csproj
@@ -17,7 +17,6 @@
     <Compile Include="Conversions\Boxing\box_isinst_unbox.cs" />
     <Compile Include="Coverage\chaos55915408cs.cs" />
     <Compile Include="Coverage\chaos56200037cs.cs" />
-    <Compile Include="Coverage\chaos65204782cs.cs" />
     <Compile Include="Typeof\dynamicTypes.cs" />
     <Compile Include="Typeof\objectBoxing.cs" />
     <Compile Include="Typeof\refTypesdynamic.cs" />


### PR DESCRIPTION
## Summary

PR #132167 compiled `chaos65204782cs.cs` into both merged `JIT.Generics` runners. Mono FullAOT rejects its recursive generic metadata, causing the entire runners to fail AOT compilation.

Restore the dedicated test project and:

- run it process-isolated in normal configurations
- exclude only this test from Mono MiniFullAOT/LLVMFullAOT
- keep both merged `JIT.Generics` runners enabled for FullAOT coverage

The standalone project remains referenced by the PdbOnly runner so it participates in normal test execution.

## Validation

MSBuild evaluation confirmed:

- normal builds discover one runnable process-isolated test
- Mono MiniFullAOT disables only the standalone project
- both merged runners remain enabled

The full build was not run because the pinned SDK was unavailable from its feeds.

Addresses #132942 without closing it, since the issue also tracks the underlying Mono AOT recursion failure.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.

Fixes: #132942