### PR TITLE
[release/11.0] Fix Crossgen2 variance validation for type constraints

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -94,7 +94,7 @@ public class R2RTestSuites
         }
     }
 
-    [ConditionalFact(typeof(TestPaths), nameof(TestPaths.IsWasmTarget))]
+    [Fact]
     public void WasmWebcilModule()
     {
         var wasmWebcilModule = new CompiledAssembly

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -63,6 +63,38 @@ public class R2RTestSuites
     }
 
     [Fact]
+    public void GenericTypeConstraintsAllowVariantParameters()
+    {
+        var genericTypeConstraints = new CompiledAssembly
+        {
+            AssemblyName = nameof(GenericTypeConstraintsAllowVariantParameters),
+            SourceResourceNames = ["TypeValidation/GenericTypeConstraints.cs"],
+        };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(GenericTypeConstraintsAllowVariantParameters),
+            [
+                new(nameof(GenericTypeConstraintsAllowVariantParameters), [new CrossgenAssembly(genericTypeConstraints)])
+                {
+                    AdditionalArgs =
+                    {
+                        "--compile-no-methods",
+                        "--type-validation",
+                        "AutomaticWithLogging",
+                    },
+                    Validate = Validate,
+                },
+            ]));
+
+        static void Validate(ReadyToRunReader reader)
+        {
+            Assert.True(
+                (reader.ReadyToRunHeader.Flags & (uint)ReadyToRunFlags.READYTORUN_FLAG_SkipTypeValidation) != 0,
+                "Expected the ReadyToRun image to skip runtime type validation.");
+        }
+    }
+
+    [ConditionalFact(typeof(TestPaths), nameof(TestPaths.IsWasmTarget))]
     public void WasmWebcilModule()
     {
         var wasmWebcilModule = new CompiledAssembly

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/TypeValidation/GenericTypeConstraints.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/TypeValidation/GenericTypeConstraints.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+public interface IStrongEnumerator<T>
+{
+}
+
+public interface IStrongEnumerable<out T, TEnumerator>
+    where TEnumerator : struct, IStrongEnumerator<T>
+{
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
@@ -310,7 +310,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
 
                     // Validate that generic variance is properly respected in method signatures
-                    if (type.IsInterface && method.IsVirtual && !method.Signature.IsStatic && type.HasInstantiation)
+                    if (type.IsInterface && type.HasInstantiation && (method.IsVirtual || !method.Signature.IsStatic))
                     {
                         if (!ValidateVarianceInSignature(type.Instantiation, method.Signature, Internal.TypeSystem.GenericVariance.Covariant, Internal.TypeSystem.GenericVariance.Contravariant))
                         {
@@ -341,18 +341,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 // Generic class special rules
                 // Validate that a generic class cannot be a ComImport class, or a ComEventInterface class -- UNIMPLEMENTED
-
-                foreach (var genericParameterType in type.Instantiation)
-                {
-                    foreach (var constraint in ((GenericParameterDesc)genericParameterType).TypeConstraints)
-                    {
-                        if (!ValidateVarianceInType(type.Instantiation, constraint, Internal.TypeSystem.GenericVariance.Contravariant))
-                        {
-                            AddTypeValidationError(type, $"'{genericParameterType}' has invalid variance in generic parameter constraint {constraint}");
-                            return false;
-                        }
-                    }
-                }
+                // A generic type's own parameter constraints have no variance restrictions (ECMA-335 II.9.7).
 
                 // Validate that generic variance is properly respected in interface signatures
                 if (type.HasInstantiation && type.IsInterface)


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/132809 to release/11.0-rc1

## Customer Impact

- [X] Customer reported
- [ ] Found internally

Crossgen2 applied method generic-constraint variance rules to a generic type's own constraints. ECMA-335 II.9.7 explicitly leaves type-owned constraints unrestricted, so valid variant interfaces could fail automatic validation and omit READYTORUN_FLAG_SkipTypeValidation, disabling the perf optimization.

This change:

- removes the invalid variance check for type-owned generic constraints
- aligns interface method signature validation with the VM by checking all instance methods and - virtual methods, including static virtual and static abstract declarations
- adds a ReadyToRun regression test based on the reported constraint pattern

Fixes https://github.com/dotnet/runtime/issues/132724

## Regression

- [x] Yes. https://github.com/dotnet/runtime/pull/120459 introduced the regression.

## Testing

A new test was added to ILCompiler.ReadyToRun.Tests that reproduced the issue. The test passes with the changes.

## Risk

Low. The change makes the validation match the ECMA spec and matches the validation in the runtime.