### PR TITLE
Suppress SYSLIB1227 for unions with custom converters

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -1217,9 +1217,8 @@ namespace System.Text.Json.SourceGeneration
                     };
                 }
 
-                // Union types: when the type is recognized as a union, enqueue all case
-                // types (constructor parameter types) for metadata generation.
-                if (isUnionType)
+                // Union types handled by the built-in converter need metadata for all case types.
+                if (isUnionType && !foundJsonConverterAttribute)
                 {
                     EnqueueUnionCaseTypes(typeToGenerate, hasUnionTypeClassifierSpecified, ref experimentalIds);
                 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
@@ -713,6 +713,43 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         }
 
         [Fact]
+        public void UnionWithCustomConverter_CompilesWithoutWarning()
+        {
+            string source = """
+                using System;
+                using System.Runtime.CompilerServices;
+                using System.Text.Json;
+                using System.Text.Json.Serialization;
+
+                namespace TestApp
+                {
+                    [JsonSerializable(typeof(IntOrLongUnion))]
+                    internal partial class MyContext : JsonSerializerContext { }
+
+                    [JsonConverter(typeof(IntOrLongUnionConverter))]
+                    [Union]
+                    public readonly struct IntOrLongUnion : IUnion
+                    {
+                        public IntOrLongUnion(int value) { Value = value; }
+                        public IntOrLongUnion(long value) { Value = value; }
+                        public object? Value { get; }
+                    }
+
+                    public sealed class IntOrLongUnionConverter : JsonConverter<IntOrLongUnion>
+                    {
+                        public override IntOrLongUnion Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => default;
+                        public override void Write(Utf8JsonWriter writer, IntOrLongUnion value, JsonSerializerOptions options) { }
+                    }
+                }
+                """;
+
+            Compilation compilation = CompilationHelper.CreateCompilation(source);
+            JsonSourceGeneratorResult result = CompilationHelper.RunJsonSourceGenerator(compilation, disableDiagnosticValidation: true);
+
+            Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Id == "SYSLIB1227");
+        }
+
+        [Fact]
         public void UnionWithListAndDictionaryCases_CompilesWithoutWarning()
         {
             string source = """


### PR DESCRIPTION
A type-level `[JsonConverter]` makes generated metadata use the custom-converter path, but the source generator still analyzed the union cases first and emitted `SYSLIB1227`.

Skip union case discovery and ambiguity diagnostics when a type-level converter owns the contract. Add source-generator coverage for an otherwise ambiguous union handled by a custom converter.

Fixes #133156.

Validated with:
- `build.cmd clr+libs -rc release`
- all five System.Text.Json test projects (131,786 test executions, 0 failures; 17 existing skips)

> [!NOTE]
> This pull request description was generated by GitHub Copilot.