### PR TITLE
Fix TextInfo.ToTitleCase Dutch IJ digraph and U+2019 apostrophe handling

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -855,11 +855,11 @@ namespace System.Globalization
             return (c_wordSeparatorMask & (1 << (int)category)) != 0;
         }
 
-        // Characters that behave like an apostrophe within a word (e.g. contractions such
-        // as "can't" or possessives such as "Grandma's") and therefore must not be treated
-        // as a word separator during titlecasing. These share Unicode's Word_Break=MidNumLet
-        // property with the ASCII apostrophe (U+0027):
-        //   U+2019 RIGHT SINGLE QUOTATION MARK - the typographic curly apostrophe
+        // Characters treated as an apostrophe within a word (e.g. contractions such as
+        // "can't" or possessives such as "Grandma's"), so a following letter is not treated
+        // as the start of a new word during titlecasing:
+        //   U+0027 APOSTROPHE
+        //   U+2019 RIGHT SINGLE QUOTATION MARK (the typographic curly apostrophe)
         //   U+2018 LEFT SINGLE QUOTATION MARK
         //   U+FF07 FULLWIDTH APOSTROPHE
         private static bool IsApostrophe(char c)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -669,7 +669,7 @@ namespace System.Globalization
                             }
                             i += charLen;
                         }
-                        else if (str[i] == '\'')
+                        else if (IsApostrophe(str[i]))
                         {
                             i++;
                             if (hasLowerCase)
@@ -853,6 +853,18 @@ namespace System.Globalization
         private static bool IsWordSeparator(UnicodeCategory category)
         {
             return (c_wordSeparatorMask & (1 << (int)category)) != 0;
+        }
+
+        // Characters that behave like an apostrophe within a word (e.g. contractions such
+        // as "can't" or possessives such as "Grandma's") and therefore must not be treated
+        // as a word separator during titlecasing. These share Unicode's Word_Break=MidNumLet
+        // property with the ASCII apostrophe (U+0027):
+        //   U+2019 RIGHT SINGLE QUOTATION MARK - the typographic curly apostrophe
+        //   U+2018 LEFT SINGLE QUOTATION MARK
+        //   U+FF07 FULLWIDTH APOSTROPHE
+        private static bool IsApostrophe(char c)
+        {
+            return c is '\'' or '\u2019' or '\u2018' or '\uFF07';
         }
 
         private static bool IsLetterCategory(UnicodeCategory uc)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -625,8 +625,11 @@ namespace System.Globalization
 
             StringBuilder result = new StringBuilder();
             string? lowercaseData = null;
-            // Store if the current culture is Dutch (special case)
-            bool isDutchCulture = CultureName.StartsWith("nl-", StringComparison.OrdinalIgnoreCase);
+            // Store if the current culture is Dutch (special case). This covers both the
+            // neutral culture ("nl") and any specific Dutch culture ("nl-NL", "nl-BE", etc.).
+            string cultureName = CultureName;
+            bool isDutchCulture = cultureName.StartsWith("nl", StringComparison.OrdinalIgnoreCase) &&
+                (cultureName.Length == 2 || cultureName[2] == '-');
 
             for (int i = 0; i < str.Length; i++)
             {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/TextInfoTests.cs
@@ -64,6 +64,8 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> DutchTitleCaseInfo_TestData()
         {
             yield return new object[] { "nl-NL", "IJ IJ IJ IJ", "ij iJ Ij IJ" };
+            yield return new object[] { "nl", "IJ IJ IJ IJ", "ij iJ Ij IJ" };
+            yield return new object[] { "nl", "De IJsvogel", "de ijsvogel" };
             yield return new object[] { "nl-be", "IJzeren Eigenschappen", "ijzeren eigenschappen" };
             yield return new object[] { "NL-NL", "Lake IJssel", "lake iJssel" };
             yield return new object[] { "NL-BE", "Boba N' IJango Fett PEW PEW", "Boba n' Ijango fett PEW PEW" };

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/TextInfoTests.cs
@@ -61,6 +61,24 @@ namespace System.Globalization.Tests
             AssertExtensions.Throws<ArgumentNullException>("str", () => ti.ToTitleCase(null));
         }
 
+        [Theory]
+        // ASCII apostrophe (U+0027) keeps a contraction/possessive as a single word.
+        [InlineData("Grandma's pictures", "Grandma's Pictures")]
+        [InlineData("can't stop", "Can't Stop")]
+        // U+2019 RIGHT SINGLE QUOTATION MARK (typographic curly apostrophe).
+        [InlineData("Grandma\u2019s pictures", "Grandma\u2019s Pictures")]
+        [InlineData("can\u2019t stop", "Can\u2019t Stop")]
+        // U+2018 LEFT SINGLE QUOTATION MARK and U+FF07 FULLWIDTH APOSTROPHE.
+        [InlineData("Grandma\u2018s pictures", "Grandma\u2018s Pictures")]
+        [InlineData("Grandma\uFF07s pictures", "Grandma\uFF07s Pictures")]
+        // A genuine separator still ends the word and titlecases what follows.
+        [InlineData("Grandma-s pictures", "Grandma-S Pictures")]
+        public void ToTitleCase_Apostrophe(string input, string expected)
+        {
+            TextInfo ti = CultureInfo.GetCultureInfo("en-US").TextInfo;
+            Assert.Equal(expected, ti.ToTitleCase(input));
+        }
+
         public static IEnumerable<object[]> DutchTitleCaseInfo_TestData()
         {
             yield return new object[] { "nl-NL", "IJ IJ IJ IJ", "ij iJ Ij IJ" };


### PR DESCRIPTION
This PR fixes two independent `TextInfo.ToTitleCase` bugs.

## 1. Dutch IJ digraph for the neutral `nl` culture

`TextInfo.ToTitleCase` special-cases Dutch to capitalize the `ij` digraph to `IJ`. The check gated this on `CultureName.StartsWith("nl-")`, which matches specific cultures (`nl-NL`, `nl-BE`, ...) but never the neutral Dutch culture, whose name is exactly `"nl"` with no trailing `-`. As a result the neutral culture fell through to the generic path:

```csharp
CultureInfo.GetCultureInfo("nl-NL").TextInfo.ToTitleCase("de ijsvogel"); // "De IJsvogel"
CultureInfo.GetCultureInfo("nl").TextInfo.ToTitleCase("de ijsvogel");    // "De Ijsvogel"  (wrong)
```

### Fix

Match the neutral name exactly or the `nl-` prefix:

```csharp
string cultureName = CultureName;
bool isDutchCulture = cultureName.StartsWith("nl", StringComparison.OrdinalIgnoreCase) &&
    (cultureName.Length == 2 || cultureName[2] == '-');
```

The `ij` digraph rule is a property of the Dutch language, not of a specific region, so every `nl*` culture (neutral and specific alike) should apply it.

### Tests

Added neutral `nl` cases to the existing `DutchTitleCaseInfo_TestData` theory in `TextInfoTests`, including the issue's repro (`"de ijsvogel"` -> `"De IJsvogel"`).

Fixes #133032.

## 2. U+2019 (and related quotes) treated as apostrophes

`ToTitleCase` only treated the ASCII apostrophe `'` (U+0027) as an in-word character. The typographic curly apostrophe `’` (U+2019) and similar characters have punctuation categories that are classified as word separators, so the letter after them was treated as the start of a new word:

```csharp
CultureInfo.GetCultureInfo("en").TextInfo.ToTitleCase("Grandma’s pictures");
// before: "Grandma’S Pictures"   after: "Grandma’s Pictures"
```

### Fix

Introduce an `IsApostrophe` helper and use it in the word scan. It covers the ASCII apostrophe plus the additional characters commonly used as an apostrophe:

```csharp
private static bool IsApostrophe(char c)
{
    return c is '\'' or '\u2019' or '\u2018' or '\uFF07';
}
```

- `U+2019` RIGHT SINGLE QUOTATION MARK (the curly apostrophe)
- `U+2018` LEFT SINGLE QUOTATION MARK
- `U+FF07` FULLWIDTH APOSTROPHE

Modifier-letter apostrophes such as `U+02BC` already work because their category (`Lm`) is not a word separator. Dot/colon-style joiners (`.`, `:`, `·`, ...) are intentionally left out of scope to avoid changing titlecasing of dotted tokens.

### Tests

Added a `ToTitleCase_Apostrophe` theory covering `U+0027`, `U+2019`, `U+2018`, and `U+FF07`, plus a control case (`"Grandma-s"` -> `"Grandma-S"`) confirming genuine separators still end the word.

Fixes #133034.

## Performance

No impact. The Dutch check remains a single `StartsWith` over a 2-character literal plus one length/index check, evaluated once per call. `IsApostrophe` is a small constant-time comparison replacing the previous single-character equality in the same loop position.

> [!NOTE]
> This PR description was drafted with GitHub Copilot.

