### PR TITLE
Remove redundant rolling build pipeline parameter

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -6,7 +6,6 @@
 parameters:
   isExtraPlatformsBuild: false
   isAndroidOnlyBuild: false
-  isRollingBuild: false
   useHelixMonitor: false
 
 jobs:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -6,7 +6,6 @@
 parameters:
   isExtraPlatformsBuild: false
   isAndroidEmulatorOnlyBuild: false
-  isRollingBuild: false
   useHelixMonitor: false
 
 jobs:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -6,7 +6,6 @@
 parameters:
   isExtraPlatformsBuild: false
   isiOSLikeOnlyBuild: false
-  isRollingBuild: false
   useHelixMonitor: false
 
 jobs:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -6,7 +6,6 @@
 parameters:
   isExtraPlatformsBuild: false
   isiOSLikeSimulatorOnlyBuild: false
-  isRollingBuild: false
   useHelixMonitor: false
 
 jobs:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-linuxbionic.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-linuxbionic.yml
@@ -6,7 +6,6 @@
 parameters:
   isExtraPlatformsBuild: false
   isLinuxBionicOnlyBuild: false
-  isRollingBuild: false
 
 jobs:
 

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
@@ -6,7 +6,6 @@
 parameters:
   isExtraPlatformsBuild: false
   isMacCatalystOnlyBuild: false
-  isRollingBuild: false
   useHelixMonitor: false
 
 jobs:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -6,7 +6,6 @@
 parameters:
   isExtraPlatformsBuild: false
   isWasmOnlyBuild: false
-  isRollingBuild: false
   useHelixMonitor: false
   excludeLibTests: false
   excludeNonLibTests: false
@@ -20,7 +19,7 @@ jobs:
 # - only run eat and aot tests
 # - rest are covered by runtime
 #
-- ${{ if eq(parameters.isRollingBuild, true) }}:
+- ${{ if eq(variables.isRollingBuild, true) }}:
   # AOT Library tests - browser_wasm
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
     parameters:
@@ -66,7 +65,7 @@ jobs:
 # - run everything, if relevant paths changed
 # - For runtime-wasm, force run all the jobs
 #
-- ${{ if and(ne(parameters.isRollingBuild, true), ne(parameters.excludeLibTests, true), ne(parameters.debuggerTestsOnly, true)) }}:
+- ${{ if and(ne(variables.isRollingBuild, true), ne(parameters.excludeLibTests, true), ne(parameters.debuggerTestsOnly, true)) }}:
   # Library tests
   # these run on runtime also
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
@@ -175,7 +174,7 @@ jobs:
       scenarios:
         - WasmTestOnWasmtime
 
-- ${{ if and(ne(parameters.isRollingBuild, true), ne(parameters.excludeNonLibTests, true), ne(parameters.debuggerTestsOnly, true)) }}:
+- ${{ if and(ne(variables.isRollingBuild, true), ne(parameters.excludeNonLibTests, true), ne(parameters.debuggerTestsOnly, true)) }}:
   # Builds only
   - template: /eng/pipelines/common/templates/wasm-build-only.yml
     parameters:
@@ -254,7 +253,7 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
-- ${{ if and(ne(parameters.isRollingBuild, true), ne(parameters.excludeOptional, true)) }}:
+- ${{ if and(ne(variables.isRollingBuild, true), ne(parameters.excludeOptional, true)) }}:
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
     parameters:
       platforms:

--- a/eng/pipelines/runtime-android.yml
+++ b/eng/pipelines/runtime-android.yml
@@ -26,5 +26,4 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isAndroidOnlyBuild: ${{ variables.isAndroidOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-androidemulator.yml
+++ b/eng/pipelines/runtime-androidemulator.yml
@@ -27,5 +27,4 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -64,7 +64,6 @@ extends:
           parameters:
             isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
             isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
-            isRollingBuild: ${{ variables.isRollingBuild }}
             useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add iOS/tvOS jobs
@@ -72,7 +71,6 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isiOSLikeOnlyBuild: ${{ variables.isiOSLikeOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add iOS/tvOS simulator jobs
@@ -80,7 +78,6 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add Android jobs
@@ -88,7 +85,6 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isAndroidOnlyBuild: ${{ variables.isAndroidOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add Android emulator jobs
@@ -96,7 +92,6 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add Mac Catalyst jobs
@@ -104,7 +99,6 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add Linux Bionic jobs
@@ -112,7 +106,6 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isLinuxBionicOnlyBuild: ${{ variables.isLinuxBionicOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
 
       # Any jobs that are not specific to any platform
       - ${{ if eq(variables.isNotSpecificPlatformOnlyBuild, true) }}:

--- a/eng/pipelines/runtime-ioslike.yml
+++ b/eng/pipelines/runtime-ioslike.yml
@@ -27,5 +27,4 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isiOSLikeOnlyBuild: ${{ variables.isiOSLikeOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-ioslikesimulator.yml
+++ b/eng/pipelines/runtime-ioslikesimulator.yml
@@ -28,5 +28,4 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-linuxbionic.yml
+++ b/eng/pipelines/runtime-linuxbionic.yml
@@ -17,4 +17,3 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isLinuxBionicOnlyBuild: ${{ variables.isLinuxBionicOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}

--- a/eng/pipelines/runtime-maccatalyst.yml
+++ b/eng/pipelines/runtime-maccatalyst.yml
@@ -27,5 +27,4 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-wasm-dbgtests.yml
+++ b/eng/pipelines/runtime-wasm-dbgtests.yml
@@ -29,6 +29,5 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           debuggerTestsOnly: true

--- a/eng/pipelines/runtime-wasm-libtests.yml
+++ b/eng/pipelines/runtime-wasm-libtests.yml
@@ -28,7 +28,6 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           excludeNonLibTests: true
           excludeLibTests: false

--- a/eng/pipelines/runtime-wasm-non-libtests.yml
+++ b/eng/pipelines/runtime-wasm-non-libtests.yml
@@ -28,7 +28,6 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           excludeNonLibTests: false
           excludeLibTests: true

--- a/eng/pipelines/runtime-wasm-optional.yml
+++ b/eng/pipelines/runtime-wasm-optional.yml
@@ -29,7 +29,6 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           excludeLibTests: true
           excludeNonLibTests: true

--- a/eng/pipelines/runtime-wasm.yml
+++ b/eng/pipelines/runtime-wasm.yml
@@ -32,6 +32,5 @@ extends:
         parameters:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
-          isRollingBuild: ${{ variables.isRollingBuild }}
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           excludeOptional: false


### PR DESCRIPTION
Use the common isRollingBuild variable directly in the extra-platform WASM template and remove the unused parameter from extra-platform templates and their callers.

Noticed in https://github.com/dotnet/runtime/pull/133002

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>