### PR TITLE
Stabilize ConnectAsync_Cancel_ThrowsCancellationException loopback test

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.Loopback.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.Loopback.cs
@@ -19,7 +19,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         // Uses a dedicated (non-echo) loopback run instead of RunEchoAsync: the server signals once it has
         // accepted the connection and received the opening handshake request, and only then does the client
-        // cancel and withholds the handshake response indefinitely. This avoids racing a fixed cancellation
+        // cancels while the server withholds the handshake response indefinitely. This avoids racing a fixed cancellation
         // delay (e.g. 100ms) against JIT-stress-induced scheduling jitter, which could previously let the
         // token fire before the client ever reached/was accepted by the server, leaving the server blocked
         // in Accept until the enclosing LoopbackWebSocketServer timeout fired a TimeoutException instead of
@@ -27,7 +27,7 @@ namespace System.Net.WebSockets.Client.Tests
         private async Task RunConnectAsync_Cancel_ThrowsCancellationException(bool useSsl)
         {
             var handshakeReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var timeoutCts = new CancellationTokenSource(TimeOutMilliseconds);
+            using var timeoutCts = new CancellationTokenSource(TimeOutMilliseconds);
 
             var options = new LoopbackWebSocketServer.Options(HttpVersion, useSsl)
             {
@@ -37,7 +37,7 @@ namespace System.Net.WebSockets.Client.Tests
             };
 
             await LoopbackWebSocketServer.RunAsync(
-                server => RunClientAsync(server, handshakeReceived.Task),
+                server => RunClientAsync(server, handshakeReceived.Task, timeoutCts.Token),
                 async (WebSocketRequestData requestData, CancellationToken token) =>
                 {
                     handshakeReceived.TrySetResult();
@@ -48,14 +48,23 @@ namespace System.Net.WebSockets.Client.Tests
                 options,
                 timeoutCts.Token);
 
-            async Task RunClientAsync(Uri server, Task handshakeReceivedTask)
+            async Task RunClientAsync(Uri server, Task handshakeReceivedTask, CancellationToken timeoutToken)
             {
                 using var cws = new ClientWebSocket();
-                var cts = new CancellationTokenSource();
+                using var cts = new CancellationTokenSource();
 
                 Task connectTask = ConnectAsync(cws, server, cts.Token);
 
-                await handshakeReceivedTask.ConfigureAwait(false);
+                Task completedTask = await Task.WhenAny(connectTask, handshakeReceivedTask)
+                    .WaitAsync(timeoutToken)
+                    .ConfigureAwait(false);
+
+                if (completedTask == connectTask)
+                {
+                    await connectTask.ConfigureAwait(false);
+                    Assert.Fail("ConnectAsync completed before the server received the handshake.");
+                }
+
                 cts.Cancel();
 
                 var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => connectTask);

--- a/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.Loopback.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.Loopback.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -14,8 +15,53 @@ namespace System.Net.WebSockets.Client.Tests
         #region Common (Echo Server) tests
 
         [Theory, MemberData(nameof(UseSsl))]
-        public Task ConnectAsync_Cancel_ThrowsCancellationException(bool useSsl) => RunEchoAsync(
-            RunClient_ConnectAsync_Cancel_ThrowsCancellationException, useSsl);
+        public Task ConnectAsync_Cancel_ThrowsCancellationException(bool useSsl) => RunConnectAsync_Cancel_ThrowsCancellationException(useSsl);
+
+        // Uses a dedicated (non-echo) loopback run instead of RunEchoAsync: the server signals once it has
+        // accepted the connection and received the opening handshake request, and only then does the client
+        // cancel and withholds the handshake response indefinitely. This avoids racing a fixed cancellation
+        // delay (e.g. 100ms) against JIT-stress-induced scheduling jitter, which could previously let the
+        // token fire before the client ever reached/was accepted by the server, leaving the server blocked
+        // in Accept until the enclosing LoopbackWebSocketServer timeout fired a TimeoutException instead of
+        // the expected OperationCanceledException.
+        private async Task RunConnectAsync_Cancel_ThrowsCancellationException(bool useSsl)
+        {
+            var handshakeReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var timeoutCts = new CancellationTokenSource(TimeOutMilliseconds);
+
+            var options = new LoopbackWebSocketServer.Options(HttpVersion, useSsl)
+            {
+                SkipServerHandshakeResponse = true,
+                IgnoreServerErrors = true,
+                AbortServerOnClientExit = true
+            };
+
+            await LoopbackWebSocketServer.RunAsync(
+                server => RunClientAsync(server, handshakeReceived.Task),
+                async (WebSocketRequestData requestData, CancellationToken token) =>
+                {
+                    handshakeReceived.TrySetResult();
+
+                    // Never respond; wait until the client cancels (or the test times out).
+                    await Task.Delay(Timeout.Infinite, token).ConfigureAwait(false);
+                },
+                options,
+                timeoutCts.Token);
+
+            async Task RunClientAsync(Uri server, Task handshakeReceivedTask)
+            {
+                using var cws = new ClientWebSocket();
+                var cts = new CancellationTokenSource();
+
+                Task connectTask = ConnectAsync(cws, server, cts.Token);
+
+                await handshakeReceivedTask.ConfigureAwait(false);
+                cts.Cancel();
+
+                var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => connectTask);
+                Assert.True(WebSocketState.Closed == cws.State, $"Actual {cws.State} when {ex}");
+            }
+        }
 
         [Theory, MemberData(nameof(UseSsl))]
         public Task SendAsync_Cancel_Success(bool useSsl) => RunEchoAsync(


### PR DESCRIPTION
## Summary

Fixes flaky `System.Net.WebSockets.Client.Tests.CancelTest_*Loopback.ConnectAsync_Cancel_ThrowsCancellationException`, tracked in #130439.

## Root cause

The test started a `CancellationTokenSource(100)` and then called `ClientWebSocket.ConnectAsync` against a loopback server configured to withhold its WebSocket handshake response for 10 seconds (via a `delay10sec` query-string echo option). Under JIT-stress CI legs, the client thread could be scheduled late enough that the 100ms token fired **before** the client's `ConnectAsync` ever established a TCP connection to the loopback server.

`LoopbackServer.AcceptConnectionAsync` is not itself cancellable, so in that case the server was left blocked in `Accept` forever, and the enclosing ~60-72s `LoopbackWebSocketServer`/`GenericLoopbackServer` timeout (`WhenAllOrAnyFailed`) fired a `TimeoutException` instead of the client observing cancellation and throwing the expected `OperationCanceledException`. This matched the observed CI failures, which were concentrated on JIT-stress legs and surfaced as `TimeoutException` from `LoopbackWebSocketServer.RunAsync` rather than a test assertion failure.

## Fix

Replaced the wall-clock race with deterministic client/server coordination. The loopback server (built directly via `LoopbackWebSocketServer.RunAsync` with `SkipServerHandshakeResponse = true`, bypassing the echo/query-delay path entirely) now signals a `TaskCompletionSource` once it has accepted the connection and fully read the opening handshake request, then withholds the handshake response indefinitely. The client only cancels its own token after awaiting that signal, guaranteeing cancellation always occurs while genuinely waiting on the handshake response — never before the connection has been accepted.

This keeps the fix narrowly scoped to `ConnectAsync_Cancel_ThrowsCancellationException` and preserves coverage across the `SharedHandler`/`Invoker`/`HttpClient` and HTTP/1.1 + HTTP/2 loopback variants via the existing class hierarchy (`CancelTest_Loopback` / `CancelTest_Http2Loopback`). `SendAsync_Cancel_Success` (#132031) and other `CancelTest` methods are untouched. `CancelTest_External` (`[OuterLoop]`, real remote echo servers) and its shared helper in `CancelTest.cs` are also untouched, since there is no in-process server to coordinate with there.

## Validation

- Mandatory baseline `./build.sh clr+libs -rc release` succeeded (0 errors).
- Reproduced the original bug with a temporary repro test (old implementation plus an artificial 300ms client-side delay before `ConnectAsync`, simulating JIT-stress scheduling jitter): reliably reproduced `System.TimeoutException` from `LoopbackWebSocketServer.HttpRunner.RunAsync`, matching the CI failure signature exactly. The repro was removed before committing.
- New implementation: all 10 variants (SharedHandler/Invoker/HttpClient × HTTP/1.1, Invoker/HttpClient × HTTP/2, × `useSsl` true/false) pass consistently.
- Full `System.Net.WebSockets.Client.Tests` suite: 685 total, 663 passed, 22 skipped (pre-existing `[ActiveIssue]` HTTP/2 skips, unrelated), 0 failed.
- Repeated stress: 10 iterations (100 total runs) of the target test under `DOTNET_JitStress=1` + `DOTNET_TieredCompilation=0`, 0 failures.
- `system-net-review` specialist review: no blocking findings.

**Limitation:** true JIT-stress instrumentation is DEBUG-only in the JIT source and wasn't exercised, since the baseline CoreCLR was built as Release (`-rc release`) per the standard build workflow. This doesn't weaken confidence in the fix, though, since it removes the timing dependency structurally (explicit handshake-received signal) rather than relying on winning a race under any particular JIT speed — determinism holds by construction regardless of JIT stress.

> [!NOTE]
> This PR description and the underlying fix were produced with GitHub Copilot assistance.
