### PR TITLE
Don't pass empty string as SNI to QUIC

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -428,7 +428,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
             unsafe
             {
-                byte* targetHostPtr = sni != null ? Utf8StringMarshaller.ConvertToUnmanaged(sni) : null;
+                byte* targetHostPtr = !string.IsNullOrEmpty(sni) ? Utf8StringMarshaller.ConvertToUnmanaged(sni) : null;
                 try
                 {
                     ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ConnectionStart(

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -424,11 +424,11 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
             // RFC 6066 forbids IP literals.
             // IDN mapping is handled by MsQuic.
-            string sni = (IPAddress.IsValid(options.ClientAuthenticationOptions.TargetHost) ? null : options.ClientAuthenticationOptions.TargetHost) ?? host ?? string.Empty;
+            string? sni = (IPAddress.IsValid(options.ClientAuthenticationOptions.TargetHost) ? null : options.ClientAuthenticationOptions.TargetHost) ?? host;
 
             unsafe
             {
-                byte* targetHostPtr = Utf8StringMarshaller.ConvertToUnmanaged(sni);
+                byte* targetHostPtr = sni != null ? Utf8StringMarshaller.ConvertToUnmanaged(sni) : null;
                 try
                 {
                     ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ConnectionStart(
@@ -441,7 +441,10 @@ public sealed partial class QuicConnection : IAsyncDisposable
                 }
                 finally
                 {
-                    Utf8StringMarshaller.Free(targetHostPtr);
+                    if (targetHostPtr != null)
+                    {
+                        Utf8StringMarshaller.Free(targetHostPtr);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/133096