### PR TITLE
Reject "root" culture name in ICU globalization mode

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -124,6 +124,16 @@ namespace System.Globalization
                 return false;
             }
 
+            // "root" is the CLDR moniker for the root/invariant locale and is not a valid culture name.
+            // Reject it up front so the behavior is consistent across ICU builds: desktop ICU normalizes
+            // "root" to an empty name while some mobile ICU builds return it unchanged. This matches NLS,
+            // which does not recognize "root" either. The invariant culture ("" and "und") is handled by
+            // the short-circuits in GetCultureData before reaching this method.
+            if (realNameBuffer.Equals("root", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
             // Replace _ (alternate sort) with @collation= for ICU
             if (index > 0)
             {
@@ -152,12 +162,9 @@ namespace System.Globalization
 
             Debug.Assert(_sWindowsName != null);
 
-            // ICU normalizes the CLDR "root" locale (and any alias of it) to an empty name, which represents
-            // the invariant/root locale. The invariant culture is already handled by the empty-string and "und"
-            // short-circuits in GetCultureData, so reaching this point with an empty name means the caller passed
-            // a name such as "root" that is not a valid culture name. Reject it rather than producing an incomplete
-            // culture whose Name is "" (which raises NullReferenceException on internals and poisons the invariant
-            // culture's cache slot).
+            // Defense in depth: if an ICU build normalizes some other name to an empty locale name, reject it
+            // rather than producing a culture whose Name is "" (which is not the Invariant singleton and raises
+            // NullReferenceException on internals and poisons the invariant culture's cache slot).
             if (_sWindowsName.Length == 0)
             {
                 return false;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -152,6 +152,17 @@ namespace System.Globalization
 
             Debug.Assert(_sWindowsName != null);
 
+            // ICU normalizes the CLDR "root" locale (and any alias of it) to an empty name, which represents
+            // the invariant/root locale. The invariant culture is already handled by the empty-string and "und"
+            // short-circuits in GetCultureData, so reaching this point with an empty name means the caller passed
+            // a name such as "root" that is not a valid culture name. Reject it rather than producing an incomplete
+            // culture whose Name is "" (which raises NullReferenceException on internals and poisons the invariant
+            // culture's cache slot).
+            if (_sWindowsName.Length == 0)
+            {
+                return false;
+            }
+
             _sRealName = NormalizeCultureName(_sWindowsName, indexOfExtensions > 0 ? _sRealName.AsSpan(indexOfExtensions) : ReadOnlySpan<char>.Empty, _sRealName, out int collationStart);
 
             _iLanguage = LCID;

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/GetCultureInfo.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/GetCultureInfo.cs
@@ -82,8 +82,9 @@ namespace System.Globalization.Tests
         public void GetCultureInfo_RootCultureName_Throws(string name)
         {
             // "root" is the CLDR moniker for the invariant/root locale, but it is not a valid culture name.
-            // ICU normalizes it to an empty name, which previously produced an incomplete culture whose Name
-            // was "" (raising NullReferenceException on internals and poisoning the invariant cache slot).
+            // On desktop ICU it normalizes to an empty name, which previously produced an incomplete culture
+            // whose Name was "" (raising NullReferenceException on internals and poisoning the invariant cache
+            // slot). Some other ICU builds return "root" unchanged. It is rejected consistently in all cases.
             Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name));
             Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name, predefinedOnly: false));
             Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name, predefinedOnly: true));

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/GetCultureInfo.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/GetCultureInfo.cs
@@ -88,7 +88,9 @@ namespace System.Globalization.Tests
             Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name));
             Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name, predefinedOnly: false));
             Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name, predefinedOnly: true));
+            Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name, "en-US"));
             Assert.Throws<CultureNotFoundException>(() => new CultureInfo(name));
+            Assert.Throws<CultureNotFoundException>(() => new CultureInfo(name, useUserOverride: false));
         }
 
         [ConditionalFact(typeof(GetCultureInfoTests), nameof(PlatformRejectsRootCultureAndRemoteExecutor))]

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/GetCultureInfo.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/GetCultureInfo.cs
@@ -14,6 +14,11 @@ namespace System.Globalization.Tests
         public static bool PlatformSupportsFakeCulture => (!PlatformDetection.IsWindows || PlatformDetection.WindowsVersion >= 10) && PlatformDetection.IsNotBrowser;
         public static bool PlatformSupportsFakeCultureAndRemoteExecutor => PlatformSupportsFakeCulture && RemoteExecutor.IsSupported;
 
+        // "root" is only rejected when a real globalization backend (ICU/NLS) is used. In invariant
+        // globalization mode any well-formed name is fabricated into a custom culture instead.
+        public static bool PlatformRejectsRootCulture => PlatformSupportsFakeCulture && PlatformDetection.IsNotInvariantGlobalization;
+        public static bool PlatformRejectsRootCultureAndRemoteExecutor => PlatformRejectsRootCulture && RemoteExecutor.IsSupported;
+
         public static IEnumerable<object[]> GetCultureInfoTestData()
         {
             yield return new object[] { "en" };
@@ -68,6 +73,39 @@ namespace System.Globalization.Tests
                 yield return new object[] { "zh-Hant-MO", "zh-MO" };
                 yield return new object[] { "zh-Hant-TW", "zh-TW" };
             }
+        }
+
+        [ConditionalTheory(typeof(GetCultureInfoTests), nameof(PlatformRejectsRootCulture))]
+        [InlineData("root")]
+        [InlineData("ROOT")]
+        [InlineData("Root")]
+        public void GetCultureInfo_RootCultureName_Throws(string name)
+        {
+            // "root" is the CLDR moniker for the invariant/root locale, but it is not a valid culture name.
+            // ICU normalizes it to an empty name, which previously produced an incomplete culture whose Name
+            // was "" (raising NullReferenceException on internals and poisoning the invariant cache slot).
+            Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name));
+            Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name, predefinedOnly: false));
+            Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name, predefinedOnly: true));
+            Assert.Throws<CultureNotFoundException>(() => new CultureInfo(name));
+        }
+
+        [ConditionalFact(typeof(GetCultureInfoTests), nameof(PlatformRejectsRootCultureAndRemoteExecutor))]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "Remote executor has problems with exit codes")]
+        public void GetCultureInfo_RootCultureName_DoesNotPoisonInvariantCache()
+        {
+            // Resolving "root" before the invariant culture must not corrupt the "" cache slot.
+            RemoteExecutor.Invoke(() =>
+            {
+                Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo("root"));
+
+                CultureInfo invariant = CultureInfo.GetCultureInfo("");
+                Assert.Equal("", invariant.Name);
+                Assert.Equal("-", invariant.NumberFormat.NegativeSign);
+
+                // "und" continues to map to the invariant culture.
+                Assert.Equal("", CultureInfo.GetCultureInfo("und").Name);
+            }).Dispose();
         }
 
         [Theory]


### PR DESCRIPTION
## Summary

Fixes #132429.

`CultureInfo.GetCultureInfo("root")` was accepted in ICU globalization mode but produced an incomplete culture. ICU normalizes the CLDR `root` locale to an empty name, so the resulting `CultureData` had `Name == ""` without being the `Invariant` singleton. This caused two problems:

1. Reading `NumberFormat` on it threw `NullReferenceException` from `NumberFormatInfo.InitializeInvariantAndNegativeSignFlags` because the negative sign was never populated.
2. Resolving `"root"` before the invariant culture poisoned the `""` cache slot, so later lookups of the invariant culture returned the broken instance.

## Fix

The empty-string and `"und"` names are already short-circuited to the invariant culture in `CultureData.GetCultureData`, so an empty name reaching `InitIcuCultureDataCore` can only come from a name such as `"root"` that is not a valid culture. The change rejects that case, so `GetCultureInfo("root")` now throws `CultureNotFoundException`, matching the existing NLS behavior (Windows does not recognize `root`).

This is a single length check on the culture creation cold path (cache miss only), so there is no impact on the hot path or on any valid culture.

## Behavior by globalization mode

| Mode | Before | After |
|------|--------|-------|
| ICU (default) | Incomplete culture, NRE on `NumberFormat`, cache poisoning | `CultureNotFoundException` |
| NLS | `CultureNotFoundException` | Unchanged |
| Invariant (predefined-only) | `CultureNotFoundException` | Unchanged |
| Invariant, predefined-only disabled | Fabricated culture named `root` from invariant data | Unchanged |

## Tests

Added to `System.Globalization.Tests.GetCultureInfoTests` (gated on `IsNotInvariantGlobalization`):

- `GetCultureInfo_RootCultureName_Throws` for `root`, `ROOT`, `Root` across all overloads and the `CultureInfo` constructor.
- `GetCultureInfo_RootCultureName_DoesNotPoisonInvariantCache` using RemoteExecutor to verify that resolving `root` first leaves the invariant culture intact and that `und` still maps to invariant.

Verified locally on Windows x64 (ICU): the full `GetCultureInfoTests` class passes (65/65) with the fix, and the new tests fail without it.
