### PR TITLE
[release/11.0] Fix SIMD MinMax constant special cases

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -21033,23 +21033,32 @@ bool GenTreeVecCon::IsBroadcast(var_types simdBaseType) const
 bool GenTreeVecCon::IsNaN(var_types simdBaseType) const
 {
     assert(varTypeIsFloating(simdBaseType));
-    uint32_t elementCount = ElementCount(genTypeSize(gtType), simdBaseType);
 
-    for (uint32_t i = 0; i < elementCount; i++)
-    {
-        double element = GetElementFloating(simdBaseType, i);
-
-        if (!FloatingPointUtils::isNaN(element))
-        {
-            return false;
-        }
-    }
-
-    return true;
+    unsigned simdSize = genTypeSize(gtType);
+    simd_t   result   = EvaluateSimdIsNaN(simdBaseType, gtSimdVal, simdSize);
+    return EvaluateSimdAllWhereAllBitsSet(simdBaseType, result, simdSize);
 }
 
 //------------------------------------------------------------------------
-// GenTreeVecCon::IsNaN: Determines if this vector constant has all elements being -0
+// GenTreeVecCon::ContainsNaN: Determines if this vector constant contains a NaN
+//
+// Arguments:
+//    simdBaseType - the base type of the constant being checked
+//
+// Returns:
+//    true if any element is NaN; otherwise, false
+//
+bool GenTreeVecCon::ContainsNaN(var_types simdBaseType) const
+{
+    assert(varTypeIsFloating(simdBaseType));
+
+    unsigned simdSize = genTypeSize(gtType);
+    simd_t   result   = EvaluateSimdIsNaN(simdBaseType, gtSimdVal, simdSize);
+    return EvaluateSimdAnyWhereAllBitsSet(simdBaseType, result, simdSize);
+}
+
+//------------------------------------------------------------------------
+// GenTreeVecCon::IsNegativeZero: Determines if this vector constant has all elements being -0
 //
 // Arguments:
 //    simdBaseType - the base type of the constant being checked
@@ -21060,19 +21069,46 @@ bool GenTreeVecCon::IsNaN(var_types simdBaseType) const
 bool GenTreeVecCon::IsNegativeZero(var_types simdBaseType) const
 {
     assert(varTypeIsFloating(simdBaseType));
-    uint32_t elementCount = ElementCount(genTypeSize(gtType), simdBaseType);
 
-    for (uint32_t i = 0; i < elementCount; i++)
-    {
-        double element = GetElementFloating(simdBaseType, i);
+    unsigned simdSize = genTypeSize(gtType);
+    simd_t   result   = EvaluateSimdIsNegativeZero(simdBaseType, gtSimdVal, simdSize);
+    return EvaluateSimdAllWhereAllBitsSet(simdBaseType, result, simdSize);
+}
 
-        if (!FloatingPointUtils::isNegativeZero(element))
-        {
-            return false;
-        }
-    }
+//------------------------------------------------------------------------
+// GenTreeVecCon::ContainsNegativeZero: Determines if this vector constant contains -0
+//
+// Arguments:
+//    simdBaseType - the base type of the constant being checked
+//
+// Returns:
+//    true if any element is -0; otherwise, false
+//
+bool GenTreeVecCon::ContainsNegativeZero(var_types simdBaseType) const
+{
+    assert(varTypeIsFloating(simdBaseType));
 
-    return true;
+    unsigned simdSize = genTypeSize(gtType);
+    simd_t   result   = EvaluateSimdIsNegativeZero(simdBaseType, gtSimdVal, simdSize);
+    return EvaluateSimdAnyWhereAllBitsSet(simdBaseType, result, simdSize);
+}
+
+//------------------------------------------------------------------------
+// GenTreeVecCon::ContainsPositiveZero: Determines if this vector constant contains +0
+//
+// Arguments:
+//    simdBaseType - the base type of the constant being checked
+//
+// Returns:
+//    true if any element is +0; otherwise, false
+//
+bool GenTreeVecCon::ContainsPositiveZero(var_types simdBaseType) const
+{
+    assert(varTypeIsFloating(simdBaseType));
+
+    unsigned simdSize = genTypeSize(gtType);
+    simd_t   result   = EvaluateSimdIsPositiveZero(simdBaseType, gtSimdVal, simdSize);
+    return EvaluateSimdAnyWhereAllBitsSet(simdBaseType, result, simdSize);
 }
 
 #if defined(FEATURE_MASKED_HW_INTRINSICS)
@@ -26578,8 +26614,15 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
 
             if (!isMagnitude)
             {
-                bool needsFixup = false;
-                bool canHandle  = false;
+                // xarch min/max return op2 if both inputs are 0 of either sign or if either input
+                // is NaN. We can exploit that to get the IEEE 754 behavior for free by ordering
+                // the operands such that the constant is the one that gets returned.
+
+                // Partially NaN constants cannot use operand ordering, while mixed zero constants
+                // require the per-element fixup below.
+                bool hasPartialNaN = !isScalar && cnsNode->AsVecCon()->ContainsNaN(simdBaseType);
+                bool needsFixup    = false;
+                bool canHandle     = false;
 
                 if (isMax)
                 {
@@ -26588,10 +26631,10 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                     // not be propagated for isNumber and to be propagated otherwise.
                     //
                     // This means for isNumber we want to do `max other, cns` and
-                    // can only handle cns being -0 if Avx512F is supported. This is
-                    // because if other was NaN, we want to return the non-NaN cns.
-                    // But if cns was -0 and other was +0 we'd want to return +0 and
-                    // so need to be able to fixup the result.
+                    // cannot handle cns being -0. If other was NaN, we want to return
+                    // the non-NaN cns. But if cns was -0 and other was +0 we'd want
+                    // to return +0, and the ZERO fixup token cannot distinguish the
+                    // opaque operand's sign.
                     //
                     // For !isNumber we have the inverse and want `max cns, other` and
                     // can only handle cns being +0 if Avx512F is supported. This is
@@ -26607,7 +26650,7 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                         }
                         else
                         {
-                            needsFixup = cnsNode->IsVectorNegativeZero(simdBaseType);
+                            needsFixup |= cnsNode->AsVecCon()->ContainsNegativeZero(simdBaseType);
                         }
                     }
                     else if (isScalar)
@@ -26616,10 +26659,11 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                     }
                     else
                     {
-                        needsFixup = cnsNode->IsVectorZero();
+                        needsFixup |= cnsNode->AsVecCon()->ContainsPositiveZero(simdBaseType);
                     }
 
-                    if (!needsFixup || compOpportunisticallyDependsOn(InstructionSet_AVX512))
+                    if (!hasPartialNaN &&
+                        (!needsFixup || (!isNumber && compOpportunisticallyDependsOn(InstructionSet_AVX512))))
                     {
                         // Given the checks, op1 can safely be the cns and op2 the other node
 
@@ -26638,10 +26682,10 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                     // not be propagated for isNumber and to be propagated otherwise.
                     //
                     // This means for isNumber we want to do `min other, cns` and
-                    // can only handle cns being +0 if Avx512F is supported. This is
-                    // because if other was NaN, we want to return the non-NaN cns.
-                    // But if cns was +0 and other was -0 we'd want to return -0 and
-                    // so need to be able to fixup the result.
+                    // cannot handle cns being +0. If other was NaN, we want to return
+                    // the non-NaN cns. But if cns was +0 and other was -0 we'd want
+                    // to return -0, and the ZERO fixup token cannot distinguish the
+                    // opaque operand's sign.
                     //
                     // For !isNumber we have the inverse and want `min cns, other` and
                     // can only handle cns being -0 if Avx512F is supported. This is
@@ -26657,7 +26701,7 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                         }
                         else
                         {
-                            needsFixup = cnsNode->IsVectorZero();
+                            needsFixup |= cnsNode->AsVecCon()->ContainsPositiveZero(simdBaseType);
                         }
                     }
                     else if (isScalar)
@@ -26666,10 +26710,11 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                     }
                     else
                     {
-                        needsFixup = cnsNode->IsVectorNegativeZero(simdBaseType);
+                        needsFixup |= cnsNode->AsVecCon()->ContainsNegativeZero(simdBaseType);
                     }
 
-                    if (!needsFixup || compOpportunisticallyDependsOn(InstructionSet_AVX512))
+                    if (!hasPartialNaN &&
+                        (!needsFixup || (!isNumber && compOpportunisticallyDependsOn(InstructionSet_AVX512))))
                     {
                         // Given the checks, op1 can safely be the cns and op2 the other node
 
@@ -26702,18 +26747,16 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                         GenTree* op2Clone               = fgMakeMultiUse(&op2);
                         retNode->AsHWIntrinsic()->Op(2) = op2;
 
-                        GenTreeVecCon* tblVecCon = gtNewVconNode(type);
-
-                        // FixupScalar(left, right, table, control) computes the input type of right
+                        // Fixup(left, right, table, control) computes the input type of right
                         // adjusts it based on the table and then returns
                         //
-                        // In our case, left is going to be the result of the RangeScalar operation
-                        // and right is going to be op1 or op2. In the case op1/op2 is QNaN or SNaN
-                        // we want to preserve it instead. Otherwise we want to preserve the original
-                        // result computed by RangeScalar.
-                        //
-                        // If both inputs are NaN, then we'll end up taking op1 by virtue of it being
-                        // the latter fixup.
+                        // In our case, left is the result of the min/max operation and right is the
+                        // opaque operand. The table preserves left except where the constant is the
+                        // problematic zero.
+
+                        GenTreeVecCon* tblVecCon = gtNewVconNode(type);
+                        int64_t        tblValue;
+                        simd_t         zeroMask = {};
 
                         if (isMax)
                         {
@@ -26726,9 +26769,13 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                             // -VAL: 0b0000
                             // +VAL: 0b0000
 
-                            const int64_t tblValue = 0x00000800;
-                            tblVecCon->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG,
-                                                                tblValue);
+                            tblValue = 0x00000800;
+
+                            if (!isScalar)
+                            {
+                                zeroMask =
+                                    EvaluateSimdIsPositiveZero(simdBaseType, cnsNode->AsVecCon()->gtSimdVal, simdSize);
+                            }
                         }
                         else
                         {
@@ -26741,9 +26788,24 @@ GenTree* Compiler::gtNewSimdMinMaxNode(var_types type,
                             // -VAL: 0b0000
                             // +VAL: 0b0000
 
-                            const int64_t tblValue = 0x00000700;
-                            tblVecCon->EvaluateBroadcastInPlace((simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG,
-                                                                tblValue);
+                            tblValue = 0x00000700;
+
+                            if (!isScalar)
+                            {
+                                zeroMask =
+                                    EvaluateSimdIsNegativeZero(simdBaseType, cnsNode->AsVecCon()->gtSimdVal, simdSize);
+                            }
+                        }
+
+                        var_types tblType = (simdBaseType == TYP_FLOAT) ? TYP_INT : TYP_LONG;
+                        tblVecCon->EvaluateBroadcastInPlace(tblType, tblValue);
+
+                        if (!isScalar)
+                        {
+                            simd_t result = {};
+                            EvaluateBinarySimd<simd_t>(GT_AND, false, tblType, &result, tblVecCon->gtSimdVal, zeroMask,
+                                                       simdSize);
+                            tblVecCon->gtSimdVal = result;
                         }
 
                         intrinsic = isScalar ? NI_AVX512_FixupScalar : NI_AVX512_Fixup;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7434,6 +7434,12 @@ struct GenTreeVecCon : public GenTree
 
     bool IsNegativeZero(var_types simdBaseType) const;
 
+    bool ContainsNaN(var_types simdBaseType) const;
+
+    bool ContainsNegativeZero(var_types simdBaseType) const;
+
+    bool ContainsPositiveZero(var_types simdBaseType) const;
+
     bool IsZero() const
     {
         switch (gtType)

--- a/src/coreclr/jit/simd.h
+++ b/src/coreclr/jit/simd.h
@@ -1323,9 +1323,17 @@ inline void EvaluateBinaryMask(genTreeOps        oper,
 #endif // FEATURE_MASKED_HW_INTRINSICS
 
 template <typename TSimd, typename TBase>
-void EvaluateBinarySimd(genTreeOps oper, bool scalar, TSimd* result, const TSimd& arg0, const TSimd& arg1)
+void EvaluateBinarySimd(genTreeOps   oper,
+                        bool         scalar,
+                        TSimd*       result,
+                        const TSimd& arg0,
+                        const TSimd& arg1,
+                        unsigned     simdSize = sizeof(TSimd))
 {
-    uint32_t count = sizeof(TSimd) / sizeof(TBase);
+    assert(simdSize <= sizeof(TSimd));
+    assert((simdSize % sizeof(TBase)) == 0);
+
+    uint32_t count = simdSize / sizeof(TBase);
 
     if (scalar)
     {
@@ -1356,8 +1364,13 @@ void EvaluateBinarySimd(genTreeOps oper, bool scalar, TSimd* result, const TSimd
 }
 
 template <typename TSimd>
-void EvaluateBinarySimd(
-    genTreeOps oper, bool scalar, var_types baseType, TSimd* result, const TSimd& arg0, const TSimd& arg1)
+void EvaluateBinarySimd(genTreeOps   oper,
+                        bool         scalar,
+                        var_types    baseType,
+                        TSimd*       result,
+                        const TSimd& arg0,
+                        const TSimd& arg1,
+                        unsigned     simdSize = sizeof(TSimd))
 {
     switch (baseType)
     {
@@ -1370,11 +1383,11 @@ void EvaluateBinarySimd(
 
             if (IsBinaryBitwiseOperation(oper))
             {
-                EvaluateBinarySimd<TSimd, int32_t>(oper, scalar, result, arg0, arg1);
+                EvaluateBinarySimd<TSimd, int32_t>(oper, scalar, result, arg0, arg1, simdSize);
             }
             else
             {
-                EvaluateBinarySimd<TSimd, float>(oper, scalar, result, arg0, arg1);
+                EvaluateBinarySimd<TSimd, float>(oper, scalar, result, arg0, arg1, simdSize);
             }
             break;
         }
@@ -1388,60 +1401,60 @@ void EvaluateBinarySimd(
 
             if (IsBinaryBitwiseOperation(oper))
             {
-                EvaluateBinarySimd<TSimd, int64_t>(oper, scalar, result, arg0, arg1);
+                EvaluateBinarySimd<TSimd, int64_t>(oper, scalar, result, arg0, arg1, simdSize);
             }
             else
             {
-                EvaluateBinarySimd<TSimd, double>(oper, scalar, result, arg0, arg1);
+                EvaluateBinarySimd<TSimd, double>(oper, scalar, result, arg0, arg1, simdSize);
             }
             break;
         }
 
         case TYP_BYTE:
         {
-            EvaluateBinarySimd<TSimd, int8_t>(oper, scalar, result, arg0, arg1);
+            EvaluateBinarySimd<TSimd, int8_t>(oper, scalar, result, arg0, arg1, simdSize);
             break;
         }
 
         case TYP_SHORT:
         {
-            EvaluateBinarySimd<TSimd, int16_t>(oper, scalar, result, arg0, arg1);
+            EvaluateBinarySimd<TSimd, int16_t>(oper, scalar, result, arg0, arg1, simdSize);
             break;
         }
 
         case TYP_INT:
         {
-            EvaluateBinarySimd<TSimd, int32_t>(oper, scalar, result, arg0, arg1);
+            EvaluateBinarySimd<TSimd, int32_t>(oper, scalar, result, arg0, arg1, simdSize);
             break;
         }
 
         case TYP_LONG:
         {
-            EvaluateBinarySimd<TSimd, int64_t>(oper, scalar, result, arg0, arg1);
+            EvaluateBinarySimd<TSimd, int64_t>(oper, scalar, result, arg0, arg1, simdSize);
             break;
         }
 
         case TYP_UBYTE:
         {
-            EvaluateBinarySimd<TSimd, uint8_t>(oper, scalar, result, arg0, arg1);
+            EvaluateBinarySimd<TSimd, uint8_t>(oper, scalar, result, arg0, arg1, simdSize);
             break;
         }
 
         case TYP_USHORT:
         {
-            EvaluateBinarySimd<TSimd, uint16_t>(oper, scalar, result, arg0, arg1);
+            EvaluateBinarySimd<TSimd, uint16_t>(oper, scalar, result, arg0, arg1, simdSize);
             break;
         }
 
         case TYP_UINT:
         {
-            EvaluateBinarySimd<TSimd, uint32_t>(oper, scalar, result, arg0, arg1);
+            EvaluateBinarySimd<TSimd, uint32_t>(oper, scalar, result, arg0, arg1, simdSize);
             break;
         }
 
         case TYP_ULONG:
         {
-            EvaluateBinarySimd<TSimd, uint64_t>(oper, scalar, result, arg0, arg1);
+            EvaluateBinarySimd<TSimd, uint64_t>(oper, scalar, result, arg0, arg1, simdSize);
             break;
         }
 
@@ -1450,6 +1463,97 @@ void EvaluateBinarySimd(
             unreached();
         }
     }
+}
+
+template <typename TSimd>
+TSimd EvaluateSimdIsNaN(var_types baseType, const TSimd& value, unsigned simdSize = sizeof(TSimd))
+{
+    assert(varTypeIsArithmetic(baseType));
+
+    TSimd result = {};
+
+    if (varTypeIsFloating(baseType))
+    {
+        EvaluateBinarySimd<TSimd>(GT_NE, false, baseType, &result, value, value, simdSize);
+    }
+    return result;
+}
+
+inline var_types GetSimdIntegralBaseType(var_types baseType)
+{
+    if (baseType == TYP_FLOAT)
+    {
+        return TYP_INT;
+    }
+    if (baseType == TYP_DOUBLE)
+    {
+        return TYP_LONG;
+    }
+    return baseType;
+}
+
+template <typename TSimd>
+TSimd EvaluateSimdIsNegative(var_types baseType, const TSimd& value, unsigned simdSize = sizeof(TSimd))
+{
+    assert(varTypeIsArithmetic(baseType));
+
+    TSimd result = {};
+
+    if (!varTypeIsUnsigned(baseType))
+    {
+        EvaluateBinarySimd<TSimd>(GT_LT, false, GetSimdIntegralBaseType(baseType), &result, value, TSimd::Zero(),
+                                  simdSize);
+    }
+    return result;
+}
+
+template <typename TSimd>
+TSimd EvaluateSimdIsZero(var_types baseType, const TSimd& value, unsigned simdSize = sizeof(TSimd))
+{
+    TSimd result = {};
+    EvaluateBinarySimd<TSimd>(GT_EQ, false, baseType, &result, value, TSimd::Zero(), simdSize);
+    return result;
+}
+
+template <typename TSimd>
+TSimd EvaluateSimdIsNegativeZero(var_types baseType, const TSimd& value, unsigned simdSize = sizeof(TSimd))
+{
+    assert(varTypeIsFloating(baseType));
+
+    TSimd result = EvaluateSimdIsZero(baseType, value, simdSize);
+    TSimd sign   = EvaluateSimdIsNegative(baseType, value, simdSize);
+    EvaluateBinarySimd<TSimd>(GT_AND, false, baseType, &result, result, sign, simdSize);
+    return result;
+}
+
+template <typename TSimd>
+TSimd EvaluateSimdIsPositiveZero(var_types baseType, const TSimd& value, unsigned simdSize = sizeof(TSimd))
+{
+    assert(varTypeIsFloating(baseType));
+
+    TSimd result = EvaluateSimdIsZero(baseType, value, simdSize);
+    TSimd sign   = EvaluateSimdIsNegative(baseType, value, simdSize);
+    EvaluateBinarySimd<TSimd>(GT_AND_NOT, false, baseType, &result, result, sign, simdSize);
+    return result;
+}
+
+template <typename TSimd>
+bool EvaluateSimdAnyWhereAllBitsSet(var_types baseType, const TSimd& value, unsigned simdSize = sizeof(TSimd))
+{
+    TSimd result     = {};
+    TSimd zero       = TSimd::Zero();
+    TSimd allBitsSet = TSimd::AllBitsSet();
+    EvaluateBinarySimd<TSimd>(GT_EQ, false, GetSimdIntegralBaseType(baseType), &result, value, allBitsSet, simdSize);
+    return memcmp(&result, &zero, simdSize) != 0;
+}
+
+template <typename TSimd>
+bool EvaluateSimdAllWhereAllBitsSet(var_types baseType, const TSimd& value, unsigned simdSize = sizeof(TSimd))
+{
+    TSimd result     = {};
+    TSimd allBitsSet = TSimd::AllBitsSet();
+    EvaluateBinarySimd<TSimd>(GT_EQ, false, GetSimdIntegralBaseType(baseType), &result, value, allBitsSet, simdSize);
+    return memcmp(&result, &allBitsSet, simdSize) == 0;
 }
 
 template <typename TSimd>

--- a/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
+++ b/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
@@ -42,6 +42,11 @@ namespace System.Tests
         internal const double MaxSubnormalDouble = 2.2250738585072009E-308;
         internal const float MaxSubnormalSingle = 1.17549421E-38f;
 
+        private static readonly double PositiveNaNDouble = BitConverter.Int64BitsToDouble(0x7FF8_0000_0000_0001);
+        private static readonly double NegativeNaNDouble = BitConverter.Int64BitsToDouble(unchecked((long)0xFFF8_0000_0000_0001));
+        private static readonly float PositiveNaNSingle = BitConverter.Int32BitsToSingle(0x7FC0_0001);
+        private static readonly float NegativeNaNSingle = BitConverter.Int32BitsToSingle(unchecked((int)0xFFC0_0001));
+
         public static IEnumerable<object[]> ClampDouble
         {
             get
@@ -1367,6 +1372,8 @@ namespace System.Tests
                 yield return new object[] {  double.NegativeInfinity,    double.NaN,                double.NaN };
                 yield return new object[] {  double.NaN,                 double.PositiveInfinity,   double.NaN };
                 yield return new object[] {  double.NaN,                 double.NegativeInfinity,   double.NaN };
+                yield return new object[] {  PositiveNaNDouble,          -0.0,                      PositiveNaNDouble };
+                yield return new object[] { -0.0,                        NegativeNaNDouble,          NegativeNaNDouble };
                 yield return new object[] { -0.0f,                       0.0f,                      0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      2.0f };
@@ -1391,6 +1398,8 @@ namespace System.Tests
                 yield return new object[] {  float.NegativeInfinity,     float.NaN,                 float.NaN };
                 yield return new object[] {  float.NaN,                  float.PositiveInfinity,    float.NaN };
                 yield return new object[] {  float.NaN,                  float.NegativeInfinity,    float.NaN };
+                yield return new object[] {  PositiveNaNSingle,          -0.0f,                      PositiveNaNSingle };
+                yield return new object[] { -0.0f,                       NegativeNaNSingle,          NegativeNaNSingle };
                 yield return new object[] { -0.0f,                       0.0f,                      0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      2.0f };
@@ -1511,6 +1520,8 @@ namespace System.Tests
                 yield return new object[] {  double.NegativeInfinity,    double.NaN,                double.NegativeInfinity };
                 yield return new object[] {  double.NaN,                 double.PositiveInfinity,   double.PositiveInfinity };
                 yield return new object[] {  double.NaN,                 double.NegativeInfinity,   double.NegativeInfinity };
+                yield return new object[] {  PositiveNaNDouble,          -0.0,                     -0.0 };
+                yield return new object[] { -0.0,                        NegativeNaNDouble,         -0.0 };
                 yield return new object[] { -0.0f,                       0.0f,                      0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      2.0f };
@@ -1535,6 +1546,8 @@ namespace System.Tests
                 yield return new object[] {  float.NegativeInfinity,     float.NaN,                 float.NegativeInfinity };
                 yield return new object[] {  float.NaN,                  float.PositiveInfinity,    float.PositiveInfinity };
                 yield return new object[] {  float.NaN,                  float.NegativeInfinity,    float.NegativeInfinity };
+                yield return new object[] {  PositiveNaNSingle,          -0.0f,                     -0.0f };
+                yield return new object[] { -0.0f,                       NegativeNaNSingle,         -0.0f };
                 yield return new object[] { -0.0f,                       0.0f,                      0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      2.0f };
@@ -1559,6 +1572,8 @@ namespace System.Tests
                 yield return new object[] {  double.NegativeInfinity,    double.NaN,                 double.NaN };
                 yield return new object[] {  double.NaN,                 double.PositiveInfinity,    double.NaN };
                 yield return new object[] {  double.NaN,                 double.NegativeInfinity,    double.NaN };
+                yield return new object[] {  PositiveNaNDouble,          -0.0,                       PositiveNaNDouble };
+                yield return new object[] { -0.0,                        NegativeNaNDouble,           NegativeNaNDouble };
                 yield return new object[] { -0.0f,                       0.0f,                      -0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      -0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      -3.0f };
@@ -1583,6 +1598,8 @@ namespace System.Tests
                 yield return new object[] {  float.NegativeInfinity,     float.NaN,                  float.NaN };
                 yield return new object[] {  float.NaN,                  float.PositiveInfinity,     float.NaN };
                 yield return new object[] {  float.NaN,                  float.NegativeInfinity,     float.NaN };
+                yield return new object[] {  PositiveNaNSingle,          -0.0f,                       PositiveNaNSingle };
+                yield return new object[] { -0.0f,                       NegativeNaNSingle,           NegativeNaNSingle };
                 yield return new object[] { -0.0f,                       0.0f,                      -0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      -0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      -3.0f };
@@ -1703,6 +1720,8 @@ namespace System.Tests
                 yield return new object[] {  double.NegativeInfinity,    double.NaN,                 double.NegativeInfinity };
                 yield return new object[] {  double.NaN,                 double.PositiveInfinity,    double.PositiveInfinity };
                 yield return new object[] {  double.NaN,                 double.NegativeInfinity,    double.NegativeInfinity };
+                yield return new object[] {  PositiveNaNDouble,          -0.0,                       -0.0 };
+                yield return new object[] { -0.0,                        NegativeNaNDouble,           -0.0 };
                 yield return new object[] { -0.0f,                       0.0f,                      -0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      -0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      -3.0f };
@@ -1727,6 +1746,8 @@ namespace System.Tests
                 yield return new object[] {  float.NegativeInfinity,     float.NaN,                  float.NegativeInfinity };
                 yield return new object[] {  float.NaN,                  float.PositiveInfinity,     float.PositiveInfinity };
                 yield return new object[] {  float.NaN,                  float.NegativeInfinity,     float.NegativeInfinity };
+                yield return new object[] {  PositiveNaNSingle,          -0.0f,                       -0.0f };
+                yield return new object[] { -0.0f,                       NegativeNaNSingle,           -0.0f };
                 yield return new object[] { -0.0f,                       0.0f,                      -0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      -0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      -3.0f };

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133022/Runtime_133022.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133022/Runtime_133022.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Runtime_133022;
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public static class Runtime_133022
+{
+    [Fact]
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void TestEntryPoint()
+    {
+        Vector128<double> nan128 = Vector128.Create(double.NaN, double.PositiveInfinity);
+        Vector128<double> otherNan128 = Opaque(Vector128.Create(double.PositiveInfinity, double.NaN));
+        Vector128<double> propagatedNaN128 = Vector128.Create(double.NaN);
+        Vector128<double> numberNaN128 = Vector128.Create(double.PositiveInfinity);
+
+        AssertEqual(propagatedNaN128, Vector128.Min(nan128, otherNan128));
+        AssertEqual(propagatedNaN128, Vector128.Min(otherNan128, nan128));
+        AssertEqual(propagatedNaN128, Vector128.Max(nan128, otherNan128));
+        AssertEqual(propagatedNaN128, Vector128.Max(otherNan128, nan128));
+        AssertEqual(numberNaN128, Vector128.MinNumber(nan128, otherNan128));
+        AssertEqual(numberNaN128, Vector128.MinNumber(otherNan128, nan128));
+        AssertEqual(numberNaN128, Vector128.MaxNumber(nan128, otherNan128));
+        AssertEqual(numberNaN128, Vector128.MaxNumber(otherNan128, nan128));
+
+        Vector128<double> zero128 = Vector128.Create(-1.0, -0.0);
+        Vector128<double> otherZero128 = Opaque(Vector128.Create(-0.0, +0.0));
+        Vector128<double> minZero128 = Vector128.Create(-1.0, -0.0);
+        Vector128<double> maxZero128 = Vector128.Create(-0.0, +0.0);
+
+        AssertEqual(minZero128, Vector128.Min(zero128, otherZero128));
+        AssertEqual(minZero128, Vector128.Min(otherZero128, zero128));
+        AssertEqual(maxZero128, Vector128.Max(zero128, otherZero128));
+        AssertEqual(maxZero128, Vector128.Max(otherZero128, zero128));
+        AssertEqual(minZero128, Vector128.MinNumber(zero128, otherZero128));
+        AssertEqual(minZero128, Vector128.MinNumber(otherZero128, zero128));
+        AssertEqual(maxZero128, Vector128.MaxNumber(zero128, otherZero128));
+        AssertEqual(maxZero128, Vector128.MaxNumber(otherZero128, zero128));
+
+        Vector128<float> nanSingle128 = Vector128.Create(float.NaN, float.PositiveInfinity, 1.0f, 2.0f);
+        Vector128<float> otherNanSingle128 = Opaque(Vector128.Create(float.PositiveInfinity, float.NaN, 2.0f, 1.0f));
+
+        AssertEqual(Vector128.Create(float.NaN, float.NaN, 1.0f, 1.0f), Vector128.Min(nanSingle128, otherNanSingle128));
+        AssertEqual(Vector128.Create(float.NaN, float.NaN, 2.0f, 2.0f), Vector128.Max(nanSingle128, otherNanSingle128));
+        AssertEqual(Vector128.Create(float.PositiveInfinity, float.PositiveInfinity, 1.0f, 1.0f),
+                    Vector128.MinNumber(nanSingle128, otherNanSingle128));
+        AssertEqual(Vector128.Create(float.PositiveInfinity, float.PositiveInfinity, 2.0f, 2.0f),
+                    Vector128.MaxNumber(nanSingle128, otherNanSingle128));
+
+        Vector128<float> zeroSingle128 = Vector128.Create(-1.0f, -0.0f, -2.0f, +0.0f);
+        Vector128<float> otherZeroSingle128 = Opaque(Vector128.Create(-0.0f, +0.0f, -3.0f, -0.0f));
+
+        AssertEqual(Vector128.Create(-1.0f, -0.0f, -3.0f, -0.0f), Vector128.Min(zeroSingle128, otherZeroSingle128));
+        AssertEqual(Vector128.Create(-0.0f, +0.0f, -2.0f, +0.0f), Vector128.Max(zeroSingle128, otherZeroSingle128));
+        AssertEqual(Vector128.Create(-1.0f, -0.0f, -3.0f, -0.0f),
+                    Vector128.MinNumber(zeroSingle128, otherZeroSingle128));
+        AssertEqual(Vector128.Create(-0.0f, +0.0f, -2.0f, +0.0f),
+                    Vector128.MaxNumber(zeroSingle128, otherZeroSingle128));
+
+        float positiveNaN = BitConverter.Int32BitsToSingle(0x7FC0_0001);
+        float negativeNaN = BitConverter.Int32BitsToSingle(unchecked((int)0xFFC0_0001));
+        Vector128<float> mixedSingle128 = Vector128.Create(-1.0f, -2.0f, -0.0f, +0.0f);
+        Vector128<float> otherMixedSingle128 = Opaque(Vector128.Create(positiveNaN, negativeNaN, +0.0f, -0.0f));
+        Vector128<float> minMixedSingle128 = Vector128.Create(float.NaN, float.NaN, -0.0f, -0.0f);
+        Vector128<float> maxMixedSingle128 = Vector128.Create(float.NaN, float.NaN, +0.0f, +0.0f);
+
+        AssertEqualIgnoringNaNBits(minMixedSingle128, Vector128.Min(mixedSingle128, otherMixedSingle128));
+        AssertEqualIgnoringNaNBits(minMixedSingle128, Vector128.Min(otherMixedSingle128, mixedSingle128));
+        AssertEqualIgnoringNaNBits(maxMixedSingle128, Vector128.Max(mixedSingle128, otherMixedSingle128));
+        AssertEqualIgnoringNaNBits(maxMixedSingle128, Vector128.Max(otherMixedSingle128, mixedSingle128));
+
+        Vector256<double> nan256 = Vector256.Create(double.NaN, double.PositiveInfinity, 1.0, 2.0);
+        Vector256<double> otherNan256 = Opaque(Vector256.Create(double.PositiveInfinity, double.NaN, 2.0, 1.0));
+        Vector256<double> propagatedNaN256 = Vector256.Create(double.NaN, double.NaN, 1.0, 1.0);
+        Vector256<double> minNumberNaN256 = Vector256.Create(double.PositiveInfinity, double.PositiveInfinity, 1.0, 1.0);
+        Vector256<double> maxNumberNaN256 = Vector256.Create(double.PositiveInfinity, double.PositiveInfinity, 2.0, 2.0);
+
+        AssertEqual(propagatedNaN256, Vector256.Min(nan256, otherNan256));
+        AssertEqual(propagatedNaN256, Vector256.Min(otherNan256, nan256));
+        AssertEqual(Vector256.Create(double.NaN, double.NaN, 2.0, 2.0), Vector256.Max(nan256, otherNan256));
+        AssertEqual(Vector256.Create(double.NaN, double.NaN, 2.0, 2.0), Vector256.Max(otherNan256, nan256));
+        AssertEqual(minNumberNaN256, Vector256.MinNumber(nan256, otherNan256));
+        AssertEqual(minNumberNaN256, Vector256.MinNumber(otherNan256, nan256));
+        AssertEqual(maxNumberNaN256, Vector256.MaxNumber(nan256, otherNan256));
+        AssertEqual(maxNumberNaN256, Vector256.MaxNumber(otherNan256, nan256));
+
+        Vector256<double> zero256 = Vector256.Create(-1.0, -0.0, -2.0, +0.0);
+        Vector256<double> otherZero256 = Opaque(Vector256.Create(-0.0, +0.0, -3.0, -0.0));
+        Vector256<double> minZero256 = Vector256.Create(-1.0, -0.0, -3.0, -0.0);
+        Vector256<double> maxZero256 = Vector256.Create(-0.0, +0.0, -2.0, +0.0);
+
+        AssertEqual(minZero256, Vector256.Min(zero256, otherZero256));
+        AssertEqual(minZero256, Vector256.Min(otherZero256, zero256));
+        AssertEqual(maxZero256, Vector256.Max(zero256, otherZero256));
+        AssertEqual(maxZero256, Vector256.Max(otherZero256, zero256));
+        AssertEqual(minZero256, Vector256.MinNumber(zero256, otherZero256));
+        AssertEqual(minZero256, Vector256.MinNumber(otherZero256, zero256));
+        AssertEqual(maxZero256, Vector256.MaxNumber(zero256, otherZero256));
+        AssertEqual(maxZero256, Vector256.MaxNumber(otherZero256, zero256));
+
+        AssertEqual(Vector128.Create(double.NaN), MinConstants128());
+        AssertEqual(Vector128.Create(double.NaN), MaxConstants128());
+        AssertEqual(Vector128.Create(1.0), MinWithoutSpecialValues(Opaque(Vector128.Create(3.0, 1.0))));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<double> Opaque(Vector128<double> value) => value;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<float> Opaque(Vector128<float> value) => value;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector256<double> Opaque(Vector256<double> value) => value;
+
+    private static void AssertEqual(Vector128<double> expected, Vector128<double> actual)
+        => Assert.Equal(expected.AsUInt64(), actual.AsUInt64());
+
+    private static void AssertEqual(Vector128<float> expected, Vector128<float> actual)
+        => Assert.Equal(expected.AsUInt32(), actual.AsUInt32());
+
+    private static void AssertEqualIgnoringNaNBits(Vector128<float> expected, Vector128<float> actual)
+    {
+        for (int index = 0; index < Vector128<float>.Count; index++)
+        {
+            float expectedElement = expected.GetElement(index);
+            float actualElement = actual.GetElement(index);
+
+            if (float.IsNaN(expectedElement))
+            {
+                Assert.True(float.IsNaN(actualElement));
+            }
+            else
+            {
+                Assert.Equal(BitConverter.SingleToInt32Bits(expectedElement),
+                             BitConverter.SingleToInt32Bits(actualElement));
+            }
+        }
+    }
+
+    private static void AssertEqual(Vector256<double> expected, Vector256<double> actual)
+        => Assert.Equal(expected.AsUInt64(), actual.AsUInt64());
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<double> MinConstants128()
+    {
+        Vector128<double> left = Vector128.Create(double.NaN, 3.0);
+        Vector128<double> right = Vector128.Create(3.0, double.NaN);
+
+        return Vector128.Min(left, right);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<double> MaxConstants128()
+    {
+        Vector128<double> left = Vector128.Create(double.NaN, 3.0);
+        Vector128<double> right = Vector128.Create(3.0, double.NaN);
+
+        return Vector128.Max(left, right);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Vector128<double> MinWithoutSpecialValues(Vector128<double> value)
+        => Vector128.Min(Vector128.Create(1.0, 2.0), value);
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -131,6 +131,7 @@
     <Compile Include="JitBlue\Runtime_131716\Runtime_131716.cs" />
     <Compile Include="JitBlue\Runtime_132268\Runtime_132268.cs" />
     <Compile Include="JitBlue\Runtime_132902\Runtime_132902.cs" />
+    <Compile Include="JitBlue\Runtime_133022\Runtime_133022.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Backport of #133173 to release/11.0

/cc @AndyAyersMS

## Customer Impact

- [ ] Customer reported
- [x] Found internally

SIMD `Min`, `Max`, `MinNumber`, and `MaxNumber` can return incorrect results on xarch when a constant vector contains a mix of ordinary values and NaN or signed-zero lanes. The AVX-512 path can incorrectly return the opaque operand wholesale.

## Regression

- [x] Yes
- [ ] No

The vector mixed-lane regression was introduced by #116804 during .NET 10 development.

## Testing

The focused `Runtime_133022` regression fails against the pre-fix JIT and passes with the fix. The original change was verified on checked x64 and x86 with AVX-512 enabled and with `DOTNET_EnableAVX512=0`; all 13,082 `System.Runtime.Intrinsics` tests also passed under both AVX-512 settings.

For this backport, the checked x64 JIT build and `jit-format` passed. The source patch matches the merged change; the test-project conflict was resolved by adding only `Runtime_133022` to the target branch's merged regression project. A full `clr+libs` baseline was attempted but hit unrelated MSVC `C1041` PDB contention in `System.Globalization.Native`.

## Risk

Medium. The change is localized to JIT import-time SIMD constant classification and fixup-table construction, but affects shared Min/Max code generation. Mixed NaN and signed-zero cases are covered across `float`/`double`, `Vector128`/`Vector256`, operand order, and AVX-512 enabled/disabled configurations.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- For .NET 8 and .NET 9: The PR target branch is `release/X.0-staging`, not `release/X.0`.
- For .NET 10+: The PR target branch is `release/X.0` (no `-staging` suffix).

## Package authoring no longer needed in .NET 9

**IMPORTANT**: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.

> [!NOTE]
> This pull request description was generated with GitHub Copilot assistance.