### PR TITLE
[release/10.0] Use lock-free reads for ETW rundown versions

### DIFF
--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -84,7 +84,7 @@ NativeCodeVersionNode::NativeCodeVersionNode(
 PCODE NativeCodeVersionNode::GetNativeCode() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
-    return m_pNativeCode;
+    return VolatileLoad(&m_pNativeCode);
 }
 
 ReJITID NativeCodeVersionNode::GetILVersionId() const
@@ -1205,7 +1205,7 @@ NativeCodeVersionId MethodDescVersioningState::AllocateVersionId()
 PTR_NativeCodeVersionNode MethodDescVersioningState::GetFirstVersionNode() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
-    return m_pFirstVersionNode;
+    return VolatileLoadWithoutBarrier(&m_pFirstVersionNode);
 }
 
 BOOL MethodDescVersioningState::IsDefaultVersionActiveChild() const
@@ -1280,7 +1280,7 @@ ILCodeVersion ILCodeVersioningState::GetActiveVersion() const
 PTR_ILCodeVersionNode ILCodeVersioningState::GetFirstVersionNode() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
-    return m_pFirstVersionNode;
+    return VolatileLoadWithoutBarrier(&m_pFirstVersionNode);
 }
 
 #ifndef DACCESS_COMPILE
@@ -1470,7 +1470,14 @@ NativeCodeVersion CodeVersionManager::GetNativeCodeVersion(PTR_MethodDesc pMetho
     NativeCodeVersionCollection nativeCodeVersions = GetNativeCodeVersions(pMethod);
     for (NativeCodeVersionIterator cur = nativeCodeVersions.Begin(), end = nativeCodeVersions.End(); cur != end; cur++)
     {
+#ifndef DACCESS_COMPILE
+        PCODE nativeCode = cur->IsDefaultVersion()
+            ? pMethod->GetNativeCodeVolatile()
+            : cur->GetNativeCode();
+        if (nativeCode == codeStartAddress)
+#else
         if (cur->GetNativeCode() == codeStartAddress)
+#endif
         {
             return *cur;
         }

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -4963,8 +4963,8 @@ VOID ETW::MethodLog::SendEventsForNgenMethods(Module *pModule, DWORD dwEventOpti
 #endif // FEATURE_READYTORUN
 }
 
-// Called be ETW::MethodLog::SendEventsForJitMethods
-// Sends the ETW events once our caller determines whether or not rejit locks can be acquired
+// Called by ETW::MethodLog::SendEventsForJitMethods
+// Sends the ETW events for methods in the selected code heaps.
 VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAllocatorFilter,
                                                    DWORD dwEventOptions,
                                                    BOOL fLoadOrDCStart,
@@ -5007,20 +5007,21 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
 
         // Get info relevant to the native code version. In some cases, such as collectible loader
         // allocators, we don't support code versioning so we need to short circuit the call.
-        // This also allows our caller to avoid having to pre-enter the relevant locks.
-        // see code:#TableLockHolder
         DWORD nativeCodeVersionId = 0;
         ReJITID ilCodeId = 0;
         NativeCodeVersion nativeCodeVersion;
 #ifdef FEATURE_CODE_VERSIONING
         if (fGetCodeIds && pMD->IsVersionable())
         {
-            _ASSERTE(CodeVersionManager::IsLockOwnedByCurrentThread());
             nativeCodeVersion = pMD->GetCodeVersionManager()->GetNativeCodeVersion(pMD, codeStart);
             if (nativeCodeVersion.IsNull())
             {
-                // The code version manager hasn't been updated with the jitted code
+                // The code version state may be published concurrently with rundown.
+#ifndef DACCESS_COMPILE
+                if (codeStart != pMD->GetNativeCodeVolatile())
+#else
                 if (codeStart != pMD->GetNativeCode())
+#endif
                 {
                     continue;
                 }
@@ -5124,28 +5125,9 @@ VOID ETW::MethodLog::SendEventsForJitMethods(BOOL getCodeVersionIds, LoaderAlloc
         BOOL fSendRichDebugInfoEvent =
             (dwEventOptions & ETW::EnumerationLog::EnumerationStructs::JittedMethodRichDebugInfo) != 0;
 
-        // #TableLockHolder:
-        //
-        // A word about ReJitManager::TableLockHolder... As we enumerate through the functions,
-        // we may need to grab their code IDs. The ReJitManager grabs its table Crst in order to
-        // fetch these. However, several other kinds of locks are being taken during this
-        // enumeration, such as the SystemDomain lock and the CodeHeapIterator's
-        // lock. In order to avoid lock-leveling issues, we grab the appropriate ReJitManager
-        // table locks after SystemDomain and before CodeHeapIterator. In particular, we need to
-        // grab the SharedDomain's ReJitManager table lock as well as the specific AppDomain's
-        // ReJitManager table lock for the current AppDomain we're iterating. Why the SharedDomain's
-        // ReJitManager lock? For any given AppDomain we're iterating over, the MethodDescs we
-        // find may be managed by that AppDomain's ReJitManger OR the SharedDomain's ReJitManager.
-        // (This is due to generics and whether given instantiations may be shared based on their
-        // arguments.) Therefore, we proactively take the SharedDomain's ReJitManager's table
-        // lock up front, and then individually take the appropriate AppDomain's ReJitManager's
-        // table lock that corresponds to the domain or module we're currently iterating over.
-        //
-
 #ifdef FEATURE_CODE_VERSIONING
         if (getCodeVersionIds)
         {
-            CodeVersionManager::LockHolder codeVersioningLockHolder;
             SendEventsForJitMethodsHelper(
                 pLoaderAllocatorFilter,
                 dwEventOptions,

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1047,6 +1047,31 @@ PCODE MethodDesc::GetNativeCode()
     return GetStableEntryPoint();
 }
 
+#ifndef DACCESS_COMPILE
+PCODE MethodDesc::GetNativeCodeVolatile()
+{
+    WRAPPER_NO_CONTRACT;
+    SUPPORTS_DAC;
+    _ASSERTE(!IsDefaultInterfaceMethod() || HasNativeCodeSlot());
+    if (HasNativeCodeSlot())
+    {
+        PTR_PCODE ppCode = GetAddrOfNativeCodeSlot();
+        PCODE pCode = VolatileLoad(ppCode);
+
+#ifdef TARGET_ARM
+        if (pCode != (PCODE)NULL)
+            pCode |= THUMB_CODE;
+#endif
+        return pCode;
+    }
+
+    if (!HasStableEntryPoint() || HasPrecode())
+        return (PCODE)NULL;
+
+    return VolatileLoad(GetAddrOfSlot());
+}
+#endif
+
 PCODE MethodDesc::GetNativeCodeAnyVersion()
 {
     WRAPPER_NO_CONTRACT;

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1577,6 +1577,9 @@ public:
     //*******************************************************************************
     // Returns the address of the native code.
     PCODE GetNativeCode();
+#ifndef DACCESS_COMPILE
+    PCODE GetNativeCodeVolatile();
+#endif
 
     // Returns GetNativeCode() if it exists, but also checks to see if there
     // is a non-default code version that is populated with a code body and returns that.


### PR DESCRIPTION
Backport of #132757 to release/10.0

/cc @tommcdon

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Reported by an internal partner team.  Applications with large numbers of JIT-compiled methods can spend several seconds performing ETW rundown while holding the global code-versioning lock.  JIT paths that need the same lock can be delayed for the duration of rundown, blocking code execution.

## Regression

- [ ] Yes
- [x] No

No. This fixes longstanding lock contention in the ETW rundown implementation.

## Testing

- Validated the backport changes with concurrent ReJIT, revert, tiered compilation, OSR, and repeated CLR ETW rundown cycles.
- Both Release and Debug stress runs completed with three observed ReJIT compilations and a revert request
- Processed the generated Release and Debug ETL traces with TraceEvent, forcing rundown events; no malformed payloads or decoding errors were found.

## Risk

- Low
- Diagnostics only.  The primary behavioral tradeoff is that we might not report a method that is in-progress of being JIT'd during rundown.  This is acceptable because rundown does not guarantee a globally atomic snapshot.