### PR TITLE
Avoid xcodebuild probe error without Xcode during NativeAOT

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -318,7 +318,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-L&quot;$(SysRoot)/$(_TizenToolchainLibDir)&quot;" Condition="'$(_IsTizenExitCode)' == '0'" />
     </ItemGroup>
 
-    <Exec Command="xcodebuild -version" Condition="'$(_IsApplePlatform)' == 'true' and '$(UseLdClassicXCodeLinker)' == ''" IgnoreExitCode="true" StandardOutputImportance="Low" ConsoleToMSBuild="true">
+    <Exec Command="xcodebuild -version" Condition="'$(_IsApplePlatform)' == 'true' and '$(UseLdClassicXCodeLinker)' == ''" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" StandardOutputImportance="Low" ConsoleToMSBuild="true">
       <Output TaskParameter="ExitCode" PropertyName="_XcodeVersionStringExitCode" />
       <Output TaskParameter="ConsoleOutput" PropertyName="_XcodeVersionString" />
     </Exec>


### PR DESCRIPTION
## Description

On macOS machines with only the Command Line Tools installed, `xcodebuild -version` writes an `xcode-select : error :` diagnostic to stderr. Although this probe already ignores its exit code, MSBuild recognizes that stderr line as a standard error and fails the NativeAOT publishing projects.

Set `IgnoreStandardErrorWarningFormat` on the NativeAOT probe, matching the equivalent probes in `crossgen-corelib.proj` and `Microsoft.NET.CrossGen.targets`.

This is a regression from .NET 10, where this target checked `clang --version` instead of invoking `xcodebuild`.
This worked in the past when the clang version was aligned to the Xcode version (specifically for 15 and 16 which we're using to decide whether to use classic ld) but nowadays it's not aligned anymore and will fail the build if Xcode isn't installed.

It changed in [`25f2dcb` (#123386)](https://github.com/dotnet/runtime/pull/123386/changes/25f2dcb378642a8bc33798b0d14e42dd6759a52b).

## Testing

- `./build.sh clr` on macOS with Command Line Tools installed but no Xcode

> [!NOTE]
> This pull request description was generated with GitHub Copilot.