### PR TITLE
[wasm] Recognize R2R virtual IPs in IsManagedCode

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -5688,7 +5688,17 @@ BOOL ExecutionManager::IsManagedCodeWorker(PCODE currentPC, RangeSectionLockStat
     // taken over the call to JitCodeToMethodInfo too so that nobody pulls out
     // the range section from underneath us.
 
-    RangeSection * pRS = GetRangeSection(currentPC, pLockState);
+    RangeSection* pRS;
+#ifdef TARGET_WASM
+    if (IsVirtualIP(currentPC))
+    {
+        pRS = FindCodeRange(currentPC, ScanNoReaderLock);
+    }
+    else
+#endif // TARGET_WASM
+    {
+        pRS = GetRangeSection(currentPC, pLockState);
+    }
     if (pRS == NULL)
         return FALSE;
 

--- a/src/tests/JIT/Methodical/eh/basics/tryfinallytryfinally.cs
+++ b/src/tests/JIT/Methodical/eh/basics/tryfinallytryfinally.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace hello_tryfinallytryfinally_basics_cs
@@ -53,6 +54,59 @@ namespace hello_tryfinallytryfinally_basics_cs
             testLog.StopRecording();
 
             return testLog.VerifyOutput();
+        }
+    }
+
+    public class NestedFinallyGc
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void Test(bool throwException)
+        {
+            int[] values = new int[1];
+            bool caught = false;
+            try
+            {
+                Run(values, throwException);
+            }
+            catch (InvalidOperationException)
+            {
+                caught = true;
+            }
+
+            Assert.Equal(throwException, caught);
+            Assert.Equal(111, values[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Run(int[] values, bool throwException)
+        {
+            try
+            {
+                values[0] = 1;
+                if (throwException)
+                    throw new InvalidOperationException();
+            }
+            finally
+            {
+                try
+                {
+                    Update(values);
+                }
+                finally
+                {
+                    // This finally is called normally, including during exceptional entry to the outer finally.
+                    GC.Collect();
+                    values[0] += 100;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Update(int[] values)
+        {
+            values[0] += 10;
         }
     }
 }


### PR DESCRIPTION
Fixes #133264.

`ExecutionManager::IsManagedCodeWorker` looks up wasm R2R virtual instruction pointers in the native code-range map, incorrectly classifying managed funclet callers as native. GC stack walking inside a normally called nested finally can then assert `fFrameWasUnwound` in `stackwalk.cpp`.

Route wasm virtual IPs through the existing `FindCodeRange(..., ScanNoReaderLock)` lookup. Native addresses retain `GetRangeSection` and its existing lock-state handling. Registered virtual ranges still undergo the existing R2R method check, including its deadlock-safe early return when no `MethodDesc` is requested.

Add a two-case nested-finally regression covering normal and exceptional entry, explicit GC, expected exception handling, and the post-GC array value.

### Validation

Reused completed local validation from the source worktree after confirming that the isolated branch has the identical `main` base tree (`de29e26a4f69da5d446900a6ba9d68ba3ddc5ba9`) and both changed files match byte-for-byte; no new build was run in the publication worktree.

- Browser-wasm Checked runtime build and targeted `corerun` rebuild succeeded; `Methodical_do` and `Methodical_d1` were rebuilt with the new cases.
- The unmodified native host asserts `fFrameWasUnwound` on the first new case in both runners.
- The fixed native host passes both new cases and the existing `Test_throwinfinallynestedintry_30_cs` in each runner: six focused passes.
- Independence control: `Methodical_do`, recompiled with the saved unmodified cross-JIT, passes both new cases and the existing `_30` test with the fixed native runtime.

Execution used the browser-wasm R2R runner under Node.js on macOS ARM64 with a retained managed Core_Root. Graphical-browser and native-ARM64 execution were not performed.

This PR contains no JIT changes and is independent of the separate conditional-EH-fallthrough fix. It is also distinct from #133219's post-catch cooperative-mode restoration; no GC-mode patch was applied for this validation.

> [!NOTE]
> This PR description was generated by GitHub Copilot from the reviewed patch and local validation evidence.