### PR TITLE
Stop the DBI from unloading any DAC on non-Windows

### DIFF
--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -1484,8 +1484,20 @@ void CordbProcess::FreeDac()
 
     if (m_hDacModule != NULL)
     {
+#ifdef HOST_UNIX
+        // Release ownership of the DAC without unloading it. The DAC embeds the PAL, whose TLS
+        // initialization registers a pthread key with a destructor that lives in the DAC image,
+        // and nothing deletes that key on unload: the DAC's DLL_PROCESS_DETACH only destroys the
+        // DAC mutex, and the PAL's TLSCleanup is reachable only from the PAL_Initialize failure
+        // path or from PAL_TerminateEx, which exits the process. Unloading would therefore leave
+        // glibc holding a destructor pointer into unmapped memory, and any thread that entered the
+        // DAC's PAL faults in __nptl_deallocate_tsd once it exits.
+        LOG((LF_CORDB, LL_INFO1000, "Leaving DAC loaded\n"));
+        m_hDacModule.Detach();
+#else
         LOG((LF_CORDB, LL_INFO1000, "Unloading DAC\n"));
         m_hDacModule.Free();
+#endif // HOST_UNIX
     }
 }
 


### PR DESCRIPTION
`CordbProcess::FreeDac` calls `FreeLibrary` on the DAC module, which `dlclose`s it on Unix. That is not safe for either DAC flavor.

The DAC embeds the PAL. `TLSInitialize` registers a pthread key whose destructor (`InternalEndCurrentThreadWrapper`) lives in the DAC image, and nothing deletes that key before the unload:

- the DAC's `DLL_PROCESS_DETACH` (`daccess.cpp` `DllMain2`) only destroys the DAC mutex,
- `TLSCleanup` / `pthread_key_delete` is reachable only from the `PAL_Initialize` failure unwind or from `PAL_TerminateEx`, which ends in `exit()`.

So glibc keeps a destructor pointer into memory that has just been unmapped, and any thread that entered the DAC's PAL faults in `__nptl_deallocate_tsd` when it exits. This is the same defect fixed host-side in microsoft/clrmd#1499.

It reproduces deterministically with the universal DBI: `dbgshim` hands `libmscordaccore_universal.so` to the DBI as its DAC module, so every debuggee teardown unloads the cDAC and the next launch remaps it at a new base. The NativeAOT runtime never calls `pthread_key_delete` at all (`PalUnix.cpp` creates the key with `RuntimeThreadShutdown` and there is no matching delete). The legacy DAC has the same hazard, just intermittently.

### Fix

Detach the holder instead of freeing it on non-Windows, so the image stays mapped. Effectively leaks one mapping per DAC path. There is no reversible in-process PAL teardown to call instead.

### Validation

Root-caused on Linux x64 with a `dlclose` breakpoint under gdb: the faulting `dlclose` of `libmscordaccore_universal.so` originates in `CordbProcess::FreeDac` inside `libmscordbi_universal.so`, reached from `CordbProcess::Neuter` on the RC event thread. Suppressing the unload clears a reproducible 4-test crash cluster in the diagnostics debugger tests
