### PR TITLE
Release ThreadStore lock before blocking for shutdown

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -303,6 +303,36 @@ HelperCanary * Debugger::GetCanary()
     return g_pRCThread->GetCanary();
 }
 
+void Debugger::ReleaseDebuggerLockAndBlockForShutdownIfNotSpecialThread(Thread *pThread)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        MODE_ANY;
+        GC_NOTRIGGER;
+        PRECONDITION(m_mutex.OwnedByCurrentThread());
+    }
+    CONTRACTL_END;
+
+    if ((t_ThreadType & (ThreadType_Finalizer|ThreadType_DbgHelper|ThreadType_Shutdown|ThreadType_GC)) == 0)
+    {
+        m_mutex.Leave();
+
+        // Debugger event sending acquires the ThreadStore lock before the debugger lock.
+        // Since this thread is about to block forever, release the ThreadStore lock explicitly.
+        if (ThreadStore::HoldingThreadStore(pThread))
+        {
+            ThreadSuspend::UnlockThreadStore();
+        }
+
+        GCX_ASSERT_PREEMP();
+
+        WaitForEndOfShutdown();
+        __SwitchToThread(INFINITE, CALLER_LIMITS_SPINNING);
+        _ASSERTE(!"Can not reach here");
+    }
+}
+
 // IMPORTANT!!!!!
 // Do not call Lock and Unlock directly. Because you might not unlock
 // if exception takes place. Use DebuggerLockHolder instead!!!
@@ -372,17 +402,7 @@ void Debugger::DoNotCallDirectlyPrivateLock(void)
         // We need to be in preemptive to block for shutdown, so we don't do this block in Coop mode.
         // Fortunately, it's safe to take this lock in coop mode because we know the thread can't block
         // on anything interesting because we're in a GC-forbid region (see crst flags).
-        if (!IsFinalizerThread() &&
-            !IsDbgHelperSpecialThread() &&
-            !IsShutdownSpecialThread() &&
-            !IsGCSpecialThread() &&
-            ThreadStore::HoldingThreadStore(pThread))
-        {
-            // This thread is about to block forever, so the outer holder cannot release the lock.
-            ThreadSuspend::UnlockThreadStore();
-        }
-
-        m_mutex.ReleaseAndBlockForShutdownIfNotSpecialThread();
+        ReleaseDebuggerLockAndBlockForShutdownIfNotSpecialThread(pThread);
     }
 
 

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -372,6 +372,16 @@ void Debugger::DoNotCallDirectlyPrivateLock(void)
         // We need to be in preemptive to block for shutdown, so we don't do this block in Coop mode.
         // Fortunately, it's safe to take this lock in coop mode because we know the thread can't block
         // on anything interesting because we're in a GC-forbid region (see crst flags).
+        if (!IsFinalizerThread() &&
+            !IsDbgHelperSpecialThread() &&
+            !IsShutdownSpecialThread() &&
+            !IsGCSpecialThread() &&
+            ThreadStore::HoldingThreadStore(pThread))
+        {
+            // This thread is about to block forever, so the outer holder cannot release the lock.
+            ThreadSuspend::UnlockThreadStore();
+        }
+
         m_mutex.ReleaseAndBlockForShutdownIfNotSpecialThread();
     }
 

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -2288,6 +2288,7 @@ public:
 private:
     void DoNotCallDirectlyPrivateLock(void);
     void DoNotCallDirectlyPrivateUnlock(void);
+    void ReleaseDebuggerLockAndBlockForShutdownIfNotSpecialThread(Thread *pThread);
 
     // This function gets the jit debugger launched and waits for the native attach to complete
     // Make sure you called PreJitAttach and it returned TRUE before you call this

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1175,6 +1175,14 @@ void WaitForEndOfShutdown()
     CONTRACT_VIOLATION(GCViolation);
 
     Thread *pThread = GetThreadNULLOk();
+
+    // This method never returns, so an outer ThreadStore lock holder cannot release
+    // the lock. Release it here so shutdown work cannot be permanently blocked.
+    if (ThreadStore::HoldingThreadStore(pThread))
+    {
+        ThreadSuspend::UnlockThreadStore();
+    }
+
     // After a thread is blocked in WaitForEndOfShutdown, the thread should not enter runtime again,
     // and block at WaitForEndOfShutdown again.
     if (pThread)

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1176,13 +1176,6 @@ void WaitForEndOfShutdown()
 
     Thread *pThread = GetThreadNULLOk();
 
-    // This method never returns, so an outer ThreadStore lock holder cannot release
-    // the lock. Release it here so shutdown work cannot be permanently blocked.
-    if (ThreadStore::HoldingThreadStore(pThread))
-    {
-        ThreadSuspend::UnlockThreadStore();
-    }
-
     // After a thread is blocked in WaitForEndOfShutdown, the thread should not enter runtime again,
     // and block at WaitForEndOfShutdown again.
     if (pThread)

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1175,7 +1175,6 @@ void WaitForEndOfShutdown()
     CONTRACT_VIOLATION(GCViolation);
 
     Thread *pThread = GetThreadNULLOk();
-
     // After a thread is blocked in WaitForEndOfShutdown, the thread should not enter runtime again,
     // and block at WaitForEndOfShutdown again.
     if (pThread)

--- a/src/coreclr/vm/crst.cpp
+++ b/src/coreclr/vm/crst.cpp
@@ -77,43 +77,6 @@ void CrstBase::Destroy()
     ResetFlags();
 }
 
-extern void WaitForEndOfShutdown();
-
-//-----------------------------------------------------------------
-// If we're in shutdown (as determined by caller since each lock needs its
-// own shutdown flag) and this is a non-special thread (not helper/finalizer/shutdown),
-// then release the crst and block forever.
-// See the prototype for more details.
-//-----------------------------------------------------------------
-void CrstBase::ReleaseAndBlockForShutdownIfNotSpecialThread()
-{
-    CONTRACTL {
-        NOTHROW;
-
-        // We're almost always MODE_PREEMPTIVE, but if it's a thread suspending for GC,
-        // then we might be MODE_COOPERATIVE. Fortunately in that case, we don't block on shutdown.
-        // We assert this below.
-        MODE_ANY;
-        GC_NOTRIGGER;
-
-        PRECONDITION(this->OwnedByCurrentThread());
-    }
-    CONTRACTL_END;
-
-    if ((t_ThreadType & (ThreadType_Finalizer|ThreadType_DbgHelper|ThreadType_Shutdown|ThreadType_GC)) == 0)
-    {
-        // The process is shutting down. Release the lock and just block forever.
-        this->Leave();
-
-        // is this safe to use here since we never return?
-        GCX_ASSERT_PREEMP();
-
-        WaitForEndOfShutdown();
-        __SwitchToThread(INFINITE, CALLER_LIMITS_SPINNING);
-        _ASSERTE (!"Can not reach here");
-    }
-}
-
 #endif // DACCESS_COMPILE
 
 

--- a/src/coreclr/vm/crst.h
+++ b/src/coreclr/vm/crst.h
@@ -138,23 +138,6 @@ public:
 #endif
 
 private:
-    // Some Crsts have a "shutdown" mode.
-    // A Crst in shutdown mode can only be taken / released by special
-    // (the helper / finalizer / shutdown) threads. Any other thread that tries to take
-    // the a "shutdown" crst will immediately release the Crst and instead just block forever.
-    //
-    // This prevents random threads from blocking the special threads from doing finalization on shutdown.
-    //
-    // Unfortunately, each Crst needs its own "shutdown" flag because we can't convert all the locks
-    // into shutdown locks at once. For eg, the TSL needs to suspend the runtime before
-    // converting to a shutdown lock. But it can't suspend the runtime while holding
-    // a UNSAFE_ANYMODE lock (such as the debugger-lock). So at least the debugger-lock
-    // and TSL need to be set separately.
-    //
-    // So for such Crsts, it's the caller's responsibility to detect if the crst is in
-    // shutdown mode, and if so, call this function after enter.
-    void ReleaseAndBlockForShutdownIfNotSpecialThread();
-
     // Enter & Leave are deliberately private to force callers to use the
     // Holder class.  If you bypass the Holder class and access these members
     // directly, your lock is not exception-safe.


### PR DESCRIPTION
## Summary

Prevent a debugger shutdown hang by releasing the ThreadStore lock before a non-special thread is permanently parked for shutdown.

Addresses #126096.

## Background

Paired debugger and target dumps showed this wait chain:

1. A non-special runtime thread begins sending a debugger class-load event and acquires ThreadStore.
2. It attempts to acquire the debugger lock after shutdown mode has begun.
3. The shutdown-aware debugger lock releases its own lock and parks the thread permanently in `WaitForEndOfShutdown`.
4. The enclosing ThreadStore lock holder never unwinds, leaving ThreadStore permanently held.
5. The debugger helper cannot acquire ThreadStore to process `DB_IPCE_ASYNC_BREAK`, so `ICorDebugProcess::Stop` never receives SyncComplete.

This is distinct from the previously fixed ReadyToRun/`PtrHashMap` deadlock paths.

## Fix

`Debugger::DoNotCallDirectlyPrivateLock` knows when a shutdown-mode debugger lock will reject and permanently park a non-special thread. If that thread owns ThreadStore, release it immediately before entering the shutdown wait.

Using `ThreadSuspend::UnlockThreadStore` preserves the ThreadStore ownership and cant-stop bookkeeping rather than releasing the underlying Crst directly. Finalizer, debugger-helper, shutdown, and GC threads retain ThreadStore because they are allowed to continue during shutdown.

## Testing

- `.\build.cmd -subset clr`
- Built and ran `foreground-shutdown` five times successfully.

> [!NOTE]
> This pull request description was drafted with GitHub Copilot.