### PR TITLE
Use rolling internal Windows queue for helix_windows_x64_latest_internal

### DIFF
--- a/eng/pipelines/helix-platforms.yml
+++ b/eng/pipelines/helix-platforms.yml
@@ -216,7 +216,7 @@ variables:
     value: Windows.Amd64.Open.rt
 
   - name: helix_windows_x64_latest_internal
-    value: Windows.11.Amd64
+    value: Windows.Amd64.rt
 
   # Oldest: Windows 10
   - name: helix_windows_x64_oldest


### PR DESCRIPTION
The Windows.11.Amd64 Helix queue was retired, so all internal Windows x64 legs (including runtime-coreclr superpmi-collect) fail with 'Helix API does not contain an entry for Windows.11.Amd64'. Point the internal latest alias at Windows.Amd64.rt, the internal counterpart of the public Windows.Amd64.Open.rt rolling queue already used by helix_windows_x64_latest.