### PR TITLE
JIT: protect delegate invoke with a NoGC region

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -160,6 +160,16 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             GetEmitter()->emitDisableGC();
             break;
 
+        case GT_END_NONGC:
+            // The call consumed this marker. Emit a nop if its return address would otherwise
+            // remain in the NoGC instruction group.
+            assert(GetEmitter()->emitNoGCRequestCount == 0);
+            if (GetEmitter()->emitLastCodeIsNoGC())
+            {
+                instGen(INS_nop);
+            }
+            break;
+
         case GT_START_PREEMPTGC:
             // Kill callee saves GC registers, and create a label
             // so that information gets propagated to the emitter.

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1794,8 +1794,31 @@ void CodeGen::genEmitCallWithCurrentGC(EmitCallParams& params)
     params.byrefRegs = gcInfo.gcRegByrefSetCur;
     GetEmitter()->emitIns_Call(params);
 
-    // Emit an entry for managed return value reporting, if needed.
     GenTreeCall* call = params.returnValueCall;
+
+    if ((call != nullptr) && !params.isJump && (GetEmitter()->emitNoGCRequestCount > 0))
+    {
+        // Argument placement may move ahead of the marker. Stop at another call so a CFG
+        // validator does not consume the final call's marker.
+        GenTree* next = call->gtNext;
+        while ((next != nullptr) && !next->OperIs(GT_CALL, GT_END_NONGC))
+        {
+            next = next->gtNext;
+        }
+
+        if ((next != nullptr) && next->OperIs(GT_END_NONGC))
+        {
+            GetEmitter()->emitEnableGC();
+        }
+#ifdef DEBUG
+        else
+        {
+            assert(call->IsHelperCall(CORINFO_HELP_VALIDATE_INDIRECT_CALL));
+        }
+#endif
+    }
+
+    // Emit an entry for managed return value reporting, if needed.
     if ((call == nullptr) || !m_compiler->opts.compDbgInfo || !m_compiler->opts.compScopeInfo ||
         (m_compiler->genCallSite2DebugInfoMap == nullptr) || params.isJump)
     {

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -3975,6 +3975,16 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             GetEmitter()->emitDisableGC();
             break;
 
+        case GT_END_NONGC:
+            // The call consumed this marker. Emit a nop if its return address would otherwise
+            // remain in the NoGC instruction group.
+            assert(GetEmitter()->emitNoGCRequestCount == 0);
+            if (GetEmitter()->emitLastCodeIsNoGC())
+            {
+                instGen(INS_nop);
+            }
+            break;
+
         case GT_START_PREEMPTGC:
             // Kill callee saves GC registers, and create a label
             // so that information gets propagated to the emitter.

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3815,6 +3815,16 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             GetEmitter()->emitDisableGC();
             break;
 
+        case GT_END_NONGC:
+            // The call consumed this marker. Emit a nop if its return address would otherwise
+            // remain in the NoGC instruction group.
+            assert(GetEmitter()->emitNoGCRequestCount == 0);
+            if (GetEmitter()->emitLastCodeIsNoGC())
+            {
+                instGen(INS_nop);
+            }
+            break;
+
         case GT_START_PREEMPTGC:
             // Kill callee saves GC registers, and create a label
             // so that information gets propagated to the emitter.

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1850,6 +1850,16 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             GetEmitter()->emitDisableGC();
             break;
 
+        case GT_END_NONGC:
+            // The call consumed this marker. Emit a nop if its return address would otherwise
+            // remain in the NoGC instruction group.
+            assert(GetEmitter()->emitNoGCRequestCount == 0);
+            if (GetEmitter()->emitLastCodeIsNoGC())
+            {
+                instGen(INS_nop);
+            }
+            break;
+
         case GT_START_PREEMPTGC:
             // Kill callee saves GC registers, and create a label
             // so that information gets propagated to the emitter.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -12063,6 +12063,7 @@ GenTreeUseEdgeIterator::GenTreeUseEdgeIterator(GenTree* node)
         case GT_SETCC:
         case GT_NO_OP:
         case GT_START_NONGC:
+        case GT_END_NONGC:
         case GT_START_PREEMPTGC:
         case GT_PROF_HOOK:
         case GT_PHI_ARG:
@@ -14257,6 +14258,7 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
         case GT_NOP:
         case GT_NO_OP:
         case GT_START_NONGC:
+        case GT_END_NONGC:
         case GT_START_PREEMPTGC:
         case GT_PROF_HOOK:
         case GT_CATCH_ARG:

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -348,6 +348,7 @@ GTNODE(PATCHPOINT       , GenTreeOp          ,0,1,GTK_BINOP|GTK_NOVALUE)
 GTNODE(PATCHPOINT_FORCED, GenTreeOp          ,0,1,GTK_UNOP|GTK_NOVALUE)
 
 GTNODE(START_NONGC      , GenTree            ,0,0,GTK_LEAF|GTK_NOVALUE|DBK_NOTHIR) // Starts a new instruction group that will be non-gc interruptible.
+GTNODE(END_NONGC        , GenTree            ,0,0,GTK_LEAF|GTK_NOVALUE|DBK_NOTHIR) // Ends a call-spanning non-gc interruptible region.
 GTNODE(START_PREEMPTGC  , GenTree            ,0,0,GTK_LEAF|GTK_NOVALUE|DBK_NOTHIR) // Starts a new instruction group where preemptive GC is enabled.
 GTNODE(PROF_HOOK        , GenTree            ,0,0,GTK_LEAF|GTK_NOVALUE|DBK_NOTHIR) // Profiler Enter/Leave/TailCall hook.
 

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -2471,6 +2471,7 @@ void Liveness<TLiveness>::ComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VAR
             case GT_SWITCH:
             case GT_RETFILT:
             case GT_START_NONGC:
+            case GT_END_NONGC:
             case GT_START_PREEMPTGC:
             case GT_PROF_HOOK:
             case GT_SWITCH_TABLE:

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2880,9 +2880,11 @@ GenTree* Lowering::LowerCall(GenTree* node)
     // Check for Delegate.Invoke(). If so, we inline it. We get the
     // target-object and target-function from the delegate-object, and do
     // an indirect call.
+    GenTree* delegateAccess = nullptr;
+    GenTree* delegateTarget = nullptr;
     if (call->IsDelegateInvoke())
     {
-        controlExpr = LowerDelegateInvoke(call);
+        controlExpr = LowerDelegateInvoke(call, &delegateAccess, &delegateTarget);
     }
     else
     {
@@ -3015,6 +3017,72 @@ GenTree* Lowering::LowerCall(GenTree* node)
     }
 
     ContainCheckCallOperands(call);
+
+    // An uncontained delegate target leaves an unreported code pointer live between its load and
+    // the control transfer. Keep that sequence non-interruptible if the code may be collectible.
+    bool targetContainedByCall =
+        (delegateTarget != nullptr) && delegateTarget->isContained() && (call->gtControlExpr == delegateTarget);
+    if ((delegateTarget != nullptr) && m_compiler->GetInterruptible() && !targetContainedByCall)
+    {
+        bool               isClosed;
+        LIR::ReadOnlyRange targetRange = BlockRange().GetTreeRange(delegateTarget, &isClosed);
+        assert(isClosed);
+
+        GenTree* firstAccess = LIR::FirstNode(delegateAccess, targetRange.FirstNode());
+        GenTree* startNoGC   = nullptr;
+
+        if (call->IsFastTailCall())
+        {
+            // Stack argument setup may have already opened a region that lasts through the epilog.
+            for (GenTree* node = firstAccess->gtPrev; node != nullptr; node = node->gtPrev)
+            {
+                if (node->OperIs(GT_END_NONGC))
+                {
+                    break;
+                }
+
+                if (node->OperIs(GT_START_NONGC))
+                {
+                    startNoGC = node;
+                    break;
+                }
+            }
+        }
+
+        if (call->IsFastTailCall())
+        {
+            for (GenTree* node = firstAccess; node != call; node = node->gtNext)
+            {
+                if (node->OperIs(GT_PROF_HOOK))
+                {
+                    BlockRange().Remove(node);
+                    BlockRange().InsertBefore((startNoGC != nullptr) ? startNoGC : firstAccess, node);
+                    break;
+                }
+            }
+        }
+
+        if (startNoGC == nullptr)
+        {
+            startNoGC = new (m_compiler, GT_START_NONGC) GenTree(GT_START_NONGC, TYP_VOID);
+            BlockRange().InsertBefore(firstAccess, startNoGC);
+
+            if (call->IsFastTailCall() && (m_compiler->fgBBcount == 1) &&
+                !m_compiler->compCurBB->HasFlag(BBF_GC_SAFE_POINT))
+            {
+                // Keep this region from merging with the prolog and making the method non-interruptible.
+                BlockRange().InsertBefore(startNoGC, new (m_compiler, GT_NO_OP) GenTree(GT_NO_OP, TYP_VOID));
+            }
+        }
+
+        // Fast tail calls transfer control in the epilog, which closes any open NoGC region.
+        if (!call->IsFastTailCall())
+        {
+            GenTree* endNoGC = new (m_compiler, GT_END_NONGC) GenTree(GT_END_NONGC, TYP_VOID);
+            BlockRange().InsertAfter(call, endNoGC);
+        }
+    }
+
     JITDUMP("lowering call (after):\n");
     DISPTREERANGE(BlockRange(), call);
     JITDUMP("\n");
@@ -6471,12 +6539,14 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
 // LowerDelegateInvoke: lower a delegate invoke, accessing fields of the delegate
 //
 // Arguments:
-//     call - call representing a delegate invoke.
+//     call           - call representing a delegate invoke.
+//     delegateAccess - [out] the first access to the delegate.
+//     delegateTarget - [out] the target loaded from the delegate.
 //
 // Return Value:
 //    Control expr for the delegate invoke call, for further lowering.
 //
-GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
+GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call, GenTree** delegateAccess, GenTree** delegateTarget)
 {
     noway_assert(call->gtCallType == CT_USER_FUNC);
 
@@ -6558,6 +6628,9 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
     unsigned targetOffs = m_compiler->eeGetEEInfo()->offsetOfDelegateFirstTarget;
     GenTree* result     = new (m_compiler, GT_LEA) GenTreeAddrMode(TYP_REF, base, nullptr, 0, targetOffs);
     GenTree* callTarget = Ind(result);
+
+    *delegateAccess = newThisAddr;
+    *delegateTarget = callTarget;
 
     // don't need to sequence and insert this tree, caller will do it
 

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -197,7 +197,7 @@ private:
 #if !defined(WINDOWS_AMD64_ABI)
     GenTreeLclVar* SpillStructCallResult(GenTreeCall* call) const;
 #endif // WINDOWS_AMD64_ABI
-    GenTree* LowerDelegateInvoke(GenTreeCall* call);
+    GenTree* LowerDelegateInvoke(GenTreeCall* call, GenTree** delegateAccess, GenTree** delegateTarget);
     void     OptimizeCallIndirectTargetEvaluation(GenTreeCall* call);
     GenTree* LowerDirectCall(GenTreeCall* call);
     GenTree* LowerNonvirtPinvokeCall(GenTreeCall* call);

--- a/src/coreclr/jit/lsraarm.cpp
+++ b/src/coreclr/jit/lsraarm.cpp
@@ -422,6 +422,7 @@ int LinearScan::BuildNode(GenTree* tree)
 
         case GT_NO_OP:
         case GT_START_NONGC:
+        case GT_END_NONGC:
         case GT_PROF_HOOK:
             srcCount = 0;
             assert(dstCount == 0);

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -695,6 +695,7 @@ int LinearScan::BuildNode(GenTree* tree)
 
         case GT_NO_OP:
         case GT_START_NONGC:
+        case GT_END_NONGC:
             srcCount = 0;
             assert(dstCount == 0);
             break;

--- a/src/coreclr/jit/lsraloongarch64.cpp
+++ b/src/coreclr/jit/lsraloongarch64.cpp
@@ -122,6 +122,7 @@ int LinearScan::BuildNode(GenTree* tree)
 
         case GT_NO_OP:
         case GT_START_NONGC:
+        case GT_END_NONGC:
             srcCount = 0;
             assert(dstCount == 0);
             break;

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -123,6 +123,7 @@ int LinearScan::BuildNode(GenTree* tree)
 
         case GT_NO_OP:
         case GT_START_NONGC:
+        case GT_END_NONGC:
             srcCount = 0;
             assert(dstCount == 0);
             break;

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -130,6 +130,7 @@ int LinearScan::BuildNode(GenTree* tree)
 
         case GT_NO_OP:
         case GT_START_NONGC:
+        case GT_END_NONGC:
             srcCount = 0;
             assert(dstCount == 0);
             break;


### PR DESCRIPTION
Fixes #105082.

```diff
 G_M4108_IG04:        ; bbWeight=1, gcrefRegs=0004 {x2}, byrefRegs=0000 {}, byref
             mov     w1, w0
+						;; size=4 bbWeight=1 PerfScore 0.50
+G_M4108_IG05:        ; bbWeight=1, nogc, extend
             ldp     x0, x2, [x2, #0x10]
                              ; gcrRegs -[x2] +[x0]
             blr     x2      // code for System.Action`1[int]:Invoke(int):this
                              ; gcrRegs -[x0]
+						;; size=8 bbWeight=1 PerfScore 5.00
+G_M4108_IG06:        ; bbWeight=1, extend
+            nop
```

```diff
-Defining interruptible range: [0xc, 0x40).
+Defining interruptible range: [0xc, 0x38).
+Defining interruptible range: [0x3c, 0x44).
```
