### PR TITLE
Use writable UserSecrets path on Apple mobile

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/PathHelper.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/PathHelper.cs
@@ -59,8 +59,16 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
 
             // For backwards compat, this checks env vars first before using Env.GetFolderPath
             string? appData = Environment.GetEnvironmentVariable("APPDATA");
+            string? home = Environment.GetEnvironmentVariable("HOME");
+#if NET
+            if (OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsMacCatalyst())
+            {
+                // The Apple mobile HOME directory is the app container root, which is not writable.
+                home = null;
+            }
+#endif
             string? root = appData                                                                   // On Windows it goes to %APPDATA%\Microsoft\UserSecrets\
-                       ?? Environment.GetEnvironmentVariable("HOME")                             // On Mac/Linux it goes to ~/.microsoft/usersecrets/
+                       ?? home                                                                       // On Mac/Linux it goes to ~/.microsoft/usersecrets/
                        ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
                        ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
                        ?? Environment.GetEnvironmentVariable(userSecretsFallbackDir);            // this fallback is an escape hatch if everything else fails

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/ConfigurationExtensionTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/ConfigurationExtensionTest.cs
@@ -52,7 +52,6 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Test
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60584", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void AddUserSecrets_FindsAssemblyAttribute()
         {
             var randValue = Guid.NewGuid().ToString();
@@ -67,7 +66,6 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Test
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60584", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void AddUserSecrets_FindsAssemblyAttributeFromType()
         {
             var randValue = Guid.NewGuid().ToString();
@@ -121,7 +119,6 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Test
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60584", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void AddUserSecrets_With_SecretsId_Passed_Explicitly()
         {
             var userSecretsId = Guid.NewGuid().ToString();

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/PathHelperTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/PathHelperTest.cs
@@ -16,10 +16,16 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Test
             var userSecretsId = "abcxyz123";
             var actualSecretPath = PathHelper.GetSecretsPathFromSecretsId(userSecretsId);
 
-            var root = Environment.GetEnvironmentVariable("APPDATA") ??         // On Windows it goes to %APPDATA%\Microsoft\UserSecrets\
-                        Environment.GetEnvironmentVariable("HOME");             // On Mac/Linux it goes to ~/.microsoft/usersecrets/
+            var appData = Environment.GetEnvironmentVariable("APPDATA");
+            var root = appData ?? Environment.GetEnvironmentVariable("HOME");
+#if NET
+            if (appData is null && (OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsMacCatalyst()))
+            {
+                root = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            }
+#endif
 
-            var expectedSecretPath = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPDATA")) ?
+            var expectedSecretPath = !string.IsNullOrEmpty(appData) ?
                 Path.Combine(root, "Microsoft", "UserSecrets", userSecretsId, "secrets.json") :
                 Path.Combine(root, ".microsoft", "usersecrets", userSecretsId, "secrets.json");
 


### PR DESCRIPTION
Fixes #132074
Fixes #60584

## Summary

- ignore the unwritable `HOME` directory when resolving the UserSecrets path on iOS, tvOS, and MacCatalyst
- fall back to the platform-specific writable application data directory
- re-enable the UserSecrets tests previously disabled on iOS and tvOS

## Testing

- `dotnet build src\libraries\Microsoft.Extensions.Configuration.UserSecrets\src\Microsoft.Extensions.Configuration.UserSecrets.csproj`
- `dotnet build /t:test src\libraries\Microsoft.Extensions.Configuration.UserSecrets\tests\Microsoft.Extensions.Configuration.UserSecrets.Tests.csproj`
- `dotnet build /t:test src\libraries\Microsoft.Extensions.Configuration\tests\FunctionalTests\Microsoft.Extensions.Configuration.Functional.Tests.csproj`

> [!NOTE]
> This pull request description was drafted with GitHub Copilot.