### PR TITLE
Fix Wasm SCC profile weights for #133120

### DIFF
--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -821,6 +821,12 @@ public:
                 headerNumber++;
             }
 
+            // All entry flow now passes through the try header before reaching the dispatcher.
+            if (tryHeader != nullptr)
+            {
+                tryHeader->setBBProfileWeight(TotalEntryWeight());
+            }
+
             // Create the dispatch switch... really there should be no default but for now we'll have one.
             //
             JITDUMP("\nDispatch header is " FMT_BB "; %u cases\n", dispatcher->bbNum, numHeaders);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Runtime_133120
+{
+    private static readonly Dictionary<int, Func<CancellationToken, Task>> s_validators = new()
+    {
+        [0] = static _ => Task.CompletedTask,
+    };
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        ValidateAsync().GetAwaiter().GetResult();
+    }
+
+    private static async Task ValidateAsync(CancellationToken cancellationToken = default)
+    {
+        List<Exception>? exceptions = null;
+
+        foreach (Func<CancellationToken, Task> validator in s_validators.Values)
+        {
+            try
+            {
+                await validator(cancellationToken).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException ex)
+            {
+                exceptions ??= new();
+                exceptions.Add(ex);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                (exceptions ??= new()).Add(ex);
+                break;
+            }
+        }
+
+        if (exceptions is not null)
+        {
+            if (exceptions.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+            }
+
+            if (exceptions.Count > 1)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>true</Optimize>
+    <AlwaysUseCrossGen2 Condition="'$(TargetOS)' == 'browser'">true</AlwaysUseCrossGen2>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
+    <CrossGen2TestExtraArguments>$(CrossGen2TestExtraArguments) --codegenopt:JitSynthesizeCounts=1</CrossGen2TestExtraArguments>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes #133120.

The Wasm SCC switch-dispatch transformation routes all entry flow through an enclosing try header, but previously left that header's profile weight unchanged. This produced inconsistent profile weights and CrossGen2 assertions for ReadyToRun/PGO compilation.

This change updates the try header to the aggregate SCC entry weight after rewiring and adds a regression test covering the async validator/catch control-flow shape.

Validation performed:
- Checked browser-wasm CoreCLR/JIT rebuild
- Original Microsoft.Extensions.Options CrossGen2 repro
- Single-method and reduced synthetic-profile repros
- Browser-wasm regression test CrossGen2/R2R generation

End-to-end Node.js execution was unavailable because Node.js is not installed in the environment.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.