### PR TITLE
JIT: Expand REFANYTYPE QMARK before physical promotion

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10565,7 +10565,13 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 //          CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE(handle)
                 GenTree* cond =
                     gtNewOperNode(GT_NE, TYP_INT, gtNewLclVarNode(handleTemp, TYP_BYREF), gtNewZeroConNode(TYP_BYREF));
-                GenTree* qmark = gtNewQmarkNode(TYP_VOID, cond, gtNewColonNode(TYP_VOID, storeResult, storeDefault));
+                GenTreeQmark* qmark =
+                    gtNewQmarkNode(TYP_VOID, cond, gtNewColonNode(TYP_VOID, storeResult, storeDefault));
+
+                // Struct QMARKs should be expanded early since physical promotion does not support decomposing struct
+                // stores inside QMARK arms. REFANYTYPE is uncommon, so early expansion is acceptable.
+                optMethodFlags |= OMF_HAS_EARLY_QMARKS;
+                qmark->SetEarlyExpandableQmark();
 
                 impAppendTree(qmark, CHECK_SPILL_ALL, impCurStmtDI);
                 op1 = gtNewLclVarNode(resultTmp, TYP_STRUCT);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -15176,14 +15176,11 @@ PhaseStatus Compiler::fgExpandQmarkNodes(bool early)
         }
     }
 
-#ifdef DEBUG
     if (!early)
     {
-        fgPostExpandQmarkChecks();
+        INDEBUG(fgPostExpandQmarkChecks());
+        compQmarkRationalized = true;
     }
-#endif
-
-    compQmarkRationalized = true;
 
     // TODO: if qmark expansion created throw blocks, try and merge them
     //

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -1116,6 +1116,15 @@ public:
                     accessFlags  = ClassifyLocalAccess(lcl, effectiveUser);
                 }
 
+#ifdef DEBUG
+                if ((accessFlags & (AccessKindFlags::IsCallRetBuf | AccessKindFlags::IsStoreDestination)) !=
+                    AccessKindFlags::None)
+                {
+                    assert(!IsInsideQmarkArm() &&
+                           "Stores to physical promotion candidates in QMARK arms must be expanded early");
+                }
+#endif
+
                 LocalUses* uses = GetOrCreateUses(lcl->GetLclNum());
                 unsigned   offs = lcl->GetLclOffs();
                 uses->RecordAccess(offs, accessType, accessLayout, accessFlags, m_curBB->getBBWeight(m_compiler));
@@ -1352,6 +1361,28 @@ public:
     }
 
 private:
+#ifdef DEBUG
+    //------------------------------------------------------------------------
+    // IsInsideQmarkArm:
+    //   Check whether the current node is contained in a QMARK arm.
+    //
+    // Returns:
+    //   True if the current node is contained in a QMARK arm.
+    //
+    bool IsInsideQmarkArm()
+    {
+        for (int i = 1; i < m_ancestors.Height(); i++)
+        {
+            if (m_ancestors.Top(i)->OperIs(GT_COLON))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+#endif
+
     //------------------------------------------------------------------------
     // GetOrCreateUses:
     //   Get the uses information for a local. Create it if it does not already exist.

--- a/src/tests/JIT/Directed/physicalpromotion/readbackbeforeqmark.cs
+++ b/src/tests/JIT/Directed/physicalpromotion/readbackbeforeqmark.cs
@@ -14,19 +14,7 @@ public class Runtime_87508
     [Fact]
     public static int TestEntryPoint()
     {
-        if (!TestRefAnyType())
-        {
-            return -3;
-        }
-
         return new Runtime_87508().WriteBlock("1234");
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static bool TestRefAnyType()
-    {
-        int value = 0;
-        return __reftype(__makeref(value)) == typeof(int);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/JIT/Directed/physicalpromotion/readbackbeforeqmark.cs
+++ b/src/tests/JIT/Directed/physicalpromotion/readbackbeforeqmark.cs
@@ -14,7 +14,19 @@ public class Runtime_87508
     [Fact]
     public static int TestEntryPoint()
     {
+        if (!TestRefAnyType())
+        {
+            return -3;
+        }
+
         return new Runtime_87508().WriteBlock("1234");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool TestRefAnyType()
+    {
+        int value = 0;
+        return __reftype(__makeref(value)) == typeof(int);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Until now, physical promotion had no candidates stored in QMARK arms. MarkForReadBack documents readbacks there as unsupported.

The REFANYTYPE null check introduced a conditional RuntimeTypeHandle store that changed this. Since REFANYTYPE is uncommon, mark this QMARK for early expansion rather than complicating physical promotion's replacement state.

Add a debug check for stores and retbuf definitions of promotion candidates in QMARK arms, and add regression coverage for REFANYTYPE.

Fix #133047