### PR TITLE
[release/8.0] Don't pass empty string as SNI to QUIC

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -300,11 +300,11 @@ public sealed partial class QuicConnection : IAsyncDisposable
                 options.ClientAuthenticationOptions.CertificateChainPolicy?.Clone());
             _configuration = MsQuicConfiguration.Create(options);
 
-            // RFC 6066 forbids IP literals
-            // DNI mapping is handled by MsQuic
-            string sni = (TargetHostNameHelper.IsValidAddress(options.ClientAuthenticationOptions.TargetHost) ? null : options.ClientAuthenticationOptions.TargetHost) ?? host ?? address?.ToString() ?? string.Empty;
+            // RFC 6066 forbids IP literals.
+            // IDN mapping is handled by MsQuic.
+            string? sni = (TargetHostNameHelper.IsValidAddress(options.ClientAuthenticationOptions.TargetHost) ? null : options.ClientAuthenticationOptions.TargetHost) ?? host;
 
-            IntPtr targetHostPtr = Marshal.StringToCoTaskMemUTF8(sni);
+            IntPtr targetHostPtr = !string.IsNullOrEmpty(sni) ? Marshal.StringToCoTaskMemUTF8(sni) : IntPtr.Zero;
             try
             {
                 unsafe
@@ -320,7 +320,10 @@ public sealed partial class QuicConnection : IAsyncDisposable
             }
             finally
             {
-                Marshal.FreeCoTaskMem(targetHostPtr);
+                if (targetHostPtr != IntPtr.Zero)
+                {
+                    Marshal.FreeCoTaskMem(targetHostPtr);
+                }
             }
         }
 


### PR DESCRIPTION
Backport of #133097 to `release/8.0-staging`.

Fixes #133096.

## Customer Impact

- [ ] Customer reported
- [X] Found internally

Customers would be unable to establish QUIC or HTTP/3 connections on Linux without providing the target host name (to verify against the server certificate).

## Regression

- [X] Yes
- [ ] No

Regression by updating MsQuic (optional dependency to light-up QUIC support)

## Testing

Affected tests succeed on CI.

## Risk

Low, change is small and well understood.