### PR TITLE
[release/11.0] Wire the job monitor flag through YAML correctly

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -247,3 +247,5 @@ extends:
             nameSuffix: PALTests
             postBuildSteps:
               - template: /eng/pipelines/coreclr/templates/run-paltests-step.yml
+                parameters:
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/coreclr/templates/run-paltests-step.yml
+++ b/eng/pipelines/coreclr/templates/run-paltests-step.yml
@@ -5,6 +5,7 @@ parameters:
   archType: ''                    # required -- targeting CPU architecture
   osGroup: ''                     # required -- operating system for the job
   osSubgroup: ''                  # optional -- operating system subgroup
+  useHelixMonitor: false
 
 steps:
   - template: /eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -20,3 +21,4 @@ steps:
       osGroup: ${{ parameters.osGroup }}
       archType: ${{ parameters.archType }}
       shouldContinueOnError: ${{ parameters.continueOnError }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -7,6 +7,7 @@ parameters:
   isExtraPlatformsBuild: false
   isAndroidOnlyBuild: false
   isRollingBuild: false
+  useHelixMonitor: false
 
 jobs:
 
@@ -41,7 +42,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
 #
 # Android arm64 devices and x64 emulators
@@ -73,4 +74,4 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -7,6 +7,7 @@ parameters:
   isExtraPlatformsBuild: false
   isAndroidEmulatorOnlyBuild: false
   isRollingBuild: false
+  useHelixMonitor: false
 
 jobs:
 
@@ -46,7 +47,7 @@ jobs:
             creator: dotnet-bot
             testBuildArgs: nativeaot tree nativeaot/SmokeTests /p:BuildNativeAOTRuntimePack=true
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
@@ -86,7 +87,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
 #
 # Android emulators
@@ -118,7 +119,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
 #
 # Android arm64 devices and x64 emulators
@@ -152,4 +153,4 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -7,6 +7,7 @@ parameters:
   isExtraPlatformsBuild: false
   isiOSLikeOnlyBuild: false
   isRollingBuild: false
+  useHelixMonitor: false
 
 jobs:
 
@@ -41,7 +42,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -77,7 +78,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -121,7 +122,7 @@ jobs:
             creator: dotnet-bot
             testBuildArgs: /p:DevTeamProvisioning=- /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -157,5 +158,5 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -7,6 +7,7 @@ parameters:
   isExtraPlatformsBuild: false
   isiOSLikeSimulatorOnlyBuild: false
   isRollingBuild: false
+  useHelixMonitor: false
 
 jobs:
 
@@ -42,7 +43,7 @@ jobs:
             creator: dotnet-bot
             interpreter: true
             testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
 #
 # iOSSimulator
@@ -76,7 +77,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -113,7 +114,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -157,7 +158,7 @@ jobs:
             creator: dotnet-bot
             testBuildArgs: /p:DevTeamProvisioning=- /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -193,5 +194,5 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
@@ -7,6 +7,7 @@ parameters:
   isExtraPlatformsBuild: false
   isMacCatalystOnlyBuild: false
   isRollingBuild: false
+  useHelixMonitor: false
 
 jobs:
 
@@ -42,7 +43,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -76,7 +77,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -113,7 +114,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -157,7 +158,7 @@ jobs:
             creator: dotnet-bot
             testBuildArgs: /p:DevTeamProvisioning=- /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -194,7 +195,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
 
 #
@@ -230,5 +231,5 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -4,6 +4,7 @@
 
 parameters:
   isExtraPlatformsBuild: ''
+  useHelixMonitor: false
 
 jobs:
 
@@ -35,7 +36,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Libraries_Release_CoreCLR
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       condition: >-
         or(
@@ -60,7 +61,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: NET481_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             extraHelixArguments: /p:BuildTargetFramework=net481
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       condition: >-
@@ -105,7 +106,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
             condition: >-
               or(
               eq(variables['librariesContainsChange'], true),
@@ -149,7 +150,7 @@ jobs:
             creator: dotnet-bot
             llvmAotStepContainer: linux_x64
             testRunNamePrefixSuffix: Mono_Release
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
@@ -188,7 +189,7 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_Release
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
@@ -226,6 +227,6 @@ jobs:
           parameters:
             creator: dotnet-bot
             testRunNamePrefixSuffix: Mono_Release
-            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            useHelixMonitor: ${{ parameters.useHelixMonitor }}
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -7,6 +7,7 @@ parameters:
   isExtraPlatformsBuild: false
   isWasmOnlyBuild: false
   isRollingBuild: false
+  useHelixMonitor: false
   excludeLibTests: false
   excludeNonLibTests: false
   excludeOptional: true
@@ -32,7 +33,7 @@ jobs:
       buildAOTOnHelix: false
       shouldRunSmokeOnly: true
       alwaysRun: true
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
   # AOT Library tests - wasi_wasm
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -45,6 +46,7 @@ jobs:
       runAOT: true
       alwaysRun: true
       shouldContinueOnError: true
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
   # High resource AOT Library tests
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -57,7 +59,7 @@ jobs:
       buildAOTOnHelix: false
       runAOT: true
       alwaysRun: true
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
 #
 # ********** For !rolling builds, IOW - PR builds *************
@@ -75,7 +77,7 @@ jobs:
       extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
       scenarios:
         - WasmTestOnChrome
 
@@ -93,6 +95,7 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       shouldRunSmokeOnly: onLibrariesAndIllinkChanges
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
       scenarios:
         - WasmTestOnChrome
 
@@ -107,7 +110,7 @@ jobs:
       buildAOTOnHelix: false
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
   # AOT Library tests - browser_wasm
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -123,7 +126,7 @@ jobs:
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
   # AOT Library tests - wasi_wasm
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -138,6 +141,7 @@ jobs:
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
   # High resource AOT Library tests
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -152,7 +156,7 @@ jobs:
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
   # Wasi - run only smoke tests by default
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
@@ -167,6 +171,7 @@ jobs:
       # is run as part of a wasm specific pipeline like runtime-wasm
       shouldContinueOnError: ${{ not(parameters.isWasmOnlyBuild) }}
       alwaysRun: ${{ variables.isRollingBuild }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
       scenarios:
         - WasmTestOnWasmtime
 
@@ -228,7 +233,7 @@ jobs:
       # The CoreCLR build-only job above stages the CoreCLR runtime pack for the
       # wasm-tools workload install.
       includeCoreClrRuntimePack: true
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
   - template: /eng/pipelines/common/templates/simple-wasm-build-tests.yml
     parameters:
@@ -238,7 +243,7 @@ jobs:
       extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
   - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
     parameters:
@@ -247,7 +252,7 @@ jobs:
       extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
 - ${{ if and(ne(parameters.isRollingBuild, true), ne(parameters.excludeOptional, true)) }}:
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
@@ -261,6 +266,6 @@ jobs:
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-      useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+      useHelixMonitor: ${{ parameters.useHelixMonitor }}
       scenarios:
         - WasmTestOnWasmtime

--- a/eng/pipelines/runtime-android.yml
+++ b/eng/pipelines/runtime-android.yml
@@ -27,3 +27,4 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isAndroidOnlyBuild: ${{ variables.isAndroidOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-androidemulator.yml
+++ b/eng/pipelines/runtime-androidemulator.yml
@@ -28,3 +28,4 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -65,6 +65,7 @@ extends:
             isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
             isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
             isRollingBuild: ${{ variables.isRollingBuild }}
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add iOS/tvOS jobs
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -72,6 +73,7 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isiOSLikeOnlyBuild: ${{ variables.isiOSLikeOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add iOS/tvOS simulator jobs
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -79,6 +81,7 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add Android jobs
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -86,6 +89,7 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isAndroidOnlyBuild: ${{ variables.isAndroidOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add Android emulator jobs
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -93,6 +97,7 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add Mac Catalyst jobs
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
@@ -100,6 +105,7 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
 
       # Add Linux Bionic jobs
       - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-linuxbionic.yml
@@ -113,3 +119,4 @@ extends:
         - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
           parameters:
             isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-ioslike.yml
+++ b/eng/pipelines/runtime-ioslike.yml
@@ -28,3 +28,4 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isiOSLikeOnlyBuild: ${{ variables.isiOSLikeOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-ioslikesimulator.yml
+++ b/eng/pipelines/runtime-ioslikesimulator.yml
@@ -29,3 +29,4 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-maccatalyst.yml
+++ b/eng/pipelines/runtime-maccatalyst.yml
@@ -28,3 +28,4 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}

--- a/eng/pipelines/runtime-wasm-dbgtests.yml
+++ b/eng/pipelines/runtime-wasm-dbgtests.yml
@@ -30,4 +30,5 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           debuggerTestsOnly: true

--- a/eng/pipelines/runtime-wasm-libtests.yml
+++ b/eng/pipelines/runtime-wasm-libtests.yml
@@ -29,5 +29,6 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           excludeNonLibTests: true
           excludeLibTests: false

--- a/eng/pipelines/runtime-wasm-non-libtests.yml
+++ b/eng/pipelines/runtime-wasm-non-libtests.yml
@@ -29,5 +29,6 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           excludeNonLibTests: false
           excludeLibTests: true

--- a/eng/pipelines/runtime-wasm-optional.yml
+++ b/eng/pipelines/runtime-wasm-optional.yml
@@ -30,6 +30,7 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           excludeLibTests: true
           excludeNonLibTests: true
           excludeOptional: false

--- a/eng/pipelines/runtime-wasm.yml
+++ b/eng/pipelines/runtime-wasm.yml
@@ -33,4 +33,5 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           excludeOptional: false


### PR DESCRIPTION
Backport of #133002 to `release/11.0`.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.