### PR TITLE
Fix JsonSchemaExporter handling of default struct parameters

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Schema/JsonSchemaExporter.cs
@@ -256,7 +256,7 @@ namespace System.Text.Json.Schema
                         if (property.AssociatedParameter is { HasDefaultValue: true } parameterInfo)
                         {
                             JsonSchema.EnsureMutable(ref propertySchema);
-                            propertySchema.DefaultValue = JsonSerializer.SerializeToNode(parameterInfo.DefaultValue, property.JsonTypeInfo);
+                            propertySchema.DefaultValue = JsonSerializer.SerializeToNode(parameterInfo.EffectiveDefaultValue, property.JsonTypeInfo);
                             propertySchema.HasDefaultValue = true;
                         }
 

--- a/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
+++ b/src/libraries/System.Text.Json/tests/Common/JsonSchemaExporterTests.TestTypes.cs
@@ -919,7 +919,8 @@ namespace System.Text.Json.Schema.Tests
                         "X7": {"type":["integer","null"], "default": 42 },
                         "X8": {"type":["boolean","null"], "default": true },
                         "X9": {"type":["number","null"], "default": 0 },
-                        "X10": {"enum":["A","B","C", null], "default": "A" }
+                        "X10": {"enum":["A","B","C", null], "default": "A" },
+                        "X11": {"type":"string", "format":"uuid", "default":"00000000-0000-0000-0000-000000000000" }
                     }
                 }
                 """);
@@ -1592,7 +1593,8 @@ namespace System.Text.Json.Schema.Tests
 
         public class PocoWithOptionalConstructorParams(
             string x1 = "str", int x2 = 42, bool x3 = true, double x4 = 0, StringEnum x5 = StringEnum.A,
-            string? x6 = "str", int? x7 = 42, bool? x8 = true, double? x9 = 0, StringEnum? x10 = StringEnum.A)
+            string? x6 = "str", int? x7 = 42, bool? x8 = true, double? x9 = 0, StringEnum? x10 = StringEnum.A,
+            Guid x11 = default)
         {
             public string X1 { get; } = x1;
             public int X2 { get; } = x2;
@@ -1605,6 +1607,7 @@ namespace System.Text.Json.Schema.Tests
             public bool? X8 { get; } = x8;
             public double? X9 { get; } = x9;
             public StringEnum? X10 { get; } = x10;
+            public Guid X11 { get; } = x11;
         }
 
         // Regression test for https://github.com/dotnet/runtime/issues/92487


### PR DESCRIPTION
`ParameterInfo.DefaultValue` can be `null` for optional non-nullable value-type parameters declared with `= default`, even when `HasDefaultValue` is `true`. `JsonSchemaExporter` attempted to serialize that `null` value using the non-nullable contract and threw `JsonException`.

Use `JsonParameterInfo.EffectiveDefaultValue`, which already supplies `default(T)` for constructor invocation, when emitting the schema `default` keyword. Extend the existing optional-constructor-parameter coverage with `Guid = default`.

Fixes #133178

Validation:
- `.\build.cmd clr+libs -rc release`
- Built `src\libraries\System.Text.Json\src\System.Text.Json.csproj`
- Passed `System.Text.Json.Tests` and both Roslyn variants of the source-generation integration and unit test projects

> [!NOTE]
> This pull request description was generated with GitHub Copilot.