### PR TITLE
[release/10.0] Fix Crossgen2 variance validation for type constraints

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
@@ -309,7 +309,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
 
                     // Validate that generic variance is properly respected in method signatures
-                    if (type.IsInterface && method.IsVirtual && !method.Signature.IsStatic && type.HasInstantiation)
+                    if (type.IsInterface && type.HasInstantiation && (method.IsVirtual || !method.Signature.IsStatic))
                     {
                         if (!ValidateVarianceInSignature(type.Instantiation, method.Signature, Internal.TypeSystem.GenericVariance.Covariant, Internal.TypeSystem.GenericVariance.Contravariant))
                         {
@@ -340,18 +340,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 // Generic class special rules
                 // Validate that a generic class cannot be a ComImport class, or a ComEventInterface class -- UNIMPLEMENTED
-
-                foreach (var genericParameterType in type.Instantiation)
-                {
-                    foreach (var constraint in ((GenericParameterDesc)genericParameterType).TypeConstraints)
-                    {
-                        if (!ValidateVarianceInType(type.Instantiation, constraint, Internal.TypeSystem.GenericVariance.Contravariant))
-                        {
-                            AddTypeValidationError(type, $"'{genericParameterType}' has invalid variance in generic parameter constraint {constraint}");
-                            return false;
-                        }
-                    }
-                }
+                // A generic type's own parameter constraints have no variance restrictions (ECMA-335 II.9.7).
 
                 // Validate that generic variance is properly respected in interface signatures
                 if (type.HasInstantiation && type.IsInterface)


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/132809 to release/10.0

## Customer Impact

- [X] Customer reported
- [ ] Found internally

Crossgen2 applied method generic-constraint variance rules to a generic type's own constraints. ECMA-335 II.9.7 explicitly leaves type-owned constraints unrestricted, so valid variant interfaces could fail automatic validation and omit `READYTORUN_FLAG_SkipTypeValidation`, disabling the perf optimization.

This change:

- removes the invalid variance check for type-owned generic constraints
- aligns interface method signature validation with the VM by checking all instance methods and - virtual methods, including static virtual and static abstract declarations
- adds a ReadyToRun regression test based on the reported constraint pattern

Fixes https://github.com/dotnet/runtime/issues/132724

## Regression

- [x] Yes. 
- [ ] No
https://github.com/dotnet/runtime/pull/120459 introduced the regression.

## Testing

Testing was done on `main` and `release/11.0-rc1`. `release/10.0` does not have the test project that the test was added to. The test project was manually built locally and contained the expected `READYTORUN_FLAG_SkipTypeValidation` flag.

## Risk

Low. The change makes the validation match the ECMA spec and matches the validation in the runtime.