### PR TITLE
JIT: avoid GS cookie conflict with secret stub argument in non-standard register

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1176,6 +1176,9 @@ protected:
 #if defined(FEATURE_SIMD) || defined(FEATURE_HW_INTRINSICS)
     void genConsumeMultiOpOperands(GenTreeMultiOp* tree);
 #endif
+#ifdef DEBUG
+    void genCheckTailCallEpilogRegisters(GenTreeCall* call);
+#endif
     void genEmitGSCookieCheck(bool tailCall);
     void genCodeForShift(GenTree* tree);
 

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3350,33 +3350,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     {
         params.sigInfo = call->callSig;
     }
-
-    if (call->IsFastTailCall())
-    {
-        regMaskTP trashedByEpilog = RBM_CALLEE_SAVED;
-
-        // The epilog may use and trash some registers for the GS cookie check.
-        // Make sure we have no non-standard args that may be trash if this is
-        // a tailcall.
-        if (m_compiler->getNeedsGSSecurityCookie())
-        {
-            trashedByEpilog |= genGetGSCookieTempRegs(/* tailCall */ true);
-        }
-
-        for (CallArg& arg : call->gtArgs.Args())
-        {
-            for (const ABIPassingSegment& seg : arg.AbiInfo.Segments())
-            {
-                if (seg.IsPassedInRegister() && ((trashedByEpilog & seg.GetRegisterMask()) != 0))
-                {
-                    JITDUMP("Tail call node:\n");
-                    DISPTREE(call);
-                    JITDUMP("Register used: %s\n", getRegName(seg.GetRegister()));
-                    assert(!"Argument to tailcall may be trashed by epilog");
-                }
-            }
-        }
-    }
+    genCheckTailCallEpilogRegisters(call);
 #endif // DEBUG
 
     GenTree* target = getCallTarget(call, &params.methHnd);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2925,25 +2925,70 @@ CorInfoHelpFunc CodeGenInterface::genWriteBarrierHelperForWriteBarrierForm(GCInf
 
 #if !defined(TARGET_WASM)
 
+#ifdef DEBUG
+// -----------------------------------------------------------------------------
+// genCheckTailCallEpilogRegisters:
+//   Check that the tailcall arguments do not use registers trashed by the epilog.
+//
+// Parameters:
+//   call - The tailcall node
+//
+void CodeGen::genCheckTailCallEpilogRegisters(GenTreeCall* call)
+{
+    if (!call->IsFastTailCall())
+    {
+        return;
+    }
+
+    regMaskTP trashedByEpilog = RBM_CALLEE_SAVED;
+    if (m_compiler->getNeedsGSSecurityCookie())
+    {
+        trashedByEpilog |= genGetGSCookieTempRegs(/* tailCall */ true, call);
+    }
+
+    for (CallArg& arg : call->gtArgs.Args())
+    {
+        for (const ABIPassingSegment& seg : arg.AbiInfo.Segments())
+        {
+            if (seg.IsPassedInRegister() && ((trashedByEpilog & seg.GetRegisterMask()) != 0))
+            {
+                JITDUMP("Tail call node:\n");
+                DISPTREE(call);
+                JITDUMP("Register used: %s\n", getRegName(seg.GetRegister()));
+                assert(!"Argument to tailcall may be trashed by epilog");
+            }
+        }
+    }
+}
+#endif // DEBUG
+
 // -----------------------------------------------------------------------------
 // genGetGSCookieTempRegs:
 //   Get a mask of registers to use for the GS cookie check generated in a
 //   block.
 //
 // Parameters:
-//   tailCall - Whether the block is a tailcall
+//   tailCall     - Whether the block is a tailcall
+//   tailCallNode - The tailcall node, if available
 //
 // Returns:
 //   Mask of all the registers that can be used. Some targets may need more
 //   than one register.
 //
-regMaskTP CodeGenInterface::genGetGSCookieTempRegs(bool tailCall)
+regMaskTP CodeGenInterface::genGetGSCookieTempRegs(bool tailCall, GenTreeCall* tailCallNode)
 {
 #ifdef TARGET_AMD64
     if (tailCall)
     {
+        if ((tailCallNode != nullptr) &&
+            (tailCallNode->gtArgs.FindWellKnownArg(WellKnownArg::SecretStubParam) != nullptr))
+        {
+            return RBM_RAX;
+        }
+
         // If we are tailcalling then arg regs cannot be used. For both SysV and winx64 that
-        // leaves rax, r10, r11. rax and r11 are used for indirection cells, so we pick r10.
+        // leaves rax, r10, r11. RAX and r11 are used for indirection cells, so we pick r10
+        // unless it is used for the secret stub argument.
         return RBM_R10;
     }
     // Otherwise on x64 (win-x64, SysV and Swift) r9 is never used for return values

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2983,12 +2983,12 @@ regMaskTP CodeGenInterface::genGetGSCookieTempRegs(bool tailCall, GenTreeCall* t
         if ((tailCallNode != nullptr) &&
             (tailCallNode->gtArgs.FindWellKnownArg(WellKnownArg::SecretStubParam) != nullptr))
         {
-            return RBM_RAX;
+            return RBM_R11;
         }
 
         // If we are tailcalling then arg regs cannot be used. For both SysV and winx64 that
-        // leaves rax, r10, r11. RAX and r11 are used for indirection cells, so we pick r10
-        // unless it is used for the secret stub argument.
+        // leaves rax, r10, r11. Rax and r11 are used for indirection cells, so we pick r10
+        // unless it is used for the secret stub argument, in which case we pick r11.
         return RBM_R10;
     }
     // Otherwise on x64 (win-x64, SysV and Swift) r9 is never used for return values

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -248,7 +248,7 @@ public:
     bool genWriteBarrierUsed;
 #endif
 
-    regMaskTP genGetGSCookieTempRegs(bool tailCall);
+    regMaskTP genGetGSCookieTempRegs(bool tailCall, GenTreeCall* tailCallNode = nullptr);
 
     // The following property indicates whether the current method sets up
     // an explicit stack frame or not.

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -5687,33 +5687,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     {
         params.sigInfo = call->callSig;
     }
-
-    if (call->IsFastTailCall())
-    {
-        regMaskTP trashedByEpilog = RBM_CALLEE_SAVED;
-
-        // The epilog may use and trash REG_GSCOOKIE_TMP. Make sure we have no
-        // non-standard args that may be trash if this is a tailcall.
-        if (m_compiler->getNeedsGSSecurityCookie())
-        {
-            trashedByEpilog |= genGetGSCookieTempRegs(/* tailCall */ true);
-        }
-
-        for (CallArg& arg : call->gtArgs.Args())
-        {
-            for (unsigned i = 0; i < arg.AbiInfo.NumSegments; i++)
-            {
-                const ABIPassingSegment& seg = arg.AbiInfo.Segment(i);
-                if (seg.IsPassedInRegister() && ((trashedByEpilog & seg.GetRegisterMask()) != 0))
-                {
-                    JITDUMP("Tail call node:\n");
-                    DISPTREE(call);
-                    JITDUMP("Register used: %s\n", getRegName(seg.GetRegister()));
-                    assert(!"Argument to tailcall may be trashed by epilog");
-                }
-            }
-        }
-    }
+    genCheckTailCallEpilogRegisters(call);
 #endif // DEBUG
     GenTree* target = getCallTarget(call, &params.methHnd);
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5521,34 +5521,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     {
         params.sigInfo = call->callSig;
     }
-
-    if (call->IsFastTailCall())
-    {
-        regMaskTP trashedByEpilog = RBM_CALLEE_SAVED;
-
-        // The epilog may use and trash some registers for the GS cookie check.
-        // Make sure we have no non-standard args that may be trash if this is
-        // a tailcall.
-        if (m_compiler->getNeedsGSSecurityCookie())
-        {
-            trashedByEpilog |= genGetGSCookieTempRegs(/* tailCall */ true);
-        }
-
-        for (CallArg& arg : call->gtArgs.Args())
-        {
-            for (unsigned i = 0; i < arg.AbiInfo.NumSegments; i++)
-            {
-                const ABIPassingSegment& seg = arg.AbiInfo.Segment(i);
-                if (seg.IsPassedInRegister() && ((trashedByEpilog & seg.GetRegisterMask()) != 0))
-                {
-                    JITDUMP("Tail call node:\n");
-                    DISPTREE(call);
-                    JITDUMP("Register used: %s\n", getRegName(seg.GetRegister()));
-                    assert(!"Argument to tailcall may be trashed by epilog");
-                }
-            }
-        }
-    }
+    genCheckTailCallEpilogRegisters(call);
 #endif // DEBUG
     GenTree* target = getCallTarget(call, &params.methHnd);
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -95,7 +95,19 @@ void CodeGen::genEmitGSCookieCheck(bool tailCall)
 {
     noway_assert(m_compiler->gsGlobalSecurityCookieAddr || m_compiler->gsGlobalSecurityCookieVal);
 
-    regMaskTP tempRegs = genGetGSCookieTempRegs(tailCall);
+    GenTreeCall* tailCallNode = nullptr;
+    if (tailCall)
+    {
+        assert(m_compiler->compCurBB != nullptr);
+        GenTree* lastNode = m_compiler->compCurBB->lastNode();
+        if (lastNode->OperIs(GT_CALL))
+        {
+            tailCallNode = lastNode->AsCall();
+            assert(tailCallNode->IsFastTailCall());
+        }
+    }
+
+    regMaskTP tempRegs = genGetGSCookieTempRegs(tailCall, tailCallNode);
     assert(tempRegs != RBM_NONE);
     regNumber regGSCheck = genFirstRegNumFromMask(tempRegs);
 
@@ -6074,6 +6086,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call X86_ARG(target_ssize_t stackA
     {
         params.sigInfo = call->callSig;
     }
+    genCheckTailCallEpilogRegisters(call);
 #endif // DEBUG
 
     GenTree* target = getCallTarget(call, &params.methHnd);

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2495,8 +2495,15 @@ void LinearScan::buildIntervals()
             // The cookie check will kill some registers that it is using.
             // Model this to ensure values that are kept live throughout the
             // method are properly made available.
-            bool isTailCall = block->HasFlag(BBF_HAS_JMP);
-            addKillForRegs(m_compiler->codeGen->genGetGSCookieTempRegs(isTailCall), currentLoc + 1);
+            bool         isTailCall   = block->HasFlag(BBF_HAS_JMP);
+            GenTreeCall* tailCallNode = nullptr;
+            if (isTailCall && block->lastNode()->OperIs(GT_CALL))
+            {
+                tailCallNode = block->lastNode()->AsCall();
+                assert(tailCallNode->IsFastTailCall());
+            }
+
+            addKillForRegs(m_compiler->codeGen->genGetGSCookieTempRegs(isTailCall, tailCallNode), currentLoc + 1);
             currentLoc += 2;
         }
 

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1309,7 +1309,8 @@ int LinearScan::BuildCall(GenTreeCall* call)
             ctrlExprCandidates = RBM_INT_CALLEE_TRASH.GetIntRegSet();
             if (m_compiler->getNeedsGSSecurityCookie())
             {
-                ctrlExprCandidates &= ~m_compiler->codeGen->genGetGSCookieTempRegs(/* tailCall */ true).GetIntRegSet();
+                ctrlExprCandidates &=
+                    ~m_compiler->codeGen->genGetGSCookieTempRegs(/* tailCall */ true, call).GetIntRegSet();
             }
         }
 #ifdef TARGET_X86


### PR DESCRIPTION
AMD64 fast tailcall epilogs use R10 as a scratch register for GS cookie checks. SecretStubParam is also passed in the non-standard R10 argument register, so the epilog could overwrite the argument before jumping to the target.

Use R11 for the GS cookie check when the fast tailcall carries SecretStubParam, and pass the tailcall context through LSRA so register kills and target candidates remain consistent with code generation.

Fix #132801

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>