### PR TITLE
Fix NativeAOT thread-static debug info

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -607,9 +607,12 @@ namespace ILCompiler
                 {
                     if (isCanonical)
                         continue;
-                    if (fieldDesc.IsThreadStatic && !hasThreadStatics)
-                        continue;
-                    if (fieldDesc.HasGCStaticBase)
+                    if (fieldDesc.IsThreadStatic)
+                    {
+                        if (!hasThreadStatics)
+                            continue;
+                    }
+                    else if (fieldDesc.HasGCStaticBase)
                     {
                         if (!hasGcStatics)
                             continue;


### PR DESCRIPTION
## Summary

- Treat thread-static, GC-static, and non-GC-static fields as mutually exclusive storage categories when emitting NativeAOT debug types.
- Preserve thread-static fields when the owning type has a generated thread-static index but no separately generated ordinary GC-static base.

## Problem

`FieldDesc.HasGCStaticBase` returns `true` for NativeAOT thread-static fields. The debug type writer first accepted a thread-static field based on `HasThreadStaticBase`, but then independently tested the same field as an ordinary GC-static field:

```csharp
if (fieldDesc.IsThreadStatic && !hasThreadStatics)
    continue;

if (fieldDesc.HasGCStaticBase)
{
    if (!hasGcStatics)
        continue;
}
```

This dropped all thread-static fields from types that had no separately generated GC-static base. An example is the `AsyncDispatcherInfo` ref struct:

```csharp
internal unsafe ref struct AsyncDispatcherInfo
{
    // Instance fields omitted.

    [ThreadStatic]
    internal static AsyncDispatcherInfo* t_current;
}
```

The index symbol was emitted because the type had thread-static storage, but the PDB omitted the typed parent member, thread-static storage UDT, helper UDT, and `t_current` field offset.

The fix makes the three storage categories mutually exclusive by changing the second test to `else if`.

## CDB validation

I built a small runtime-async NativeAOT application that roots `AsyncDispatcherInfo` and inspected its Windows PDB with CDB.

Before the fix, the index existed only as an untyped symbol. The parent type had no `__THREADSTATICINDEX`, and the thread-static storage type did not exist:

```text
0:000> x AsyncDispatcherPdb!S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo::__THREADSTATICINDEX
00007ff7`cd8a7ed8 AsyncDispatcherPdb!S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo::__THREADSTATICINDEX = <no type information>

0:000> dt AsyncDispatcherPdb!S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo
   +0x000 Next             : Ptr64 S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo
   +0x008 NextContinuation : Ptr64 S_P_CoreLib_System_Runtime_CompilerServices_Continuation
   +0x010 CurrentTask      : Ptr64 S_P_CoreLib_System_Threading_Tasks_Task
   +0x018 AsyncProfilerInfo : S_P_CoreLib_System_Runtime_CompilerServices_AsyncProfiler_Info

0:000> dt AsyncDispatcherPdb!__type__THREADSTATICSS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo
Symbol AsyncDispatcherPdb!__type__THREADSTATICSS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo not found.
```

After the fix, the parent UDT has a typed `__THREADSTATICINDEX`, the storage UDT contains `t_current` at offset `+0x008`, and the helper UDT is present:

```text
0:000> dt AsyncDispatcherPdb!S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo
   +0x000 Next             : Ptr64 S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo
   +0x008 NextContinuation : Ptr64 S_P_CoreLib_System_Runtime_CompilerServices_Continuation
   +0x010 CurrentTask      : Ptr64 S_P_CoreLib_System_Threading_Tasks_Task
   +0x018 AsyncProfilerInfo : S_P_CoreLib_System_Runtime_CompilerServices_AsyncProfiler_Info
   =00007ff6`a5957ed8 __THREADSTATICINDEX : __ThreadStaticHelper<__type__THREADSTATICSS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo>

0:000> dt AsyncDispatcherPdb!__type__THREADSTATICSS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo
   +0x000 __VFN_table      : Ptr64
   +0x000 m_pEEType        : Ptr64 S_P_CoreLib_Internal_Runtime_MethodTable
   +0x008 t_current        : Ptr64 S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo

0:000> dt AsyncDispatcherPdb!__ThreadStaticHelper*AsyncDispatcherInfo*
          AsyncDispatcherPdb!__ThreadStaticHelper<__type__THREADSTATICSS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo>
```

## Testing

```text
ILCompiler.Compiler.Tests: Passed 22, Failed 0, Skipped 0
```

> [!NOTE]
> This PR description was generated with GitHub Copilot.
