### PR TITLE
[Mono][browser] Quarantine double Min/Max NaN payload tests

### DIFF
--- a/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
+++ b/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
@@ -1372,14 +1372,21 @@ namespace System.Tests
                 yield return new object[] {  double.NegativeInfinity,    double.NaN,                double.NaN };
                 yield return new object[] {  double.NaN,                 double.PositiveInfinity,   double.NaN };
                 yield return new object[] {  double.NaN,                 double.NegativeInfinity,   double.NaN };
-                yield return new object[] {  PositiveNaNDouble,          -0.0,                      PositiveNaNDouble };
-                yield return new object[] { -0.0,                        NegativeNaNDouble,          NegativeNaNDouble };
                 yield return new object[] { -0.0f,                       0.0f,                      0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      2.0f };
                 yield return new object[] { -3.0f,                       2.0f,                      2.0f };
                 yield return new object[] {  3.0f,                      -2.0f,                      3.0f };
                 yield return new object[] { -2.0f,                       3.0f,                      3.0f };
+            }
+        }
+
+        public static IEnumerable<object[]> MaxDoubleNaNSignAndPayload
+        {
+            get
+            {
+                yield return new object[] {  PositiveNaNDouble,          -0.0,                      PositiveNaNDouble };
+                yield return new object[] { -0.0,                        NegativeNaNDouble,          NegativeNaNDouble };
             }
         }
 
@@ -1572,14 +1579,21 @@ namespace System.Tests
                 yield return new object[] {  double.NegativeInfinity,    double.NaN,                 double.NaN };
                 yield return new object[] {  double.NaN,                 double.PositiveInfinity,    double.NaN };
                 yield return new object[] {  double.NaN,                 double.NegativeInfinity,    double.NaN };
-                yield return new object[] {  PositiveNaNDouble,          -0.0,                       PositiveNaNDouble };
-                yield return new object[] { -0.0,                        NegativeNaNDouble,           NegativeNaNDouble };
                 yield return new object[] { -0.0f,                       0.0f,                      -0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      -0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      -3.0f };
                 yield return new object[] { -3.0f,                       2.0f,                      -3.0f };
                 yield return new object[] {  3.0f,                      -2.0f,                      -2.0f };
                 yield return new object[] { -2.0f,                       3.0f,                      -2.0f };
+            }
+        }
+
+        public static IEnumerable<object[]> MinDoubleNaNSignAndPayload
+        {
+            get
+            {
+                yield return new object[] {  PositiveNaNDouble,          -0.0,                       PositiveNaNDouble };
+                yield return new object[] { -0.0,                        NegativeNaNDouble,           NegativeNaNDouble };
             }
         }
 

--- a/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
+++ b/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
@@ -1372,21 +1372,18 @@ namespace System.Tests
                 yield return new object[] {  double.NegativeInfinity,    double.NaN,                double.NaN };
                 yield return new object[] {  double.NaN,                 double.PositiveInfinity,   double.NaN };
                 yield return new object[] {  double.NaN,                 double.NegativeInfinity,   double.NaN };
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/133311")]
+                if (!(PlatformDetection.IsMonoRuntime && PlatformDetection.IsWasm))
+                {
+                    yield return new object[] {  PositiveNaNDouble,          -0.0,                      PositiveNaNDouble };
+                    yield return new object[] { -0.0,                        NegativeNaNDouble,          NegativeNaNDouble };
+                }
                 yield return new object[] { -0.0f,                       0.0f,                      0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      2.0f };
                 yield return new object[] { -3.0f,                       2.0f,                      2.0f };
                 yield return new object[] {  3.0f,                      -2.0f,                      3.0f };
                 yield return new object[] { -2.0f,                       3.0f,                      3.0f };
-            }
-        }
-
-        public static IEnumerable<object[]> MaxDoubleNaNSignAndPayload
-        {
-            get
-            {
-                yield return new object[] {  PositiveNaNDouble,          -0.0,                      PositiveNaNDouble };
-                yield return new object[] { -0.0,                        NegativeNaNDouble,          NegativeNaNDouble };
             }
         }
 
@@ -1579,21 +1576,18 @@ namespace System.Tests
                 yield return new object[] {  double.NegativeInfinity,    double.NaN,                 double.NaN };
                 yield return new object[] {  double.NaN,                 double.PositiveInfinity,    double.NaN };
                 yield return new object[] {  double.NaN,                 double.NegativeInfinity,    double.NaN };
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/133311")]
+                if (!(PlatformDetection.IsMonoRuntime && PlatformDetection.IsWasm))
+                {
+                    yield return new object[] {  PositiveNaNDouble,          -0.0,                       PositiveNaNDouble };
+                    yield return new object[] { -0.0,                        NegativeNaNDouble,           NegativeNaNDouble };
+                }
                 yield return new object[] { -0.0f,                       0.0f,                      -0.0f };
                 yield return new object[] {  0.0f,                      -0.0f,                      -0.0f };
                 yield return new object[] {  2.0f,                      -3.0f,                      -3.0f };
                 yield return new object[] { -3.0f,                       2.0f,                      -3.0f };
                 yield return new object[] {  3.0f,                      -2.0f,                      -2.0f };
                 yield return new object[] { -2.0f,                       3.0f,                      -2.0f };
-            }
-        }
-
-        public static IEnumerable<object[]> MinDoubleNaNSignAndPayload
-        {
-            get
-            {
-                yield return new object[] {  PositiveNaNDouble,          -0.0,                       PositiveNaNDouble };
-                yield return new object[] { -0.0,                        NegativeNaNDouble,           NegativeNaNDouble };
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.GenericMath.cs
@@ -944,6 +944,14 @@ namespace System.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/133311", TestPlatforms.Browser, TargetFrameworkMonikers.Any, TestRuntimes.Mono)]
+        [MemberData(nameof(GenericMathTestMemberData.MaxDoubleNaNSignAndPayload), MemberType = typeof(GenericMathTestMemberData))]
+        public static void MaxNaNSignAndPayloadTest(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, NumberHelper<double>.Max(x, y));
+        }
+
+        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.MaxNumberDouble), MemberType = typeof(GenericMathTestMemberData))]
         public static void MaxNumberTest(double x, double y, double expectedResult)
         {
@@ -953,6 +961,14 @@ namespace System.Tests
         [Theory]
         [MemberData(nameof(GenericMathTestMemberData.MinDouble), MemberType = typeof(GenericMathTestMemberData))]
         public static void MinTest(double x, double y, double expectedResult)
+        {
+            AssertExtensions.Equal(expectedResult, NumberHelper<double>.Min(x, y));
+        }
+
+        [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/133311", TestPlatforms.Browser, TargetFrameworkMonikers.Any, TestRuntimes.Mono)]
+        [MemberData(nameof(GenericMathTestMemberData.MinDoubleNaNSignAndPayload), MemberType = typeof(GenericMathTestMemberData))]
+        public static void MinNaNSignAndPayloadTest(double x, double y, double expectedResult)
         {
             AssertExtensions.Equal(expectedResult, NumberHelper<double>.Min(x, y));
         }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.GenericMath.cs
@@ -944,14 +944,6 @@ namespace System.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/133311", TestPlatforms.Browser, TargetFrameworkMonikers.Any, TestRuntimes.Mono)]
-        [MemberData(nameof(GenericMathTestMemberData.MaxDoubleNaNSignAndPayload), MemberType = typeof(GenericMathTestMemberData))]
-        public static void MaxNaNSignAndPayloadTest(double x, double y, double expectedResult)
-        {
-            AssertExtensions.Equal(expectedResult, NumberHelper<double>.Max(x, y));
-        }
-
-        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.MaxNumberDouble), MemberType = typeof(GenericMathTestMemberData))]
         public static void MaxNumberTest(double x, double y, double expectedResult)
         {
@@ -961,14 +953,6 @@ namespace System.Tests
         [Theory]
         [MemberData(nameof(GenericMathTestMemberData.MinDouble), MemberType = typeof(GenericMathTestMemberData))]
         public static void MinTest(double x, double y, double expectedResult)
-        {
-            AssertExtensions.Equal(expectedResult, NumberHelper<double>.Min(x, y));
-        }
-
-        [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/133311", TestPlatforms.Browser, TargetFrameworkMonikers.Any, TestRuntimes.Mono)]
-        [MemberData(nameof(GenericMathTestMemberData.MinDoubleNaNSignAndPayload), MemberType = typeof(GenericMathTestMemberData))]
-        public static void MinNaNSignAndPayloadTest(double x, double y, double expectedResult)
         {
             AssertExtensions.Equal(expectedResult, NumberHelper<double>.Min(x, y));
         }


### PR DESCRIPTION
Quarantines the four double generic-math `Max`/`Min` cases tracked by #133311 on Mono browser-WASM without splitting the shared test methods or data sets.

The affected NaN sign-and-payload rows remain in `MaxDouble` and `MinDouble` for every other runtime. Each pair is conditionally omitted only when `PlatformDetection.IsMonoRuntime && PlatformDetection.IsWasm`; all other Max/Min coverage remains unchanged.

Validation:
- `PATH=/opt/homebrew/bin:$PATH ./build.sh mono+libs -os browser`
- Focused Mono browser-WASM runs: 17/17 applicable `MaxTest` cases passed and 17/17 applicable `MinTest` cases passed

Contributes to #133311

> [!NOTE]
> This pull request description was generated with GitHub Copilot.