### PR TITLE
JIT: Synthesize profile data when invalid counts are discarded

### DIFF
--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3041,10 +3041,19 @@ PhaseStatus Compiler::fgIncorporateProfileData()
             fgIncorporateBlockCounts();
         }
 
-        // We now always run repair, to get consistent initial counts
+        // Repair retains existing likelihoods. If the counts were discarded,
+        // start over and let the normal heuristics set them.
         //
-        JITDUMP("\nRepairing profile...\n");
-        ProfileSynthesis::Run(this, ProfileSynthesisOption::RepairLikelihoods);
+        if (fgPgoHaveWeights)
+        {
+            JITDUMP("\nRepairing profile...\n");
+            ProfileSynthesis::Run(this, ProfileSynthesisOption::RepairLikelihoods);
+        }
+        else
+        {
+            JITDUMP("\nSynthesizing profile...\n");
+            ProfileSynthesis::Run(this, ProfileSynthesisOption::ResetAndSynthesize);
+        }
     }
 
 #ifdef DEBUG


### PR DESCRIPTION
Edge-count reconstruction can discard stale, malformed, all-zero, or unreconstructable PGO data after profile incorporation has already begun. Running `RepairLikelihoods` afterward preserves the default edge likelihoods as profile-derived, preventing later heuristics from adjusting cold throw paths.

Use `ResetAndSynthesize` when incorporation clears `fgPgoHaveWeights`; successfully incorporated profiles continue through repair.

> [!NOTE]
> This pull request description was generated by GitHub Copilot.