### PR TITLE
Remove createdump PID argument

### DIFF
--- a/docs/design/coreclr/botr/xplat-minidump-generation.md
+++ b/docs/design/coreclr/botr/xplat-minidump-generation.md
@@ -82,10 +82,10 @@ DOTNET_DbgMiniDumpType values:
 
 **Command Line Usage**
 
-The createdump utility can also be run from the command line on arbitrary .NET Core processes. The type of dump can be controlled with the below command switches. The default is a "minidump" which contains the majority the memory and managed state needed. Unless you have ptrace (CAP_SYS_PTRACE) administrative privilege, you need to run with sudo or su. The same as if you were attaching with lldb or other native debugger.
+The createdump utility only dumps the parent process that launched it. A target PID cannot be specified. The type of dump can be controlled with the command switches below. The default is a "minidump" which contains the majority of the memory and managed state needed.
 
 ```
-createdump [options] pid
+createdump [options]
 -f, --name - dump path and file name. The default is '/tmp/coredump.%p'. These specifiers are substituted with following values:
    %p  PID of dumped process.
    %e  The process executable filename.

--- a/docs/design/coreclr/botr/xplat-minidump-generation.md
+++ b/docs/design/coreclr/botr/xplat-minidump-generation.md
@@ -82,7 +82,7 @@ DOTNET_DbgMiniDumpType values:
 
 **Command Line Usage**
 
-The createdump utility only dumps the parent process that launched it. A target PID cannot be specified. The type of dump can be controlled with the command switches below. The default is a "minidump" which contains the majority of the memory and managed state needed.
+The createdump utility is normally launched by the runtime as a child of the process being dumped. It only dumps the parent process that launched it, and a target PID cannot be specified. The type of dump can be controlled with the command switches below. The default is a "minidump" which contains the majority of the memory and managed state needed.
 
 ```
 createdump [options]

--- a/src/coreclr/debug/createdump/createdumpmain.cpp
+++ b/src/coreclr/debug/createdump/createdumpmain.cpp
@@ -12,11 +12,7 @@
 #define DEFAULT_DUMP_TEMPLATE "coredump.%p"
 #endif
 
-#ifdef HOST_UNIX
-const char* g_help = "createdump [options] pid\n"
-#else
 const char* g_help = "createdump [options]\n"
-#endif
 "-f, --name - dump path and file name. The default is '" DEFAULT_DUMP_PATH DEFAULT_DUMP_TEMPLATE "'. These specifiers are substituted with following values:\n"
 "   %p  PID of dumped process.\n"
 "   %e  The process executable filename.\n"
@@ -69,7 +65,11 @@ int createdump_main(const int argc, const char* argv[])
     options.CreateDump = true;
     options.Signal = 0;
     options.CrashThread = 0;
+#ifdef HOST_UNIX
+    options.Pid = static_cast<int>(getppid());
+#else
     options.Pid = 0;
+#endif
     options.SignalCode = 0;
     options.SignalErrno = 0;
     options.SignalAddress = 0;
@@ -77,7 +77,7 @@ int createdump_main(const int argc, const char* argv[])
     bool help = false;
     int exitCode = 0;
 
-    // Parse the command line options and target pid
+    // Parse the command line options
     argv++;
     for (int i = 1; i < argc; i++)
     {
@@ -172,27 +172,15 @@ int createdump_main(const int argc, const char* argv[])
             }
             else
             {
-#ifdef HOST_UNIX
-                options.Pid = atoi(*argv);
-#else
                 printf_error("The pid argument is no longer supported\n");
                 return -1;
-#endif
             }
             argv++;
         }
     }
 
-#ifdef HOST_UNIX
-    if (options.Pid == 0)
-    {
-        help = true;
-    }
-#endif
-
     if (help)
     {
-        // if no pid or invalid command line option
         printf_error("%s", g_help);
         return -1;
     }

--- a/src/coreclr/debug/createdump/createdumpmain.cpp
+++ b/src/coreclr/debug/createdump/createdumpmain.cpp
@@ -13,6 +13,7 @@
 #endif
 
 const char* g_help = "createdump [options]\n"
+"createdump writes a dump of its parent process; a target PID cannot be specified.\n"
 "-f, --name - dump path and file name. The default is '" DEFAULT_DUMP_PATH DEFAULT_DUMP_TEMPLATE "'. These specifiers are substituted with following values:\n"
 "   %p  PID of dumped process.\n"
 "   %e  The process executable filename.\n"
@@ -172,7 +173,7 @@ int createdump_main(const int argc, const char* argv[])
             }
             else
             {
-                printf_error("The pid argument is no longer supported\n");
+                printf_error("Unrecognized argument '%s'\n", *argv);
                 return -1;
             }
             argv++;

--- a/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalCreateDump.cpp
@@ -57,7 +57,6 @@
 #define MAX_ARGV_ENTRIES 32 
 const char* g_argvCreateDump[MAX_ARGV_ENTRIES] = { nullptr };
 char* g_szCreateDumpPath = nullptr;
-char* g_ppidarg  = nullptr;
 
 const size_t MaxUnsigned32BitDecString = STRING_LENGTH("4294967295");
 const size_t MaxUnsigned64BitDecString = STRING_LENGTH("18446744073709551615");
@@ -128,7 +127,7 @@ BuildCreateDumpCommandLine(
     int dumpType,
     uint32_t flags)
 {
-    if (g_szCreateDumpPath == nullptr || g_ppidarg == nullptr)
+    if (g_szCreateDumpPath == nullptr)
     {
         return false;
     }
@@ -187,7 +186,6 @@ BuildCreateDumpCommandLine(
     }
 
     argv[argc++] = "--nativeaot";
-    argv[argc++] = g_ppidarg;
     argv[argc++] = nullptr;
 
     assert(argc < MAX_ARGV_ENTRIES);
@@ -653,13 +651,6 @@ PalCreateDumpInitialize()
         }
 
         g_szCreateDumpPath = program;
-
-        // Format the app pid for the createdump command line
-        g_ppidarg = FormatInt(getpid());
-        if (g_ppidarg == nullptr)
-        {
-            return false;
-        }
 
         if (!BuildCreateDumpCommandLine(g_argvCreateDump, dumpName, logFilePath, dumpType, flags))
         {

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -1348,7 +1348,6 @@ BOOL
 PROCBuildCreateDumpCommandLine(
     const char* argv[],
     char** pprogram,
-    char** ppidarg,
     const char* dumpName,
     const char* logFileName,
     INT dumpType,
@@ -1379,11 +1378,6 @@ PROCBuildCreateDumpCommandLine(
         program[0] = '\0';
     }
     if (strcat_s(program, programLen, DumpGeneratorName) != SAFECRT_SUCCESS)
-    {
-        return FALSE;
-    }
-    *ppidarg = PROCFormatInt(gPID);
-    if (*ppidarg == nullptr)
     {
         return FALSE;
     }
@@ -1445,8 +1439,6 @@ PROCBuildCreateDumpCommandLine(
         argv[argc++] = "--logtofile";
         argv[argc++] = logFileName;
     }
-
-    argv[argc++] = *ppidarg;
 
     argv[argc] = nullptr;
     _ASSERTE(argc < MAX_ARGV_ENTRIES);
@@ -1728,8 +1720,7 @@ PROCAbortInitialize()
         }
 
         char* program = nullptr;
-        char* pidarg = nullptr;
-        if (!PROCBuildCreateDumpCommandLine(g_argvCreateDump, &program, &pidarg, dumpName, logFilePath, dumpType, flags))
+        if (!PROCBuildCreateDumpCommandLine(g_argvCreateDump, &program, dumpName, logFilePath, dumpType, flags))
         {
             return FALSE;
         }
@@ -1778,14 +1769,12 @@ PAL_GenerateCoreDump(
         dumpName = nullptr;
     }
     char* program = nullptr;
-    char* pidarg = nullptr;
-    BOOL result = PROCBuildCreateDumpCommandLine(argvCreateDump, &program, &pidarg, dumpName, nullptr, dumpType, flags);
+    BOOL result = PROCBuildCreateDumpCommandLine(argvCreateDump, &program, dumpName, nullptr, dumpType, flags);
     if (result)
     {
         result = PROCCreateCrashDump(argvCreateDump, errorMessageBuffer, cbErrorMessageBuffer, CrashDumpSerialize_None);
     }
     free(program);
-    free(pidarg);
     return result;
 }
 


### PR DESCRIPTION
Align Linux/macOS createdump behavior with Windows by removing the target PID command-line argument and always dumping the parent process that launched createdump. 