### PR TITLE
Expand cryptography instruction scope

### DIFF
--- a/.github/instructions/system-security-cryptography.instructions.md
+++ b/.github/instructions/system-security-cryptography.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "src/libraries/System.Security.Cryptography/**"
+applyTo: "src/libraries/System.Security.Cryptography*/**,src/libraries/Microsoft.Bcl.Cryptography/**,src/libraries/Common/src/System/Security/Cryptography/**,src/libraries/Common/tests/System/Security/Cryptography/**"
 ---
 
 # System.Security.Cryptography — Folder-Specific Guidance

--- a/.github/instructions/system-security-cryptography.instructions.md
+++ b/.github/instructions/system-security-cryptography.instructions.md
@@ -2,7 +2,7 @@
 applyTo: "src/libraries/System.Security.Cryptography*/**,src/libraries/Microsoft.Bcl.Cryptography/**,src/libraries/Common/src/System/Security/Cryptography/**,src/libraries/Common/tests/System/Security/Cryptography/**"
 ---
 
-# System.Security.Cryptography — Folder-Specific Guidance
+# Guidance for .NET Cryptography Libraries
 
 ## Code Style
 


### PR DESCRIPTION
Expand the cryptography folder-specific instructions to cover all `System.Security.Cryptography*` libraries, `Microsoft.Bcl.Cryptography`, and shared cryptography source and tests.

This ensures the guidance applies consistently across related cryptography directories.

> [!NOTE]
> GitHub Copilot helped create this PR.