### PR TITLE
Fix EC public key export for provider keys

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -593,6 +593,7 @@ extern bool g_libSslUses32BitTime;
     LIGHTUP_FUNCTION(EVP_PKEY_get_bn_param) \
     LIGHTUP_FUNCTION(EVP_PKEY_get_utf8_string_param) \
     LIGHTUP_FUNCTION(EVP_PKEY_get_octet_string_param) \
+    LIGHTUP_FUNCTION(EVP_PKEY_todata) \
     LIGHTUP_FUNCTION(EVP_rc2_cbc) \
     LIGHTUP_FUNCTION(EVP_rc2_ecb) \
     REQUIRED_FUNCTION(EVP_sha1) \
@@ -680,6 +681,8 @@ extern bool g_libSslUses32BitTime;
     LIGHTUP_FUNCTION(OSSL_PARAM_BLD_push_BN) \
     LIGHTUP_FUNCTION(OSSL_PARAM_BLD_to_param) \
     LIGHTUP_FUNCTION(OSSL_PARAM_free) \
+    LIGHTUP_FUNCTION(OSSL_PARAM_get_octet_string_ptr) \
+    LIGHTUP_FUNCTION(OSSL_PARAM_locate_const) \
     REQUIRED_FUNCTION(PKCS8_PRIV_KEY_INFO_free) \
     REQUIRED_FUNCTION(PEM_read_bio_PKCS7) \
     REQUIRED_FUNCTION(PEM_read_bio_X509) \
@@ -1197,6 +1200,7 @@ extern TYPEOF(OPENSSL_gmtime)* OPENSSL_gmtime_ptr;
 #define EVP_PKEY_get_bn_param EVP_PKEY_get_bn_param_ptr
 #define EVP_PKEY_get_utf8_string_param EVP_PKEY_get_utf8_string_param_ptr
 #define EVP_PKEY_get_octet_string_param EVP_PKEY_get_octet_string_param_ptr
+#define EVP_PKEY_todata EVP_PKEY_todata_ptr
 #define EVP_rc2_cbc EVP_rc2_cbc_ptr
 #define EVP_rc2_ecb EVP_rc2_ecb_ptr
 #define EVP_sha1 EVP_sha1_ptr
@@ -1285,6 +1289,8 @@ extern TYPEOF(OPENSSL_gmtime)* OPENSSL_gmtime_ptr;
 #define OSSL_PARAM_BLD_push_BN OSSL_PARAM_BLD_push_BN_ptr
 #define OSSL_PARAM_BLD_to_param OSSL_PARAM_BLD_to_param_ptr
 #define OSSL_PARAM_free OSSL_PARAM_free_ptr
+#define OSSL_PARAM_get_octet_string_ptr OSSL_PARAM_get_octet_string_ptr_ptr
+#define OSSL_PARAM_locate_const OSSL_PARAM_locate_const_ptr
 #define PKCS8_PRIV_KEY_INFO_free PKCS8_PRIV_KEY_INFO_free_ptr
 #define PEM_read_bio_PKCS7 PEM_read_bio_PKCS7_ptr
 #define PEM_read_bio_X509 PEM_read_bio_X509_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/osslcompat_30.h
+++ b/src/native/libs/System.Security.Cryptography.Native/osslcompat_30.h
@@ -136,6 +136,7 @@ int EVP_PKEY_get_bn_param(const EVP_PKEY *pkey, const char *key_name, BIGNUM **b
 int EVP_PKEY_get_utf8_string_param(const EVP_PKEY *pkey, const char *key_name, char *str, size_t max_buf_sz, size_t *out_len);
 int EVP_PKEY_get_octet_string_param(const EVP_PKEY *pkey, const char *key_name, unsigned char *buf, size_t max_buf_sz, size_t *out_len);
 int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name);
+int EVP_PKEY_todata(const EVP_PKEY *pkey, int selection, OSSL_PARAM **params);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OSSL_LIB_CTX *libctx,
                                          EVP_PKEY *pkey,
                                          const char *propquery);
@@ -153,6 +154,8 @@ int OSSL_PARAM_BLD_push_octet_string(OSSL_PARAM_BLD *bld, const char *key, const
 int OSSL_PARAM_BLD_push_BN(OSSL_PARAM_BLD *bld, const char *key, const BIGNUM *bn);
 OSSL_PARAM *OSSL_PARAM_BLD_to_param(OSSL_PARAM_BLD *bld);
 void OSSL_PARAM_free(OSSL_PARAM *params);
+int OSSL_PARAM_get_octet_string_ptr(const OSSL_PARAM *p, const void **val, size_t *used_len);
+const OSSL_PARAM *OSSL_PARAM_locate_const(const OSSL_PARAM *p, const char *key);
 
 void OSSL_LIB_CTX_free(OSSL_LIB_CTX*);
 OSSL_LIB_CTX* OSSL_LIB_CTX_new(void);

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ecc_import_export.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ecc_import_export.c
@@ -737,8 +737,8 @@ static int32_t EvpPKeyGetEcKeyParameters(
 
     ERR_clear_error();
 
-    // Some providers, like the PKCS#11 provider, only support exporting the public key through the `export` KEYMGMT
-    // API, not the `get_params` KEYMGMT APIs. like the PKCS#11 provider here:
+    // Some providers (e.g., the PKCS#11 provider) only support exporting the public key through the `export` KEYMGMT
+    // API, not the `get_params` KEYMGMT APIs. See:
     // https://github.com/openssl-projects/pkcs11-provider/blame/c7a5c8b62a0ff012b16574f01651254ef7e664ee/src/kmgmt/ec.c#L548
     // If the `get_params` KEYMGMT surface does not work, use the `export` KEYMGMT API, which some providers use for hydrating their internal
     // representation. https://github.com/openssl-projects/pkcs11-provider/blob/c7a5c8b62a0ff012b16574f01651254ef7e664ee/src/kmgmt/common.c#L496-L498

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ecc_import_export.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ecc_import_export.c
@@ -711,6 +711,9 @@ static int32_t EvpPKeyGetEcKeyParameters(
     // Get the public key as an encoded point (may be compressed or uncompressed).
     if (EVP_PKEY_get_octet_string_param(pkey, OSSL_PKEY_PARAM_PUB_KEY, NULL, 0, &pubKeyLen))
     {
+        if (pubKeyLen == 0)
+            goto error;
+
         pubKeyBuf = (uint8_t*)OPENSSL_zalloc(pubKeyLen);
         if (pubKeyBuf == NULL)
             goto error;

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ecc_import_export.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ecc_import_export.c
@@ -693,7 +693,11 @@ static int32_t EvpPKeyGetEcKeyParameters(
     BIGNUM *ecA = NULL;
     BIGNUM *ecB = NULL;
     uint8_t* pubKeyBuf = NULL;
+    const uint8_t* pubKeyData = NULL;
     size_t pubKeyLen = 0;
+    OSSL_PARAM* exportedParameters = NULL;
+    const OSSL_PARAM* publicKeyParameter = NULL;
+    const void* publicKeyValue = NULL;
     EC_GROUP* group = NULL;
     EC_POINT* point = NULL;
     char curveName[80] = {0};
@@ -705,18 +709,61 @@ static int32_t EvpPKeyGetEcKeyParameters(
     ERR_clear_error();
 
     // Get the public key as an encoded point (may be compressed or uncompressed).
-    // We use OSSL_PKEY_PARAM_PUB_KEY instead of OSSL_PKEY_PARAM_EC_PUB_X/Y
-    // because the individual X/Y components may not be materialized yet.
-    if (!EVP_PKEY_get_octet_string_param(pkey, OSSL_PKEY_PARAM_PUB_KEY, NULL, 0, &pubKeyLen))
-        goto error;
+    if (EVP_PKEY_get_octet_string_param(pkey, OSSL_PKEY_PARAM_PUB_KEY, NULL, 0, &pubKeyLen))
+    {
+        pubKeyBuf = (uint8_t*)OPENSSL_zalloc(pubKeyLen);
+        if (pubKeyBuf == NULL)
+            goto error;
 
-    pubKeyBuf = (uint8_t*)OPENSSL_zalloc(pubKeyLen);
-    if (pubKeyBuf == NULL)
-        goto error;
+        if (!EVP_PKEY_get_octet_string_param(pkey, OSSL_PKEY_PARAM_PUB_KEY, pubKeyBuf, pubKeyLen, &pubKeyLen))
+            goto error;
 
-    if (!EVP_PKEY_get_octet_string_param(pkey, OSSL_PKEY_PARAM_PUB_KEY, pubKeyBuf, pubKeyLen, &pubKeyLen))
-        goto error;
+        pubKeyData = pubKeyBuf;
+        goto public_key_exported;
+    }
 
+#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
+    if (!API_EXISTS(EVP_PKEY_todata) ||
+        !API_EXISTS(OSSL_PARAM_free) ||
+        !API_EXISTS(OSSL_PARAM_get_octet_string_ptr) ||
+        !API_EXISTS(OSSL_PARAM_locate_const))
+    {
+        goto error;
+    }
+#endif
+
+    ERR_clear_error();
+
+    // Some providers, like the PKCS#11 provider, implement parameter fetching by simply passing it straight through to their
+    // internal key representation. If the provider loads key material "lazily" then those fetches will fail.
+    // Other providers simply don't implement some of the OSSL_PARAM fetches, like OSSL_PKEY_PARAM_PUB_KEY, like the PKCS#11
+    // provider here. https://github.com/openssl-projects/pkcs11-provider/blame/c7a5c8b62a0ff012b16574f01651254ef7e664ee/src/kmgmt/ec.c#L548
+    // The most reliable way it seems is to go through a KEYMGMT API, which some providers use for hydrating their internal
+    // representation.
+    // https://github.com/openssl-projects/pkcs11-provider/blob/c7a5c8b62a0ff012b16574f01651254ef7e664ee/src/kmgmt/common.c#L496-L498
+    if (!EVP_PKEY_todata(pkey, EVP_PKEY_PUBLIC_KEY, &exportedParameters) || exportedParameters == NULL)
+    {
+        goto error;
+    }
+
+    // OSSL_PKEY_PARAM_PUB_KEY is "pub" https://docs.openssl.org/3.4/man7/EVP_PKEY-EC/#common-ec-parameters:
+    // > The public key value in encoded EC point format conforming to Sec. 2.3.3 and 2.3.4 of the SECG SEC 1
+    // > ("Elliptic Curve Cryptography") standard.
+    // It notes that the exported key may be compressed or uncompressed. This is later given to EC_POINT_oct2point
+    // which handles both compressed and uncompressed keys.
+    publicKeyParameter = OSSL_PARAM_locate_const(exportedParameters, OSSL_PKEY_PARAM_PUB_KEY);
+
+    if (publicKeyParameter == NULL ||
+        !OSSL_PARAM_get_octet_string_ptr(publicKeyParameter, &publicKeyValue, &pubKeyLen) ||
+        publicKeyValue == NULL ||
+        pubKeyLen == 0)
+    {
+        goto error;
+    }
+
+    pubKeyData = (const uint8_t*)publicKeyValue;
+
+public_key_exported:
     // Decode the encoded point (compressed or uncompressed) to extract X and Y.
     // Build an EC_GROUP from the key's parameters to perform the decoding.
 
@@ -766,7 +813,7 @@ static int32_t EvpPKeyGetEcKeyParameters(
 
     point = EC_POINT_new(group);
     if (point == NULL ||
-        !EC_POINT_oct2point(group, point, pubKeyBuf, pubKeyLen, NULL))
+        !EC_POINT_oct2point(group, point, pubKeyData, pubKeyLen, NULL))
     {
         goto error;
     }
@@ -816,6 +863,7 @@ error:
     *cbD = 0;
 
 exit:
+    if (exportedParameters) OSSL_PARAM_free(exportedParameters);
     if (xBn) BN_free(xBn);
     if (yBn) BN_free(yBn);
     if (dBn) BN_clear_free(dBn);

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ecc_import_export.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ecc_import_export.c
@@ -737,13 +737,11 @@ static int32_t EvpPKeyGetEcKeyParameters(
 
     ERR_clear_error();
 
-    // Some providers, like the PKCS#11 provider, implement parameter fetching by simply passing it straight through to their
-    // internal key representation. If the provider loads key material "lazily" then those fetches will fail.
-    // Other providers simply don't implement some of the OSSL_PARAM fetches, like OSSL_PKEY_PARAM_PUB_KEY, like the PKCS#11
-    // provider here. https://github.com/openssl-projects/pkcs11-provider/blame/c7a5c8b62a0ff012b16574f01651254ef7e664ee/src/kmgmt/ec.c#L548
-    // The most reliable way it seems is to go through a KEYMGMT API, which some providers use for hydrating their internal
-    // representation.
-    // https://github.com/openssl-projects/pkcs11-provider/blob/c7a5c8b62a0ff012b16574f01651254ef7e664ee/src/kmgmt/common.c#L496-L498
+    // Some providers, like the PKCS#11 provider, only support exporting the public key through the `export` KEYMGMT
+    // API, not the `get_params` KEYMGMT APIs. like the PKCS#11 provider here:
+    // https://github.com/openssl-projects/pkcs11-provider/blame/c7a5c8b62a0ff012b16574f01651254ef7e664ee/src/kmgmt/ec.c#L548
+    // If the `get_params` KEYMGMT surface does not work, use the `export` KEYMGMT API, which some providers use for hydrating their internal
+    // representation. https://github.com/openssl-projects/pkcs11-provider/blob/c7a5c8b62a0ff012b16574f01651254ef7e664ee/src/kmgmt/common.c#L496-L498
     if (!EVP_PKEY_todata(pkey, EVP_PKEY_PUBLIC_KEY, &exportedParameters) || exportedParameters == NULL)
     {
         goto error;


### PR DESCRIPTION
Most of the explanation for this change is documented as comments in this pull request. However, before:

```
.NET 11.0.0-preview.6.26359.118
Unhandled exception. System.Security.Cryptography.CryptographicException: Error occurred during a cryptographic operation.
   at Interop.Crypto.EvpPKeyGetEcKeyParameters(SafeEvpPKeyHandle key, Boolean includePrivate)
   at System.Security.Cryptography.ECOpenSsl.ExportNamedCurveParametersFromEvpPKeyUsingParams(SafeEvpPKeyHandle pkey, String curveName, Boolean includePrivateParameters)
   at System.Security.Cryptography.X509Certificates.ECDsaCertificateExtensions.CopyWithPrivateKey(X509Certificate2 certificate, ECDsa privateKey)
   at Program.<Main>$(String[] args) in /home/vcsjones/ecdsa-pkcs11-repro/HsmPoc/Program.cs:line 17
```

After:

```
.NET 11.0.0-dev
Subject: CN=hsm-poc
Has private key: True
Public X: 1AE3DAFDDE6536E1FC23C7227ABA86E5A9F678BFBBF74674A0A75D29CDDB5770
Public Y: 97FB07F101E2E07D7D4828E3EB3C33B5B6DE4060CFA3D9EE9FF703700FFFA136
Signature valid: True
```

The general gist of the change is the the PKCS#11 OpenSSL provider does not "materialize" the public key until you go through an `export` KEYMGMT interface:

https://github.com/openssl-projects/pkcs11-provider/blob/c7a5c8b62a0ff012b16574f01651254ef7e664ee/src/kmgmt/common.c#L496-L498

Attempting to directly export the public key before this materialization happens results in an error.

We continue to try out existing way first - this is both performance and works in scenarios where a Provider has not implemented KEYMGMT APIs. If it fails, we attempt with EVP_PKEY_todata, which gives us the public key through a KEYMGMT API. It uses the same OSSL_PARAM `OSSL_PKEY_PARAM_PUB_KEY` as we were using before, so we can use the same point handling for the existing and fallback way.

Contributes to #133171