### PR TITLE
Fix SIMD primitive zero initialization

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -453,6 +453,8 @@ void MorphInitBlockHelper::TryPrimitiveInit()
         if (varTypeIsSIMD(lclVarType))
         {
             m_src = m_compiler->gtNewZeroConNode(lclVarType);
+            m_src->SetMorphed(m_compiler);
+            m_store->Data() = m_src;
         }
         else
         {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133085/Runtime_133085.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133085/Runtime_133085.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_133085
+{
+    private struct Struct128
+    {
+        public ulong U0;
+        public ulong U1;
+    }
+
+    private struct Struct256
+    {
+        public ulong U0;
+        public ulong U1;
+        public ulong U2;
+        public ulong U3;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Equal(Vector128<ulong>.Zero, ZeroVector128FullOpts());
+        Assert.Equal(Vector256<ulong>.Zero, ZeroVector256FullOpts());
+        Assert.Equal(Vector128<ulong>.Zero, ZeroVector128Tier0());
+        Assert.Equal(Vector256<ulong>.Zero, ZeroVector256Tier0());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<ulong> ZeroVector128FullOpts()
+    {
+        Unsafe.SkipInit(out Vector128<ulong> result);
+        Unsafe.As<Vector128<ulong>, Struct128>(ref result) = default;
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector256<ulong> ZeroVector256FullOpts()
+    {
+        Unsafe.SkipInit(out Vector256<ulong> result);
+        Unsafe.As<Vector256<ulong>, Struct256>(ref result) = default;
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<ulong> ZeroVector128Tier0()
+    {
+        Unsafe.SkipInit(out Vector128<ulong> result);
+        Unsafe.As<Vector128<ulong>, Struct128>(ref result) = default;
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector256<ulong> ZeroVector256Tier0()
+    {
+        Unsafe.SkipInit(out Vector256<ulong> result);
+        Unsafe.As<Vector256<ulong>, Struct256>(ref result) = default;
+        return result;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133085/Runtime_133085.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133085/Runtime_133085.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
`TryPrimitiveInit` created a SIMD zero node when converting a zero block initialization into a primitive local store, but the rationalized store retained its original integer-zero data node. This produced a SIMD store with an integer source, leading to invalid codegen and Tier0 compilation failures.

The missing source replacement was introduced by the assignment rationalization changes in #85585 (`53b4cd0912d`), where the legacy `GT_ASG` path updated `gtOp2` but the rationalized store path did not update `Data()`.

Before the fix, the `Vector256` case encoded `C4 E1 FD 6E C0` (`vmovq` with `VEX.L=1`). The corrected tree emits a SIMD zero (`vxorps`) in both FullOpts and Tier0. Regression coverage includes `Vector128` and `Vector256` in both modes.

Fixes #133085

> [!NOTE]
> This pull request description was generated with GitHub Copilot.