### PR TITLE
Check method signature as part of loadability checks

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
@@ -205,7 +205,8 @@ namespace ILCompiler
 
         public void EnsureLoadableMethod(MethodDesc method)
         {
-            EnsureLoadableType(method.OwningType);
+            TypeDesc owningType = method.OwningType;
+            EnsureLoadableType(owningType);
 
             // If this is an instantiated generic method, check the instantiation.
             MethodDesc methodDef = method.GetMethodDefinition();
@@ -215,11 +216,20 @@ namespace ILCompiler
                     EnsureLoadableType(instType);
             }
 
-            MethodSignature sig = method.Signature;
-            EnsureLoadableType(sig.ReturnType);
+            // In rare situations (ldtoken of an uninstantiated method)
+            // we might end up seeing uninstantiated methods here. Don't try
+            // to drill into it, it would introduce instantiations over signature variables
+            // that are difficult to deal with without spending cycles on it.
+            // Many type system APIs don't deal with them and they're expensive to test for
+            // ("Is there a signature variable somewhere in type construction?" is expensive.)
+            if (!method.IsGenericMethodDefinition && !owningType.IsGenericDefinition)
+            {
+                MethodSignature sig = method.Signature;
+                EnsureLoadableType(sig.ReturnType);
 
-            foreach (TypeDesc p in sig)
-                EnsureLoadableType(p);
+                foreach (TypeDesc p in sig)
+                    EnsureLoadableType(p);
+            }
         }
 
         private sealed class ValidTypeHashTable : LockFreeReaderHashtable<TypeDesc, TypeDesc>

--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
@@ -214,6 +214,12 @@ namespace ILCompiler
                 foreach (var instType in method.Instantiation)
                     EnsureLoadableType(instType);
             }
+
+            MethodSignature sig = method.Signature;
+            EnsureLoadableType(sig.ReturnType);
+
+            foreach (TypeDesc p in sig)
+                EnsureLoadableType(p);
         }
 
         private sealed class ValidTypeHashTable : LockFreeReaderHashtable<TypeDesc, TypeDesc>


### PR DESCRIPTION
Fixes #133007.

We can't generate debug info for these so we shouldn't allow compiling method bodies either.

I did consider just generating dummy debug info but I think it's possible to get a compiler crash for similarly invalid methods elsewhere in the compiler, depending on if it's also a target of reflection, or if the invalid type is a valuetype. We shouldn't allow them in the graph.

I considered caching this result but EnsureLoadableType is already cached and a cache here didn't seem warranted (we often ask this question only once).