### PR TITLE
Convert AssemblyChecker to use MetadataLoadContext to avoid file locking.

### DIFF
--- a/src/coreclr/tools/AssemblyChecker/AssemblyChecker.csproj
+++ b/src/coreclr/tools/AssemblyChecker/AssemblyChecker.csproj
@@ -13,4 +13,8 @@
     <OutputPath>$(RuntimeBinDir)\AssemblyChecker</OutputPath>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="$(SystemReflectionMetadataLoadContextPackageVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/coreclr/tools/AssemblyChecker/AssemblyInspector.cs
+++ b/src/coreclr/tools/AssemblyChecker/AssemblyInspector.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Reflection;
+
+namespace AssemblyChecker
+{
+    internal static class AssemblyInspector
+    {
+        private static readonly RuntimeAssemblyResolver s_resolver = new();
+
+        internal static bool IsDebug(string path)
+        {
+            string assemblyPath = Path.GetFullPath(path);
+            using MetadataLoadContext loadContext = new(s_resolver);
+            Assembly assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+            foreach (CustomAttributeData attribute in assembly.GetCustomAttributesData())
+            {
+                if (attribute.AttributeType.FullName != typeof(DebuggableAttribute).FullName)
+                {
+                    continue;
+                }
+
+                IList<CustomAttributeTypedArgument> arguments = attribute.ConstructorArguments;
+                if (arguments.Count == 1)
+                {
+                    if (arguments[0].Value is not int modes)
+                    {
+                        throw new BadImageFormatException();
+                    }
+
+                    if (((DebuggableAttribute.DebuggingModes)modes & DebuggableAttribute.DebuggingModes.DisableOptimizations) != 0)
+                    {
+                        return true;
+                    }
+                }
+                else if (arguments.Count == 2)
+                {
+                    if (arguments[1].Value is not bool optimizationsDisabled)
+                    {
+                        throw new BadImageFormatException();
+                    }
+
+                    if (optimizationsDisabled)
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    throw new BadImageFormatException();
+                }
+            }
+
+            return false;
+        }
+
+        private sealed class RuntimeAssemblyResolver : MetadataAssemblyResolver
+        {
+            private readonly string _runtimeDirectory = Path.GetDirectoryName(typeof(object).Assembly.Location)
+                ?? throw new InvalidOperationException("The runtime assembly directory is not available.");
+
+            public override Assembly? Resolve(MetadataLoadContext context, AssemblyName assemblyName)
+            {
+                if (assemblyName.Name is not string name)
+                {
+                    return null;
+                }
+
+                string assemblyPath = Path.Combine(_runtimeDirectory, name + ".dll");
+                return File.Exists(assemblyPath) ? context.LoadFromAssemblyPath(assemblyPath) : null;
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/AssemblyChecker/Program.cs
+++ b/src/coreclr/tools/AssemblyChecker/Program.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text;
-using System.Diagnostics;
-using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
@@ -40,14 +37,6 @@ Usage:
             // Check that file has an assembly manifest.
             MetadataReader reader = peReader.GetMetadataReader();
             return reader.IsAssembly;
-        }
-
-        static bool IsDebug(string path)
-        {
-            return
-                Assembly.LoadFrom(path)
-                .GetCustomAttributes(typeof(DebuggableAttribute), false)
-                .OfType<DebuggableAttribute>().Any(x => x.IsJITOptimizerDisabled);
         }
 
         static bool IsExe(string path)
@@ -92,7 +81,7 @@ Usage:
                 {
                     case "--is-debug":
                         {
-                            return IsDebug(args[1]) ? 0 : 1;
+                            return AssemblyInspector.IsDebug(args[1]) ? 0 : 1;
                         }
 
                     case "--is-exe":


### PR DESCRIPTION
The existing implementation was leading to file lock conflicts on #133188 and other managed ILASM PRs.