### PR TITLE
NativeAOT: keep non-ASCII identifiers distinct when mangling names

### DIFF
--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Text;
 
 using Internal.Text;
 using Internal.TypeSystem;
@@ -74,16 +76,38 @@ namespace ILCompiler
                         sb.Append(s.Slice(0, i));
                 }
 
+                if ((sbyte)c < 0)
+                {
+                    // Non-ASCII codepoint: encode it as "_u" followed by the hex value of the scalar so that
+                    // distinct non-ASCII identifiers stay distinct after sanitization. Replacing every codepoint
+                    // with a single underscore made identifiers that consist only of non-ASCII characters (for
+                    // example Japanese type and method names) collapse into runs of underscores. Because the
+                    // mangled name of a method is "<type>__<method>", a type with an 8-character name and a
+                    // 9-character method then produced exactly the same symbol as a type with a 9-character
+                    // name and an 8-character method, and the linker rejected the duplicate symbols.
+                    int codepoint;
+                    if (Rune.DecodeFromUtf8(s.Slice(i), out Rune rune, out int bytesConsumed) == OperationStatus.Done)
+                    {
+                        codepoint = rune.Value;
+                        i += bytesConsumed - 1;
+                    }
+                    else
+                    {
+                        // Malformed sequence: keep the lead byte as the discriminator and skip its continuation bytes
+                        // so that the produced name is still deterministic.
+                        codepoint = c;
+                        while ((i + 1 < s.Length) && ((s[i + 1] & 0b1100_0000) == 0b1000_0000))
+                            i++;
+                    }
+                    sb.Append('_');
+                    sb.Append('u');
+                    AppendHex(sb, codepoint);
+                    continue;
+                }
+
                 // Everything else is replaced by underscore.
                 // TODO: We assume that there won't be collisions with our own or C++ built-in identifiers.
                 sb.Append('_');
-
-                // If this is a multibyte codepoint, seek to the next character
-                if ((sbyte)c < 0)
-                {
-                    while ((i + 1 < s.Length) && ((s[i + 1] & 0b1100_0000) == 0b1000_0000))
-                        i++;
-                }
             }
 
             Utf8String sanitizedName = (sb != null) ? sb.ToUtf8String() : new Utf8String(s.ToArray());
@@ -92,6 +116,15 @@ namespace ILCompiler
             // restricted to that use only. Replace them if they happened to be used in any identifiers in
             // the compilation input.
             return sanitizedName;
+        }
+
+        private static void AppendHex(Utf8StringBuilder sb, int value)
+        {
+            const string hexDigits = "0123456789abcdef";
+            // At least four digits so that names read like "\uXXXX" escapes; longer for supplementary planes.
+            int digits = value > 0xFFFF ? 6 : 4;
+            for (int shift = (digits - 1) * 4; shift >= 0; shift -= 4)
+                sb.Append(hexDigits[(value >> shift) & 0xF]);
         }
 
         private static bool ContainsUtf8ReplacementCharacter(ReadOnlySpan<byte> bytes)

--- a/src/tests/nativeaot/SmokeTests/UnitTests/MiscTests.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/MiscTests.cs
@@ -9,6 +9,7 @@ class MiscTests
     internal static int Run()
     {
         TestSurrogateStringLiterals.Run();
+        TestNonAsciiIdentifiers.Run();
         return 100;
     }
 
@@ -33,6 +34,42 @@ class MiscTests
 
             if (value[0] != expected)
                 throw new Exception(((int)value[0]).ToString("X4"));
+        }
+    }
+
+    // Regression test: identifiers made only of non-ASCII characters used to be sanitized into runs of
+    // underscores. A type with an 8-character name and a 9-character method then produced the same symbol
+    // ("<type>__<method>") as a type with a 9-character name and an 8-character method, and the linker
+    // (or the object writer) rejected the duplicate symbols. The exception handling clauses below make sure
+    // per-method symbols such as the EH info are emitted for both methods.
+    class TestNonAsciiIdentifiers
+    {
+        public static void Run()
+        {
+            if (new ラベルを登録する().実行して検分する() != "a")
+                throw new Exception();
+            if (new 配置対象を選び出す().実行して検分す() != "c")
+                throw new Exception();
+        }
+
+        sealed class ラベルを登録する
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public string 実行して検分する()
+            {
+                try { return "a"; }
+                catch (Exception) { return "b"; }
+            }
+        }
+
+        sealed class 配置対象を選び出す
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public string 実行して検分す()
+            {
+                try { return "c"; }
+                catch (Exception) { return "d"; }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #133229

`NativeAotNameMangler.SanitizeName` replaced every non-ASCII codepoint with a single `_`. Identifiers that consist only of non-ASCII characters (for example Japanese type and method names) collapsed into runs of underscores, so different identifiers of the same length sanitized to the same string. Uniqueness is enforced per scope only, but a method's mangled name is `<type>__<method>` with an underscore separator, so a type with an 8-character name and a 9-character method produced exactly the same symbol as a type with a 9-character name and an 8-character method. The linker (ILC 8, `symbol ... is already defined`) or the object writer (ILC 10, `An item with the same key has already been added. Key: ___ehinfo_...`) then rejected the duplicates.

This change encodes each non-ASCII codepoint as `_u` followed by its hex value (4 digits, 6 for supplementary planes), similar to a `\u` escape, so that distinct identifiers stay distinct after sanitization. `ラベルを登録する` now mangles to `_u30e9_u30d9_u30eb_u3092_u767b_u9332_u3059_u308b` instead of `________`. Malformed UTF-8 keeps the lead byte as the discriminator so the result stays deterministic. ASCII characters are handled exactly as before.

I verified the fix with an ILC built from the 10.0 servicing branch (`v10.0.11` + this change): the minimal repro from the issue and a 19,000-line assembly with 285 colliding member groups both publish and run with NativeAOT on `osx-arm64`, and the `ios-arm64` build that originally failed now links (the produced dSYM contains 10,266 `_uXXXX` symbols). Symbol names get longer for non-ASCII identifiers (7 bytes per BMP character), which seemed acceptable next to the alternative of not being able to compile at all; happy to switch to a hashed suffix if that is preferred.

A regression test with the two colliding types is added to the NativeAOT `UnitTests` smoke test.
