### PR TITLE
[Release/10.0] Initialize debugger sequence map before binding patches

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -4786,7 +4786,9 @@ HRESULT Debugger::MapAndBindFunctionPatches(DebuggerJitInfo *djiNew,
     // and then send the whole list when under the big lock.
     PATCH_UNORDERED_ARRAY listUnbindablePatches;
 
-    djiNew->GetSequenceMapCount();
+    // Ensure LazyInitBounds() runs before taking the controller lock; it may transition to COOP and
+    // wait for a debugger suspension (e.g. for ReadyToRun), which can deadlock if CrstDebuggerController is held.
+    (void)djiNew->GetSequenceMapCount();
 
     // First lock the patch table so it doesn't move while we're
     //  examining it.

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -4786,6 +4786,8 @@ HRESULT Debugger::MapAndBindFunctionPatches(DebuggerJitInfo *djiNew,
     // and then send the whole list when under the big lock.
     PATCH_UNORDERED_ARRAY listUnbindablePatches;
 
+    djiNew->GetSequenceMapCount();
+
     // First lock the patch table so it doesn't move while we're
     //  examining it.
     LOG((LF_CORDB,LL_INFO10000, "D::MABFP: About to lock patch table\n"));


### PR DESCRIPTION
Fixes Issue https://github.com/dotnet/runtime/issues/126096

main PR https://github.com/dotnet/runtime/pull/123492

# Description

Initialize the debugger JIT info sequence map before `MapAndBindFunctionPatches` acquires `CrstDebuggerController`.

Binding an IL breakpoint can lazily initialize this map while holding the controller lock. For ReadyToRun methods, initialization can transition the thread to cooperative GC mode and wait for an active debugger suspension while retaining the lock. Initializing the map before entering the locked patch-mapping scope avoids that deadlock.

# Customer Impact

This deadlock has been observed by an external customer while debugging ReadyToRun applications with a breakpoint on the thread starter.

The debugger and IDE can hang while binding the breakpoint, requiring the debugging session to be terminated.

# Regression

No. The underlying lock and GC transition interaction predates .NET 10, although it has become more visible in .NET 10 servicing.

# Testing

A native ICorDebug harness exercised binding a pending non-zero IL breakpoint during the first ReadyToRun invocation. The affected breakpoint-binding route completed successfully in 5/5 runs.

The timing-dependent suspension deadlock was not reproduced on the baseline build.

# Risk

Low. The change initializes debugger information already required for IL breakpoint mapping, but does so before acquiring the controller lock. The existing synchronization and error handling in `LazyInitBounds` remain unchanged.

The tradeoff is earlier debug-info decompression for each applicable `JITComplete`.