### PR TITLE
[ci-scan-feedback] Add build-break KBE dedup variation

### DIFF
--- a/.github/workflows/ci-failure-scan.md
+++ b/.github/workflows/ci-failure-scan.md
@@ -301,7 +301,8 @@ search the most distinctive single substring even when you intend to file the
 array form. If any of these variant-form searches surfaces a candidate, treat it
 as `existing-kbe` rather than filing a duplicate.
 
-Record the same outcomes described there:
+Record the same lookup outcomes described there, retaining any
+`linked-tracker` result as cross-link context rather than a terminal outcome:
 
 - `existing-kbe #<n>`
 - `linked-tracker #<n>`
@@ -338,9 +339,19 @@ Stable means >= 2 occurrences across >= 2 distinct builds in the ~10-build windo
 
 **Match-count gate.** Reject the emit unless the KBE body contains the collapsed, workflow-identified verification block defined by check #7 of the shared instructions, with `N >= 1`. Treat an absent block or field as `N=0` and record the same skip reason check #7 uses: `skipped: signature did not match failure.log (N=<count>)`. Rationale, log-source caveats, and native-assert handling live in check #7.
 
-If the shared KBE lookup flow recorded `linked-tracker #<tracker>`, cross-link it as `Tracking: dotnet/runtime#<tracker>` in the KBE body.
+If the shared KBE lookup flow recorded `linked-tracker #<tracker>`, retain it as
+cross-link context and continue through Branch A. An unlabeled tracker is not a
+KBE substitute and must not suppress creation of the labeled KBE that Build
+Analysis requires. When Branch A emits a KBE, cross-link it as
+`Tracking: dotnet/runtime#<tracker>` in the body.
 
-**Existing KBE / PR — record, emit nothing.** If Step 4.2–4.7 found a matching open KBE (`existing-kbe #<n>`), linked tracker (`linked-tracker #<n>`), or a PR already handling the failure (`existing-PR #<n>`), record that outcome and stop for this signature. `ci-failure-fix` will pick up the open KBE and decide on a fix or owner hand-off; this scan does not emit a follow-up.
+**Existing KBE / PR — record, emit nothing.** If Step 4.2–4.7 found a
+matching open KBE (`existing-kbe #<n>`) or a PR already handling the failure
+(`existing-PR #<n>`), record that outcome and stop for this signature. A
+`linked-tracker` alone is nonterminal cross-link context; if no KBE, PR, or
+independent skip condition applies, continue to Branch A and create the KBE.
+`ci-failure-fix` will pick up the open KBE and decide on a fix or owner
+hand-off; this scan does not emit a follow-up for an existing KBE or PR.
 
 After emitting, record the outcome per signature (Step 6).
 

--- a/.github/workflows/shared/create-kbe.instructions.md
+++ b/.github/workflows/shared/create-kbe.instructions.md
@@ -72,6 +72,26 @@ uses `user.login` to recognize trusted bots before filtering search results.
    human-filed report (`Test failure: ...`) that lacks both the
    `Known Build Error` and area labels, so the label-scoped variations above
    skip over it.
+8. Build-break invariant plus leg root. For a build break with no test or method
+   identifier, derive two bounded, verbatim fragments:
+   - an invariant error phrase from `ErrorMessage` / `ErrorPattern`, removing
+     only volatile paths, line numbers, hashes, GUIDs, timestamps, and exit
+     codes; keep a distinctive 1–8 word literal fragment and reject generic
+     tool or build-failed text;
+   - a leg root from `Build error leg or test failing`, taking the leg portion
+     before the template's final `-` separator (commonly rendered as ` - `),
+     then removing platform, architecture, configuration, retry, and
+     parenthesized run-specific details; keep at most 4 distinctive words
+     (80 characters).
+
+   Search the pair together in the same issue:
+   `is:issue is:open label:"Known Build Error" in:body "<invariant-error-phrase>" "<leg-root>"`.
+   For an `ErrorMessage` array, try each stable element separately. Treat a
+   result as a candidate only when both fragments match and the full candidate
+   verification below succeeds. If more than one candidate remains plausible,
+   do not guess: record `skipped: ambiguous dup #<a>/#<b>, needs human review`.
+   If either fragment cannot be bounded, do not broaden the search; record the
+   existing `skipped: weak signature` outcome instead.
 
 When a failure includes a complete test method identifier, search that
 identifier verbatim before deriving any shorter stem. Do not truncate
@@ -84,6 +104,8 @@ different platform or runtime variant, plus pre-existing area-team trackers
 that lack the `Known Build Error` label. Variation 6 catches siblings at
 different bit widths, instantiations, script runners, or exit/signal
 descriptors. Variation 7 catches an open human report with no label at all.
+Variation 8 catches build-break duplicates whose invariant error text and leg
+root remain stable while title prose drifts.
 
 If two candidate KBEs share more than 70% of their `ErrorMessage` /
 `ErrorPattern` tokens, do **not** guess: record

--- a/.github/workflows/shared/create-kbe.instructions.md
+++ b/.github/workflows/shared/create-kbe.instructions.md
@@ -76,10 +76,10 @@ uses `user.login` to recognize trusted bots before filtering search results.
    identifier, derive two bounded, verbatim fragments:
    - an invariant error phrase from `ErrorMessage` / `ErrorPattern`, removing
      only volatile paths, line numbers, hashes, GUIDs, timestamps, and exit
-     codes; keep a distinctive 1–8 word literal fragment and reject generic
+     codes; keep a distinctive 1-8 word literal fragment and reject generic
      tool or build-failed text;
    - a leg root from `Build error leg or test failing`, taking the leg portion
-     before the template's final `-` separator (commonly rendered as ` - `),
+     before the last hyphen (whether rendered as ` - ` or `-`),
      then removing platform, architecture, configuration, retry, and
      parenthesized run-specific details; keep at most 4 distinctive words
      (80 characters).
@@ -90,8 +90,9 @@ uses `user.login` to recognize trusted bots before filtering search results.
    result as a candidate only when both fragments match and the full candidate
    verification below succeeds. If more than one candidate remains plausible,
    do not guess: record `skipped: ambiguous dup #<a>/#<b>, needs human review`.
-   If either fragment cannot be bounded, do not broaden the search; record the
-   existing `skipped: weak signature` outcome instead.
+   If either fragment cannot be bounded, skip variation 8 without broadening
+   the search and continue the normal flow. Reserve `skipped: weak signature`
+   for failures whose error signature itself does not meet the specificity bar.
 
 When a failure includes a complete test method identifier, search that
 identifier verbatim before deriving any shorter stem. Do not truncate
@@ -147,6 +148,14 @@ candidates:
   across runs and survives cases where the predecessor was integrity-filtered or
   cross-linked rather than directly readable.
 
+For a build break with no test or method identifier, when the open variation 8
+search misses, also search recently closed KBEs with the same pair:
+
+- `is:issue is:closed label:"Known Build Error" in:body "<invariant-error-phrase>" "<leg-root>" closed:>=<30-days-ago>`
+
+Apply the closed-candidate timing and full candidate-verification rules below
+to any pair match.
+
 On a closed-candidate hit, compare the failing AzDO build's `finishTime` (read
 it from the build metadata, not the queue time) against the issue's `closed_at`:
 
@@ -166,8 +175,12 @@ lets a recurring signature surface at all. If that widened scan returns **two or
 more** closed `[ci-scan]` predecessors sharing the stem, treat it as a recurring
 signature, not a fresh regression: do **not** file — record `existing-kbe #<n>`
 against the most recently closed predecessor, even if the current build finished
-after that predecessor's `closed_at`. Fewer than two hits is not a recurring
-signature; fall back to the post-close recurrence rule above.
+after that predecessor's `closed_at`. For a build break with no test or method
+identifier, use the invariant-error-phrase + leg-root pair instead of a
+test-name stem and widen the pair search to `closed:>=<90-days-ago>`; two or
+more closed `[ci-scan]` predecessors matching both fragments have the same
+recurring-signature outcome. Fewer than two hits is not a recurring signature;
+fall back to the post-close recurrence rule above.
 
 <a id="search-area-team-tracker"></a>
 
@@ -177,6 +190,14 @@ Search for a plain tracker with:
 
 - `is:issue is:open in:title "<test-name>"`
 - `in:body "<test-file-path>"`
+
+For a build break with no test or method identifier, also search the pair from
+variation 8 without a label filter:
+
+- `is:issue is:open in:body "<invariant-error-phrase>" "<leg-root>"`
+
+Treat a matching unlabelled issue as `linked-tracker #<n>` and apply the same
+two-fragment verification and ambiguity rules before recording it.
 
 On hit, record `linked-tracker #<n>`.
 

--- a/.github/workflows/shared/create-kbe.instructions.md
+++ b/.github/workflows/shared/create-kbe.instructions.md
@@ -77,12 +77,12 @@ uses `user.login` to recognize trusted bots before filtering search results.
    - an invariant error phrase from `ErrorMessage` / `ErrorPattern`, removing
      only volatile paths, line numbers, hashes, GUIDs, timestamps, and exit
      codes; keep a distinctive 1-8 word literal fragment and reject generic
-     tool or build-failed text;
+     tool-failure text such as `dotnet build failed`;
    - a leg root from `Build error leg or test failing`, taking the leg portion
      before the last hyphen (whether rendered as ` - ` or `-`),
      then removing platform, architecture, configuration, retry, and
-     parenthesized run-specific details; keep at most 4 distinctive words
-     (80 characters).
+     parenthesized run-specific details; keep at most 4 distinctive words and
+     80 characters.
 
    Search the pair together in the same issue:
    `is:issue is:open label:"Known Build Error" in:body "<invariant-error-phrase>" "<leg-root>"`.
@@ -196,7 +196,7 @@ variation 8 without a label filter:
 
 - `is:issue is:open in:body "<invariant-error-phrase>" "<leg-root>"`
 
-Treat a matching unlabelled issue as `linked-tracker #<n>` and apply the same
+Treat a matching unlabeled issue as `linked-tracker #<n>` and apply the same
 two-fragment verification and ambiguity rules before recording it.
 
 On hit, record `linked-tracker #<n>`.


### PR DESCRIPTION
## Triggering problem

- [#132669](https://github.com/dotnet/runtime/issues/132669) reported that the scanner filed the same build-break failure as duplicate KBEs, including the `SYSTEM_ACCESSTOKEN` and `JIT.Generics_ro` examples.
- [#132700](https://github.com/dotnet/runtime/issues/132700) is the later duplicate feedback report. It expands the same proposed fix with a bounded leg/root descriptor and an explicit human-review fallback.
- The referenced duplicate KBE sets were filed under drifting titles and leg prose, while build breaks often have no test/assertion key for the existing search variations.

## Proposed fix

- Add variation 8 to `.github/workflows/shared/create-kbe.instructions.md` for build breaks without a test or method identifier.
- Derive a bounded invariant error fragment and a bounded leg root, then search both as exact body terms with `is:issue is:open label:"Known Build Error" in:body`.
- Use each stable array element independently, require both terms plus the existing full candidate verification, and reuse the existing `ambiguous dup` / `weak signature` outcomes rather than adding a new tally vocabulary.

## Why this works

The stable invariant phrase catches title and prose drift, while the leg root prevents unrelated build breaks sharing a generic diagnostic from colliding. Requiring both fragments in the same KBE body and refusing to guess among multiple candidates prevents false reuse; the prescribed query is expressible through the workflow's integrity-gated GitHub issue search.

## Validation

- `github-agentic-workflows-compile` passed for `ci-failure-scan.md` and `ci-failure-fix.md` with no compilation errors.
- The combined invariant-plus-leg `in:body` search syntax was verified against the referenced KBE body shape using the authenticated GitHub API.

> [!NOTE]
> This pull request was generated by GitHub Copilot.
