### PR TITLE
Cross-build browser WASM performance host tools

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -383,6 +383,8 @@
     The cross tools are used as part of the build process with the downloaded build tools, so we need to build them for the host architecture and build them as unsanitized binaries.
     -->
   <PropertyGroup>
+    <!-- Cross-build only the host cross-components; the target runtime build keeps its own CrossBuild setting. -->
+    <CrossBuildHostTools Condition="'$(CrossBuildHostTools)' == ''">false</CrossBuildHostTools>
     <!-- linux-bionic reports TargetOS as 'linux', so the HostOS/TargetOS check below never fires for it.
          It always targets the bionic libc via the NDK though, so host tools must be built separately. -->
     <_BuildAnyCrossArch Condition="('$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(HostOS)' != '$(TargetOS)' or '$(TargetsLinuxBionic)' == 'true' or '$(EnableNativeSanitizers)' != '')">true</_BuildAnyCrossArch>
@@ -414,7 +416,7 @@
                             HostCrossOS=$(HostOS);
                             PgoInstrument=false;
                             NoPgoOptimize=true;
-                            CrossBuild=false;
+                            CrossBuild=$(CrossBuildHostTools);
                             BuildSubdirectory=$(BuildArchitecture);
                             CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1"
       UndefineProperties="EnableNativeSanitizers"

--- a/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
@@ -31,7 +31,7 @@ jobs:
     platforms:
     - browser_wasm
     jobParameters:
-      buildArgs: -s clr+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS) /p:BuildHostTools=true
+      buildArgs: -s clr+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS) /p:BuildHostTools=true /p:CrossBuildHostTools=true
       nameSuffix: wasm_coreclr
       isOfficialBuild: false
       postBuildSteps:


### PR DESCRIPTION
## Summary

- add an opt-in `CrossBuildHostTools` property that defaults to `false`
- use it only for the host cross-component CoreCLR child build
- enable it for the browser CoreCLR performance build so the universal WASM JIT uses the existing Bionic sysroot
- leave the actual browser runtime build, normal browser builds, Mono, and mobile platforms unchanged

## Validation

- evaluated `ProjectToBuild` with the repository SDK and confirmed the default host child remains `CrossBuild=false`
- confirmed the performance opt-in changes only the x64/Linux host child to `CrossBuild=true`, with `ClrWasmJitSubset=true` and `CLR_CROSS_COMPONENTS_BUILD=1`
- confirmed the top-level browser runtime build keeps `CrossBuild` unset
- confirmed Android and Mono continue to exclude the host Crossgen2 package
- confirmed the targeted `clr.crossarchtools+clr.tools+packs` graph includes the cross-built WASM JIT and host Crossgen2 pack
- parsed the modified YAML and ran `git diff --check`

Native GLIBC dependency inspection was not run locally because the development workspace is macOS without the Linux webassembly container. A `runtime-wasm-perf` run is required to verify the packaged JIT against Ubuntu 22.04 end to end.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.