### PR TITLE
[perf][wasm] Stage Crossgen2 pack for CoreCLR R2R benchmarks

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -752,10 +752,10 @@
           </ItemGroup>
           <ItemGroup>
             <!--
-              When we're building in the VMR, we need to provide a crossgen2 that runs on the host machine for downstream repos to use to R2R their code.
-              In non-VMR builds, downstream repos can use the crossgen2 built for the target host SDK from another build leg, but in the VMR we need to provide one to use.
+              When BuildHostTools is enabled, we need to provide a crossgen2 that runs on the host machine for downstream repos to use to R2R their code.
+              Non-VMR builds normally use the crossgen2 built for the target host SDK from another build leg, but builds without one can opt in.
             -->
-            <ProjectToBuild Condition="'$(RuntimeFlavor)' != 'Mono' and '$(TargetsMobile)' != 'true' and '$(TargetsLinuxBionic)' != 'true' and '$(BuildHostTools)' == 'true'" Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\Microsoft.NETCore.App.Crossgen2.Host.sfxproj" Category="packs" />
+            <ProjectToBuild Condition="'$(RuntimeFlavor)' != 'Mono' and ('$(TargetsMobile)' != 'true' or '$(TargetOS)' == 'browser') and '$(TargetsLinuxBionic)' != 'true' and '$(BuildHostTools)' == 'true'" Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\Microsoft.NETCore.App.Crossgen2.Host.sfxproj" Category="packs" />
           </ItemGroup>
           <ItemGroup>
             <SharedFrameworkProjectToBuild Condition="'$(_BuildHostPack)' == 'true'" Include="$(InstallerProjectRoot)pkg\archives\dotnet-nethost.proj" />

--- a/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
@@ -41,4 +41,5 @@ jobs:
             artifactName: BrowserWasmCoreCLR
             sdkDirName: dotnet-none
             includeRefPack: false
+            includeCrossgen2Pack: true
             publishCoreClrRuntimePack: true

--- a/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
@@ -31,7 +31,7 @@ jobs:
     platforms:
     - browser_wasm
     jobParameters:
-      buildArgs: -s clr+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      buildArgs: -s clr+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS) /p:BuildHostTools=true
       nameSuffix: wasm_coreclr
       isOfficialBuild: false
       postBuildSteps:

--- a/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
@@ -4,6 +4,7 @@ parameters:
   runtimeFlavor: 'mono'
   sdkDirName: 'dotnet-latest'
   includeRefPack: true
+  includeCrossgen2Pack: false
   # The Mono (default) build installs the wasm-tools workload, whose manifest now includes the
   # CoreCLR browser-wasm runtime pack (Microsoft.NETCore.App.Runtime.browser-wasm). A Mono-only
   # build doesn't produce that pack, so download it from the CoreCLR build job and stage it into
@@ -50,6 +51,15 @@ steps:
   - ${{ if eq(parameters.includeRefPack, true) }}:
     - script: cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging
       displayName: "Stage ref pack directory"
+
+  - ${{ if eq(parameters.includeCrossgen2Pack, true) }}:
+    - script: >-
+        find $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping -maxdepth 1
+        -name 'Microsoft.NETCore.App.Crossgen2.*.nupkg' -not -name '*.symbols.nupkg'
+        -exec cp {} $(Build.SourcesDirectory)/artifacts/staging/built-nugets \; &&
+        test -n "$(find $(Build.SourcesDirectory)/artifacts/staging/built-nugets -maxdepth 1
+        -name 'Microsoft.NETCore.App.Crossgen2.*.nupkg' -not -name '*.symbols.nupkg' -print -quit)"
+      displayName: "Stage Crossgen2 pack"
 
   # Publish the CoreCLR browser-wasm runtime pack nuget on its own so the Mono build job can stage
   # it into its local feed for the wasm-tools workload install.


### PR DESCRIPTION
## Summary

Stage the matching locally built, non-symbol `Microsoft.NETCore.App.Crossgen2` package in the `BrowserWasmCoreCLR` performance artifact under `staging/built-nugets`.

This enables isolated Helix machines to resolve the same-build Crossgen2 pack when per-application browser-WASM benchmarks publish with `PublishReadyToRun=true`. The CoreCLR performance build enables `BuildHostTools`, and the pack subset permits browser builds with that explicit opt-in to run `Microsoft.NETCore.App.Crossgen2.Host.sfxproj`. The package selection excludes `*.symbols.nupkg` and fails if no matching non-symbol package is available. These changes apply only to `BrowserWasmCoreCLR`; Mono artifact behavior is unchanged.

End-to-end `runtime-wasm-perf` validation depends on the companion `dotnet/performance` change currently at commit `17449e9826d0ecc224e92a3ad854796b0be41219`.

## Validation

- Parsed the changed XML and YAML build configuration.
- Ran `git diff --check` and commit checks.
- Simulated staging with matching non-symbol, symbols, and unrelated nupkgs; only the non-symbol Crossgen2 package was copied.
- Evaluated the MSBuild project graph and confirmed:
  - browser CoreCLR with `BuildHostTools=true` includes `Microsoft.NETCore.App.Crossgen2.Host.sfxproj`;
  - browser CoreCLR without the opt-in excludes it;
  - Android remains excluded even with `BuildHostTools=true`.

> [!NOTE]
> This pull request was generated with the assistance of GitHub Copilot.