### PR TITLE
[LoongArch64] Mark Runtime_101046.il test unsupport on LoongArch64.

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_101046/Runtime_101046.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_101046/Runtime_101046.ilproj
@@ -10,6 +10,9 @@
     <!-- Excluded on x64 Unix due to LLVM non-standard ABI handling for small integer upper bits:
          https://github.com/llvm/llvm-project/issues/43573 -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x64' and '$(TargetsUnix)' == 'true'">true</CLRTestTargetUnsupported>
+    <!-- Excluded on loongarch64 due to LoongArch ABI request caller handling for small integer upper bits:
+         https://github.com/loongson/la-abi-specs/blob/release/lapcs.adoc -->
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'loongarch64'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <CMakeProjectReference Include="CMakeLists.txt" />


### PR DESCRIPTION
* LoongArch ABI request caller handling for small integer upper bits, so mark the Runtime_101046.il test unsupport on LoongArch64.