### PR TITLE
Invalidate PGO after Wasm SCC transform

### DIFF
--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -1560,6 +1560,14 @@ PhaseStatus Compiler::fgWasmTransformSccs()
         transformed = fgWasm.WasmTransformSccs(sccs);
         assert(transformed);
 
+        // Weight moved from the SCC entry blocks through the dispatcher, so any
+        // profile data we had is no longer self-consistent.
+        if (fgPgoConsistent)
+        {
+            JITDUMP("Profile is now inconsistent: SCC entry flow was rerouted\n");
+            fgPgoConsistent = false;
+        }
+
 #ifdef DEBUG
         // Rebuild DFS and loops; verify no improper headers remain.
         // We should not have altered the EH reachability of any block.


### PR DESCRIPTION
## Summary

The Wasm SCC transform rewrites multi-entry SCCs to route entry flow through a dispatcher. When profile data has already been incorporated, that rewrite can leave block weights structurally inconsistent with the new CFG and trigger checked JIT profile verification asserts.

This conservatively marks PGO data inconsistent after the SCC transform, matching the existing approach used by `fgWasmRepairTryEntries` when it reroutes weighted flow.

Fixes #133120.

## Validation

- `./build.sh clr+libs+host`
- `python3 src/coreclr/scripts/jitformat.py -r . -o osx -a arm64`
- `./build.sh clr`

> [!NOTE]
> This PR description was generated by GitHub Copilot.