### PR TITLE
Fix ManagedWebSocket send cancellation leaving state Open

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -599,40 +599,53 @@ namespace System.Net.WebSockets
 
         private async ValueTask SendFrameFallbackAsync(MessageOpcode opcode, bool endOfMessage, bool disableCompression, ReadOnlyMemory<byte> payloadBuffer, Task lockTask, CancellationToken cancellationToken)
         {
-            await lockTask.ConfigureAwait(false);
-            if (NetEventSource.Log.IsEnabled()) NetEventSource.MutexEntered(_sendMutex);
-
-            try
+            // Register for cancellation before waiting on the lock so that if cancellation races with
+            // acquiring the mutex, we still abort the connection, just as we would if cancellation raced
+            // with the write itself. Without this, a cancellation that fires while we're waiting to enter
+            // the mutex would propagate out without transitioning the WebSocket to the Aborted state.
+            using (cancellationToken.Register(static s => ((ManagedWebSocket)s!).Abort(), this))
             {
-                int sendBytes = WriteFrameToSendBuffer(opcode, endOfMessage, disableCompression, payloadBuffer.Span);
-                using (cancellationToken.Register(static s => ((ManagedWebSocket)s!).Abort(), this))
+                try
                 {
-                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_sendBuffer, 0, sendBytes), cancellationToken).ConfigureAwait(false);
-                    await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    await lockTask.ConfigureAwait(false);
                 }
-            }
-            catch (Exception exc)
-            {
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.TraceException(this, exc);
-
-                if (exc is OperationCanceledException)
+                catch (Exception exc)
                 {
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.TraceException(this, exc);
                     throw;
                 }
 
-                throw _state == WebSocketState.Aborted ?
-                    CreateOperationCanceledException(exc, cancellationToken) :
-                    new WebSocketException(WebSocketError.ConnectionClosedPrematurely, exc);
-            }
-            finally
-            {
-                ReleaseSendBuffer();
-                _sendMutex.Exit();
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.MutexEntered(_sendMutex);
 
-                if (NetEventSource.Log.IsEnabled())
+                try
                 {
-                    NetEventSource.MutexExited(_sendMutex);
-                    NetEventSource.SendFrameAsyncCompleted(this);
+                    int sendBytes = WriteFrameToSendBuffer(opcode, endOfMessage, disableCompression, payloadBuffer.Span);
+                    await _stream.WriteAsync(new ReadOnlyMemory<byte>(_sendBuffer, 0, sendBytes), cancellationToken).ConfigureAwait(false);
+                    await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception exc)
+                {
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.TraceException(this, exc);
+
+                    if (exc is OperationCanceledException)
+                    {
+                        throw;
+                    }
+
+                    throw _state == WebSocketState.Aborted ?
+                        CreateOperationCanceledException(exc, cancellationToken) :
+                        new WebSocketException(WebSocketError.ConnectionClosedPrematurely, exc);
+                }
+                finally
+                {
+                    ReleaseSendBuffer();
+                    _sendMutex.Exit();
+
+                    if (NetEventSource.Log.IsEnabled())
+                    {
+                        NetEventSource.MutexExited(_sendMutex);
+                        NetEventSource.SendFrameAsyncCompleted(this);
+                    }
                 }
             }
         }

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -252,6 +252,74 @@ namespace System.Net.WebSockets.Tests
                 ex.Message);
         }
 
+        [Fact]
+        public async Task SendAsync_AlreadyCanceledToken_AbortsConnectionAndThrowsOperationCanceledException()
+        {
+            using var stream = new WebSocketTestStream();
+            using var websocket = WebSocket.CreateFromStream(stream, new WebSocketCreationOptions());
+
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                websocket.SendAsync(new byte[] { 1, 2, 3 }, WebSocketMessageType.Binary, endOfMessage: true, cts.Token).AsTask());
+
+            Assert.Equal(WebSocketState.Aborted, websocket.State);
+        }
+
+        [Fact]
+        public async Task SendAsync_CancelWhileWaitingForSendMutex_AbortsConnectionAndThrowsOperationCanceledException()
+        {
+            using var stream = new GatedWriteStream();
+            using var websocket = WebSocket.CreateFromStream(stream, new WebSocketCreationOptions());
+
+            // Start a send with a non-cancelable token; it acquires the send mutex synchronously
+            // and then blocks inside the (gated) write, simulating another in-flight send -- e.g. a
+            // keep-alive ping -- holding the mutex.
+            Task firstSend = websocket.SendAsync(new byte[] { 1 }, WebSocketMessageType.Binary, endOfMessage: true, CancellationToken.None).AsTask();
+            await stream.WriteStarted;
+
+            // Issue a second, cancelable send. Since the mutex is held, it must wait to acquire it.
+            using var cts = new CancellationTokenSource();
+            Task secondSend = websocket.SendAsync(new byte[] { 2 }, WebSocketMessageType.Binary, endOfMessage: true, cts.Token).AsTask();
+
+            // Cancel while the second send is still waiting on the send mutex.
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => secondSend);
+
+            Assert.Equal(WebSocketState.Aborted, websocket.State);
+
+            // Unblock the first send so it can finish (successfully or not -- that's not what this
+            // test is about) and the test can complete deterministically.
+            stream.ReleaseWrite();
+            try
+            {
+                await firstSend;
+            }
+            catch
+            {
+            }
+        }
+
+        /// <summary>A test stream whose first WriteAsync blocks until released, allowing tests to
+        /// deterministically create contention on the WebSocket's internal send mutex.</summary>
+        private sealed class GatedWriteStream : WebSocketTestStream
+        {
+            private readonly TaskCompletionSource _writeStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _releaseWrite = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task WriteStarted => _writeStarted.Task;
+
+            public void ReleaseWrite() => _releaseWrite.TrySetResult();
+
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            {
+                _writeStarted.TrySetResult();
+                await _releaseWrite.Task.ConfigureAwait(false);
+                await base.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         public abstract class ExposeProtectedWebSocket : WebSocket
         {
             public static new bool IsStateTerminal(WebSocketState state) =>

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -262,7 +262,7 @@ namespace System.Net.WebSockets.Tests
             cts.Cancel();
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-                websocket.SendAsync(new byte[] { 1, 2, 3 }, WebSocketMessageType.Binary, endOfMessage: true, cts.Token).AsTask());
+                websocket.SendAsync(new byte[] { 1, 2, 3 }, WebSocketMessageType.Binary, endOfMessage: true, cts.Token));
 
             Assert.Equal(WebSocketState.Aborted, websocket.State);
         }
@@ -276,12 +276,12 @@ namespace System.Net.WebSockets.Tests
             // Start a send with a non-cancelable token; it acquires the send mutex synchronously
             // and then blocks inside the (gated) write, simulating another in-flight send -- e.g. a
             // keep-alive ping -- holding the mutex.
-            Task firstSend = websocket.SendAsync(new byte[] { 1 }, WebSocketMessageType.Binary, endOfMessage: true, CancellationToken.None).AsTask();
+            Task firstSend = websocket.SendAsync(new byte[] { 1 }, WebSocketMessageType.Binary, endOfMessage: true, CancellationToken.None);
             await stream.WriteStarted;
 
             // Issue a second, cancelable send. Since the mutex is held, it must wait to acquire it.
             using var cts = new CancellationTokenSource();
-            Task secondSend = websocket.SendAsync(new byte[] { 2 }, WebSocketMessageType.Binary, endOfMessage: true, cts.Token).AsTask();
+            Task secondSend = websocket.SendAsync(new byte[] { 2 }, WebSocketMessageType.Binary, endOfMessage: true, cts.Token);
 
             // Cancel while the second send is still waiting on the send mutex.
             cts.Cancel();


### PR DESCRIPTION
## Summary

Fixes #132031.

`ManagedWebSocket.SendFrameFallbackAsync` awaited the send-mutex acquisition task (`lockTask`) before entering its `try` block and before registering the `cancellationToken.Register(... => Abort())` callback. If cancellation raced with acquiring `_sendMutex` (e.g. because a keep-alive ping or another in-flight send already held it), the resulting `OperationCanceledException` propagated out without ever calling `Abort()`, leaving `WebSocketState` stuck at `Open` instead of transitioning to `Aborted`.

This caused the flaky `System.Net.WebSockets.Client.Tests.CancelTest_*.SendAsync_Cancel_Success` failures tracked by #132031 across many PR checks (mostly on Android/JIT-stress legs, where lock contention is more likely).

The receive path (`ReceiveAsyncPrivate`, and the close-frame-wait loop) already registers/handles cancellation around its mutex wait — the send path was the odd one out.

## Fix

`src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs`: moved the `cancellationToken.Register(static s => ((ManagedWebSocket)s!).Abort(), this)` registration to wrap the entire method body, including `await lockTask`, matching the existing pattern in the receive path. Added a small `try`/`catch` around the lock-wait to trace a canceled wait via `NetEventSource.TraceException` before rethrowing, for diagnostics parity with the write/flush cancellation path.

Mutex-release semantics are preserved: `_sendMutex.Exit()` only runs in the inner `try`/`finally`, which is only entered after the lock is actually acquired — so an unacquired mutex is never released, and there's no double-exit.

## Tests

Added two deterministic regression tests to `src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs` (no timing sleeps):

- `SendAsync_AlreadyCanceledToken_AbortsConnectionAndThrowsOperationCanceledException` — uses an already-canceled token so `AsyncMutex.EnterAsync` returns `Task.FromCanceled` immediately, deterministically hitting the pre-lock cancellation path with no contention needed.
- `SendAsync_CancelWhileWaitingForSendMutex_AbortsConnectionAndThrowsOperationCanceledException` — uses a new `GatedWriteStream` test helper whose `WriteAsync` blocks on a `TaskCompletionSource` until released, to deterministically create genuine send-mutex contention: a first send holds the mutex blocked in its write, a second cancelable send must wait for the mutex, and canceling the second send's token while it's waiting is asserted to abort the connection and throw `OperationCanceledException`.

Both were traced by hand against the pre-fix code and confirmed to fail (state stays `Open`) without the fix, and pass with it.

## Validation

`dotnet build src/libraries/System.Net.WebSockets/src/System.Net.WebSockets.csproj -c Release` — succeeded with 0 warnings/0 errors across all target frameworks (net, -browser, -unix, -windows).

Full xunit execution of the affected test projects wasn't performed in this environment due to local disk constraints; the `system-net-review` specialist agent reviewed the diff and traced correctness (mutex release/idempotent `Abort()`/no new races) with no blocking findings.

## Scope

Limited to #132031 — does not touch `ConnectAsync` cancellation tests (#130439) or Known Build Error metadata.

> [!NOTE]
> This PR description and the underlying investigation/fix were generated with GitHub Copilot assistance.