### PR TITLE
Implicit byref arguments are never on the GC heap

### DIFF
--- a/docs/design/coreclr/botr/clr-abi.md
+++ b/docs/design/coreclr/botr/clr-abi.md
@@ -128,9 +128,11 @@ call(["this" pointer] [return buffer pointer] [generics context] [continuation] 
 call(["this" pointer] [return buffer pointer] [userargs] [continuation] [generics context])   // x86
 ```
 
-## AMD64-only: by-value value types
+## By-value value types passed by reference
 
-Just like native, AMD64 has implicit-byrefs. Any structure (value type in IL parlance) that is not 1, 2, 4, or 8 bytes in size (i.e., 3, 5, 6, 7, or >= 9 bytes in size) that is declared to be passed by value, is instead passed by reference. For JIT generated code, it follows the native ABI where the passed-in reference is a pointer to a compiler generated temp local on the stack. However, there are some cases within remoting or reflection where apparently stackalloc is too hard, and so they pass in pointers within the GC heap, thus the JITed code must report these implicit byref parameters as interior pointers (BYREFs in JIT parlance), in case the callee is one of these reflection paths. Similarly, all writes must use checked write barriers.
+Just like native, Windows AMD64 has implicit-byrefs. Any structure (value type in IL parlance) that is not 1, 2, 4, or 8 bytes in size (i.e., 3, 5, 6, 7, or >= 9 bytes in size) that is declared to be passed by value, is instead passed by reference. For JIT generated code, it follows the native ABI where the passed-in reference is a pointer to a compiler generated temp local on the stack.
+
+Since .NET 11, implicit-byref argument storage must be outside the GC heap on all architectures that use this convention. Runtime callers may use explicitly GC-protected native memory instead of the stack. The caller is responsible for making a writable copy as required by by-value semantics and for reporting any GC references in that copy. Callees may omit write barriers when modifying the argument. This does not apply to explicit byref parameters or the `this` pointer of a value type, and does not remove aliasing caused by taking the argument's address within the callee. Implicit-byref argument pointers are still represented and reported as GC byrefs.
 
 The AMD64 native calling conventions (Windows 64 and System V) require return buffer address to be returned by callee in RAX. JIT also follows this rule.
 

--- a/docs/design/coreclr/botr/clr-abi.md
+++ b/docs/design/coreclr/botr/clr-abi.md
@@ -130,11 +130,16 @@ call(["this" pointer] [return buffer pointer] [userargs] [continuation] [generic
 
 ## By-value value types passed by reference
 
-Just like native, Windows AMD64 has implicit-byrefs. Any structure (value type in IL parlance) that is not 1, 2, 4, or 8 bytes in size (i.e., 3, 5, 6, 7, or >= 9 bytes in size) that is declared to be passed by value, is instead passed by reference. For JIT generated code, it follows the native ABI where the passed-in reference is a pointer to a compiler generated temp local on the stack.
+Structures (value types in IL parlance) that are declared to be passed by value are, above a certain size, passed by reference to a caller-allocated shadow copy instead. Just like native, the exact rule is architecture specific:
+
+| Architecture | Structures passed by implicit reference |
+| --- | --- |
+| Windows AMD64 | Not 1, 2, 4, or 8 bytes in size (i.e., 3, 5, 6, 7, or >= 9 bytes) |
+| ARM64, LoongArch64, RISC-V | Larger than 16 bytes |
+
+System V AMD64, x86 and ARM32 do not use this convention. For JIT generated code, it follows the native ABI where the passed-in reference is a pointer to a compiler generated temp local on the stack.
 
 Since .NET 11, implicit-byref argument storage must be outside the GC heap on all architectures that use this convention. Runtime callers may use explicitly GC-protected native memory instead of the stack. The caller is responsible for making a writable copy as required by by-value semantics and for reporting any GC references in that copy. Callees may omit write barriers when modifying the argument. This does not apply to explicit byref parameters or the `this` pointer of a value type, and does not remove aliasing caused by taking the argument's address within the callee. Implicit-byref argument pointers are still represented and reported as GC byrefs.
-
-The AMD64 native calling conventions (Windows 64 and System V) require return buffer address to be returned by callee in RAX. JIT also follows this rule.
 
 ## RISC-V only: structs passed/returned according to hardware floating-point calling convention
 
@@ -143,6 +148,8 @@ Passing/returning structs according to hardware floating-point calling conventio
 ## Return buffers
 
 Since .NET 10, return buffers must always be allocated on the stack by the caller. After the call, the caller is responsible for copying the return buffer to the final destination using write barriers if necessary. The JIT can assume that the return buffer is always on the stack and may optimize accordingly, such as by omitting write barriers when writing GC pointers to the return buffer. In addition, the buffer is allowed to be used for temporary storage within the method since its content must not be aliased or cross-thread visible.
+
+AMD64-only: The AMD64 native calling conventions (Windows 64 and System V) require the return buffer address to be returned by the callee in RAX. The JIT also follows this rule.
 
 ARM64-only: When a method returns a structure that is larger than 16 bytes the caller reserves a return buffer of sufficient size and alignment to hold the result. The address of the buffer is passed as an argument to the method in `R8` (defined in the JIT as `REG_ARG_RET_BUFF`). The callee isn't required to preserve the value stored in `R8`.
 

--- a/src/coreclr/debug/ee/funceval.cpp
+++ b/src/coreclr/debug/ee/funceval.cpp
@@ -896,46 +896,14 @@ static void GetFuncEvalArgValue(DebuggerEval *pDE,
                 _ASSERTE(argTH.GetMethodTable());
 
                 unsigned size = argTH.GetMethodTable()->GetNumInstanceFieldBytes();
-                if (size <= sizeof(ARG_SLOT)
-#if defined(TARGET_AMD64)
-                    // On AMD64 we pass value types of size which are not powers of 2 by ref.
-                    && ((size & (size-1)) == 0)
-#endif // TARGET_AMD64
-                   )
+                if (size <= sizeof(ARG_SLOT))
                 {
                     memcpyNoGCRefs(ArgSlotEndiannessFixup(pArgument, sizeof(LPVOID)), pAddr, size);
                 }
                 else
                 {
                     _ASSERTE(pFEAD->argAddr != (CORDB_ADDRESS)0);
-#if defined(ENREGISTERED_PARAMTYPE_MAXSIZE)
-                    if (ArgIterator::IsArgPassedByRef(argTH))
-                    {
-                        // On X64, by-value value class arguments which are bigger than 8 bytes are passed by reference
-                        // according to the native calling convention.  The same goes for value class arguments whose size
-                        // is smaller than 8 bytes but not a power of 2.  To avoid side effets, we need to allocate a
-                        // temporary variable and pass that by reference instead. On ARM64, by-value value class
-                        // arguments which are bigger than 16 bytes are passed by reference.
-                        _ASSERTE(ppProtectedValueClasses != NULL);
-
-                        BYTE * pTemp = new (interopsafe) BYTE[ALIGN_UP(sizeof(ValueClassInfo), 8) + size];
-
-                        ValueClassInfo * pValueClassInfo = (ValueClassInfo *)pTemp;
-                        LPVOID pData = pTemp + ALIGN_UP(sizeof(ValueClassInfo), 8);
-
-                        memcpyNoGCRefs(pData, pAddr, size);
-                        *pArgument = PtrToArgSlot(pData);
-
-                        pValueClassInfo->pData = pData;
-                        pValueClassInfo->pMT = argTH.GetMethodTable();
-
-                        pValueClassInfo->pNext = *ppProtectedValueClasses;
-                        *ppProtectedValueClasses = pValueClassInfo;
-                    }
-                    else
-#endif // ENREGISTERED_PARAMTYPE_MAXSIZE
                     *pArgument = PtrToArgSlot(pAddr);
-
                 }
             }
             else
@@ -1208,6 +1176,38 @@ static void GetFuncEvalArgValue(DebuggerEval *pDE,
             }
         }
     }
+
+#if defined(ENREGISTERED_PARAMTYPE_MAXSIZE)
+    if (!isByRef && (argSigType == ELEMENT_TYPE_VALUETYPE) && ArgIterator::IsArgPassedByRef(argTH))
+    {
+        unsigned size = argTH.GetMethodTable()->GetNumInstanceFieldBytes();
+        if (size > sizeof(ARG_SLOT))
+        {
+            // Copy both unboxed and boxed arguments outside the GC heap: the callee may
+            // overwrite the argument without write barriers. Smaller arguments already
+            // have a copy in the ARG_SLOT array.
+            _ASSERTE(ppProtectedValueClasses != nullptr);
+
+            SIZE_T allocSize;
+            if (!ClrSafeInt<SIZE_T>::addition(ALIGN_UP(sizeof(ValueClassInfo), 8), size, allocSize))
+            {
+                ThrowHR(COR_E_OVERFLOW);
+            }
+
+            BYTE* pTemp = new (interopsafe) BYTE[allocSize];
+            ValueClassInfo* pValueClassInfo = reinterpret_cast<ValueClassInfo*>(pTemp);
+            void* pData = pTemp + ALIGN_UP(sizeof(ValueClassInfo), 8);
+
+            memcpyNoGCRefs(pData, ArgSlotToPtr(*pArgument), size);
+            *pArgument = PtrToArgSlot(pData);
+
+            pValueClassInfo->pData = pData;
+            pValueClassInfo->pMT = argTH.GetMethodTable();
+            pValueClassInfo->pNext = *ppProtectedValueClasses;
+            *ppProtectedValueClasses = pValueClassInfo;
+        }
+    }
+#endif // ENREGISTERED_PARAMTYPE_MAXSIZE
 }
 
 static CorDebugRegister GetArgAddrFromReg( DebuggerIPCE_FuncEvalArgData *pFEAD)

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -19,7 +19,7 @@
 //  src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
 // If you update this, ensure you run `git grep MINIMUM_READYTORUN_MAJOR_VERSION`
 // and handle pending work.
-#define READYTORUN_MAJOR_VERSION 28
+#define READYTORUN_MAJOR_VERSION 29
 #define READYTORUN_MINOR_VERSION 0x0000
 
 #define MINIMUM_READYTORUN_MAJOR_VERSION 26
@@ -69,6 +69,7 @@
 // R2R Version 26.1 adds READYTORUN_FIXUP_StoreMultiCallableAddrOfCode for storing a method's MultiCallableAddrOfCode into a location in the R2R image (used on WebAssembly)
 // R2R Version 27 redefines READYTORUN_FIXUP_DeclaringTypeHandle to be encoded as a method signature instead of a pair of type signatures
 // R2R Version 28 allows entries in the ExternalTypeMaps and ProxyTypeMaps sections to append a sequence of serialized (string, string) type map entries after the per-group NativeHashtable.
+// R2R Version 29 requires implicit byref arguments to always be outside of the GC heap
 
 struct READYTORUN_CORE_HEADER
 {

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2491,8 +2491,8 @@ bool Compiler::lvaIsArgAccessedViaVarArgsCookie(unsigned lclNum)
 // They are used on Windows x64 for structs 3, 5, 6, 7, > 8 bytes in size,
 // and on ARM64/LoongArch64 for structs larger than 16 bytes.
 //
-// They are "byrefs" because the VM sometimes uses memory allocated on the
-// GC heap for the shadow copies.
+// The shadow copies must be outside the GC heap, so stores into them do not
+// require write barriers. The caller is responsible for GC reporting their contents.
 //
 // Arguments:
 //    lclNum - The local in question

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3441,6 +3441,7 @@ GenTree* Compiler::fgMorphExpandImplicitByRefArg(GenTreeLclVarCommon* lclNode)
     {
         newArgNode = (argNodeType == TYP_STRUCT) ? gtNewStoreBlkNode(argNodeLayout, addrNode, data)
                                                  : gtNewStoreIndNode(argNodeType, addrNode, data)->AsIndir();
+        newArgNode->gtFlags |= GTF_IND_TGT_NOT_HEAP;
     }
     else if (isLoad)
     {

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -810,20 +810,6 @@ public:
         costWith += countReadBacksWtd * COST_STRUCT_ACCESS_CYCLES;
         sizeWith += countReadBacks * COST_STRUCT_ACCESS_SIZE;
 
-        // Write backs with TYP_REFs when the base local is an implicit byref
-        // involves checked write barriers, so they are very expensive. We cost that at 10 cycles.
-        const weight_t COST_WRITEBARRIER_CYCLES = 10;
-        const weight_t COST_WRITEBARRIER_SIZE   = 10;
-
-        // TODO-CQ: This should be adjusted once we type implicit byrefs as TYP_I_IMPL.
-        // Otherwise we cost it like a store to stack at 3 cycles.
-        weight_t writeBackCost = comp->lvaIsImplicitByRefLocal(lclNum) && (access.AccessType == TYP_REF)
-                                     ? COST_WRITEBARRIER_CYCLES
-                                     : COST_STRUCT_ACCESS_CYCLES;
-        weight_t writeBackSize = comp->lvaIsImplicitByRefLocal(lclNum) && (access.AccessType == TYP_REF)
-                                     ? COST_WRITEBARRIER_SIZE
-                                     : COST_STRUCT_ACCESS_SIZE;
-
         // We write back before an overlapping struct use passed as an arg.
         // TODO-CQ: A store-forwarding optimization in lowering could get rid
         // of these copies; however, it requires lowering to be able to prove
@@ -839,8 +825,8 @@ public:
         // store-forwarding/forward sub to make the write backs "free".)
         weight_t countWriteBacksWtd = countOverlappedCallArgWtd;
         unsigned countWriteBacks    = countOverlappedCallArg;
-        costWith += countWriteBacksWtd * writeBackCost;
-        sizeWith += countWriteBacks * writeBackSize;
+        costWith += countWriteBacksWtd * COST_STRUCT_ACCESS_CYCLES;
+        sizeWith += countWriteBacks * COST_STRUCT_ACCESS_SIZE;
 
         // Overlapping stores are decomposable so we don't cost them as
         // being more expensive than their unpromoted counterparts (i.e. we
@@ -864,7 +850,7 @@ public:
         weight_t sizeImprovement          = sizeWithout - sizeWith;
 
         JITDUMP("  Evaluating access %s @ %03u\n", varTypeName(access.AccessType), access.Offset);
-        JITDUMP("    Single write-back cost: " FMT_WT "\n", writeBackCost);
+        JITDUMP("    Single write-back cost: " FMT_WT "\n", COST_STRUCT_ACCESS_CYCLES);
         JITDUMP("    Write backs: " FMT_WT "\n", countWriteBacksWtd);
         JITDUMP("    Read backs: " FMT_WT "\n", countReadBacksWtd);
         JITDUMP("    Estimated cycle improvement: " FMT_WT " cycles per invocation\n", cycleImprovementPerInvoc);

--- a/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
+++ b/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
@@ -11,7 +11,7 @@ struct ReadyToRunHeaderConstants
 {
     static const uint32_t Signature = 0x00525452; // 'RTR'
 
-    static const uint32_t CurrentMajorVersion = 28;
+    static const uint32_t CurrentMajorVersion = 29;
     static const uint32_t CurrentMinorVersion = 0;
 };
 

--- a/src/coreclr/scripts/superpmi_diffs_setup.py
+++ b/src/coreclr/scripts/superpmi_diffs_setup.py
@@ -242,12 +242,35 @@ def build_partitions(partitions_dir, do_asmdiffs, bin_path, host_bitness):
     prefix_urlencoded = urllib.parse.quote(prefix)
     list_superpmi_container_uri = az_blob_storage_superpmi_container_uri + "?restype=container&comp=list&prefix=" + prefix_urlencoded + "/"
 
-    try:
-        contents = urllib.request.urlopen(list_superpmi_container_uri).read().decode('utf-8')
-    except Exception as exception:
-        raise Exception("Didn't find any collections using %s", list_superpmi_container_uri)
+    # The Blob Service "List Blobs" API returns results in pages, and the page size it
+    # chooses is not guaranteed to cover the whole prefix. When more results remain, the
+    # response carries a NextMarker that must be passed back to retrieve the next page.
+    #
+    # Failing to follow it silently yields a subset of the collections: the listing is
+    # ordered by blob name, so a truncated first page can drop entire target directories
+    # (e.g. everything from linux/x64 onwards). That produces zero partitions for the
+    # affected targets, and the Helix send then fails with "given no WorkItems to send".
+    blobs = []
+    marker = None
+    while True:
+        list_uri = list_superpmi_container_uri
+        if marker:
+            list_uri += "&marker=" + urllib.parse.quote(marker)
 
-    elem = ET.fromstring(contents)
+        try:
+            contents = urllib.request.urlopen(list_uri).read().decode('utf-8-sig')
+        except Exception as exception:
+            raise Exception("Didn't find any collections using {}".format(list_uri))
+
+        elem = ET.fromstring(contents)
+        blobs.extend(elem.findall(".//Blob"))
+
+        next_marker = elem.find("NextMarker")
+        marker = next_marker.text if next_marker is not None else None
+        if not marker:
+            break
+
+    print("Found {} blobs under {}".format(len(blobs), prefix))
 
     # Each tuple is (target_os, target_arch, blob_arch) where blob_arch is the architecture
     # directory used in blob storage. For wasm collections the MCH files are uploaded under
@@ -272,7 +295,7 @@ def build_partitions(partitions_dir, do_asmdiffs, bin_path, host_bitness):
 
     targets = [(target_os, target_arch, blob_arch, []) for (target_os, target_arch, blob_arch) in targets]
 
-    for blob in elem.findall(".//Blob"):
+    for blob in blobs:
         name = blob.find("Name").text
         for (target_os, target_arch, blob_arch, collections) in targets:
             name_pref = prefix + "/" + target_os + "/" + blob_arch + "/"

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime
     {
         public const uint Signature = 0x00525452; // 'RTR'
 
-        public const ushort CurrentMajorVersion = 28;
+        public const ushort CurrentMajorVersion = 29;
         public const ushort CurrentMinorVersion = 0;
     }
 #if READYTORUN

--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -460,6 +460,7 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
     #ifdef ENREGISTERED_PARAMTYPE_MAXSIZE
                         if (m_argIt.IsArgPassedByRef())
                         {
+                            _ASSERTE(!GCHeapUtilities::GetGCHeap()->IsHeapPointer(pSrc));
                             *(PVOID*)pDest = pSrc;
                         }
                         else

--- a/src/coreclr/vm/callhelpers.h
+++ b/src/coreclr/vm/callhelpers.h
@@ -270,10 +270,10 @@ public:
         //
         // Calls with value type parameters must use the CallXXXWithValueTypes
         // variants.  Using the WithValueTypes variant indicates that the caller
-        // has gc-protected the contents of value types of size greater than
-        // ENREGISTERED_PARAMTYPE_MAXSIZE (when it is defined, which is currently
-        // only on AMD64).  ProtectValueClassFrame can be used to accomplish this,
-        // see CallDescrWithObjectArray in stackbuildersink.cpp.
+        // has GC-protected the contents of value types passed as implicit byrefs.
+        // These require writable copies outside the GC heap, since the callee
+        // may modify them without write barriers. ProtectValueClassFrame can be
+        // used to report the GC references in these copies.
         //
         // Not all usages of MethodDesc::CallXXX have been ported to the new convention. The end goal is to port them all and get
         //      rid of the non-portable BYTE* version.


### PR DESCRIPTION
Implicit byref arguments (structs passed by reference under the hood: not 1/2/4/8 bytes on win-x64, larger than 16 bytes on arm64) are now guaranteed to never live on the GC heap, so callees can store into them without write barriers.

```csharp
struct S16 { public object A; public object B; }

[MethodImpl(MethodImplOptions.NoInlining)]
static void Store(S16 s, object o) { s.A = o; Sink(ref s); }
```

```diff
 ; P:Store(S16,System.Object)   win-x64
-       push     rbx
-       sub      rsp, 32
-       mov      rbx, rcx
-       mov      rcx, rbx
-       call     CORINFO_HELP_CHECKED_ASSIGN_REF
-       mov      rcx, rbx
+       sub      rsp, 40
+       mov      gword ptr [rcx], rdx
        call     [P:Sink(byref)]
        nop
-       add      rsp, 32
-       pop      rbx
+       add      rsp, 40
        ret
-; Total bytes of code 32
+; Total bytes of code 19
```

Bumps `READYTORUN_MAJOR_VERSION` to 29: crossgen2 now emits barrier-free stores, so older runtimes must reject these images. `MINIMUM_READYTORUN_MAJOR_VERSION` stays at 26 - existing images can only forward an incoming implicit byref, never originate heap-backed storage for one.
