### PR TITLE
Normalise charset in the ReadBufferAsString method in System.Net.Http fixes #133319

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -145,7 +145,19 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        encoding = Encoding.GetEncoding(charset);
+                        var normalised = charset switch
+                        {
+                            // discovered in https://github.com/PowerShell/PowerShell/issues/27788
+                            // where a server may reply with utf8, added below additional options,
+                            // with a fall back to current behaviour.
+                            "utf8" or "utf-8" or "utf_8" => "utf-8",
+                            "utf16" or "utf-16" or "utf_16" => "utf-16",
+                            "unicode" => "utf-16",
+                            "latin1" or "latin-1" => "iso-8859-1",
+                            "us-ascii" or "ascii" => "us-ascii",
+                            _ => charset
+                        };
+                        encoding = Encoding.GetEncoding(normalised);
                     }
 
                     // Byte-order-mark (BOM) characters may be present even if a charset was specified.


### PR DESCRIPTION
This PR Fixes 
- #133319

I have built the System.Net.Http library, plonked the resulting dll into a local build of PowerShell to confirm it that this does indeed also fix https://github.com/PowerShell/PowerShell/issues/27788 

As can be seen in this screenshot

<img width="1633" height="875" alt="image" src="https://github.com/user-attachments/assets/1b94feaf-9716-4338-87ca-ef07d0564b57" />


I felt this was the smallest code change needed and in the right place
Happy to take comment out if that's desired