### PR TITLE
Deduplicate "all managed object wrappers" mapping

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -841,7 +841,12 @@ namespace System.Runtime.InteropServices
             List<ManagedObjectWrapperHolder> allWrappersForThisInstance = s_allManagedObjectWrapperTable.GetOrCreateValue(instance);
             lock (allWrappersForThisInstance)
             {
-                allWrappersForThisInstance.Add(wrapper);
+                // While this can be an O(n) search for an object that is exposed via N ComWrappers instances to native code
+                // in practice, N = 1 for the vast majority of scenarios.
+                if (!allWrappersForThisInstance.Contains(wrapper))
+                {
+                    allWrappersForThisInstance.Add(wrapper);
+                }
             }
         }
 


### PR DESCRIPTION
Prevent duplicate entries in the "all managed object wrappers" table.

Fixes https://github.com/dotnet/runtime/issues/129191

For the case in #129191, there is always only one ComWrappers instance, so this collection will be length 1.

I chose to do a simple fix like this for the following reasons:

1. This collection is read from the DAC and cDAC directly to support the `!DumpObj` command. Any significant changes to the structure (such as moving to a `HashSet<ManagedObjectWrapperHolder>`) would require very large changes to enable enumerating the structure from DAC or cDAC code, creating a higher risk change for backporting.
2. In practice, objects are passed to unmanaged code via 1 ComWrappers instance in the vast majority of cases outside of our own tests. In the unlikely case it's passed via more than 1, it would be via 2, the CsWinRT ComWrappers instance and the StrategyBasedComWrappers default instance.
3. I considered adding a parallel HashSet for deduplication. However, that felt like a very large memory cost for the common scenario (.NET object passed to native via only one ComWrappers instance) for a minor savings in a very unlikely scenario (many ComWrappers for the same .NET object).