### PR TITLE
JIT: Include method name in Release disassembly footer

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2592,7 +2592,9 @@ void CodeGen::genEmitMachineCode()
 #else
     if (m_compiler->opts.disAsm)
     {
-        printf("\n; Total bytes of code %d\n\n", codeSize);
+        printf("\n; Total bytes of code %d for method %s (%s)\n\n", codeSize,
+               m_compiler->eeGetMethodFullName(m_compiler->info.compMethodHnd),
+               m_compiler->compGetTieringName(true));
     }
 #endif
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2593,8 +2593,7 @@ void CodeGen::genEmitMachineCode()
     if (m_compiler->opts.disAsm)
     {
         printf("\n; Total bytes of code %d for method %s (%s)\n\n", codeSize,
-               m_compiler->eeGetMethodFullName(m_compiler->info.compMethodHnd),
-               m_compiler->compGetTieringName(true));
+               m_compiler->eeGetMethodFullName(m_compiler->info.compMethodHnd), m_compiler->compGetTieringName(true));
     }
 #endif
 


### PR DESCRIPTION
Include method identity in the Release JIT disassembly footer so jit-analyze can attribute code size.

Companion to dotnet/jitutils#440.

Should enable jit-utils (and namely MihuBot) to use Release bits only for diffs.