### PR TITLE
Update jit-format workflow to install .NET 10 SDK

### DIFF
--- a/.github/workflows/jit-format.yml
+++ b/.github/workflows/jit-format.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       - name: Checkout runtime
         uses: actions/checkout@v7
         with:

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -69,8 +69,8 @@ bool Compiler::impILConsumesAddr(const BYTE* codeAddr, const BYTE* codeEndp)
 
 void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolvedToken, CorInfoTokenKind kind)
 {
-    pResolvedToken->tokenScope   = info.compScopeHnd;
     pResolvedToken->tokenContext = impTokenLookupContextHandle;
+    pResolvedToken->tokenScope   = info.compScopeHnd;
     pResolvedToken->token        = getU4LittleEndian(addr);
     pResolvedToken->tokenType    = kind;
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -69,8 +69,8 @@ bool Compiler::impILConsumesAddr(const BYTE* codeAddr, const BYTE* codeEndp)
 
 void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolvedToken, CorInfoTokenKind kind)
 {
-    pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->tokenScope   = info.compScopeHnd;
+    pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->token        = getU4LittleEndian(addr);
     pResolvedToken->tokenType    = kind;
 


### PR DESCRIPTION
jitutils now targets net10.0, so bootstrapping it with the 8.0 SDK fails on the Linux leg.