### PR TITLE
Revert "[mono][interp] Preserve nullable boxing for GetType"

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5063,8 +5063,7 @@ interp_handle_box_patterns (TransformData *td, MonoClass *box_class, const unsig
 		return FALSE;
 	MonoMethod *method = td->inlined_method ? td->inlined_method : td->method;
 	MonoMethod *cmethod;
-	if (!mono_class_is_nullable (box_class) &&
-			*next_ip == CEE_CALL &&
+	if (*next_ip == CEE_CALL &&
 			(cmethod = interp_get_method (method, read32 (next_ip + 1), image, generic_context, error)) &&
 			(cmethod->klass == mono_defaults.object_class) &&
 			(strcmp (cmethod->name, "GetType") == 0)) {

--- a/src/tests/JIT/Directed/nullabletypes/gettype.cs
+++ b/src/tests/JIT/Directed/nullabletypes/gettype.cs
@@ -4,9 +4,8 @@
 namespace JitTest_Directed_nullabletypes_gettype;
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
+using System.Collections.Generic;
 using Xunit;
 
 class C<T>
@@ -23,16 +22,6 @@ class C<T>
 
 public class P
 {
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static Type GetNullableType(bool? value) => value.GetType();
-
-    [Fact]
-    public static void BoxedNullableGetType()
-    {
-        Assert.Same(typeof(bool), GetNullableType(true));
-        Assert.Throws<NullReferenceException>(() => GetNullableType(null));
-    }
-
     [OuterLoop]
     [Fact]
     public static int TestEntryPoint()
@@ -61,3 +50,4 @@ public class P
         return 100;
     }
 }
+


### PR DESCRIPTION
Reverts dotnet/runtime#132732

Contributes to #133207. The new test is failing on many CoreCLR legs.