### PR TITLE
[Wasm RyuJIT] Fix: Pass Call's struct type to Wasm ABI Classifier Instead of Dest Store Type

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6279,13 +6279,9 @@ void Lowering::LowerStoreSingleRegCallStruct(GenTreeBlk* store)
 #endif
 
 #if defined(TARGET_WASM)
-        CORINFO_CLASS_HANDLE clsHnd = layout->GetClassHandle();
-        if (clsHnd != NO_CLASS_HANDLE)
-        {
-            CorInfoWasmType wasmAbiType = m_compiler->info.compCompHnd->getWasmLowering(clsHnd);
-            assert(wasmAbiType != CORINFO_WASM_TYPE_VOID);
-            regType = WasmClassifier::ToJitType(wasmAbiType);
-        }
+        CorInfoWasmType wasmAbiType = m_compiler->info.compCompHnd->getWasmLowering(call->gtRetClsHnd);
+        assert(wasmAbiType != CORINFO_WASM_TYPE_VOID);
+        regType = WasmClassifier::ToJitType(wasmAbiType);
 #endif // TARGET_WASM
 
         store->ChangeType(regType);


### PR DESCRIPTION
When we store the return value of a function returning a struct with a single reg return, the ABI classification may not match the destination's. For example,
```csharp
V2<int> result = Unsafe.BitCast<Vector64<int>, V2<int>>(CreateVector());
```
with 
```csharp
  [StructLayout(LayoutKind.Sequential)]
    private struct V2<T>(T x, T y)
    {
        public T X = x;
        public T Y = y;
    }
```
V2<int> has a pass by ref ABI classification since it has *two* fields, whereas Vector64<int>, the result of CreateVector(), has a by-value classification since Vector64<int> has only *one* field. We were using the struct ABI classification of the destination of the store in these cases instead of the return value of the call. 

Resolves #133224
