### PR TITLE
Fix Vector2 and Vector3 comparison reductions

### DIFF
--- a/src/libraries/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -1921,6 +1921,14 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public void GreaterThanAnyTest()
+        {
+            Assert.False(Vector2.GreaterThanAny(Vector2.Create(1, 2), Vector2.Create(1, 2)));
+            Assert.True(Vector2.GreaterThanAny(Vector2.Create(2, 2), Vector2.Create(1, 2)));
+            Assert.True(Vector2.GreaterThanAny(Vector2.Create(1, 3), Vector2.Create(1, 2)));
+        }
+
+        [Fact]
         public void GreaterThanOrEqualAnyTest()
         {
             // Test case that would have failed before fix: no elements pass, but 3rd/4th (0 >= 0) would pass
@@ -1944,6 +1952,14 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public void LessThanAnyTest()
+        {
+            Assert.False(Vector2.LessThanAny(Vector2.Create(1, 2), Vector2.Create(1, 2)));
+            Assert.True(Vector2.LessThanAny(Vector2.Create(0, 2), Vector2.Create(1, 2)));
+            Assert.True(Vector2.LessThanAny(Vector2.Create(1, 1), Vector2.Create(1, 2)));
+        }
+
+        [Fact]
         public void LessThanOrEqualAnyTest()
         {
             // Test case that would have failed before fix: no elements pass, but 3rd/4th (0 <= 0) would pass
@@ -1958,27 +1974,29 @@ namespace System.Numerics.Tests
         [Fact]
         public void GreaterThanOrEqualAllTest()
         {
-            // Test case that would have failed before fix: all 2 elements pass, but 3rd/4th (0 >= 0) could give false positive
-            // with undefined upper elements from AsVector128Unsafe
+            // The zero-filled padding lanes must not affect the result.
             Assert.True(Vector2.GreaterThanOrEqualAll(Vector2.Create(2, 3), Vector2.Create(1, 2)));
             Assert.True(Vector2.GreaterThanOrEqualAll(Vector2.Create(1, 2), Vector2.Create(1, 2))); // All equal
 
             // Test cases where not all elements pass
             Assert.False(Vector2.GreaterThanOrEqualAll(Vector2.Create(0, 3), Vector2.Create(1, 2))); // X not greater or equal
             Assert.False(Vector2.GreaterThanOrEqualAll(Vector2.Create(2, 1), Vector2.Create(1, 2))); // Y not greater or equal
+            Assert.False(Vector2.GreaterThanOrEqualAll(Vector2.Create(float.NaN, 3), Vector2.Create(1, 2)));
+            Assert.False(Vector2.GreaterThanOrEqualAll(Vector2.Create(2, float.NaN), Vector2.Create(1, 2)));
         }
 
         [Fact]
         public void LessThanOrEqualAllTest()
         {
-            // Test case that would have failed before fix: all 2 elements pass, but 3rd/4th could give false positive
-            // with undefined upper elements from AsVector128Unsafe
+            // The zero-filled padding lanes must not affect the result.
             Assert.True(Vector2.LessThanOrEqualAll(Vector2.Create(1, 2), Vector2.Create(2, 3)));
             Assert.True(Vector2.LessThanOrEqualAll(Vector2.Create(1, 2), Vector2.Create(1, 2))); // All equal
 
             // Test cases where not all elements pass
             Assert.False(Vector2.LessThanOrEqualAll(Vector2.Create(3, 2), Vector2.Create(2, 3))); // X not less or equal
             Assert.False(Vector2.LessThanOrEqualAll(Vector2.Create(1, 4), Vector2.Create(2, 3))); // Y not less or equal
+            Assert.False(Vector2.LessThanOrEqualAll(Vector2.Create(float.NaN, 2), Vector2.Create(2, 3)));
+            Assert.False(Vector2.LessThanOrEqualAll(Vector2.Create(1, float.NaN), Vector2.Create(2, 3)));
         }
     }
 }

--- a/src/libraries/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -1951,6 +1951,15 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public void GreaterThanAnyTest()
+        {
+            Assert.False(Vector3.GreaterThanAny(Vector3.Create(1, 2, 3), Vector3.Create(1, 2, 3)));
+            Assert.True(Vector3.GreaterThanAny(Vector3.Create(2, 2, 3), Vector3.Create(1, 2, 3)));
+            Assert.True(Vector3.GreaterThanAny(Vector3.Create(1, 3, 3), Vector3.Create(1, 2, 3)));
+            Assert.True(Vector3.GreaterThanAny(Vector3.Create(1, 2, 4), Vector3.Create(1, 2, 3)));
+        }
+
+        [Fact]
         public void GreaterThanOrEqualAnyTest()
         {
             // Test case that would have failed before fix: no elements pass, but 4th (0 >= 0) would pass
@@ -1976,6 +1985,15 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        public void LessThanAnyTest()
+        {
+            Assert.False(Vector3.LessThanAny(Vector3.Create(1, 2, 3), Vector3.Create(1, 2, 3)));
+            Assert.True(Vector3.LessThanAny(Vector3.Create(0, 2, 3), Vector3.Create(1, 2, 3)));
+            Assert.True(Vector3.LessThanAny(Vector3.Create(1, 1, 3), Vector3.Create(1, 2, 3)));
+            Assert.True(Vector3.LessThanAny(Vector3.Create(1, 2, 2), Vector3.Create(1, 2, 3)));
+        }
+
+        [Fact]
         public void LessThanOrEqualAnyTest()
         {
             // Test case that would have failed before fix: no elements pass, but 4th (0 <= 0) would pass
@@ -1991,8 +2009,7 @@ namespace System.Numerics.Tests
         [Fact]
         public void GreaterThanOrEqualAllTest()
         {
-            // Test case that would have failed before fix: all 3 elements pass, but 4th could give false positive
-            // with undefined upper element from AsVector128Unsafe
+            // The zero-filled padding lane must not affect the result.
             Assert.True(Vector3.GreaterThanOrEqualAll(Vector3.Create(2, 3, 4), Vector3.Create(1, 2, 3)));
             Assert.True(Vector3.GreaterThanOrEqualAll(Vector3.Create(1, 2, 3), Vector3.Create(1, 2, 3))); // All equal
 
@@ -2000,13 +2017,15 @@ namespace System.Numerics.Tests
             Assert.False(Vector3.GreaterThanOrEqualAll(Vector3.Create(0, 3, 4), Vector3.Create(1, 2, 3))); // X not greater or equal
             Assert.False(Vector3.GreaterThanOrEqualAll(Vector3.Create(2, 1, 4), Vector3.Create(1, 2, 3))); // Y not greater or equal
             Assert.False(Vector3.GreaterThanOrEqualAll(Vector3.Create(2, 3, 2), Vector3.Create(1, 2, 3))); // Z not greater or equal
+            Assert.False(Vector3.GreaterThanOrEqualAll(Vector3.Create(float.NaN, 3, 4), Vector3.Create(1, 2, 3)));
+            Assert.False(Vector3.GreaterThanOrEqualAll(Vector3.Create(2, float.NaN, 4), Vector3.Create(1, 2, 3)));
+            Assert.False(Vector3.GreaterThanOrEqualAll(Vector3.Create(2, 3, float.NaN), Vector3.Create(1, 2, 3)));
         }
 
         [Fact]
         public void LessThanOrEqualAllTest()
         {
-            // Test case that would have failed before fix: all 3 elements pass, but 4th could give false positive
-            // with undefined upper element from AsVector128Unsafe
+            // The zero-filled padding lane must not affect the result.
             Assert.True(Vector3.LessThanOrEqualAll(Vector3.Create(1, 2, 3), Vector3.Create(2, 3, 4)));
             Assert.True(Vector3.LessThanOrEqualAll(Vector3.Create(1, 2, 3), Vector3.Create(1, 2, 3))); // All equal
 
@@ -2014,6 +2033,9 @@ namespace System.Numerics.Tests
             Assert.False(Vector3.LessThanOrEqualAll(Vector3.Create(3, 2, 3), Vector3.Create(2, 3, 4))); // X not less or equal
             Assert.False(Vector3.LessThanOrEqualAll(Vector3.Create(1, 4, 3), Vector3.Create(2, 3, 4))); // Y not less or equal
             Assert.False(Vector3.LessThanOrEqualAll(Vector3.Create(1, 2, 5), Vector3.Create(2, 3, 4))); // Z not less or equal
+            Assert.False(Vector3.LessThanOrEqualAll(Vector3.Create(float.NaN, 2, 3), Vector3.Create(2, 3, 4)));
+            Assert.False(Vector3.LessThanOrEqualAll(Vector3.Create(1, float.NaN, 3), Vector3.Create(2, 3, 4)));
+            Assert.False(Vector3.LessThanOrEqualAll(Vector3.Create(1, 2, float.NaN), Vector3.Create(2, 3, 4)));
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
@@ -552,7 +552,7 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.GreaterThanAny(Vector4, Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool GreaterThanAny(Vector2 left, Vector2 right) => Vector128.EqualsAny(Vector128.GreaterThan(left.AsVector128(), right.AsVector128()).AsInt32(), Vector128.Create(-1, -1, 0, 0));
+        public static bool GreaterThanAny(Vector2 left, Vector2 right) => Vector128.GreaterThanAny(left.AsVector128(), right.AsVector128());
 
         /// <inheritdoc cref="Vector4.GreaterThanOrEqual(Vector4, Vector4)" />
         [Intrinsic]
@@ -562,7 +562,7 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.GreaterThanOrEqualAll(Vector4, Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool GreaterThanOrEqualAll(Vector2 left, Vector2 right) => Vector128.EqualsAll(Vector128.GreaterThanOrEqual(left.AsVector128(), right.AsVector128()).AsInt32(), Vector128<int>.AllBitsSet);
+        public static bool GreaterThanOrEqualAll(Vector2 left, Vector2 right) => Vector128.GreaterThanOrEqualAll(left.AsVector128(), right.AsVector128());
 
         /// <inheritdoc cref="Vector4.GreaterThanOrEqualAny(Vector4, Vector4)" />
         [Intrinsic]
@@ -682,7 +682,7 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.LessThanAny(Vector4, Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool LessThanAny(Vector2 left, Vector2 right) => Vector128.EqualsAny(Vector128.LessThan(left.AsVector128(), right.AsVector128()).AsInt32(), Vector128.Create(-1, -1, 0, 0));
+        public static bool LessThanAny(Vector2 left, Vector2 right) => Vector128.LessThanAny(left.AsVector128(), right.AsVector128());
 
         /// <inheritdoc cref="Vector4.LessThanOrEqual(Vector4, Vector4)" />
         [Intrinsic]
@@ -692,7 +692,7 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.LessThanOrEqualAll(Vector4, Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool LessThanOrEqualAll(Vector2 left, Vector2 right) => Vector128.EqualsAll(Vector128.LessThanOrEqual(left.AsVector128(), right.AsVector128()).AsInt32(), Vector128<int>.AllBitsSet);
+        public static bool LessThanOrEqualAll(Vector2 left, Vector2 right) => Vector128.LessThanOrEqualAll(left.AsVector128(), right.AsVector128());
 
         /// <inheritdoc cref="Vector4.LessThanOrEqualAny(Vector4, Vector4)" />
         [Intrinsic]

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -588,7 +588,7 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.GreaterThanAny(Vector4, Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool GreaterThanAny(Vector3 left, Vector3 right) => Vector128.EqualsAny(Vector128.GreaterThan(left.AsVector128(), right.AsVector128()).AsInt32(), Vector128.Create(-1, -1, -1, 0));
+        public static bool GreaterThanAny(Vector3 left, Vector3 right) => Vector128.GreaterThanAny(left.AsVector128(), right.AsVector128());
 
         /// <inheritdoc cref="Vector4.GreaterThanOrEqual(Vector4, Vector4)" />
         [Intrinsic]
@@ -598,7 +598,7 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.GreaterThanOrEqualAll(Vector4, Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool GreaterThanOrEqualAll(Vector3 left, Vector3 right) => Vector128.EqualsAll(Vector128.GreaterThanOrEqual(left.AsVector128(), right.AsVector128()).AsInt32(), Vector128<int>.AllBitsSet);
+        public static bool GreaterThanOrEqualAll(Vector3 left, Vector3 right) => Vector128.GreaterThanOrEqualAll(left.AsVector128(), right.AsVector128());
 
         /// <inheritdoc cref="Vector4.GreaterThanOrEqualAny(Vector4, Vector4)" />
         [Intrinsic]
@@ -719,7 +719,7 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.LessThanAny(Vector4, Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool LessThanAny(Vector3 left, Vector3 right) => Vector128.EqualsAny(Vector128.LessThan(left.AsVector128(), right.AsVector128()).AsInt32(), Vector128.Create(-1, -1, -1, 0));
+        public static bool LessThanAny(Vector3 left, Vector3 right) => Vector128.LessThanAny(left.AsVector128(), right.AsVector128());
 
         /// <inheritdoc cref="Vector4.LessThanOrEqual(Vector4, Vector4)" />
         [Intrinsic]
@@ -729,7 +729,7 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.LessThanOrEqualAll(Vector4, Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool LessThanOrEqualAll(Vector3 left, Vector3 right) => Vector128.EqualsAll(Vector128.LessThanOrEqual(left.AsVector128(), right.AsVector128()).AsInt32(), Vector128<int>.AllBitsSet);
+        public static bool LessThanOrEqualAll(Vector3 left, Vector3 right) => Vector128.LessThanOrEqualAll(left.AsVector128(), right.AsVector128());
 
         /// <inheritdoc cref="Vector4.LessThanOrEqualAny(Vector4, Vector4)" />
         [Intrinsic]


### PR DESCRIPTION
`Vector2` and `Vector3` strict `Any` comparisons incorrectly returned `true` when no logical lanes matched because zero-filled padding lanes matched zero entries in the validity mask. Use the direct `Vector128` comparison reductions, which the JIT expands to the canonical comparison forms, and simplify the inclusive `All` reductions similarly.

Add coverage for padding-sensitive outcomes and NaN in every valid lane.

> [!NOTE]
> This pull request was created with GitHub Copilot.