### PR TITLE
[release/10.0] Fix SIMD primitive zero initialization

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -453,6 +453,8 @@ void MorphInitBlockHelper::TryPrimitiveInit()
         if (varTypeIsSIMD(lclVarType))
         {
             m_src = m_comp->gtNewZeroConNode(lclVarType);
+            m_src->SetMorphed(m_comp);
+            m_store->Data() = m_src;
         }
         else
         {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133085/Runtime_133085.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133085/Runtime_133085.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_133085
+{
+    private struct Struct128
+    {
+        public ulong U0;
+        public ulong U1;
+    }
+
+    private struct Struct256
+    {
+        public ulong U0;
+        public ulong U1;
+        public ulong U2;
+        public ulong U3;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Equal(Vector128<ulong>.Zero, ZeroVector128FullOpts());
+        Assert.Equal(Vector256<ulong>.Zero, ZeroVector256FullOpts());
+        Assert.Equal(Vector128<ulong>.Zero, ZeroVector128Tier0());
+        Assert.Equal(Vector256<ulong>.Zero, ZeroVector256Tier0());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<ulong> ZeroVector128FullOpts()
+    {
+        Unsafe.SkipInit(out Vector128<ulong> result);
+        Unsafe.As<Vector128<ulong>, Struct128>(ref result) = default;
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector256<ulong> ZeroVector256FullOpts()
+    {
+        Unsafe.SkipInit(out Vector256<ulong> result);
+        Unsafe.As<Vector256<ulong>, Struct256>(ref result) = default;
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<ulong> ZeroVector128Tier0()
+    {
+        Unsafe.SkipInit(out Vector128<ulong> result);
+        Unsafe.As<Vector128<ulong>, Struct128>(ref result) = default;
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector256<ulong> ZeroVector256Tier0()
+    {
+        Unsafe.SkipInit(out Vector256<ulong> result);
+        Unsafe.As<Vector256<ulong>, Struct256>(ref result) = default;
+        return result;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133085/Runtime_133085.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133085/Runtime_133085.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <CLRTestPriority>1</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #133100 to release/10.0

/cc @tannergooding

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Reported in #133085. Zero-initializing a struct through a byref that the JIT can see is the address of a `Vector128<T>`/`Vector256<T>` local (`Unsafe.As<Vector256<ulong>, S>(ref v) = default;`) produces a SIMD store whose source is an integer zero constant. With optimizations that lowers to `vmovq ymm0, rax` (`C4 E1 FD 6E C0`), which has no valid VEX.256 encoding, so the process dies with `ExecutionEngineException: Illegal instruction`; at Tier0 the same method fails to compile and throws `InvalidProgramException`. Expected behavior is a SIMD zero (`vxorps`) in both modes.

The pattern shows up in code that reinterprets vector locals as multi-limb structs, and there is no compile-time diagnostic — it fails at runtime on any AVX-capable x64 machine.

## Regression

- [ ] Yes
- [x] No

Not a regression in 10.0 — .NET 9 fails the same way. The bad tree dates to the assignment rationalization work in #85585 (`53b4cd0912d`), where the legacy `GT_ASG` path updated `gtOp2` but the rationalized store path never updated `Data()`.

## Testing

New regression test `src/tests/JIT/Regression/JitBlue/Runtime_133085`, covering `Vector128<ulong>` and `Vector256<ulong>` in both FullOpts (`AggressiveOptimization`) and Tier0. It reproduces the illegal encoding / `InvalidProgramException` without the fix and passes with it.

Missed previously because `TryPrimitiveInit` looked correct in isolation — it built the SIMD zero node and assigned it to `m_src` — and no existing test zero-initialized a SIMD local through a reinterpreted struct view, so nothing exercised the path where the store's data operand still had to be replaced.

## Risk

Low. Two lines in `TryPrimitiveInit`, reached only when a block zero-init of a SIMD-typed local is converted into a primitive store. It makes the store's data node match the store's type, which is what the transform already intended; every other case was already consistent.

This is a manual backport: the cherry-pick conflicted only because the member is named `m_comp` on release/10.0 rather than `m_compiler`. The change is otherwise identical to #133100.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
