### PR TITLE
Expose the executing RuntimeAsync continuation to diagnostics

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -153,7 +153,8 @@ namespace System.Runtime.CompilerServices
         [FieldOffset(0)]
         public AsyncDispatcherInfo* Next;
 
-        // Next continuation the dispatcher will process.
+        // Next continuation the dispatcher will process. While a continuation
+        // is executing, this field remains set to that continuation.
 #if TARGET_64BIT
         [FieldOffset(8)]
 #else
@@ -963,12 +964,10 @@ namespace System.Runtime.CompilerServices
                 while (true)
                 {
                     Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
+                    Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
+                    Continuation? nextContinuation = curContinuation.Next;
                     try
                     {
-                        Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
-                        Continuation? nextContinuation = curContinuation.Next;
-                        asyncDispatcherInfo.NextContinuation = nextContinuation;
-
                         Debug.Assert(awaitState.CurrentThread != null);
                         if (curContinuation.TryGetExecutionContext(out ExecutionContext? execContext))
                         {
@@ -989,11 +988,13 @@ namespace System.Runtime.CompilerServices
                             refDispatcherInfo = asyncDispatcherInfo.Next;
                             return;
                         }
+
+                        asyncDispatcherInfo.NextContinuation = nextContinuation;
                     }
                     catch (Exception ex)
                     {
                         uint unwindedFrames = 1; // Count current frame.
-                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
+                        Continuation? handlerContinuation = UnwindToPossibleHandler(nextContinuation, ex, ref unwindedFrames);
                         if (handlerContinuation == null)
                         {
                             // Tail of AsyncTaskMethodBuilderT.SetException
@@ -1085,11 +1086,9 @@ namespace System.Runtime.CompilerServices
                 {
                     Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
                     Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
+                    Continuation? nextContinuation = curContinuation.Next;
                     try
                     {
-                        Continuation? nextContinuation = curContinuation.Next;
-                        asyncDispatcherInfo.NextContinuation = nextContinuation;
-
                         RuntimeAsyncInstrumentationHelpers.SyncPointCheck(ref asyncDispatcherInfo, flags, curContinuation);
 
                         Debug.Assert(awaitState.CurrentThread != null);
@@ -1117,11 +1116,12 @@ namespace System.Runtime.CompilerServices
                         }
 
                         RuntimeAsyncInstrumentationHelpers.CompleteRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
+                        asyncDispatcherInfo.NextContinuation = nextContinuation;
                     }
                     catch (Exception ex)
                     {
                         uint unwindedFrames = 1; // Count current frame.
-                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
+                        Continuation? handlerContinuation = UnwindToPossibleHandler(nextContinuation, ex, ref unwindedFrames);
                         if (handlerContinuation == null)
                         {
                             RuntimeAsyncInstrumentationHelpers.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);


### PR DESCRIPTION
## Summary

Delay advancing `AsyncDispatcherInfo.NextContinuation` until the current RuntimeAsync continuation finishes executing.

While a RuntimeAsync method is active, diagnostics can now observe:

```text
NextContinuation      -> currently executing continuation
NextContinuation.Next -> remaining RuntimeAsync callers
CurrentTask            -> owning RuntimeAsyncTask
```

This allows diagnostics tools to reconstruct the active logical RuntimeAsync stack from managed runtime state without relying on physical stack frames.

## Previous behavior

The dispatcher advanced `NextContinuation` before calling `Resume`:

```csharp
Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
Continuation? nextContinuation = curContinuation.Next;
asyncDispatcherInfo.NextContinuation = nextContinuation;
curContinuation.Resume(...);
```

Consequently, the executing continuation was held only in a local variable. For the final continuation in a chain, `NextContinuation` was null while user code was executing.

## New behavior

Both dispatcher loops cache the successor but leave `NextContinuation` pointing at the active continuation until processing completes:

```csharp
Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
Continuation? nextContinuation = curContinuation.Next;
curContinuation.Resume(...);
asyncDispatcherInfo.NextContinuation = nextContinuation;
```

Dispatch order and task behavior remain unchanged.

Exception unwinding starts from the cached `nextContinuation`, preserving the previous behavior of skipping the continuation that threw when searching for a handler. Suspension also remains unchanged because the dispatcher is removed from `AsyncDispatcherInfo.t_current` before returning.

The normal and instrumented dispatch loops use the same continuation-field semantics.

## Compatibility

This does not change the name, type, offset, size, layout, or GC-reference count of `AsyncDispatcherInfo`. It only changes when the existing continuation slot is updated.

## Testing

- Checked `clr+libs+host` build
- CoreCLR `async` subtree: 133 passed
- `profiler/runtimeasyncapis`: passed

> [!NOTE]
> This PR description was generated with GitHub Copilot.
