### PR TITLE
Fix MemoryCache OTEL size units and improve tag name

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -935,8 +935,8 @@ namespace Microsoft.Extensions.Caching.Memory
                         ? []
                         : new Measurement<long>[]
                         {
-                            new(stats.TotalHits, cacheNameTag, new("dotnet.cache.request.type", "hit")),
-                            new(stats.TotalMisses, cacheNameTag, new("dotnet.cache.request.type", "miss")),
+                            new(stats.TotalHits, cacheNameTag, new("dotnet.cache.request.result", "hit")),
+                            new(stats.TotalMisses, cacheNameTag, new("dotnet.cache.request.result", "miss")),
                         };
                 },
                 unit: "{request}",

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -987,8 +987,8 @@ namespace Microsoft.Extensions.Caching.Memory
                         ? [new Measurement<long>(size, cacheNameTag)]
                         : [];
                 },
-                unit: "By",
-                description: "Estimated size of the cache.");
+                unit: "1",
+                description: "Estimated size of the cache in application-defined units.");
         }
 
         private sealed class SharedMeter : Meter

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheMetricsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheMetricsTests.cs
@@ -45,12 +45,12 @@ namespace Microsoft.Extensions.Caching.Memory
 
             Assert.Contains(measurements, m =>
                 m.name == "dotnet.cache.requests" &&
-                m.tags.Any(t => t.Key == "dotnet.cache.request.type" && (string?)t.Value == "hit") &&
+                m.tags.Any(t => t.Key == "dotnet.cache.request.result" && (string?)t.Value == "hit") &&
                 m.tags.Any(t => t.Key == "dotnet.cache.name" && (string?)t.Value == "test-cache"));
 
             Assert.Contains(measurements, m =>
                 m.name == "dotnet.cache.requests" &&
-                m.tags.Any(t => t.Key == "dotnet.cache.request.type" && (string?)t.Value == "miss") &&
+                m.tags.Any(t => t.Key == "dotnet.cache.request.result" && (string?)t.Value == "miss") &&
                 m.tags.Any(t => t.Key == "dotnet.cache.name" && (string?)t.Value == "test-cache"));
 
             Assert.Contains(measurements, m => m.name == "dotnet.cache.entries");


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/semantic-conventions/pull/4068 and #126451.