### PR TITLE
Fix Wasm SCC dispatcher predecessor rewrites

### DIFF
--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -821,6 +821,12 @@ public:
                 headerNumber++;
             }
 
+            // All entry flow now passes through the try header before reaching the dispatcher.
+            if (tryHeader != nullptr)
+            {
+                tryHeader->setBBProfileWeight(TotalEntryWeight());
+            }
+
             // Create the dispatch switch... really there should be no default but for now we'll have one.
             //
             JITDUMP("\nDispatch header is " FMT_BB "; %u cases\n", dispatcher->bbNum, numHeaders);

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -624,16 +624,37 @@ public:
             //
             const unsigned controlVarNum =
                 m_compiler->lvaGrabTemp(/* shortLifetime */ false DEBUGARG("Scc control var"));
-            LclVarDsc* const controlVarDsc = m_compiler->lvaGetDesc(controlVarNum);
-            controlVarDsc->lvType          = TYP_INT;
-            BasicBlock*      dispatcher    = nullptr;
-            BasicBlock*      tryHeader     = TryHeader();
-            FlowEdge** const succs         = new (m_compiler, CMK_FlowEdge) FlowEdge*[numHeaders];
-            FlowEdge** const cases         = new (m_compiler, CMK_FlowEdge) FlowEdge*[numHeaders];
-            unsigned         headerNumber  = 0;
-            BitVecOps::Iter  iterator(m_traits, m_entries);
-            unsigned int     poHeaderNumber = 0;
-            weight_t         netLikelihood  = 0.0;
+            LclVarDsc* const controlVarDsc         = m_compiler->lvaGetDesc(controlVarNum);
+            controlVarDsc->lvType                  = TYP_INT;
+            BasicBlock*                 dispatcher = nullptr;
+            BasicBlock*                 tryHeader  = TryHeader();
+            FlowEdge** const            succs      = new (m_compiler, CMK_FlowEdge) FlowEdge*[numHeaders];
+            FlowEdge** const            cases      = new (m_compiler, CMK_FlowEdge) FlowEdge*[numHeaders];
+            CompAllocator               allocator  = m_compiler->getAllocator(CMK_WasmSccTransform);
+            jitstd::vector<BasicBlock*> predBlocks(allocator);
+            jitstd::vector<unsigned>    predOffsets(allocator);
+            unsigned                    headerNumber = 0;
+            BitVecOps::Iter             iterator(m_traits, m_entries);
+            unsigned int                poHeaderNumber = 0;
+            weight_t                    netLikelihood  = 0.0;
+
+            // Snapshot the predecessor blocks before modifying any edges. Redirecting an edge for one
+            // header can create a new predecessor of another header, and that new edge must not be
+            // transformed as if it had originally targeted the other header.
+            //
+            while (iterator.NextElem(&poHeaderNumber))
+            {
+                BasicBlock* const header = m_dfsTree->GetPostOrder(poHeaderNumber);
+                predOffsets.push_back(static_cast<unsigned>(predBlocks.size()));
+
+                for (BasicBlock* const pred : header->PredBlocks())
+                {
+                    predBlocks.push_back(pred);
+                }
+            }
+            predOffsets.push_back(static_cast<unsigned>(predBlocks.size()));
+
+            iterator = BitVecOps::Iter(m_traits, m_entries);
 
             while (iterator.NextElem(&poHeaderNumber))
             {
@@ -711,11 +732,18 @@ public:
 
                 weight_t headerWeight = header->bbWeight;
 
-                for (FlowEdge* const f : header->PredEdgesEditing())
+                for (unsigned predIndex = predOffsets[headerNumber]; predIndex < predOffsets[headerNumber + 1];
+                     predIndex++)
                 {
-                    assert(f->getDestinationBlock() == header);
-                    BasicBlock* const pred          = f->getSourceBlock();
+                    BasicBlock* const pred          = predBlocks[predIndex];
                     BasicBlock*       transferBlock = nullptr;
+
+                    // Processing an earlier header may have removed this original edge.
+                    //
+                    if (m_compiler->fgGetPredForBlock(header, pred) == nullptr)
+                    {
+                        continue;
+                    }
 
                     // When the pred source is a BBJ_EHCATCHRET, the edge does not represent real
                     // control flow in Wasm, as any resume from catch flow is captured by the post-try

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Runtime_133120
+{
+    private static readonly Dictionary<int, Func<CancellationToken, Task>> s_validators = new()
+    {
+        [0] = static _ => Task.CompletedTask,
+    };
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        ValidateAsync().GetAwaiter().GetResult();
+    }
+
+    private static async Task ValidateAsync(CancellationToken cancellationToken = default)
+    {
+        List<Exception>? exceptions = null;
+
+        foreach (Func<CancellationToken, Task> validator in s_validators.Values)
+        {
+            try
+            {
+                await validator(cancellationToken).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException ex)
+            {
+                exceptions ??= new();
+                exceptions.Add(ex);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                (exceptions ??= new()).Add(ex);
+                break;
+            }
+        }
+
+        if (exceptions is not null)
+        {
+            if (exceptions.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+            }
+
+            if (exceptions.Count > 1)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>true</Optimize>
+    <AlwaysUseCrossGen2 Condition="'$(TargetOS)' == 'browser'">true</AlwaysUseCrossGen2>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
+    <CrossGen2TestExtraArguments>$(CrossGen2TestExtraArguments) --codegenopt:JitSynthesizeCounts=1</CrossGen2TestExtraArguments>
+  </PropertyGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>true</Optimize>
-    <AlwaysUseCrossGen2 Condition="'$(TargetOS)' == 'browser'">true</AlwaysUseCrossGen2>
-    <!-- AlwaysUseCrossGen2 does not propagate to the merged regression runner, so run this
-         test separately to ensure the browser-wasm leg exercises its R2R image. -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133120/Runtime_133120.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <Optimize>true</Optimize>
     <AlwaysUseCrossGen2 Condition="'$(TargetOS)' == 'browser'">true</AlwaysUseCrossGen2>
+    <!-- AlwaysUseCrossGen2 does not propagate to the merged regression runner, so run this
+         test separately to ensure the browser-wasm leg exercises its R2R image. -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Fixes the remaining Wasm SCC dispatch failure exposed by #133120.

This is stacked on #133132 and should be retargeted to `main` after that PR merges.

When `TransformViaSwitchDispatch` processed SCC entry headers one at a time, redirects made transfer blocks for an earlier header become live predecessors of a later try header. The later iteration processed those blocks again and appended another control-variable store, overwriting the original dispatch case.

Snapshot the original predecessor set before any rewrites, and ignore original edges that an earlier header transformation has intentionally removed. This preserves each transfer block's selected SCC entry.

The regression test is process-isolated on browser-wasm so its `AlwaysUseCrossGen2` setting is exercised rather than being lost through the merged regression runner.

Validation:
- `./build.sh clr -c Checked -os browser -a wasm`
- browser-wasm Checked build of `Runtime_133120`
- `Runtime_133120.sh`: expected 100, actual 100
- focused `MoveNext` JIT dump confirms the SCC transfer blocks receive one control-variable assignment each

> [!NOTE]
> This pull request description was generated with GitHub Copilot.