### PR TITLE
Fold RuntimeInformation.IsOSPlatform / OperatingSystem.IsOSPlatform in ILLink

### DIFF
--- a/src/coreclr/tools/ILTrim.Tests/ILTrimExpectedFailures.txt
+++ b/src/coreclr/tools/ILTrim.Tests/ILTrimExpectedFailures.txt
@@ -463,6 +463,7 @@ UnreachableBlock.MethodArgumentPropagation
 UnreachableBlock.MethodWithParametersSubstitutions
 UnreachableBlock.MultiStageRemoval
 UnreachableBlock.NestedFinallyInFinallyHandler
+UnreachableBlock.OSPlatformGuard
 UnreachableBlock.ReplacedJumpTarget
 UnreachableBlock.ReplacedReturns
 UnreachableBlock.ResultInliningNotPossible

--- a/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -898,6 +898,82 @@ namespace Mono.Linker.Steps
                 return true;
             }
 
+            // Recognizes the OS platform-guard idiom and evaluates it to a constant. Unlike the
+            // OperatingSystem.IsX() predicates (per-target literals the generic analyzer already folds),
+            // IsOSPlatform routes through an instance String.Equals and, for the RuntimeInformation
+            // overload, an opaque OSPlatform struct, so it needs direct handling. The recognized platform
+            // token is mapped to its OperatingSystem.IsX() predicate, which is then folded normally -- that
+            // predicate also encodes the OSX/MacCatalyst aliasing, so no manual replication is needed.
+            bool TryEvaluateOSPlatformGuard(in UnreachableBlocksOptimizer optimizer, MethodDefinition md, Collection<Instruction> instructions, int callIndex, [NotNullWhen(true)] out Instruction? result)
+            {
+                result = null;
+
+                if (md.Name != "IsOSPlatform" || !md.IsStatic || md.GetMetadataParametersCount() != 1 || callIndex < 1)
+                    return false;
+
+                bool isRuntimeInformation = md.DeclaringType.IsTypeOf("System.Runtime.InteropServices", "RuntimeInformation");
+                bool isOperatingSystem = md.DeclaringType.IsTypeOf("System", "OperatingSystem");
+                if (!isRuntimeInformation && !isOperatingSystem)
+                    return false;
+
+                Instruction argProducer = instructions[callIndex - 1];
+                string? token;
+
+                if (isOperatingSystem)
+                {
+                    // OperatingSystem.IsOSPlatform(string) with a literal platform name.
+                    token = argProducer.OpCode.Code == Code.Ldstr ? (string)argProducer.Operand : null;
+                }
+                else
+                {
+                    // RuntimeInformation.IsOSPlatform(OSPlatform) built from a well-known OSPlatform value.
+                    if (argProducer.OpCode.Code != Code.Call)
+                        return false;
+
+                    MethodDefinition? producer = context.TryResolve((MethodReference)argProducer.Operand);
+                    if (producer == null || !producer.DeclaringType.IsTypeOf("System.Runtime.InteropServices", "OSPlatform"))
+                        return false;
+
+                    token = producer.Name switch
+                    {
+                        "get_Windows" => "WINDOWS",
+                        "get_Linux" => "LINUX",
+                        "get_OSX" => "OSX",
+                        "get_FreeBSD" => "FREEBSD",
+                        "Create" when callIndex >= 2 && instructions[callIndex - 2].OpCode.Code == Code.Ldstr
+                            => (string)instructions[callIndex - 2].Operand,
+                        _ => null,
+                    };
+                }
+
+                string? predicate = token?.ToUpperInvariant() switch
+                {
+                    "WINDOWS" => "IsWindows",
+                    "LINUX" => "IsLinux",
+                    "OSX" or "MACOS" => "IsMacOS",
+                    "BROWSER" => "IsBrowser",
+                    "WASI" => "IsWasi",
+                    "ANDROID" => "IsAndroid",
+                    "IOS" => "IsIOS",
+                    "MACCATALYST" => "IsMacCatalyst",
+                    "TVOS" => "IsTvOS",
+                    "FREEBSD" => "IsFreeBSD",
+                    _ => null, // unknown/custom platform: leave the guard untouched
+                };
+                if (predicate == null)
+                    return false;
+
+                TypeDefinition? operatingSystem = md.DeclaringType.Module.GetType("System.OperatingSystem");
+                MethodDefinition? isPlatform = operatingSystem?.Methods.FirstOrDefault(
+                    m => m.Name == predicate && m.IsStatic && m.HasBody && m.GetMetadataParametersCount() == 0);
+                if (isPlatform == null)
+                    return false;
+
+                // The predicate body is a per-target 'return true/false', which the constant analyzer folds.
+                result = optimizer.TryGetMethodCallResult(new CalleePayload(isPlatform, Array.Empty<Instruction>()))?.Instruction;
+                return result != null;
+            }
+
             public bool ApplyTemporaryInlining(in UnreachableBlocksOptimizer optimizer)
             {
                 bool changed = false;
@@ -919,6 +995,19 @@ namespace Mono.Linker.Steps
                             // Not supported
                             if (md.IsVirtual || md.CallingConvention == MethodCallingConvention.VarArg)
                                 break;
+
+                            // RuntimeInformation.IsOSPlatform(OSPlatform.X) / OperatingSystem.IsOSPlatform("X")
+                            // don't fold through the generic constant analyzer (the argument flows through an
+                            // opaque OSPlatform struct or an instance String.Equals). Recognize the guard idiom
+                            // directly so its dead branch (and any foreign P/Invoke it protects) can be trimmed.
+                            if (context.IsOptimizationEnabled(CodeOptimizations.IPConstantPropagation, Body.Method)
+                                && TryEvaluateOSPlatformGuard(optimizer, md, instructions, i, out Instruction? osGuardResult))
+                            {
+                                RewriteToNop(i - 1, 1);
+                                Rewrite(i, osGuardResult);
+                                changed = true;
+                                break;
+                            }
 
                             Instruction[]? args = GetArgumentsOnStack(md, FoldedInstructions ?? instructions, i);
                             targetResult = args?.Length > 0 && md.IsStatic ? EvaluateIntrinsicCall(md, args) : null;

--- a/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -957,6 +957,7 @@ namespace Mono.Linker.Steps
                     "IOS" => "IsIOS",
                     "MACCATALYST" => "IsMacCatalyst",
                     "TVOS" => "IsTvOS",
+                    "WATCHOS" => "IsWatchOS",
                     "FREEBSD" => "IsFreeBSD",
                     _ => null, // unknown/custom platform: leave the guard untouched
                 };

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/UnreachableBlockTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/UnreachableBlockTests.g.cs
@@ -68,6 +68,12 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task OSPlatformGuard()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task ReplacedJumpTarget()
         {
             return RunTest(allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/OSPlatformGuard.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/OSPlatformGuard.cs
@@ -1,0 +1,89 @@
+using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.UnreachableBlock
+{
+    [SetupCSharpCompilerToUse("csc")]
+    [SetupCompileArgument("/optimize+")]
+    [SetupLinkerArgument("--enable-opt", "ipconstprop")]
+    public class OSPlatformGuard
+    {
+        public static void Main()
+        {
+            TestRuntimeInformationIsOSPlatform();
+            TestRuntimeInformationCreate();
+            TestOperatingSystemIsOSPlatform();
+
+            // Keep every branch target reachable independently so their retention is platform-independent.
+            // The guards above are still folded to a constant, asserted via ExpectBodyModified (without the
+            // platform-guard folding IsOSPlatform never folds and the bodies would be unchanged).
+            Windows();
+            NotWindows();
+            Linux();
+            NotLinux();
+            FreeBSD();
+            NotFreeBSD();
+        }
+
+        [Kept]
+        [ExpectBodyModified]
+        static void TestRuntimeInformationIsOSPlatform()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Windows();
+            else
+                NotWindows();
+        }
+
+        [Kept]
+        [ExpectBodyModified]
+        static void TestRuntimeInformationCreate()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")))
+                FreeBSD();
+            else
+                NotFreeBSD();
+        }
+
+        [Kept]
+        [ExpectBodyModified]
+        static void TestOperatingSystemIsOSPlatform()
+        {
+            if (System.OperatingSystem.IsOSPlatform("Linux"))
+                Linux();
+            else
+                NotLinux();
+        }
+
+        [Kept]
+        static void Windows()
+        {
+        }
+
+        [Kept]
+        static void NotWindows()
+        {
+        }
+
+        [Kept]
+        static void Linux()
+        {
+        }
+
+        [Kept]
+        static void NotLinux()
+        {
+        }
+
+        [Kept]
+        static void FreeBSD()
+        {
+        }
+
+        [Kept]
+        static void NotFreeBSD()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

ILLink: fold `RuntimeInformation.IsOSPlatform` / `OperatingSystem.IsOSPlatform`.

`UnreachableBlocksOptimizer` already constant-folds `OperatingSystem.IsX()` (whose per-target bodies reduce to a literal), but not `RuntimeInformation.IsOSPlatform(OSPlatform.X)` or `OperatingSystem.IsOSPlatform("X")` — those go through an opaque `OSPlatform` struct plus an instance `String.Equals`, so the guarded branch (and any P/Invokes inside it) survived trimming.

This maps the `OSPlatform` token (`get_Windows`/`Linux`/`OSX`/`FreeBSD`, `OSPlatform.Create("literal")`, or a string literal) to the corresponding public `OperatingSystem.IsX()` predicate and folds it through the existing machinery — that predicate also encodes the OSX/MacCatalyst aliasing, so no manual replication is needed. Unknown/custom platform tokens are left untouched (the guard is not folded), so a branch guarding an unrecognized platform is never removed.

As a result, OS-guarded branches are removed when the shared framework is trimmed for a specific target (e.g. `browser`/`wasi`), taking their platform-specific P/Invokes with them.

## Testing

- ILLink `UnreachableBlock` linker tests pass (23/23), including a new `OSPlatformGuard` case covering `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)`, `OSPlatform.Create("FREEBSD")`, and `OperatingSystem.IsOSPlatform("Linux")`.
- The new case is registered as an expected ILTrim limitation (`ILTrimExpectedFailures.txt`) and added to the ILLink analyzer test generator snapshot; the analyzer `OSPlatformGuard` test passes.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.
