### PR TITLE
JIT: Improve cast helper fallbacks

### DIFF
--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -2064,8 +2064,10 @@ static int PickCandidatesForTypeCheck(Compiler*              comp,
             case CORINFO_HELP_CHKCASTCLASS:
             case CORINFO_HELP_CHKCASTARRAY:
             case CORINFO_HELP_CHKCASTANY:
-                likelihoods[0] = 50; // 50% speculative guess
-                candidates[0]  = NO_CLASS_HANDLE;
+                *typeCheckFailed = helper == CORINFO_HELP_CHKCASTCLASS ? TypeCheckFailedAction::CallHelper_Specialized
+                                                                       : TypeCheckFailedAction::CallHelper;
+                likelihoods[0]   = 50; // 50% speculative guess
+                candidates[0]    = NO_CLASS_HANDLE;
                 return 1;
 
             default:
@@ -2145,29 +2147,19 @@ static int PickCandidatesForTypeCheck(Compiler*              comp,
     const bool isCastToExact = comp->info.compCompHnd->isExactType(castToCls);
     if (isCastToExact && ((helper == CORINFO_HELP_CHKCASTCLASS) || (helper == CORINFO_HELP_CHKCASTARRAY)))
     {
-        // obj is string
-        // obj is string[]
+        // (string)obj
+        // (string[])obj
         //
-        if ((helper == CORINFO_HELP_CHKCASTCLASS))
-        {
-            // (string)obj
-            //
-            // Fallback for this expansion always throws InvalidCastException
-            // TODO: can we do the same for string[]? (importer did not)
-            *typeCheckFailed = TypeCheckFailedAction::CallHelper_AlwaysThrows;
+        // Fallback for this expansion always throws InvalidCastException.
+        // Exactness excludes array covariance and primitive-array interchange.
+        *typeCheckFailed = TypeCheckFailedAction::CallHelper_AlwaysThrows;
 
-            // Assume that exceptions are rare
-            likelihoods[0] = 100;
+        // Assume that exceptions are rare
+        likelihoods[0] = 100;
 
-            // Update the common denominator class to be more exact as
-            // the fallback always throws anyway, so we don't have to worry about what it returns.
-            *commonCls = castToCls;
-        }
-        else
-        {
-            // 50% chance of successful type check (speculative guess)
-            likelihoods[0] = 50;
-        }
+        // Update the common denominator class to be more exact as
+        // the fallback always throws anyway, so we don't have to worry about what it returns.
+        *commonCls    = castToCls;
         candidates[0] = castToCls;
         return 1;
     }
@@ -2177,8 +2169,6 @@ static int PickCandidatesForTypeCheck(Compiler*              comp,
         // obj is string[]
         //
         // Fallbacks for these expansions simply return null
-        // TODO: should we keep the helper call for ISINSTANCEOFARRAY like we do for CHKCASTARRAY above?
-        // The logic is copied from the importer.
         *typeCheckFailed = TypeCheckFailedAction::ReturnNull;
 
         // We're done, there is no need in consulting with PGO data
@@ -2299,6 +2289,13 @@ static int PickCandidatesForTypeCheck(Compiler*              comp,
         }
         if (castResult == TypeCompareState::Must)
         {
+            // The specialized helper skips null and exact-type checks. A failed guard against
+            // a subclass would not rule out the target class itself.
+            if ((helper == CORINFO_HELP_CHKCASTCLASS) && (candidates[0] == castToCls))
+            {
+                *typeCheckFailed = TypeCheckFailedAction::CallHelper_Specialized;
+            }
+
             // return actual object on successful type check
             *typeCheckPassed = TypeCheckPassedAction::ReturnObj;
             return 1;


### PR DESCRIPTION
Optimize fallbacks for cast expansions, e.g. Fallback for `(string[])obj` always throws.

```csharp
[MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
static string[] CastToArrayOfStrings(object obj) => (string[])obj;
```

```diff
 G_M14817_IG01:
        sub      rsp, 40
 G_M14817_IG02:
        mov      rax, rcx
        test     rax, rax
-       je       SHORT G_M14817_IG05
+       je       SHORT G_M14817_IG04
 G_M14817_IG03:
        mov      r8, 0xD1FFAB1E      ; System.String[]
        cmp      qword ptr [rax], r8
-       je       SHORT G_M14817_IG05
+       jne      SHORT G_M14817_IG05
 G_M14817_IG04:
+       add      rsp, 40
+       ret
+G_M14817_IG05:
        mov      rdx, rcx
        mov      rcx, r8
        call     [CORINFO_HELP_CHKCASTARRAY]
-G_M14817_IG05:
-       nop
-G_M14817_IG06:
-       add      rsp, 40
-       ret
+       int3
```

```csharp
// Shared generic code, e.g. T = string
[MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
static List<T> CastToList<T>(object obj) => (List<T>)obj;
```

```diff
 G_M25441_IG05:
        cmp      qword ptr [rax], rcx
        je       SHORT G_M25441_IG07
 G_M25441_IG06:
        mov      rdx, rbx
-       call     [CORINFO_HELP_CHKCASTCLASS]
+       call     [CORINFO_HELP_CHKCASTCLASS_SPECIAL]
 G_M25441_IG07:
        nop
```

```csharp
class Base { }
class Derived : Base { }

// Tier1; warmed with 80% Base instances and 20% Derived instances
[MethodImpl(MethodImplOptions.NoInlining)]
static Base CastToBase(object obj) => (Base)obj;
```

```diff
 G_M5904_IG05:
        mov      rdx, rcx
        mov      rcx, r8
-       call     CORINFO_HELP_CHKCASTCLASS
+       call     CORINFO_HELP_CHKCASTCLASS_SPECIAL
        jmp      SHORT G_M5904_IG04
```
