### PR TITLE
Enable browser WASM R2R tests in manual pipeline

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -11,6 +11,7 @@ parameters:
   excludeNonLibTests: false
   excludeOptional: true
   debuggerTestsOnly: false
+  runR2RTests: false
 
 jobs:
 
@@ -175,6 +176,78 @@ jobs:
         - WasmTestOnWasmtime
 
 - ${{ if and(ne(variables.isRollingBuild, true), ne(parameters.excludeNonLibTests, true), ne(parameters.debuggerTestsOnly, true)) }}:
+  - ${{ if eq(parameters.runR2RTests, true) }}:
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost
+        jobParameters:
+          testGroup: innerloop
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: checked
+        platforms:
+        - browser_wasm
+        jobParameters:
+          nameSuffix: CoreCLR_ReleaseLibraries
+          buildArgs: -s clr+libs+libs.tests+packs -c Release -rc $(_BuildConfig) /p:TestAssemblies=false /p:ArchiveTests=true /p:InstallWorkloadForTesting=false
+          timeoutInMinutes: 120
+          postBuildSteps:
+            - template: /eng/pipelines/coreclr/templates/build-native-test-assets-step.yml
+              parameters:
+                extraBuildArgs: -os browser
+            - template: /eng/pipelines/common/upload-artifact-step.yml
+              parameters:
+                rootFolder: $(Build.SourcesDirectory)/artifacts/bin
+                includeRootFolder: false
+                archiveType: $(archiveType)
+                archiveExtension: $(archiveExtension)
+                tarCompression: $(tarCompression)
+                artifactName: CoreCLR_ReleaseLibraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_hostedOs)_$(_BuildConfig)
+                displayName: Build Assets
+            - template: /eng/pipelines/common/upload-artifact-step.yml
+              parameters:
+                rootFolder: $(Build.SourcesDirectory)/artifacts/helix
+                includeRootFolder: false
+                archiveType: $(archiveType)
+                archiveExtension: $(archiveExtension)
+                tarCompression: $(tarCompression)
+                artifactName: CoreCLR_ReleaseLibraries_TestArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_hostedOs)_$(_BuildConfig)
+            - template: /eng/pipelines/common/wasm-post-build-steps.yml
+              parameters:
+                publishArtifactsForWorkload: true
+                publishWBT: true
+          extraVariablesTemplates:
+            - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+              parameters:
+                testGroup: innerloop
+                liveLibrariesBuildConfig: Release
+            - template: /eng/pipelines/common/templates/runtimes/native-test-assets-variables.yml
+              parameters:
+                testGroup: innerloop
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - browser_wasm
+        helixQueueGroup: pr
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: innerloop
+          readyToRun: true
+          displayNameArgs: R2R_CG2
+          liveLibrariesBuildConfig: Release
+          unifiedArtifactsName: CoreCLR_ReleaseLibraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_hostedOs)_$(_BuildConfig)
+          unifiedBuildNameSuffix: CoreCLR_ReleaseLibraries
+          useHelixMonitor: ${{ parameters.useHelixMonitor }}
+          extraBuildArgs: -os browser -p:HostConfiguration=Release
+
   # Builds only
   - template: /eng/pipelines/common/templates/wasm-build-only.yml
     parameters:

--- a/eng/pipelines/runtime-wasm-non-libtests.yml
+++ b/eng/pipelines/runtime-wasm-non-libtests.yml
@@ -31,3 +31,4 @@ extends:
           useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
           excludeNonLibTests: false
           excludeLibTests: true
+          runR2RTests: true


### PR DESCRIPTION
## Summary

Restore the browser WASM CoreCLR `R2R_CG2` runtime-test leg removed by #133294, but keep it out of the default `runtime` pipeline while its failures are investigated.

The leg and its required build jobs are enabled only by `runtime-wasm-non-libtests`, so it can be queued on a PR with:

```text
/azp run runtime-wasm-non-libtests
```

Other WASM wrappers and scheduled extra-platform runs retain their existing behavior.

## Validation

- Parsed the changed pipeline YAML files successfully.
- Confirmed the changes pass `git diff --check`.

> [!NOTE]
> This pull request was created with the assistance of GitHub Copilot.