### PR TITLE
[release/10.0] Implement SocketsHttpHandler.InitialHttp2MaxConcurrentStreams

### DIFF
--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -3,6 +3,9 @@
     <type fullname="System.Net.Http.SocketsHttpHandler">
       <!-- called through reflection by System.Net.HttpWebRequest -->
       <method name="get_Settings" />
+      <!-- called through UnsafeAccessor by System.Net.Http tests -->
+      <method name="get_InitialHttp2MaxConcurrentStreams" />
+      <method name="set_InitialHttp2MaxConcurrentStreams" />
     </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -21,5 +21,14 @@ namespace System.Net.Http
         // Should not be confused with Http2Connection.DefaultInitialWindowSize, which defines the RFC default.
         // Unlike that value, DefaultInitialHttp2StreamWindowSize might be changed in the future.
         public const int DefaultInitialHttp2StreamWindowSize = 65535;
+
+        // This is the default value for SocketsHttpHandler.InitialHttp2MaxConcurrentStreams.
+        // It defines how many concurrent streams a new HTTP/2 connection may use before it
+        // observes the server's SETTINGS_MAX_CONCURRENT_STREAMS value.
+        // 100 is the lowest limit servers are recommended to advertise by
+        // https://www.rfc-editor.org/rfc/rfc9113.html#section-6.5.2 ("It is recommended that this
+        // value be no smaller than 100, so as to not unnecessarily limit parallelism"), which makes
+        // it a safe assumption for servers we haven't talked to yet.
+        public const int DefaultInitialHttp2MaxConcurrentStreams = 100;
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -81,9 +81,6 @@ namespace System.Net.Http
 
         private const int MaxStreamId = int.MaxValue;
 
-        // Temporary workaround for request burst handling on connection start.
-        private const int InitialMaxConcurrentStreams = 100;
-
         private static ReadOnlySpan<byte> Http2ConnectionPreface => "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"u8;
 
 #if DEBUG
@@ -156,7 +153,7 @@ namespace System.Net.Http
             _nextStream = 1;
             _initialServerStreamWindowSize = DefaultInitialWindowSize;
 
-            _maxConcurrentStreams = InitialMaxConcurrentStreams;
+            _maxConcurrentStreams = (uint)pool.Settings._initialHttp2MaxConcurrentStreams;
             _streamsInUse = 0;
 
             _pendingWindowUpdate = 0;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -71,6 +71,8 @@ namespace System.Net.Http
         // Http2 flow control settings:
         internal int _initialHttp2StreamWindowSize = HttpHandlerDefaults.DefaultInitialHttp2StreamWindowSize;
 
+        internal int _initialHttp2MaxConcurrentStreams = HttpHandlerDefaults.DefaultInitialHttp2MaxConcurrentStreams;
+
         internal ClientCertificateOption _clientCertificateOptions;
 
         public HttpConnectionSettings()
@@ -127,6 +129,7 @@ namespace System.Net.Http
                 _connectCallback = _connectCallback,
                 _plaintextStreamFilter = _plaintextStreamFilter,
                 _initialHttp2StreamWindowSize = _initialHttp2StreamWindowSize,
+                _initialHttp2MaxConcurrentStreams = _initialHttp2MaxConcurrentStreams,
                 _activityHeadersPropagator = _activityHeadersPropagator,
                 _defaultCredentialsUsedForProxy = _proxy != null && (_proxy.Credentials == CredentialCache.DefaultCredentials || _defaultProxyCredentials == CredentialCache.DefaultCredentials),
                 _defaultCredentialsUsedForServer = _credentials == CredentialCache.DefaultCredentials,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -298,6 +298,18 @@ namespace System.Net.Http
             }
         }
 
+        internal int InitialHttp2MaxConcurrentStreams
+        {
+            get => _settings._initialHttp2MaxConcurrentStreams;
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+
+                CheckDisposedOrStarted();
+                _settings._initialHttp2MaxConcurrentStreams = value;
+            }
+        }
+
         /// <summary>
         /// Gets or sets the keep alive ping delay. The client will send a keep alive ping to the server if it
         /// doesn't receive any frames on a connection for this period of time. This property is used together with

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -27,6 +27,21 @@ namespace System.Net.Http.Functional.Tests
 {
     using Configuration = System.Net.Test.Common.Configuration;
 
+    internal static class SocketsHttpHandlerTestExtensions
+    {
+        internal static int GetInitialHttp2MaxConcurrentStreams(this SocketsHttpHandler handler) =>
+            GetInitialHttp2MaxConcurrentStreamsCore(handler);
+
+        internal static void SetInitialHttp2MaxConcurrentStreams(this SocketsHttpHandler handler, int value) =>
+            SetInitialHttp2MaxConcurrentStreamsCore(handler, value);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_InitialHttp2MaxConcurrentStreams")]
+        private static extern int GetInitialHttp2MaxConcurrentStreamsCore(SocketsHttpHandler handler);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_InitialHttp2MaxConcurrentStreams")]
+        private static extern void SetInitialHttp2MaxConcurrentStreamsCore(SocketsHttpHandler handler, int value);
+    }
+
     public class CertificateSetup : IDisposable
     {
         public X509Certificate2 ServerCert => _pkiHolder.EndEntity;
@@ -2645,6 +2660,34 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
+        [InlineData(1)]
+        [InlineData(42)]
+        [InlineData(int.MaxValue)]
+        public void InitialHttp2MaxConcurrentStreams_GetSet_Roundtrips(int value)
+        {
+            using var handler = new SocketsHttpHandler();
+            Assert.Equal(100, handler.GetInitialHttp2MaxConcurrentStreams()); // default value
+
+            handler.SetInitialHttp2MaxConcurrentStreams(value);
+            Assert.Equal(value, handler.GetInitialHttp2MaxConcurrentStreams());
+
+            handler.SetInitialHttp2MaxConcurrentStreams(100);
+            Assert.Equal(100, handler.GetInitialHttp2MaxConcurrentStreams());
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-42)]
+        [InlineData(int.MinValue)]
+        public void InitialHttp2MaxConcurrentStreams_InvalidValue_ThrowsArgumentOutOfRangeException(int value)
+        {
+            using var handler = new SocketsHttpHandler();
+            Assert.Throws<ArgumentOutOfRangeException>(() => handler.SetInitialHttp2MaxConcurrentStreams(value));
+            Assert.Equal(100, handler.GetInitialHttp2MaxConcurrentStreams());
+        }
+
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task AfterDisposeSendAsync_GettersUsable_SettersThrow(bool dispose)
@@ -2687,6 +2730,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Null(handler.ConnectCallback);
                 Assert.Null(handler.PlaintextStreamFilter);
                 Assert.Equal(HttpClientHandlerTestBase.DefaultInitialWindowSize, handler.InitialHttp2StreamWindowSize);
+                Assert.Equal(100, handler.GetInitialHttp2MaxConcurrentStreams());
 
                 Assert.Throws(expectedExceptionType, () => handler.AllowAutoRedirect = false);
                 Assert.Throws(expectedExceptionType, () => handler.AutomaticDecompression = DecompressionMethods.GZip);
@@ -2709,6 +2753,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Throws(expectedExceptionType, () => handler.ConnectCallback = (context, token) => default);
                 Assert.Throws(expectedExceptionType, () => handler.PlaintextStreamFilter = (context, token) => default);
                 Assert.Throws(expectedExceptionType, () => handler.InitialHttp2StreamWindowSize = 128 * 1024);
+                Assert.Throws(expectedExceptionType, () => handler.SetInitialHttp2MaxConcurrentStreams(1));
             }
         }
     }
@@ -3012,6 +3057,62 @@ namespace System.Net.Http.Functional.Tests
 
                 await VerifySendTasks(sendTasks0).ConfigureAwait(false);
                 await VerifySendTasks(sendTasks2).ConfigureAwait(false);
+            }
+        }
+
+        [ConditionalTheory(typeof(SocketsHttpHandlerTest_Http2), nameof(SupportsAlpn))]
+        [InlineData(1)]
+        [InlineData(3)]
+        public async Task InitialHttp2MaxConcurrentStreams_LimitsStreamsUsedBeforeSettingsFrameIsReceived(int initialLimit)
+        {
+            const int RequestCount = 5;
+
+            using Http2LoopbackServer server = Http2LoopbackServer.CreateServer();
+
+            using SocketsHttpHandler handler = CreateHandler();
+            handler.EnableMultipleHttp2Connections = false;
+            handler.SetInitialHttp2MaxConcurrentStreams(initialLimit);
+            using HttpClient client = CreateHttpClient(handler);
+
+            var sendTasks = new List<Task<HttpResponseMessage>>();
+            AcquireAllStreamSlots(server, client, sendTasks, RequestCount);
+
+            await using Http2LoopbackConnection connection = await server.AcceptConnectionAsync().WaitAsync(TestHelper.PassingTestTimeout);
+
+            // Read the client's SETTINGS frame, but don't send ours yet.
+            await connection.ReadSettingsAsync().WaitAsync(TestHelper.PassingTestTimeout);
+
+            // Only 'initialLimit' requests may be sent before we advertise our own limit.
+            var streamIds = new List<int>(await AcceptRequests(connection, initialLimit));
+            await AssertNoRequestHeadersSentAsync(connection);
+
+            // Advertise a higher limit. The remaining requests should now be sent.
+            await connection.SendSettingsAsync(ackTimeout: null, [new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 100 }]);
+
+            streamIds.AddRange(await AcceptRequests(connection, RequestCount - initialLimit));
+
+            await SendResponses(connection, streamIds);
+            await VerifySendTasks(sendTasks);
+        }
+
+        private static async Task AssertNoRequestHeadersSentAsync(Http2LoopbackConnection connection)
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+            while (true)
+            {
+                Frame frame;
+                try
+                {
+                    frame = await connection.ReadFrameAsync(cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                Assert.NotNull(frame);
+                Assert.NotEqual(FrameType.Headers, frame.Type);
             }
         }
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/132521 to release/10.0

The change isn't exactly the same because memorization of the last-seen server setting was also only added in .NET 11.
This PR is only backporting the minimal change to allow overwriting the initial limit.

As this is a servicing patch, I'm not exposing the new public API, and it's instead `internal`.
it can be used with a helper like this
```c#
[UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_InitialHttp2MaxConcurrentStreams")]
private static extern void SetInitialHttp2MaxConcurrentStreamsCore(SocketsHttpHandler handler, int value);
```

Servicing approved via email on 2026-09-03