### PR TITLE
Include the exception stream in Windows createdump minidumps

### DIFF
--- a/docs/design/coreclr/botr/xplat-minidump-generation.md
+++ b/docs/design/coreclr/botr/xplat-minidump-generation.md
@@ -50,6 +50,8 @@ Starting .NET 6.0, native Mach-O core files get generated and the variable COMPl
 
 As of .NET 5.0, createdump and the below configuration environment variables are supported on Windows. It is implemented using the Windows MiniDumpWriteDump API. This allows consistent crash/unhandled exception dumps across all of our platforms.
 
+The runtime also passes the crashing thread id (`--crashthread`) and the address of the crash `EXCEPTION_POINTERS` (`--exception-pointers`) to createdump on Windows, which forwards them to MiniDumpWriteDump (as `MINIDUMP_EXCEPTION_INFORMATION` with `ClientPointers`). The minidump then contains an exception stream, so debuggers and analysis tools (WinDbg, Visual Studio, ClrMD, dotnet-dump) open it on the faulting thread and show the exception record and context. Dumps written by older runtimes (or from paths where the runtime has no exception information) do not have this stream and open on the thread that was waiting for createdump.
+
 # Configuration/Policy #
 
 NOTE: Core dump generation in docker containers require the ptrace capability (--cap-add=SYS_PTRACE or --privileged run/exec options).

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -133,6 +133,8 @@ typedef struct
     int SignalErrno;
     uint64_t SignalAddress;
     uint64_t ExceptionRecord;
+    // Windows only: address of the crash EXCEPTION_POINTERS in the target process
+    uint64_t ExceptionPointers;
 } CreateDumpOptions;
 
 #ifdef HOST_UNIX

--- a/src/coreclr/debug/createdump/createdumpmain.cpp
+++ b/src/coreclr/debug/createdump/createdumpmain.cpp
@@ -29,13 +29,15 @@ const char* g_help = "createdump [options]\n"
 "-d, --diag - enable diagnostic messages.\n"
 "-v, --verbose - enable verbose diagnostic messages.\n"
 "-l, --logtofile - file path and name to log diagnostic messages.\n"
+"--crashthread <id> - the thread id of the crashing thread.\n"
 #ifdef HOST_UNIX
 "--crashreport - write crash report file (dump file path + .crashreport.json).\n"
 "--crashreportonly - write crash report file only (no dump).\n"
-"--crashthread <id> - the thread id of the crashing thread.\n"
 "--signal <code> - the signal code of the crash.\n"
 "--singlefile - single-file app model.\n"
 "--nativeaot - native AOT app model.\n"
+#else
+"--exception-pointers <address> - the address of the crash EXCEPTION_POINTERS in the target process (requires --crashthread).\n"
 #endif
 ;
 
@@ -74,6 +76,7 @@ int createdump_main(const int argc, const char* argv[])
     options.SignalErrno = 0;
     options.SignalAddress = 0;
     options.ExceptionRecord = 0;
+    options.ExceptionPointers = 0;
     bool help = false;
     int exitCode = 0;
 
@@ -103,6 +106,16 @@ int createdump_main(const int argc, const char* argv[])
             {
                 options.DumpType = DumpType::Full;
             }
+            else if (strcmp(*argv, "--crashthread") == 0)
+            {
+                options.CrashThread = (int)strtoul(*++argv, nullptr, 10);
+            }
+#ifdef HOST_WINDOWS
+            else if (strcmp(*argv, "--exception-pointers") == 0)
+            {
+                options.ExceptionPointers = strtoull(*++argv, nullptr, 10);
+            }
+#endif
 #ifdef HOST_UNIX
             else if (strcmp(*argv, "--crashreport") == 0)
             {
@@ -112,10 +125,6 @@ int createdump_main(const int argc, const char* argv[])
             {
                 options.CrashReport = true;
                 options.CreateDump = false;
-            }
-            else if (strcmp(*argv, "--crashthread") == 0)
-            {
-                options.CrashThread = atoi(*++argv);
             }
             else if (strcmp(*argv, "--signal") == 0)
             {

--- a/src/coreclr/debug/createdump/createdumpwindows.cpp
+++ b/src/coreclr/debug/createdump/createdumpwindows.cpp
@@ -15,6 +15,30 @@ typedef struct _PROCESS_BASIC_INFORMATION_ {
 } PROCESS_BASIC_INFORMATION_;
 
 //
+// Writes the dump, retrying on ERROR_PARTIAL_COPY
+//
+static bool
+WriteDump(HANDLE hProcess, int pid, HANDLE hFile, MINIDUMP_TYPE dumpType, PMINIDUMP_EXCEPTION_INFORMATION pExceptionInfo)
+{
+    int retryCount = 10;
+    for (int i = 0; i <= retryCount; i++)
+    {
+        if (MiniDumpWriteDump(hProcess, pid, hFile, dumpType, pExceptionInfo, NULL, NULL))
+        {
+            return true;
+        }
+        int err = GetLastError();
+        if (err != ERROR_PARTIAL_COPY || i == retryCount)
+        {
+            printf_error("MiniDumpWriteDump - %s\n", GetLastErrorString().c_str());
+            return false;
+        }
+        printf_error("Retry %d of MiniDumpWriteDump due to - %s\n", i, GetLastErrorString().c_str());
+    }
+    return false;
+}
+
+//
 // The Windows create dump code
 //
 bool
@@ -23,6 +47,8 @@ CreateDump(const CreateDumpOptions& options)
     HANDLE hFile = INVALID_HANDLE_VALUE;
     HANDLE hProcess = NULL;
     bool result = false;
+    MINIDUMP_EXCEPTION_INFORMATION exceptionInfo;
+    PMINIDUMP_EXCEPTION_INFORMATION pExceptionInfo = NULL;
 
     _ASSERTE(options.CreateDump);
     _ASSERTE(!options.CrashReport);
@@ -57,6 +83,19 @@ CreateDump(const CreateDumpOptions& options)
     }
     printf_status("Writing %s for process %d to file %s\n", GetDumpTypeString(options.DumpType), pid, dumpPath.c_str());
 
+    // If the runtime passed the crash context, add an exception stream to the dump. The pointers are read
+    // out of the target process (ClientPointers); they stay valid because the crashing thread waits for
+    // createdump to finish.
+    if (options.CrashThread != 0 && options.ExceptionPointers != 0)
+    {
+        memset(&exceptionInfo, 0, sizeof(exceptionInfo));
+        exceptionInfo.ThreadId = (DWORD)options.CrashThread;
+        exceptionInfo.ExceptionPointers = (PEXCEPTION_POINTERS)(ULONG_PTR)options.ExceptionPointers;
+        exceptionInfo.ClientPointers = TRUE;
+        pExceptionInfo = &exceptionInfo;
+        printf_status("Crashing thread %u exception pointers %016" PRIx64 "\n", exceptionInfo.ThreadId, options.ExceptionPointers);
+    }
+
     hFile = CreateFileA(dumpPath.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {
@@ -64,28 +103,14 @@ CreateDump(const CreateDumpOptions& options)
         goto exit;
     }
 
-    int retryCount = 10;
-    // Retry the write dump on ERROR_PARTIAL_COPY
-    for (int i = 0; i <= retryCount; i++)
+    result = WriteDump(hProcess, pid, hFile, GetMiniDumpType(options.DumpType), pExceptionInfo);
+    if (!result && pExceptionInfo != NULL)
     {
-        if (MiniDumpWriteDump(hProcess, pid, hFile, GetMiniDumpType(options.DumpType), NULL, NULL, NULL))
-        {
-            result = true;
-            break;
-        }
-        else
-        {
-            int err = GetLastError();
-            if (err != ERROR_PARTIAL_COPY || i == retryCount)
-            {
-                printf_error("MiniDumpWriteDump - %s\n", GetLastErrorString().c_str());
-                break;
-            }
-            else
-            {
-                 printf_error("Retry %d of MiniDumpWriteDump due to - %s\n", i, GetLastErrorString().c_str());
-            }
-        }
+        // The exception information must never prevent the dump from being written: retry without it.
+        printf_error("Retrying MiniDumpWriteDump without the exception information\n");
+        SetFilePointer(hFile, 0, NULL, FILE_BEGIN);
+        SetEndOfFile(hFile);
+        result = WriteDump(hProcess, pid, hFile, GetMiniDumpType(options.DumpType), NULL);
     }
 
 exit:

--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -26,7 +26,7 @@
 
 #ifdef HOST_WINDOWS
 extern "C" _CRTIMP int __cdecl _flushall(void);
-void CreateCrashDumpIfEnabled(bool stackoverflow = false);
+void CreateCrashDumpIfEnabled(EXCEPTION_POINTERS* pExceptionInfo = nullptr, bool stackoverflow = false);
 #endif
 
 // Global state counter to implement SUPPRESS_ALLOCATION_ASSERTS_IN_THIS_SCOPE.

--- a/src/coreclr/utilcode/hostimpl.cpp
+++ b/src/coreclr/utilcode/hostimpl.cpp
@@ -74,7 +74,7 @@ void GetLastThrownObjectExceptionFromThread(Exception** ppException)
 }
 
 #ifdef HOST_WINDOWS
-void CreateCrashDumpIfEnabled(bool stackoverflow)
+void CreateCrashDumpIfEnabled(EXCEPTION_POINTERS* pExceptionInfo, bool stackoverflow)
 {
 }
 #endif

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -3092,7 +3092,7 @@ LONG WatsonLastChance(                  // EXCEPTION_CONTINUE_SEARCH, _CONTINUE_
 
                 STRESS_LOG0(LF_CORDB, LL_INFO10, "D::RFFE: About to call RaiseFailFastException\n");
 #ifdef HOST_WINDOWS
-                CreateCrashDumpIfEnabled(fSOException);
+                CreateCrashDumpIfEnabled(pExceptionInfo, fSOException);
 #endif
                 // RaiseFailFastException validates that the context matches a valid return address on the stack as part of CET.
                 // If the return address is not valid, it rejects the context, flags it as a potential attack and asserts in
@@ -3290,8 +3290,20 @@ LONG WatsonLastChance(                  // EXCEPTION_CONTINUE_SEARCH, _CONTINUE_
 
 #ifdef HOST_WINDOWS
 
-// Crash dump generating program arguments if enabled.
-LPCWSTR g_createDumpCommandLine = nullptr;
+// Crash dump generating program command line if enabled. Prebuilt at startup with room reserved at the end
+// so the crash-time arguments can be appended without allocating.
+static LPWSTR g_createDumpCommandLine = nullptr;
+
+// Room for " --crashthread <DWORD> --exception-pointers <UINT64>" (at most 66 characters) and the terminator
+static const size_t CreateDumpCrashArgumentsReserve = 80;
+
+// Arguments of LaunchCreateDumpOnCrash, which runs on a utility thread in the stack overflow case.
+struct CreateDumpOnCrashArgs
+{
+    LPWSTR commandLine;
+    DWORD crashThreadId;
+    EXCEPTION_POINTERS* pExceptionInfo;
+};
 
 static void
 BuildCreateDumpCommandLine(
@@ -3382,16 +3394,41 @@ LaunchCreateDump(LPCWSTR lpCommandLine)
     return fSuccess;
 }
 
+static DWORD WINAPI
+LaunchCreateDumpOnCrash(LPVOID pArgs)
+{
+    CreateDumpOnCrashArgs* args = (CreateDumpOnCrashArgs*)pArgs;
+
+    if (args->pExceptionInfo != nullptr)
+    {
+        // Append the crash context so createdump can add an exception stream to the minidump. The pointers
+        // stay valid because the crashing thread waits for createdump to complete.
+        size_t length = u16_strlen(args->commandLine);
+        _snwprintf_s(args->commandLine + length, CreateDumpCrashArgumentsReserve, _TRUNCATE,
+            W(" --crashthread %u --exception-pointers %llu"),
+            args->crashThreadId, (unsigned long long)(ULONG_PTR)args->pExceptionInfo);
+    }
+
+    return LaunchCreateDump(args->commandLine);
+}
+
 void
-CreateCrashDumpIfEnabled(bool stackoverflow)
+CreateCrashDumpIfEnabled(EXCEPTION_POINTERS* pExceptionInfo, bool stackoverflow)
 {
     // If enabled, launch the create minidump utility and wait until it completes. Only launch createdump once for this process.
-    LPCWSTR createDumpCommandLine = InterlockedExchangeT<LPCWSTR>(&g_createDumpCommandLine, nullptr);
+    LPWSTR createDumpCommandLine = InterlockedExchangeT<LPWSTR>(&g_createDumpCommandLine, nullptr);
     if (createDumpCommandLine != nullptr)
     {
+        CreateDumpOnCrashArgs args;
+        args.commandLine = createDumpCommandLine;
+        // This function is always called on the crashing thread
+        args.crashThreadId = GetCurrentThreadId();
+        // Only complete exception information is useful to createdump
+        args.pExceptionInfo = (pExceptionInfo != nullptr && pExceptionInfo->ExceptionRecord != nullptr && pExceptionInfo->ContextRecord != nullptr) ? pExceptionInfo : nullptr;
+
         if (stackoverflow)
         {
-            HandleHolder createDumpThreadHandle{ Thread::CreateUtilityThread(Thread::StackSize_Small, (LPTHREAD_START_ROUTINE)LaunchCreateDump, (void*)createDumpCommandLine, W(".NET SO Dumper")) };
+            HandleHolder createDumpThreadHandle{ Thread::CreateUtilityThread(Thread::StackSize_Small, LaunchCreateDumpOnCrash, &args, W(".NET SO Dumper")) };
             if (createDumpThreadHandle != NULL)
             {
                 // Wait for the dump to be generated
@@ -3401,7 +3438,7 @@ CreateCrashDumpIfEnabled(bool stackoverflow)
         }
         else
         {
-            LaunchCreateDump(createDumpCommandLine);
+            LaunchCreateDumpOnCrash(&args);
         }
     }
 }
@@ -3437,7 +3474,13 @@ InitializeCrashDump()
 
         SString commandLine;
         BuildCreateDumpCommandLine(commandLine, dumpName, dumpType, diag == 1);
-        g_createDumpCommandLine = commandLine.GetCopyOfUnicodeString();
+
+        // Keep a copy with room reserved for the crash-time arguments (see LaunchCreateDumpOnCrash)
+        LPCWSTR unicodeCommandLine = commandLine.GetUnicode();
+        size_t capacity = u16_strlen(unicodeCommandLine) + CreateDumpCrashArgumentsReserve;
+        LPWSTR buffer = new WCHAR[capacity];
+        wcscpy_s(buffer, capacity, unicodeCommandLine);
+        g_createDumpCommandLine = buffer;
     }
 }
 
@@ -3480,7 +3523,7 @@ void CrashDumpAndTerminateProcess(UINT exitCode)
 #endif
 
 #ifdef HOST_WINDOWS
-    CreateCrashDumpIfEnabled(exitCode == static_cast<UINT>(COR_E_STACKOVERFLOW));
+    CreateCrashDumpIfEnabled(nullptr, exitCode == static_cast<UINT>(COR_E_STACKOVERFLOW));
 #endif
     TerminateProcess(GetCurrentProcess(), exitCode);
 }
@@ -4119,7 +4162,7 @@ LONG InternalUnhandledExceptionFilter(
     }
 
 #ifdef HOST_WINDOWS
-    CreateCrashDumpIfEnabled();
+    CreateCrashDumpIfEnabled(pExceptionInfo);
 #endif
 
     BOOL fShouldOurUEFDisplayUI = ShouldOurUEFDisplayUI(pExceptionInfo);
@@ -4627,7 +4670,7 @@ void NotifyAppDomainsOfUnhandledException(
     GCPROTECT_END();
 
 #ifdef HOST_WINDOWS
-    CreateCrashDumpIfEnabled();
+    CreateCrashDumpIfEnabled(pExceptionPointers);
 #endif
 
 #ifdef _DEBUG

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -160,7 +160,7 @@ LONG __stdcall COMUnhandledExceptionFilter(EXCEPTION_POINTERS *pExceptionInfo);
 #ifdef HOST_WINDOWS
 #include <generatedumpflags.h>
 void InitializeCrashDump();
-void CreateCrashDumpIfEnabled(bool stackoverflow = false);
+void CreateCrashDumpIfEnabled(EXCEPTION_POINTERS* pExceptionInfo = nullptr, bool stackoverflow = false);
 #endif
 bool GenerateDump(LPCWSTR dumpName, INT dumpType, ULONG32 flags, LPSTR errorMessageBuffer, INT cbErrorMessageBuffer);
 

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -15,7 +15,9 @@ namespace TestUnhandledExceptionTester
 {
     public class Program
     {
-        static void RunExternalProcess(string unhandledType, string assembly)
+        // When expectedDumpExceptionCodes is set, the crash writes a minidump that must contain an
+        // exception stream with one of the expected exception codes.
+        static void RunExternalProcess(string unhandledType, string assembly, uint[] expectedDumpExceptionCodes = null)
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
@@ -26,6 +28,15 @@ namespace TestUnhandledExceptionTester
             startInfo.Environment.Remove("DOTNET_DbgEnableMiniDump");
             startInfo.Environment.Remove("DOTNET_EnableCrashReport");
 
+            string dumpPath = null;
+            if (expectedDumpExceptionCodes != null)
+            {
+                dumpPath = Path.Combine(Path.GetTempPath(), $"unhandled-{Guid.NewGuid():N}.dmp");
+                startInfo.Environment["DOTNET_DbgEnableMiniDump"] = "1";
+                startInfo.Environment["DOTNET_DbgMiniDumpType"] = "1"; // MiniDumpNormal keeps the dump small
+                startInfo.Environment["DOTNET_DbgMiniDumpName"] = dumpPath;
+            }
+
             ProcessTextOutput result = Process.RunAndCaptureText(startInfo);
             Console.WriteLine($"Test process {assembly} with argument {unhandledType} exited");
 
@@ -34,7 +45,8 @@ namespace TestUnhandledExceptionTester
             {
                 string line = rawLine.TrimEnd('\r');
                 Console.WriteLine($"\"{line}\"");
-                if (!string.IsNullOrEmpty(line))
+                // createdump messages are not part of the runtime output being verified
+                if (!string.IsNullOrEmpty(line) && !line.StartsWith("[createdump]"))
                 {
                     lines.Add(line);
                 }
@@ -162,7 +174,79 @@ namespace TestUnhandledExceptionTester
                 }
             }
 
+            if (dumpPath != null)
+            {
+                try
+                {
+                    VerifyMinidumpExceptionStream(dumpPath, expectedDumpExceptionCodes);
+                }
+                finally
+                {
+                    File.Delete(dumpPath);
+                }
+            }
+
             Console.WriteLine("Test process exited with expected error code and produced expected output");
+        }
+
+        // Minidump format constants (see minidumpapiset.h)
+        private const uint MinidumpSignature = 0x504D444D; // 'MDMP'
+        private const uint ExceptionStreamType = 6;        // MINIDUMP_STREAM_TYPE.ExceptionStream
+
+        // Checks that the minidump has an exception stream identifying the crashing thread and the exception
+        static void VerifyMinidumpExceptionStream(string dumpPath, uint[] expectedExceptionCodes)
+        {
+            if (!File.Exists(dumpPath))
+            {
+                throw new Exception($"Dump file {dumpPath} was not created");
+            }
+            Console.WriteLine($"Verifying dump {dumpPath} ({new FileInfo(dumpPath).Length} bytes)");
+
+            using FileStream stream = File.OpenRead(dumpPath);
+            using BinaryReader reader = new BinaryReader(stream);
+
+            // MINIDUMP_HEADER: Signature, Version, NumberOfStreams, StreamDirectoryRva, ...
+            uint signature = reader.ReadUInt32();
+            if (signature != MinidumpSignature)
+            {
+                throw new Exception($"Invalid minidump signature 0x{signature:X8}");
+            }
+            reader.ReadUInt32(); // Version
+            uint numberOfStreams = reader.ReadUInt32();
+            uint streamDirectoryRva = reader.ReadUInt32();
+
+            // MINIDUMP_DIRECTORY entries: StreamType, Location.DataSize, Location.Rva
+            uint exceptionStreamRva = 0;
+            stream.Position = streamDirectoryRva;
+            for (uint i = 0; i < numberOfStreams; i++)
+            {
+                uint streamType = reader.ReadUInt32();
+                reader.ReadUInt32(); // DataSize
+                uint rva = reader.ReadUInt32();
+                if (streamType == ExceptionStreamType)
+                {
+                    exceptionStreamRva = rva;
+                }
+            }
+            if (exceptionStreamRva == 0)
+            {
+                throw new Exception("Dump has no exception stream");
+            }
+
+            // MINIDUMP_EXCEPTION_STREAM: ThreadId, __alignment, MINIDUMP_EXCEPTION { ExceptionCode, ... }, ThreadContext
+            stream.Position = exceptionStreamRva;
+            uint threadId = reader.ReadUInt32();
+            reader.ReadUInt32(); // __alignment
+            uint exceptionCode = reader.ReadUInt32();
+            Console.WriteLine($"Dump exception stream: thread {threadId}, exception code 0x{exceptionCode:X8}");
+            if (threadId == 0)
+            {
+                throw new Exception("Dump exception stream has no crashing thread id");
+            }
+            if (!Array.Exists(expectedExceptionCodes, code => code == exceptionCode))
+            {
+                throw new Exception($"Wrong dump exception code: 0x{exceptionCode:X8}, expected {string.Join(" or ", Array.ConvertAll(expectedExceptionCodes, code => $"0x{code:X8}"))}");
+            }
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/80356", typeof(PlatformDetection), nameof(PlatformDetection.IsOSX), nameof(PlatformDetection.IsX64Process))]
@@ -182,6 +266,14 @@ namespace TestUnhandledExceptionTester
             RunExternalProcess("missingdependency", "unhandledmissingdependency.dll");
             if (!TestLibrary.Utilities.IsMonoRuntime && !TestLibrary.Utilities.IsNativeAot)
                 RunExternalProcess("collecteddelegate", "collecteddelegate.dll");
+
+            if (OperatingSystem.IsWindows() && !TestLibrary.Utilities.IsMonoRuntime && !TestLibrary.Utilities.IsNativeAot)
+            {
+                // The minidump must record the crash: an access violation (or the managed exception raised for
+                // it when the null check is done in software) and the managed exception of the software throw.
+                RunExternalProcess("mainhardware", "unhandled.dll", new uint[] { 0xC0000005, 0xE0434352 });
+                RunExternalProcess("main", "unhandled.dll", new uint[] { 0xE0434352 });
+            }
         }
     }
 }


### PR DESCRIPTION
On Windows, the minidump written when `DOTNET_DbgEnableMiniDump` is set has no exception stream: the runtime
launches createdump without any crash context, so `MiniDumpWriteDump` gets a `NULL` exception parameter and
debuggers open the dump on an arbitrary thread with no record of the fault. Linux/macOS dumps already carry
the crash context. (Came up in #101560, [comment](https://github.com/dotnet/runtime/issues/101560#issuecomment-5494851903).)

The runtime now passes the crashing thread id (`--crashthread`, previously Unix-only) and the address of the
crash `EXCEPTION_POINTERS` (new Windows-only `--exception-pointers`) to createdump, which forwards them to
`MiniDumpWriteDump` as `MINIDUMP_EXCEPTION_INFORMATION` with `ClientPointers`.

- The command line is still fully prebuilt at startup; the crash path only appends the two arguments into
  reserved space, without allocating. The pointers stay valid because the crashing thread waits for
  createdump (the thread id is captured before the stack-overflow path hands off to a helper thread).
- A hardware fault keeps its original record (`0xC0000005` at the faulting IP rather than the wrapped
  managed exception), since the pointers are forwarded from pass 1 of unhandled-exception processing.
- If `MiniDumpWriteDump` fails with the exception information, createdump retries without it, so dump
  creation cannot regress; paths with no exception pointers behave as before. On-demand dumps
  (`dotnet-dump collect`) are unchanged.

Validation: new `unhandledTester` cases parse the minidump and assert an exception stream with the expected
code (`0xC0000005`/`0xE0434352`); full suite passes on win-x64 Checked. Verified before/after: unmodified
runtime (and .NET 10) → no exception stream; with this change → present, thread id matching the crashing
thread, including a fault on a secondary thread.