### PR TITLE
Fix SortedSet.IsSubsetOf et al

### DIFF
--- a/src/libraries/Common/src/System/Collections/Generic/BitHelper.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/BitHelper.cs
@@ -10,6 +10,8 @@ namespace System.Collections.Generic
         private const int IntSize = sizeof(int) * 8;
         private readonly Span<int> _span;
 
+        internal Span<int> Span => _span;
+
         internal BitHelper(Span<int> span, bool clear)
         {
             if (clear)

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -21,12 +21,14 @@ namespace System.Collections.Generic
             // up to date -> _countVersion = _underlying.version
             // not up to date -> _countVersion < _underlying.version
             private int _countVersion;
+            // level of the subsets root from the underlying roots.
+            // Is up-to date if _countVersion = _underlying.version
+            private int _rootLevel;
             // these exist for unbounded collections
             // for instance, you could allow this subset to be defined for i > 10. The set will throw if
             // anything <= 10 is added, but there is no upper bound. These features Head(), Tail(), were punted
             // in the spec, and are not available, but the framework is there to make them available at some point.
             private readonly bool _lBoundActive, _uBoundActive;
-            // used to see if the count is out of date
 
 #if DEBUG
             internal override bool versionUpToDate()
@@ -43,7 +45,7 @@ namespace System.Collections.Generic
                 _max = Max;
                 _lBoundActive = lowerBoundActive;
                 _uBoundActive = upperBoundActive;
-                root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive); // root is first element within range
+                root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive, out _rootLevel); // root is first element within range
                 count = 0;
                 version = -1;
                 _countVersion = -1;
@@ -287,23 +289,6 @@ namespace System.Collections.Generic
                 return base.FindNode(item);
             }
 
-            // this does indexing in an inefficient way compared to the actual sortedset, but it saves a
-            // lot of space
-            internal override int InternalIndexOf(T item)
-            {
-                int count = -1;
-                foreach (T i in this)
-                {
-                    count++;
-                    if (Comparer.Compare(item, i) == 0)
-                        return count;
-                }
-#if DEBUG
-                Debug.Assert(this.versionUpToDate() && root == _underlying.FindRange(_min, _max));
-#endif
-                return -1;
-            }
-
             /// <summary>
             /// Checks whether this subset is out of date, and updates it if necessary.
             /// </summary>
@@ -315,7 +300,7 @@ namespace System.Collections.Generic
                 Debug.Assert(_underlying != null);
                 if (version != _underlying.version)
                 {
-                    root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive);
+                    root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive, out _rootLevel);
                     version = _underlying.version;
                 }
 
@@ -334,6 +319,11 @@ namespace System.Collections.Generic
             {
                 Debug.Assert(_underlying != null);
                 return _underlying.Count;
+            }
+
+            internal override int GetApproximateMaxHeight()
+            {
+                return Math.Max(_underlying.GetApproximateMaxHeight() - _rootLevel, 0);
             }
 
             // This passes functionality down to the underlying tree, clipping edges if necessary

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Generic
             // not up to date -> _countVersion < _underlying.version
             private int _countVersion;
             // level of the subsets root from the underlying roots.
-            // Is up-to date if _countVersion = _underlying.version
+            // Is up-to date if version = _underlying.version
             private int _rootLevel;
             // these exist for unbounded collections
             // for instance, you could allow this subset to be defined for i > 10. The set will throw if

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -718,7 +718,7 @@ namespace System.Collections.Generic
         /// completely different from <see cref="TreeSubSet"/>'s, and that the two should not be mixed.
         /// </para>
         /// </remarks>
-        internal virtual int InternalIndexOf(T item)
+        internal int InternalIndexOf(T item)
         {
             Node? current = root;
             int count = 0;
@@ -737,11 +737,12 @@ namespace System.Collections.Generic
             return -1;
         }
 
-        internal Node? FindRange(T? from, T? to) => FindRange(from, to, lowerBoundActive: true, upperBoundActive: true);
+        internal Node? FindRange(T? from, T? to) => FindRange(from, to, lowerBoundActive: true, upperBoundActive: true, level: out _);
 
-        internal Node? FindRange(T? from, T? to, bool lowerBoundActive, bool upperBoundActive)
+        internal Node? FindRange(T? from, T? to, bool lowerBoundActive, bool upperBoundActive, out int level)
         {
             Node? current = root;
+            level = 0;
             while (current != null)
             {
                 if (lowerBoundActive && comparer.Compare(from, current.Item) > 0)
@@ -759,6 +760,7 @@ namespace System.Collections.Generic
                         return current;
                     }
                 }
+                level++;
             }
 
             return null;
@@ -1382,8 +1384,18 @@ namespace System.Collections.Generic
                 return result;
             }
 
-            int originalLastIndex = Count;
-            int intArrayLength = BitHelper.ToIntArrayLength(originalLastIndex);
+            int maxHeight = GetApproximateMaxHeight();
+
+            // maxHeight = 12 needs 8kb for bitHelper, use fallback with HashSet if maxHeight > 12 to mitigate
+            // this by limiting memory complexity to O(n).
+            if (maxHeight > 12)
+            {
+                return CheckUniqueAndUnfoundElementsFallback(other, returnIfUnfound);
+            }
+
+            // A perfect tree of height H has H^2 - 1 nodes; (round up to H^2).
+            int indexLimit = (1 << maxHeight);
+            int intArrayLength = BitHelper.ToIntArrayLength(indexLimit);
 
             Span<int> span = stackalloc int[StackAllocThreshold];
             BitHelper bitHelper = (uint)intArrayLength <= StackAllocThreshold ?
@@ -1391,14 +1403,14 @@ namespace System.Collections.Generic
                 new BitHelper(new int[intArrayLength], clear: false);
 
             // count of items in other not found in this
-            int UnfoundCount = 0;
+            int unfoundCount = 0;
             // count of unique items in other found in this
             int uniqueFoundCount = 0;
 
             foreach (T item in other)
             {
                 int index = InternalIndexOf(item);
-                if (index >= 0)
+                if ((uint)index < (uint)indexLimit) // Equivalent of "index >= 0 && index < indexLimit"
                 {
                     if (!bitHelper.IsMarked(index))
                     {
@@ -1407,9 +1419,53 @@ namespace System.Collections.Generic
                         uniqueFoundCount++;
                     }
                 }
+                else if (index < 0)
+                {
+                    unfoundCount++;
+                    if (returnIfUnfound)
+                    {
+                        break;
+                    }
+                }
                 else
                 {
-                    UnfoundCount++;
+                    // Safe guard: since maxHeight isn't guaranteed, we might need to grow the bitHelper.
+                    indexLimit = (int)BitOperations.RoundUpToPowerOf2((uint)index);
+                    intArrayLength = BitHelper.ToIntArrayLength(indexLimit);
+                    Span<int> newSpan = new int[intArrayLength];
+                    bitHelper.Span.CopyTo(newSpan);
+                    bitHelper = new BitHelper(newSpan, clear: false);
+                }
+            }
+
+            result.UniqueCount = uniqueFoundCount;
+            result.UnfoundCount = unfoundCount;
+            return result;
+        }
+
+        private ElementCount CheckUniqueAndUnfoundElementsFallback(IEnumerable<T> other, bool returnIfUnfound)
+        {
+            ElementCount result;
+            HashSet<Node>? seenNodes = null;
+            // count of items in other not found in this
+            int unfoundCount = 0;
+            // count of unique items in other found in this
+            int uniqueFoundCount = 0;
+
+            foreach (T item in other)
+            {
+                Node? node = FindNode(item);
+                if (node != null)
+                {
+                    seenNodes ??= new HashSet<Node>();
+                    if (seenNodes.Add(node))
+                    {
+                        uniqueFoundCount++;
+                    }
+                }
+                else
+                {
+                    unfoundCount++;
                     if (returnIfUnfound)
                     {
                         break;
@@ -1418,7 +1474,7 @@ namespace System.Collections.Generic
             }
 
             result.UniqueCount = uniqueFoundCount;
-            result.UnfoundCount = UnfoundCount;
+            result.UnfoundCount = unfoundCount;
             return result;
         }
 
@@ -2009,6 +2065,20 @@ namespace System.Collections.Generic
 
         // Used for set checking operations (using enumerables) that rely on counting
         private static int Log2(int value) => BitOperations.Log2((uint)value);
+
+        // The max height is approximate for two reasons:
+        // - SortedSet: the limit is based on "Introduction to algorithms" by Thomas H. Cormen,
+        //   but this implementation deviates slightly from the one in the book;
+        //   it does not immediately do the foxups after Adds/Removes elements, but it is lazily done
+        //   on subsequent Adds/Removes. Further proof is needed to guarantee the max height.
+        // - TreeSubSet: it is based on _rootLevel which can be out-of-date
+        //   (and _underlying.GetApproximateMaxHeight which is approximate).
+        internal virtual int GetApproximateMaxHeight()
+        {
+            // The maximum height of a red-black tree is 2 * log2(n+1).
+            // See page 264 of "Introduction to algorithms" by Thomas H. Cormen
+            return 2 * BitOperations.Log2((uint)count + 1);
+        }
 
         #endregion
     }

--- a/src/libraries/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -417,7 +417,7 @@ namespace System.Collections.Tests
             Assert.Equal(default(T), actualValue);
         }
 
-        #endregion
+#endregion
 
         #region SetEquals
 

--- a/src/libraries/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -417,6 +417,20 @@ namespace System.Collections.Tests
             Assert.Equal(default(T), actualValue);
         }
 
-#endregion
+        #endregion
+
+        #region SetEquals
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void SortedSet_Generic_SetEquals_SameButAllElementsDuplicated(int setLength)
+        {
+            SortedSet<T> set = (SortedSet<T>)GenericISetFactory(setLength);
+            List<T> list = set.ToList();
+            list.AddRange(set); // Duplicate all elements
+            Assert.True(set.SetEquals(list));
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes #102118

Another attempt at fixing this bug. It's a bit hard to solve because there are multiple algorithm options, each with its own pros and cons.

The solution I chose is a mix of choosing 1a/1b (see section below) depending on whether the theoretical maximum height of the binary tree is above or below a certain limit.

Finding the best choice for this limit is hard and dependent on the use case. My choice of a "max height" threshold of 14 corresponds to an element count of roughly 256 for a "regular" set (i.e., not `TreeSubSet`). It seemed like a "good enough guess" when looking at the benchmarks (both best- and worst-case).

NOTE: This is a correctness fix, so a performance impact is expected.

## 1. Algorithm options
### 1a. "Perfect tree" / "Exponential"

The name "perfect tree" comes from the idea that we use a `BitHelper` and mark seen elements by indexing them as if the tree were a perfect tree. This was the approach previously used in `SortedSet`, but the problem was that the buffer used in the `BitHelper` was not large enough.

The name "exponential" comes from the fact that the memory complexity of this algorithm grows exponentially (constant; worst/best case doesn't matter) with the set's element count (or something along those lines, at least worse than `O(n)`).

This algorithm is the fastest, but it should not be used when the set count grows above a certain limit due to its exponential memory complexity.

### 1b. "HashSet"

This fallback algorithm keeps track of which nodes have been seen with a `HashSet` (space complexity at worst `O(n)`).

The algorithm is fast and scales quite well speed-wise (time complexity `O(log(n))`).

Speed and memory footprint worsen when the `HashSet` is resized, but this could theoretically be fine-tuned.

### 1c. "Ordinal"

This algorithm uses a `BitHelper` and indexes the seen elements using their ordinal index (by iterating over them). This algorithm was used by `SortedSet.TreeSubSet`.

This algorithm has the lowest memory footprint but scales very poorly performance-wise (cf. benchmarks).

### 1d. Counted set

Each node could store the total count of its children (and itself). But I don't think this is an option since it would require an extra int to be stored for each node, as well as a performance hit on `Add` and `Remove` to update the counts.

If there is a situation where this is the best option, a type using this algorithm could be implemented outside of the .NET runtime.

## 2. Algorithm benchmarks

Below are benchmarks of algorithms 1a, 1b, and 1c. 1a fails above a certain number of elements due to memory constraint. 1d was a no-go due to the extra space requirement per node. Source code for the benchmarks can be found [here](https://github.com/lilinus/SortedSet.CheckUniqueAndUnfoundElements).

<details>
  <summary>Results for `SortedSet&lt;int&gt;` algorithm benchmarks</summary>

```
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8655/25H2/2025Update/HudsonValley2)
Intel Core Ultra 7 165H 1.40GHz, 1 CPU, 22 logical and 16 physical cores
.NET SDK 10.0.301
  [Host]     : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3 [AttachedDebugger]
  DefaultJob : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3
```
| Method                      | N      | Mean                 | Error              | StdDev             | Median               | Gen0      | Gen1      | Gen2      | Allocated |
|---------------------------- |------- |---------------------:|-------------------:|-------------------:|---------------------:|----------:|----------:|----------:|----------:|
| **Hash_WorstAllDifferentMatch** | **10**     |            **162.57 ns** |           **1.909 ns** |           **1.786 ns** |            **162.87 ns** |    **0.0629** |         **-** |         **-** |     **792 B** |
| Hash_BestOnlyRootMatch      | 10     |             76.40 ns |           0.747 ns |           0.699 ns |             76.40 ns |    0.0166 |         - |         - |     208 B |
| Ordinal_WorstAllMaxMatch    | 10     |            349.89 ns |           1.279 ns |           1.134 ns |            349.96 ns |    0.0095 |         - |         - |     120 B |
| Ordinal_BestAllBelowMin     | 10     |            118.34 ns |           1.412 ns |           1.321 ns |            118.03 ns |    0.0095 |         - |         - |     120 B |
| Exp_KindOfWorstAllBelowMin  | 10     |             72.50 ns |           0.571 ns |           0.534 ns |             72.40 ns |    0.0025 |         - |         - |      32 B |
| Exp_BestAllRootMatch        | 10     |             61.30 ns |           0.869 ns |           0.813 ns |             61.26 ns |    0.0025 |         - |         - |      32 B |
| **Hash_WorstAllDifferentMatch** | **100**    |          **1,565.43 ns** |           **9.797 ns** |           **8.685 ns** |          **1,564.84 ns** |    **0.5894** |    **0.0057** |         **-** |    **7408 B** |
| Hash_BestOnlyRootMatch      | 100    |            412.41 ns |           1.966 ns |           1.743 ns |            412.68 ns |    0.0162 |         - |         - |     208 B |
| Ordinal_WorstAllMaxMatch    | 100    |         29,882.80 ns |         175.578 ns |         137.080 ns |         29,932.25 ns |         - |         - |         - |     208 B |
| Ordinal_BestAllBelowMin     | 100    |          1,628.41 ns |           4.274 ns |           3.998 ns |          1,628.83 ns |    0.0153 |         - |         - |     208 B |
| Exp_KindOfWorstAllBelowMin  | 100    |            799.60 ns |           3.374 ns |           2.991 ns |            799.07 ns |    0.0448 |         - |         - |     568 B |
| Exp_BestAllRootMatch        | 100    |            430.34 ns |           1.925 ns |           1.706 ns |            430.43 ns |    0.0448 |         - |         - |     568 B |
| **Hash_WorstAllDifferentMatch** | **1000**   |         **46,878.13 ns** |         **535.563 ns** |         **474.762 ns** |         **46,947.13 ns** |    **5.7983** |    **0.5493** |         **-** |   **73184 B** |
| Hash_BestOnlyRootMatch      | 1000   |          3,870.13 ns |          13.112 ns |          12.265 ns |          3,867.69 ns |    0.0153 |         - |         - |     208 B |
| Ordinal_WorstAllMaxMatch    | 1000   |      2,421,882.16 ns |      34,814.727 ns |      32,565.717 ns |      2,433,587.11 ns |         - |         - |         - |     360 B |
| Ordinal_BestAllBelowMin     | 1000   |         18,426.51 ns |          37.719 ns |          35.283 ns |         18,429.62 ns |         - |         - |         - |     360 B |
| Exp_KindOfWorstAllBelowMin  | 1000   |          9,143.93 ns |         136.551 ns |         127.730 ns |          9,152.70 ns |    2.6093 |         - |         - |   32824 B |
| Exp_BestAllRootMatch        | 1000   |          4,852.18 ns |          59.744 ns |          55.885 ns |          4,858.77 ns |    2.6093 |         - |         - |   32824 B |
| **Hash_WorstAllDifferentMatch** | **10000**  |        **992,303.35 ns** |       **2,717.748 ns** |       **2,269.442 ns** |        **992,768.95 ns** |  **123.0469** |  **123.0469** |  **123.0469** |  **673121 B** |
| Hash_BestOnlyRootMatch      | 10000  |         58,244.38 ns |         438.220 ns |         388.471 ns |         58,196.37 ns |         - |         - |         - |     208 B |
| Ordinal_WorstAllMaxMatch    | 10000  |    467,737,091.67 ns |   3,307,450.069 ns |   2,582,239.460 ns |    468,235,600.00 ns |         - |         - |         - |    1640 B |
| Ordinal_BestAllBelowMin     | 10000  |        345,561.93 ns |       9,149.678 ns |      26,978.034 ns |        364,458.03 ns |         - |         - |         - |    1640 B |
| Exp_KindOfWorstAllBelowMin  | 10000  |        773,120.62 ns |      14,147.622 ns |      13,233.694 ns |        771,234.28 ns |  328.1250 |  328.1250 |  328.1250 | 8390304 B |
| Exp_BestAllRootMatch        | 10000  |        327,851.07 ns |       9,024.394 ns |      26,466.987 ns |        329,847.66 ns |  246.0938 |  246.0938 |  246.0938 | 8389982 B |
| **Hash_WorstAllDifferentMatch** | **100000** |     **15,792,459.38 ns** |     **248,869.991 ns** |     **244,423.608 ns** |     **15,730,910.16 ns** | **1015.6250** | **1000.0000** | **1000.0000** | **6037960 B** |
| Hash_BestOnlyRootMatch      | 100000 |        603,061.62 ns |       5,670.363 ns |       5,026.629 ns |        602,957.62 ns |         - |         - |         - |     208 B |
| Ordinal_WorstAllMaxMatch    | 100000 | 95,682,159,521.05 ns | 340,762,354.574 ns | 378,756,454.301 ns | 95,678,489,400.00 ns |         - |         - |         - |   13168 B |
| Ordinal_BestAllBelowMin     | 100000 |      3,637,889.54 ns |      71,525.188 ns |     146,107.017 ns |      3,647,872.66 ns |         - |         - |         - |   12888 B |
| Exp_KindOfWorstAllBelowMin  | 100000 |                   NA |                 NA |                 NA |                   NA |        NA |        NA |        NA |        NA |
| Exp_BestAllRootMatch        | 100000 |                   NA |                 NA |                 NA |                   NA |        NA |        NA |        NA |        NA |
</details>

<details>
  <summary>Results for `SortedSet&lt;Guid&gt;` algorithm benchmarks</summary>

```
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8655/25H2/2025Update/HudsonValley2)
Intel Core Ultra 7 165H 1.40GHz, 1 CPU, 22 logical and 16 physical cores
.NET SDK 10.0.301
  [Host]     : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3 [AttachedDebugger]
  DefaultJob : .NET 10.0.9 (10.0.9, 10.0.926.27113), X64 RyuJIT x86-64-v3
```
| Method                      | N     | Mean             | Error           | StdDev          | Gen0     | Gen1     | Gen2     | Allocated |
|---------------------------- |------ |-----------------:|----------------:|----------------:|---------:|---------:|---------:|----------:|
| **Hash_WorstAllDifferentMatch** | **20**    |         **397.7 ns** |         **2.23 ns** |         **2.08 ns** |   **0.1259** |   **0.0005** |        **-** |    **1584 B** |
| Hash_BestOnlyRootMatch      | 20    |         175.4 ns |         1.79 ns |         1.39 ns |   0.0165 |        - |        - |     208 B |
| Ordinal_WorstAllMaxMatch    | 20    |       1,523.8 ns |        18.64 ns |        17.43 ns |   0.0153 |        - |        - |     208 B |
| Ordinal_BestAllBelowMin     | 20    |         409.4 ns |         3.43 ns |         3.04 ns |   0.0162 |        - |        - |     208 B |
| Exp_KindOfWorstAllBelowMin  | 20    |         215.3 ns |         3.05 ns |         2.71 ns |   0.0024 |        - |        - |      32 B |
| Exp_BestAllRootMatch        | 20    |         144.7 ns |         1.20 ns |         1.00 ns |   0.0024 |        - |        - |      32 B |
| **Hash_WorstAllDifferentMatch** | **100**   |       **2,000.8 ns** |        **23.66 ns** |        **20.97 ns** |   **0.5875** |   **0.0038** |        **-** |    **7408 B** |
| Hash_BestOnlyRootMatch      | 100   |         681.3 ns |        11.05 ns |         8.63 ns |   0.0162 |        - |        - |     208 B |
| Ordinal_WorstAllMaxMatch    | 100   |      31,700.5 ns |       607.47 ns |       538.51 ns |        - |        - |        - |     208 B |
| Ordinal_BestAllBelowMin     | 100   |       1,816.3 ns |        19.33 ns |        18.08 ns |   0.0153 |        - |        - |     208 B |
| Exp_KindOfWorstAllBelowMin  | 100   |       1,217.1 ns |        11.26 ns |         9.98 ns |   0.0439 |        - |        - |     568 B |
| Exp_BestAllRootMatch        | 100   |         601.7 ns |         9.31 ns |        12.10 ns |   0.0448 |        - |        - |     568 B |
| **Hash_WorstAllDifferentMatch** | **1000**  |      **62,619.5 ns** |       **983.82 ns** |       **920.27 ns** |   **5.7373** |   **0.4883** |        **-** |   **73184 B** |
| Hash_BestOnlyRootMatch      | 1000  |       6,600.3 ns |        30.48 ns |        23.80 ns |   0.0153 |        - |        - |     208 B |
| Ordinal_WorstAllMaxMatch    | 1000  |   3,050,694.6 ns |    57,114.82 ns |    53,425.24 ns |        - |        - |        - |     360 B |
| Ordinal_BestAllBelowMin     | 1000  |      19,272.9 ns |       152.96 ns |       143.08 ns |        - |        - |        - |     360 B |
| Exp_KindOfWorstAllBelowMin  | 1000  |      15,213.8 ns |       204.60 ns |       191.39 ns |   2.6093 |        - |        - |   32824 B |
| Exp_BestAllRootMatch        | 1000  |       6,761.6 ns |       113.08 ns |       121.00 ns |   2.6093 |        - |        - |   32824 B |
| **Hash_WorstAllDifferentMatch** | **10000** |   **1,158,963.9 ns** |     **7,091.34 ns** |     **5,921.59 ns** | **123.0469** | **123.0469** | **123.0469** |  **673121 B** |
| Hash_BestOnlyRootMatch      | 10000 |      66,598.6 ns |       982.32 ns |       918.86 ns |        - |        - |        - |     208 B |
| Ordinal_WorstAllMaxMatch    | 10000 | 601,739,484.6 ns | 7,719,593.54 ns | 6,446,210.23 ns |        - |        - |        - |    1640 B |
| Ordinal_BestAllBelowMin     | 10000 |     228,204.3 ns |     2,765.64 ns |     2,451.67 ns |        - |        - |        - |    1640 B |
| Exp_KindOfWorstAllBelowMin  | 10000 |     468,254.1 ns |     9,262.26 ns |    22,545.61 ns | 488.2813 | 488.2813 | 488.2813 | 8392712 B |
| Exp_BestAllRootMatch        | 10000 |     581,270.5 ns |    11,549.08 ns |    34,052.72 ns | 243.1641 | 243.1641 | 243.1641 | 8390309 B |
</details>