### PR TITLE
Extract STJ UnsafeAccessor emitter into a shared SourceGenerators helper

### DIFF
--- a/src/libraries/Common/src/SourceGenerators/UnsafeAccessorEmitter.cs
+++ b/src/libraries/Common/src/SourceGenerators/UnsafeAccessorEmitter.cs
@@ -1,0 +1,406 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace SourceGenerators
+{
+    /// <summary>
+    /// Emits member and constructor accessors for a source generator: <c>[UnsafeAccessor]</c> externs on frameworks that
+    /// support them, and a reflection-based fallback (cached delegates / <see cref="System.Reflection.FieldInfo"/> /
+    /// <see cref="System.Reflection.ConstructorInfo"/>) downlevel. Callers describe the members to emit with the neutral,
+    /// primitive-only spec types in this file; the emitter owns accessor naming and the generic wrapper-class machinery.
+    /// </summary>
+    /// <remarks>
+    /// The reflection fallback emitted for members references an <c>InstanceMemberBindingFlags</c> constant (of type
+    /// <see cref="System.Reflection.BindingFlags"/>) that the consuming generator must emit into the same scope, and a
+    /// <c>ValueTypeSetter&lt;TDeclaringType, TValue&gt;</c> delegate when <see cref="EmitMemberAccessors"/> returns
+    /// <see langword="true"/> for a value-type setter.
+    /// </remarks>
+    internal static class UnsafeAccessorEmitter
+    {
+        private const string UnsafeAccessorAttributeTypeRef = "global::System.Runtime.CompilerServices.UnsafeAccessorAttribute";
+        private const string UnsafeAccessorKindTypeRef = "global::System.Runtime.CompilerServices.UnsafeAccessorKind";
+        private const string EmptyTypeArray = "global::System.Array.Empty<global::System.Type>()";
+
+        internal enum AccessorMemberKind
+        {
+            Property,
+            Field,
+        }
+
+        /// <summary>
+        /// Describes a single member (property or field) an accessor may be emitted for. All type names are neutral
+        /// fully-qualified strings so the spec carries no Roslyn symbols and remains incremental-pipeline safe.
+        /// </summary>
+        internal sealed record UnsafeAccessorMemberSpec
+        {
+            public required AccessorMemberKind Kind { get; init; }
+            public required string MemberName { get; init; }
+            public required bool NeedsGetter { get; init; }
+            public required bool NeedsSetter { get; init; }
+            public required bool CanUseUnsafeAccessors { get; init; }
+            public required string DeclaringTypeFQN { get; init; }
+            public required string MemberTypeFQN { get; init; }
+
+            /// <summary>Type-parameter names of the declaring type when it is generic (.NET 9+ wrapper class), otherwise <see langword="null"/>.</summary>
+            public ImmutableEquatableArray<string>? DeclaringTypeParameterNames { get; init; }
+            public string? OpenDeclaringTypeFQN { get; init; }
+            public string? OpenMemberTypeFQN { get; init; }
+            public string? DeclaringTypeParameterConstraintClauses { get; init; }
+
+            public bool IsProperty => Kind is AccessorMemberKind.Property;
+        }
+
+        /// <summary>Describes a constructor accessor to emit.</summary>
+        internal sealed record UnsafeAccessorConstructorSpec
+        {
+            public required string TypeFriendlyName { get; init; }
+            public required string TypeFQN { get; init; }
+            public required bool CanUseUnsafeAccessor { get; init; }
+            public required ImmutableEquatableArray<UnsafeAccessorParameterSpec> Parameters { get; init; }
+        }
+
+        /// <summary>A single constructor parameter of a <see cref="UnsafeAccessorConstructorSpec"/>.</summary>
+        internal sealed record UnsafeAccessorParameterSpec
+        {
+            public required string TypeFQN { get; init; }
+            public required int Index { get; init; }
+        }
+
+        /// <summary>
+        /// Gets the accessor name for a property or field. For UnsafeAccessor this is the extern method name;
+        /// for reflection fallback this is the strongly typed wrapper method name.
+        /// Use kind "get"/"set" for property getters/setters, or "field" for field UnsafeAccessor externs.
+        /// The property index suffix is only appended when needed to disambiguate shadowed members.
+        /// </summary>
+        public static string GetAccessorName(string typeFriendlyName, string accessorKind, string memberName, int propertyIndex, bool needsDisambiguation)
+            => needsDisambiguation
+                ? $"__{accessorKind}_{typeFriendlyName}_{memberName}_{propertyIndex}"
+                : $"__{accessorKind}_{typeFriendlyName}_{memberName}";
+
+        /// <summary>
+        /// For properties on generic types using wrapper-class UnsafeAccessors (.NET 9+), returns the
+        /// fully qualified accessor reference including the generic wrapper class prefix, e.g.
+        /// <c>__GenericAccessors_MyType&lt;int&gt;.__get_MyType_Name</c>.
+        /// For non-generic types, returns the plain accessor name.
+        /// </summary>
+        public static string GetQualifiedAccessorName(
+            ImmutableEquatableArray<string>? declaringTypeParameterNames,
+            string declaringTypeFQN,
+            string typeFriendlyName,
+            string accessorKind,
+            string memberName,
+            int propertyIndex,
+            bool needsDisambiguation)
+        {
+            string accessorName = GetAccessorName(typeFriendlyName, accessorKind, memberName, propertyIndex, needsDisambiguation);
+            if (declaringTypeParameterNames is null)
+            {
+                return accessorName;
+            }
+
+            int openAngle = declaringTypeFQN.IndexOf('<');
+            string typeArgsList = declaringTypeFQN.Substring(openAngle);
+            return $"__GenericAccessors_{typeFriendlyName}{typeArgsList}.{accessorName}";
+        }
+
+        public static string GetReflectionCacheName(string typeFriendlyName, string accessorKind, string memberName, int propertyIndex, bool needsDisambiguation)
+            => needsDisambiguation
+                ? $"s_{accessorKind}_{typeFriendlyName}_{memberName}_{propertyIndex}"
+                : $"s_{accessorKind}_{typeFriendlyName}_{memberName}";
+
+        /// <summary>
+        /// Gets the unified constructor accessor name. The wrapper has the same
+        /// signature for both UnsafeAccessor and reflection fallback:
+        /// <c>static TypeName __ctor_TypeName(params)</c>
+        /// </summary>
+        public static string GetConstructorAccessorName(string typeFriendlyName)
+            => $"__ctor_{typeFriendlyName}";
+
+        public static string GetConstructorReflectionCacheName(string typeFriendlyName)
+            => $"s_ctor_{typeFriendlyName}";
+
+        /// <summary>
+        /// Returns the set of member names that appear more than once in the property list.
+        /// This occurs when derived types shadow base members via the <c>new</c> keyword.
+        /// </summary>
+        public static HashSet<string> GetDuplicateMemberNames(IEnumerable<string> memberNames)
+        {
+            HashSet<string> seen = new();
+            HashSet<string> duplicates = new();
+            foreach (string memberName in memberNames)
+            {
+                if (!seen.Add(memberName))
+                {
+                    duplicates.Add(memberName);
+                }
+            }
+
+            return duplicates;
+        }
+
+        /// <summary>
+        /// Emits the member accessors for the given ordered member list. Members not requiring a getter or setter
+        /// accessor are skipped. Returns <see langword="true"/> if a value-type setter reflection fallback was emitted,
+        /// requiring the consuming generator to emit the <c>ValueTypeSetter</c> delegate type.
+        /// </summary>
+        public static bool EmitMemberAccessors(
+            SourceWriter writer,
+            string typeFriendlyName,
+            bool declaringTypeIsValueType,
+            IReadOnlyList<UnsafeAccessorMemberSpec> members)
+        {
+            HashSet<string> duplicateMemberNames = GetDuplicateMemberNames(members.Select(static m => m.MemberName));
+            bool needsAccessors = false;
+            bool needsValueTypeSetterDelegate = false;
+            Dictionary<string, List<(UnsafeAccessorMemberSpec Member, int Index, bool Disambiguate)>>? genericAccessorEntries = null;
+
+            for (int i = 0; i < members.Count; i++)
+            {
+                UnsafeAccessorMemberSpec member = members[i];
+                bool needsGetterAccessor = member.NeedsGetter;
+                bool needsSetterAccessor = member.NeedsSetter;
+
+                if (!needsGetterAccessor && !needsSetterAccessor)
+                {
+                    continue;
+                }
+
+                if (!needsAccessors)
+                {
+                    writer.WriteLine();
+                    needsAccessors = true;
+                }
+
+                string declaringTypeFQN = member.DeclaringTypeFQN;
+                string propertyTypeFQN = member.MemberTypeFQN;
+                bool disambiguate = duplicateMemberNames.Contains(member.MemberName);
+
+                if (member.CanUseUnsafeAccessors)
+                {
+                    if (member.DeclaringTypeParameterNames is not null)
+                    {
+                        // Generic types need a wrapper class for UnsafeAccessor (.NET 9+).
+                        // Collect the accessor and emit the wrapper class after the loop.
+                        string key = member.DeclaringTypeFQN;
+                        genericAccessorEntries ??= new();
+                        if (!genericAccessorEntries.TryGetValue(key, out List<(UnsafeAccessorMemberSpec Member, int Index, bool Disambiguate)>? entries))
+                        {
+                            entries = new();
+                            genericAccessorEntries[key] = entries;
+                        }
+
+                        entries.Add((member, i, disambiguate));
+                    }
+                    else
+                    {
+                        string refPrefix = declaringTypeIsValueType ? "ref " : "";
+
+                        if (member.IsProperty)
+                        {
+                            if (needsGetterAccessor)
+                            {
+                                string accessorName = GetAccessorName(typeFriendlyName, "get", member.MemberName, i, disambiguate);
+                                writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Method, Name = "get_{member.MemberName}")]""");
+                                writer.WriteLine($"private static extern {propertyTypeFQN} {accessorName}({refPrefix}{declaringTypeFQN} obj);");
+                            }
+
+                            if (needsSetterAccessor)
+                            {
+                                string accessorName = GetAccessorName(typeFriendlyName, "set", member.MemberName, i, disambiguate);
+                                writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Method, Name = "set_{member.MemberName}")]""");
+                                writer.WriteLine($"private static extern void {accessorName}({refPrefix}{declaringTypeFQN} obj, {propertyTypeFQN} value);");
+                            }
+                        }
+                        else
+                        {
+                            // Field: single UnsafeAccessor that returns ref T, used for both get and set.
+                            string fieldAccessorName = GetAccessorName(typeFriendlyName, "field", member.MemberName, i, disambiguate);
+                            writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Field, Name = "{member.MemberName}")]""");
+                            writer.WriteLine($"private static extern ref {propertyTypeFQN} {fieldAccessorName}({refPrefix}{declaringTypeFQN} obj);");
+                        }
+                    }
+                }
+                else if (member.IsProperty)
+                {
+                    // Reflection fallback for properties: use Delegate.CreateDelegate on the MethodInfo for efficient invocation.
+                    // Wrapper methods are strongly typed to match UnsafeAccessor signatures.
+                    string propertyExpr = $"typeof({declaringTypeFQN}).GetProperty({FormatStringLiteral(member.MemberName)}, InstanceMemberBindingFlags, null, typeof({propertyTypeFQN}), {EmptyTypeArray}, null)!";
+
+                    if (needsGetterAccessor)
+                    {
+                        string cacheName = GetReflectionCacheName(typeFriendlyName, "get", member.MemberName, i, disambiguate);
+                        string wrapperName = GetAccessorName(typeFriendlyName, "get", member.MemberName, i, disambiguate);
+
+                        if (declaringTypeIsValueType)
+                        {
+                            // For value types, Delegate.CreateDelegate doesn't work with struct instance getters
+                            // on .NET Framework (the this parameter is passed by-ref internally).
+                            // Cache the MethodInfo and use Invoke instead.
+                            string methodCacheType = "global::System.Reflection.MethodInfo";
+                            writer.WriteLine($"private static {methodCacheType}? {cacheName};");
+                            writer.WriteLine($"private static {propertyTypeFQN} {wrapperName}({declaringTypeFQN} obj) => ({propertyTypeFQN})({cacheName} ??= {propertyExpr}.GetGetMethod(true)!).Invoke(obj, null)!;");
+                        }
+                        else
+                        {
+                            string delegateType = $"global::System.Func<{declaringTypeFQN}, {propertyTypeFQN}>";
+                            writer.WriteLine($"private static {delegateType}? {cacheName};");
+                            writer.WriteLine($"private static {propertyTypeFQN} {wrapperName}({declaringTypeFQN} obj) => ({cacheName} ??= ({delegateType})global::System.Delegate.CreateDelegate(typeof({delegateType}), {propertyExpr}.GetGetMethod(true)!))(obj);");
+                        }
+                    }
+
+                    if (needsSetterAccessor)
+                    {
+                        string cacheName = GetReflectionCacheName(typeFriendlyName, "set", member.MemberName, i, disambiguate);
+                        string wrapperName = GetAccessorName(typeFriendlyName, "set", member.MemberName, i, disambiguate);
+
+                        if (declaringTypeIsValueType)
+                        {
+                            // For value types, use a ref-parameter delegate to mutate the unboxed value in-place.
+                            needsValueTypeSetterDelegate = true;
+                            string delegateType = $"ValueTypeSetter<{declaringTypeFQN}, {propertyTypeFQN}>";
+                            writer.WriteLine($"private static {delegateType}? {cacheName};");
+                            writer.WriteLine($"private static void {wrapperName}(ref {declaringTypeFQN} obj, {propertyTypeFQN} value) => ({cacheName} ??= ({delegateType})global::System.Delegate.CreateDelegate(typeof({delegateType}), {propertyExpr}.GetSetMethod(true)!))(ref obj, value);");
+                        }
+                        else
+                        {
+                            string delegateType = $"global::System.Action<{declaringTypeFQN}, {propertyTypeFQN}>";
+                            writer.WriteLine($"private static {delegateType}? {cacheName};");
+                            writer.WriteLine($"private static void {wrapperName}({declaringTypeFQN} obj, {propertyTypeFQN} value) => ({cacheName} ??= ({delegateType})global::System.Delegate.CreateDelegate(typeof({delegateType}), {propertyExpr}.GetSetMethod(true)!))(obj, value);");
+                        }
+                    }
+                }
+                else
+                {
+                    // Reflection fallback for fields: cache the FieldInfo and use GetValue/SetValue.
+                    // Fields don't have MethodInfo, so Delegate.CreateDelegate can't be used.
+                    string fieldExpr = $"typeof({declaringTypeFQN}).GetField({FormatStringLiteral(member.MemberName)}, InstanceMemberBindingFlags)!";
+                    string fieldCacheName = GetReflectionCacheName(typeFriendlyName, "field", member.MemberName, i, disambiguate);
+                    writer.WriteLine($"private static global::System.Reflection.FieldInfo? {fieldCacheName};");
+
+                    if (needsGetterAccessor)
+                    {
+                        string wrapperName = GetAccessorName(typeFriendlyName, "get", member.MemberName, i, disambiguate);
+                        writer.WriteLine($"private static {propertyTypeFQN} {wrapperName}(object obj) => ({propertyTypeFQN})({fieldCacheName} ??= {fieldExpr}).GetValue(obj)!;");
+                    }
+
+                    if (needsSetterAccessor)
+                    {
+                        string wrapperName = GetAccessorName(typeFriendlyName, "set", member.MemberName, i, disambiguate);
+                        writer.WriteLine($"private static void {wrapperName}(object obj, {propertyTypeFQN} value) => ({fieldCacheName} ??= {fieldExpr}).SetValue(obj, value);");
+                    }
+                }
+            }
+
+            // Emit generic wrapper classes for UnsafeAccessors on generic types (.NET 9+).
+            if (genericAccessorEntries is not null)
+            {
+                foreach (KeyValuePair<string, List<(UnsafeAccessorMemberSpec Member, int Index, bool Disambiguate)>> kvp in genericAccessorEntries)
+                {
+                    List<(UnsafeAccessorMemberSpec Member, int Index, bool Disambiguate)> entries = kvp.Value;
+                    UnsafeAccessorMemberSpec firstMember = entries[0].Member;
+                    ImmutableEquatableArray<string> typeParams = firstMember.DeclaringTypeParameterNames!;
+                    string openDeclaringTypeFQN = firstMember.OpenDeclaringTypeFQN!;
+                    string refPrefix = declaringTypeIsValueType ? "ref " : "";
+                    string typeParamList = string.Join(", ", typeParams);
+                    string constraintClauses = firstMember.DeclaringTypeParameterConstraintClauses is { } c ? $" {c}" : "";
+
+                    writer.WriteLine();
+                    writer.WriteLine($"private static class __GenericAccessors_{typeFriendlyName}<{typeParamList}>{constraintClauses}");
+                    writer.WriteLine('{');
+                    writer.Indentation++;
+
+                    foreach ((UnsafeAccessorMemberSpec member, int index, bool disambiguate) in entries)
+                    {
+                        bool needsGetter = member.NeedsGetter;
+                        bool needsSetter = member.NeedsSetter;
+                        string openPropertyTypeFQN = member.OpenMemberTypeFQN!;
+
+                        if (member.IsProperty)
+                        {
+                            if (needsGetter)
+                            {
+                                string accessorName = GetAccessorName(typeFriendlyName, "get", member.MemberName, index, disambiguate);
+                                writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Method, Name = "get_{member.MemberName}")]""");
+                                writer.WriteLine($"public static extern {openPropertyTypeFQN} {accessorName}({refPrefix}{openDeclaringTypeFQN} obj);");
+                            }
+
+                            if (needsSetter)
+                            {
+                                string accessorName = GetAccessorName(typeFriendlyName, "set", member.MemberName, index, disambiguate);
+                                writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Method, Name = "set_{member.MemberName}")]""");
+                                writer.WriteLine($"public static extern void {accessorName}({refPrefix}{openDeclaringTypeFQN} obj, {openPropertyTypeFQN} value);");
+                            }
+                        }
+                        else
+                        {
+                            string fieldAccessorName = GetAccessorName(typeFriendlyName, "field", member.MemberName, index, disambiguate);
+                            writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Field, Name = "{member.MemberName}")]""");
+                            writer.WriteLine($"public static extern ref {openPropertyTypeFQN} {fieldAccessorName}({refPrefix}{openDeclaringTypeFQN} obj);");
+                        }
+                    }
+
+                    writer.Indentation--;
+                    writer.WriteLine('}');
+                }
+            }
+
+            return needsValueTypeSetterDelegate;
+        }
+
+        /// <summary>
+        /// Emits a constructor accessor: a <c>[UnsafeAccessor(Constructor)]</c> extern where supported, otherwise a
+        /// cached <see cref="System.Reflection.ConstructorInfo"/> wrapper. The wrapper has the same signature in both
+        /// cases: <c>static TypeName __ctor_TypeName(params)</c>.
+        /// </summary>
+        public static void EmitConstructorAccessor(SourceWriter writer, UnsafeAccessorConstructorSpec spec)
+        {
+            string typeFQN = spec.TypeFQN;
+            string wrapperName = GetConstructorAccessorName(spec.TypeFriendlyName);
+            ImmutableEquatableArray<UnsafeAccessorParameterSpec> parameters = spec.Parameters;
+
+            // Build the parameter list for the wrapper method.
+            var wrapperParams = new StringBuilder();
+
+            foreach (UnsafeAccessorParameterSpec param in parameters)
+            {
+                if (wrapperParams.Length > 0)
+                {
+                    wrapperParams.Append(", ");
+                }
+
+                wrapperParams.Append($"{param.TypeFQN} p{param.Index}");
+            }
+
+            if (spec.CanUseUnsafeAccessor)
+            {
+                writer.WriteLine($"[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Constructor)]");
+                writer.WriteLine($"private static extern {typeFQN} {wrapperName}({wrapperParams});");
+            }
+            else
+            {
+                // Reflection fallback: cached ConstructorInfo + Invoke.
+                // Note: ConstructorInfo cannot be wrapped in a delegate, so we cache the ConstructorInfo directly.
+                string cacheName = GetConstructorReflectionCacheName(spec.TypeFriendlyName);
+
+                string argTypes = parameters.Count == 0
+                    ? EmptyTypeArray
+                    : $"new global::System.Type[] {{{string.Join(", ", parameters.Select(p => $"typeof({p.TypeFQN})"))}}}";
+
+                writer.WriteLine($"private static global::System.Reflection.ConstructorInfo? {cacheName};");
+
+                string invokeArgs = parameters.Count == 0
+                    ? "null"
+                    : $"new object?[] {{{string.Join(", ", parameters.Select(p => $"p{p.Index}"))}}}";
+
+                writer.WriteLine($"private static {typeFQN} {wrapperName}({wrapperParams}) => ({typeFQN})({cacheName} ??= typeof({typeFQN}).GetConstructor(InstanceMemberBindingFlags, binder: null, {argTypes}, modifiers: null)!).Invoke({invokeArgs});");
+            }
+        }
+
+        private static string FormatStringLiteral(string? value) => value is null ? "null" : SymbolDisplay.FormatLiteral(value, quote: true);
+    }
+}

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using SourceGenerators;
-using GenericAccessorEntry = (System.Text.Json.SourceGeneration.PropertyGenerationSpec Property, int Index, bool Disambiguate, bool NeedsGetter, bool NeedsSetter);
 
 namespace System.Text.Json.SourceGeneration
 {
@@ -28,8 +27,6 @@ namespace System.Text.Json.SourceGeneration
             private const string UnsafeTypeRef = "global::System.Runtime.CompilerServices.Unsafe";
             private const string EqualityComparerTypeRef = "global::System.Collections.Generic.EqualityComparer";
             private const string KeyValuePairTypeRef = "global::System.Collections.Generic.KeyValuePair";
-            private const string UnsafeAccessorAttributeTypeRef = "global::System.Runtime.CompilerServices.UnsafeAccessorAttribute";
-            private const string UnsafeAccessorKindTypeRef = "global::System.Runtime.CompilerServices.UnsafeAccessorKind";
             private const string JsonEncodedTextTypeRef = "global::System.Text.Json.JsonEncodedText";
             private const string JsonNamingPolicyTypeRef = "global::System.Text.Json.JsonNamingPolicy";
             private const string JsonSerializerTypeRef = "global::System.Text.Json.JsonSerializer";
@@ -659,7 +656,7 @@ namespace System.Text.Json.SourceGeneration
                 }
 
                 // Generate UnsafeAccessor methods or reflection cache fields for property accessors.
-                _emitValueTypeSetterDelegate |= GeneratePropertyAccessors(writer, typeMetadata);
+                _emitValueTypeSetterDelegate |= GenerateMemberAccessors(writer, typeMetadata);
 
                 // Generate constructor accessor for inaccessible [JsonConstructor] constructors.
                 GenerateConstructorAccessor(writer, typeMetadata);
@@ -829,7 +826,7 @@ namespace System.Text.Json.SourceGeneration
             private void GeneratePropMetadataInitFunc(SourceWriter writer, string propInitMethodName, TypeGenerationSpec typeGenerationSpec)
             {
                 ImmutableEquatableArray<PropertyGenerationSpec> properties = typeGenerationSpec.PropertyGenSpecs;
-                HashSet<string> duplicateMemberNames = GetDuplicateMemberNames(properties);
+                HashSet<string> duplicateMemberNames = UnsafeAccessorEmitter.GetDuplicateMemberNames(properties.Select(static p => p.MemberName));
 
                 writer.WriteLine($"private static {JsonPropertyInfoTypeRef}[] {propInitMethodName}({JsonSerializerOptionsTypeRef} options)");
                 writer.WriteLine('{');
@@ -999,14 +996,14 @@ namespace System.Text.Json.SourceGeneration
                             : $"({declaringTypeFQN})obj";
 
                         string accessorName = property.IsProperty
-                            ? GetQualifiedAccessorName(property, typeFriendlyName, "get", property.MemberName, propertyIndex, needsDisambiguation)
-                            : GetQualifiedAccessorName(property, typeFriendlyName, "field", property.MemberName, propertyIndex, needsDisambiguation);
+                            ? UnsafeAccessorEmitter.GetQualifiedAccessorName(property.DeclaringTypeParameterNames, declaringTypeFQN, typeFriendlyName, "get", property.MemberName, propertyIndex, needsDisambiguation)
+                            : UnsafeAccessorEmitter.GetQualifiedAccessorName(property.DeclaringTypeParameterNames, declaringTypeFQN, typeFriendlyName, "field", property.MemberName, propertyIndex, needsDisambiguation);
 
                         return $"static obj => {accessorName}({castExpr})";
                     }
 
                     // Reflection fallback wrappers are strongly typed; cast in the delegate.
-                    string getterName = GetAccessorName(typeFriendlyName, "get", property.MemberName, propertyIndex, needsDisambiguation);
+                    string getterName = UnsafeAccessorEmitter.GetAccessorName(typeFriendlyName, "get", property.MemberName, propertyIndex, needsDisambiguation);
 
                     return $"static obj => {getterName}(({declaringTypeFQN})obj)";
                 }
@@ -1068,16 +1065,16 @@ namespace System.Text.Json.SourceGeneration
 
                     if (property.IsProperty)
                     {
-                        string accessorName = GetQualifiedAccessorName(property, typeFriendlyName, "set", property.MemberName, propertyIndex, needsDisambiguation);
+                        string accessorName = UnsafeAccessorEmitter.GetQualifiedAccessorName(property.DeclaringTypeParameterNames, declaringTypeFQN, typeFriendlyName, "set", property.MemberName, propertyIndex, needsDisambiguation);
                         return $"static (obj, value) => {accessorName}({castExpr}, value!)";
                     }
 
-                    string fieldName = GetQualifiedAccessorName(property, typeFriendlyName, "field", property.MemberName, propertyIndex, needsDisambiguation);
+                    string fieldName = UnsafeAccessorEmitter.GetQualifiedAccessorName(property.DeclaringTypeParameterNames, declaringTypeFQN, typeFriendlyName, "field", property.MemberName, propertyIndex, needsDisambiguation);
                     return $"static (obj, value) => {fieldName}({castExpr}) = value!";
                 }
 
                 // Reflection fallback wrapper is strongly typed; cast in the delegate like UnsafeAccessor.
-                string setterName = GetAccessorName(typeFriendlyName, "set", property.MemberName, propertyIndex, needsDisambiguation);
+                string setterName = UnsafeAccessorEmitter.GetAccessorName(typeFriendlyName, "set", property.MemberName, propertyIndex, needsDisambiguation);
                 string setterCastExpr = typeGenerationSpec.TypeRef.IsValueType
                     ? $"ref {UnsafeTypeRef}.Unbox<{declaringTypeFQN}>(obj)"
                     : $"({declaringTypeFQN})obj";
@@ -1085,278 +1082,31 @@ namespace System.Text.Json.SourceGeneration
                 return $"static (obj, value) => {setterName}({setterCastExpr}, value!)";
             }
 
-            private static bool GeneratePropertyAccessors(SourceWriter writer, TypeGenerationSpec typeGenerationSpec)
+            private static bool GenerateMemberAccessors(SourceWriter writer, TypeGenerationSpec typeGenerationSpec)
             {
                 ImmutableEquatableArray<PropertyGenerationSpec> properties = typeGenerationSpec.PropertyGenSpecs;
-                HashSet<string> duplicateMemberNames = GetDuplicateMemberNames(properties);
-                bool needsAccessors = false;
-                bool needsValueTypeSetterDelegate = false;
-                Dictionary<string, List<GenericAccessorEntry>>? genericAccessorEntries = null;
+                var members = new List<UnsafeAccessorEmitter.UnsafeAccessorMemberSpec>(properties.Count);
 
-                for (int i = 0; i < properties.Count; i++)
-                {
-                    PropertyGenerationSpec property = properties[i];
-                    bool needsGetterAccessor = NeedsAccessorForGetter(property);
-                    bool needsSetterAccessor = NeedsAccessorForSetter(property);
-
-                    if (!needsGetterAccessor && !needsSetterAccessor)
-                    {
-                        continue;
-                    }
-
-                    if (!needsAccessors)
-                    {
-                        writer.WriteLine();
-                        needsAccessors = true;
-                    }
-
-                    string typeFriendlyName = typeGenerationSpec.TypeInfoPropertyName;
-                    string declaringTypeFQN = property.DeclaringType.FullyQualifiedName;
-                    string propertyTypeFQN = property.PropertyType.FullyQualifiedName;
-                    bool disambiguate = duplicateMemberNames.Contains(property.MemberName);
-
-                    if (property.CanUseUnsafeAccessors)
-                    {
-                        if (property.DeclaringTypeParameterNames is not null)
-                        {
-                            // Generic types need a wrapper class for UnsafeAccessor (.NET 9+).
-                            // Collect the accessor and emit the wrapper class after the loop.
-                            string key = property.DeclaringType.FullyQualifiedName;
-                            genericAccessorEntries ??= new();
-                            if (!genericAccessorEntries.TryGetValue(key, out List<GenericAccessorEntry>? entries))
-                            {
-                                entries = new();
-                                genericAccessorEntries[key] = entries;
-                            }
-
-                            entries.Add((property, i, disambiguate, needsGetterAccessor, needsSetterAccessor));
-                        }
-                        else
-                        {
-                            string refPrefix = typeGenerationSpec.TypeRef.IsValueType ? "ref " : "";
-
-                            if (property.IsProperty)
-                            {
-                                if (needsGetterAccessor)
-                                {
-                                    string accessorName = GetAccessorName(typeFriendlyName, "get", property.MemberName, i, disambiguate);
-                                    writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Method, Name = "get_{property.MemberName}")]""");
-                                    writer.WriteLine($"private static extern {propertyTypeFQN} {accessorName}({refPrefix}{declaringTypeFQN} obj);");
-                                }
-
-                                if (needsSetterAccessor)
-                                {
-                                    string accessorName = GetAccessorName(typeFriendlyName, "set", property.MemberName, i, disambiguate);
-                                    writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Method, Name = "set_{property.MemberName}")]""");
-                                    writer.WriteLine($"private static extern void {accessorName}({refPrefix}{declaringTypeFQN} obj, {propertyTypeFQN} value);");
-                                }
-                            }
-                            else
-                            {
-                                // Field: single UnsafeAccessor that returns ref T, used for both get and set.
-                                string fieldAccessorName = GetAccessorName(typeFriendlyName, "field", property.MemberName, i, disambiguate);
-                                writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Field, Name = "{property.MemberName}")]""");
-                                writer.WriteLine($"private static extern ref {propertyTypeFQN} {fieldAccessorName}({refPrefix}{declaringTypeFQN} obj);");
-                            }
-                        }
-                    }
-                    else if (property.IsProperty)
-                    {
-                        // Reflection fallback for properties: use Delegate.CreateDelegate on the MethodInfo for efficient invocation.
-                        // Wrapper methods are strongly typed to match UnsafeAccessor signatures.
-                        string propertyExpr = $"typeof({declaringTypeFQN}).GetProperty({FormatStringLiteral(property.MemberName)}, InstanceMemberBindingFlags, null, typeof({propertyTypeFQN}), {EmptyTypeArray}, null)!";
-
-                        if (needsGetterAccessor)
-                        {
-                            string cacheName = GetReflectionCacheName(typeFriendlyName, "get", property.MemberName, i, disambiguate);
-                            string wrapperName = GetAccessorName(typeFriendlyName, "get", property.MemberName, i, disambiguate);
-
-                            if (typeGenerationSpec.TypeRef.IsValueType)
-                            {
-                                // For value types, Delegate.CreateDelegate doesn't work with struct instance getters
-                                // on .NET Framework (the this parameter is passed by-ref internally).
-                                // Cache the MethodInfo and use Invoke instead.
-                                string methodCacheType = "global::System.Reflection.MethodInfo";
-                                writer.WriteLine($"private static {methodCacheType}? {cacheName};");
-                                writer.WriteLine($"private static {propertyTypeFQN} {wrapperName}({declaringTypeFQN} obj) => ({propertyTypeFQN})({cacheName} ??= {propertyExpr}.GetGetMethod(true)!).Invoke(obj, null)!;");
-                            }
-                            else
-                            {
-                                string delegateType = $"global::System.Func<{declaringTypeFQN}, {propertyTypeFQN}>";
-                                writer.WriteLine($"private static {delegateType}? {cacheName};");
-                                writer.WriteLine($"private static {propertyTypeFQN} {wrapperName}({declaringTypeFQN} obj) => ({cacheName} ??= ({delegateType})global::System.Delegate.CreateDelegate(typeof({delegateType}), {propertyExpr}.GetGetMethod(true)!))(obj);");
-                            }
-                        }
-
-                        if (needsSetterAccessor)
-                        {
-                            string cacheName = GetReflectionCacheName(typeFriendlyName, "set", property.MemberName, i, disambiguate);
-                            string wrapperName = GetAccessorName(typeFriendlyName, "set", property.MemberName, i, disambiguate);
-
-                            if (typeGenerationSpec.TypeRef.IsValueType)
-                            {
-                                // For value types, use a ref-parameter delegate to mutate the unboxed value in-place.
-                                needsValueTypeSetterDelegate = true;
-                                string delegateType = $"ValueTypeSetter<{declaringTypeFQN}, {propertyTypeFQN}>";
-                                writer.WriteLine($"private static {delegateType}? {cacheName};");
-                                writer.WriteLine($"private static void {wrapperName}(ref {declaringTypeFQN} obj, {propertyTypeFQN} value) => ({cacheName} ??= ({delegateType})global::System.Delegate.CreateDelegate(typeof({delegateType}), {propertyExpr}.GetSetMethod(true)!))(ref obj, value);");
-                            }
-                            else
-                            {
-                                string delegateType = $"global::System.Action<{declaringTypeFQN}, {propertyTypeFQN}>";
-                                writer.WriteLine($"private static {delegateType}? {cacheName};");
-                                writer.WriteLine($"private static void {wrapperName}({declaringTypeFQN} obj, {propertyTypeFQN} value) => ({cacheName} ??= ({delegateType})global::System.Delegate.CreateDelegate(typeof({delegateType}), {propertyExpr}.GetSetMethod(true)!))(obj, value);");
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Reflection fallback for fields: cache the FieldInfo and use GetValue/SetValue.
-                        // Fields don't have MethodInfo, so Delegate.CreateDelegate can't be used.
-                        string fieldExpr = $"typeof({declaringTypeFQN}).GetField({FormatStringLiteral(property.MemberName)}, InstanceMemberBindingFlags)!";
-                        string fieldCacheName = GetReflectionCacheName(typeFriendlyName, "field", property.MemberName, i, disambiguate);
-                        writer.WriteLine($"private static global::System.Reflection.FieldInfo? {fieldCacheName};");
-
-                        if (needsGetterAccessor)
-                        {
-                            string wrapperName = GetAccessorName(typeFriendlyName, "get", property.MemberName, i, disambiguate);
-                            writer.WriteLine($"private static {propertyTypeFQN} {wrapperName}(object obj) => ({propertyTypeFQN})({fieldCacheName} ??= {fieldExpr}).GetValue(obj)!;");
-                        }
-
-                        if (needsSetterAccessor)
-                        {
-                            string wrapperName = GetAccessorName(typeFriendlyName, "set", property.MemberName, i, disambiguate);
-                            writer.WriteLine($"private static void {wrapperName}(object obj, {propertyTypeFQN} value) => ({fieldCacheName} ??= {fieldExpr}).SetValue(obj, value);");
-                        }
-                    }
-                }
-
-                // Emit generic wrapper classes for UnsafeAccessors on generic types (.NET 9+).
-                if (genericAccessorEntries is not null)
-                {
-                    string typeFriendlyName = typeGenerationSpec.TypeInfoPropertyName;
-
-                    foreach (KeyValuePair<string, List<GenericAccessorEntry>> kvp in genericAccessorEntries)
-                    {
-                        List<GenericAccessorEntry> entries = kvp.Value;
-                        PropertyGenerationSpec firstProperty = entries[0].Property;
-                        ImmutableEquatableArray<string> typeParams = firstProperty.DeclaringTypeParameterNames!;
-                        string openDeclaringTypeFQN = firstProperty.OpenDeclaringTypeFQN!;
-                        string refPrefix = typeGenerationSpec.TypeRef.IsValueType ? "ref " : "";
-                        string typeParamList = string.Join(", ", typeParams);
-                        string constraintClauses = firstProperty.DeclaringTypeParameterConstraintClauses is { } c ? $" {c}" : "";
-
-                        writer.WriteLine();
-                        writer.WriteLine($"private static class __GenericAccessors_{typeFriendlyName}<{typeParamList}>{constraintClauses}");
-                        writer.WriteLine('{');
-                        writer.Indentation++;
-
-                        foreach (GenericAccessorEntry entry in entries)
-                        {
-                            PropertyGenerationSpec property = entry.Property;
-                            int index = entry.Index;
-                            bool disambiguate = entry.Disambiguate;
-                            bool needsGetter = entry.NeedsGetter;
-                            bool needsSetter = entry.NeedsSetter;
-                            string openPropertyTypeFQN = property.OpenPropertyTypeFQN!;
-
-                            if (property.IsProperty)
-                            {
-                                if (needsGetter)
-                                {
-                                    string accessorName = GetAccessorName(typeFriendlyName, "get", property.MemberName, index, disambiguate);
-                                    writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Method, Name = "get_{property.MemberName}")]""");
-                                    writer.WriteLine($"public static extern {openPropertyTypeFQN} {accessorName}({refPrefix}{openDeclaringTypeFQN} obj);");
-                                }
-
-                                if (needsSetter)
-                                {
-                                    string accessorName = GetAccessorName(typeFriendlyName, "set", property.MemberName, index, disambiguate);
-                                    writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Method, Name = "set_{property.MemberName}")]""");
-                                    writer.WriteLine($"public static extern void {accessorName}({refPrefix}{openDeclaringTypeFQN} obj, {openPropertyTypeFQN} value);");
-                                }
-                            }
-                            else
-                            {
-                                string fieldAccessorName = GetAccessorName(typeFriendlyName, "field", property.MemberName, index, disambiguate);
-                                writer.WriteLine($"""[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Field, Name = "{property.MemberName}")]""");
-                                writer.WriteLine($"public static extern ref {openPropertyTypeFQN} {fieldAccessorName}({refPrefix}{openDeclaringTypeFQN} obj);");
-                            }
-                        }
-
-                        writer.Indentation--;
-                        writer.WriteLine('}');
-                    }
-                }
-
-                return needsValueTypeSetterDelegate;
-            }
-
-            /// <summary>
-            /// Gets the accessor name for a property or field. For UnsafeAccessor this is the extern method name;
-            /// for reflection fallback this is the strongly typed wrapper method name.
-            /// Use kind "get"/"set" for property getters/setters, or "field" for field UnsafeAccessor externs.
-            /// The property index suffix is only appended when needed to disambiguate shadowed members.
-            /// </summary>
-            private static string GetAccessorName(string typeFriendlyName, string accessorKind, string memberName, int propertyIndex, bool needsDisambiguation)
-                => needsDisambiguation
-                    ? $"__{accessorKind}_{typeFriendlyName}_{memberName}_{propertyIndex}"
-                    : $"__{accessorKind}_{typeFriendlyName}_{memberName}";
-
-            /// <summary>
-            /// For properties on generic types using wrapper-class UnsafeAccessors (.NET 9+), returns the
-            /// fully qualified accessor reference including the generic wrapper class prefix, e.g.
-            /// <c>__GenericAccessors_MyType&lt;int&gt;.__get_MyType_Name</c>.
-            /// For non-generic types, returns the plain accessor name.
-            /// </summary>
-            private static string GetQualifiedAccessorName(PropertyGenerationSpec property, string typeFriendlyName, string accessorKind, string memberName, int propertyIndex, bool needsDisambiguation)
-            {
-                string accessorName = GetAccessorName(typeFriendlyName, accessorKind, memberName, propertyIndex, needsDisambiguation);
-                if (property.DeclaringTypeParameterNames is null)
-                {
-                    return accessorName;
-                }
-
-                string closedTypeArgs = property.DeclaringType.FullyQualifiedName;
-                int openAngle = closedTypeArgs.IndexOf('<');
-                string typeArgsList = closedTypeArgs.Substring(openAngle);
-                return $"__GenericAccessors_{typeFriendlyName}{typeArgsList}.{accessorName}";
-            }
-
-            private static string GetReflectionCacheName(string typeFriendlyName, string accessorKind, string memberName, int propertyIndex, bool needsDisambiguation)
-                => needsDisambiguation
-                    ? $"s_{accessorKind}_{typeFriendlyName}_{memberName}_{propertyIndex}"
-                    : $"s_{accessorKind}_{typeFriendlyName}_{memberName}";
-
-            /// <summary>
-            /// Returns the set of member names that appear more than once in the property list.
-            /// This occurs when derived types shadow base members via the <c>new</c> keyword.
-            /// </summary>
-            private static HashSet<string> GetDuplicateMemberNames(ImmutableEquatableArray<PropertyGenerationSpec> properties)
-            {
-                HashSet<string> seen = new();
-                HashSet<string> duplicates = new();
                 foreach (PropertyGenerationSpec property in properties)
                 {
-                    if (!seen.Add(property.MemberName))
+                    members.Add(new UnsafeAccessorEmitter.UnsafeAccessorMemberSpec
                     {
-                        duplicates.Add(property.MemberName);
-                    }
+                        Kind = property.IsProperty ? UnsafeAccessorEmitter.AccessorMemberKind.Property : UnsafeAccessorEmitter.AccessorMemberKind.Field,
+                        MemberName = property.MemberName,
+                        NeedsGetter = NeedsAccessorForGetter(property),
+                        NeedsSetter = NeedsAccessorForSetter(property),
+                        CanUseUnsafeAccessors = property.CanUseUnsafeAccessors,
+                        DeclaringTypeFQN = property.DeclaringType.FullyQualifiedName,
+                        MemberTypeFQN = property.PropertyType.FullyQualifiedName,
+                        DeclaringTypeParameterNames = property.DeclaringTypeParameterNames,
+                        OpenDeclaringTypeFQN = property.OpenDeclaringTypeFQN,
+                        OpenMemberTypeFQN = property.OpenPropertyTypeFQN,
+                        DeclaringTypeParameterConstraintClauses = property.DeclaringTypeParameterConstraintClauses,
+                    });
                 }
 
-                return duplicates;
+                return UnsafeAccessorEmitter.EmitMemberAccessors(writer, typeGenerationSpec.TypeInfoPropertyName, typeGenerationSpec.TypeRef.IsValueType, members);
             }
-
-            /// <summary>
-            /// Gets the unified constructor accessor name. The wrapper has the same
-            /// signature for both UnsafeAccessor and reflection fallback:
-            /// <c>static TypeName __ctor_TypeName(params)</c>
-            /// </summary>
-            private static string GetConstructorAccessorName(TypeGenerationSpec typeSpec)
-                => $"__ctor_{typeSpec.TypeInfoPropertyName}";
-
-            private static string GetConstructorReflectionCacheName(TypeGenerationSpec typeSpec)
-                => $"s_ctor_{typeSpec.TypeInfoPropertyName}";
 
             /// <summary>
             /// Generates the constructor accessor for inaccessible constructors.
@@ -1372,49 +1122,23 @@ namespace System.Text.Json.SourceGeneration
 
                 writer.WriteLine();
 
-                string typeFQN = typeSpec.TypeRef.FullyQualifiedName;
-                string wrapperName = GetConstructorAccessorName(typeSpec);
-                ImmutableEquatableArray<ParameterGenerationSpec> parameters = typeSpec.CtorParamGenSpecs;
-
-                // Build the parameter list for the wrapper method.
-                var wrapperParams = new StringBuilder();
-                var callArgs = new StringBuilder();
-
-                foreach (ParameterGenerationSpec param in parameters)
+                var parameters = new List<UnsafeAccessorEmitter.UnsafeAccessorParameterSpec>(typeSpec.CtorParamGenSpecs.Count);
+                foreach (ParameterGenerationSpec param in typeSpec.CtorParamGenSpecs)
                 {
-                    if (wrapperParams.Length > 0)
+                    parameters.Add(new UnsafeAccessorEmitter.UnsafeAccessorParameterSpec
                     {
-                        wrapperParams.Append(", ");
-                        callArgs.Append(", ");
-                    }
-
-                    wrapperParams.Append($"{param.ParameterType.FullyQualifiedName} p{param.ParameterIndex}");
-                    callArgs.Append($"p{param.ParameterIndex}");
+                        TypeFQN = param.ParameterType.FullyQualifiedName,
+                        Index = param.ParameterIndex,
+                    });
                 }
 
-                if (typeSpec.CanUseUnsafeAccessorForConstructor)
+                UnsafeAccessorEmitter.EmitConstructorAccessor(writer, new UnsafeAccessorEmitter.UnsafeAccessorConstructorSpec
                 {
-                    writer.WriteLine($"[{UnsafeAccessorAttributeTypeRef}({UnsafeAccessorKindTypeRef}.Constructor)]");
-                    writer.WriteLine($"private static extern {typeFQN} {wrapperName}({wrapperParams});");
-                }
-                else
-                {
-                    // Reflection fallback: cached ConstructorInfo + Invoke.
-                    // Note: ConstructorInfo cannot be wrapped in a delegate, so we cache the ConstructorInfo directly.
-                    string cacheName = GetConstructorReflectionCacheName(typeSpec);
-
-                    string argTypes = parameters.Count == 0
-                        ? EmptyTypeArray
-                        : $"new global::System.Type[] {{{string.Join(", ", parameters.Select(p => $"typeof({p.ParameterType.FullyQualifiedName})"))}}}";
-
-                    writer.WriteLine($"private static global::System.Reflection.ConstructorInfo? {cacheName};");
-
-                    string invokeArgs = parameters.Count == 0
-                        ? "null"
-                        : $"new object?[] {{{string.Join(", ", parameters.Select(p => $"p{p.ParameterIndex}"))}}}";
-
-                    writer.WriteLine($"private static {typeFQN} {wrapperName}({wrapperParams}) => ({typeFQN})({cacheName} ??= typeof({typeFQN}).GetConstructor(InstanceMemberBindingFlags, binder: null, {argTypes}, modifiers: null)!).Invoke({invokeArgs});");
-                }
+                    TypeFriendlyName = typeSpec.TypeInfoPropertyName,
+                    TypeFQN = typeSpec.TypeRef.FullyQualifiedName,
+                    CanUseUnsafeAccessor = typeSpec.CanUseUnsafeAccessorForConstructor,
+                    Parameters = parameters.ToImmutableEquatableArray(),
+                });
             }
 
             /// <summary>
@@ -1440,15 +1164,15 @@ namespace System.Text.Json.SourceGeneration
                 if (property.CanUseUnsafeAccessors)
                 {
                     string accessorName = property.IsProperty
-                        ? GetQualifiedAccessorName(property, typeFriendlyName, "get", property.MemberName, propertyIndex, needsDisambiguation)
-                        : GetQualifiedAccessorName(property, typeFriendlyName, "field", property.MemberName, propertyIndex, needsDisambiguation);
+                        ? UnsafeAccessorEmitter.GetQualifiedAccessorName(property.DeclaringTypeParameterNames, property.DeclaringType.FullyQualifiedName, typeFriendlyName, "get", property.MemberName, propertyIndex, needsDisambiguation)
+                        : UnsafeAccessorEmitter.GetQualifiedAccessorName(property.DeclaringTypeParameterNames, property.DeclaringType.FullyQualifiedName, typeFriendlyName, "field", property.MemberName, propertyIndex, needsDisambiguation);
 
                     return typeGenSpec.TypeRef.IsValueType
                         ? $"{accessorName}(ref value)"
                         : $"{accessorName}({objectExpr})";
                 }
 
-                string getterName = GetAccessorName(typeFriendlyName, "get", property.MemberName, propertyIndex, needsDisambiguation);
+                string getterName = UnsafeAccessorEmitter.GetAccessorName(typeFriendlyName, "get", property.MemberName, propertyIndex, needsDisambiguation);
 
                 return $"{getterName}({objectExpr})";
             }
@@ -1539,7 +1263,7 @@ namespace System.Text.Json.SourceGeneration
 
                 GenerateFastPathFuncHeader(writer, typeGenSpec, serializeMethodName);
 
-                HashSet<string> duplicateMemberNames = GetDuplicateMemberNames(typeGenSpec.PropertyGenSpecs);
+                HashSet<string> duplicateMemberNames = UnsafeAccessorEmitter.GetDuplicateMemberNames(typeGenSpec.PropertyGenSpecs.Select(static p => p.MemberName));
 
                 if (typeGenSpec.ImplementsIJsonOnSerializing)
                 {
@@ -1700,7 +1424,7 @@ namespace System.Text.Json.SourceGeneration
 
                     if (typeGenerationSpec.ConstructorIsInaccessible)
                     {
-                        string accessorName = GetConstructorAccessorName(typeGenerationSpec);
+                        string accessorName = UnsafeAccessorEmitter.GetConstructorAccessorName(typeGenerationSpec.TypeInfoPropertyName);
                         sb.Append($"return {accessorName}(");
                     }
                     else
@@ -1711,7 +1435,7 @@ namespace System.Text.Json.SourceGeneration
                 else if (typeGenerationSpec.ConstructorIsInaccessible)
                 {
                     // Inaccessible constructor: use the unified constructor accessor wrapper.
-                    string accessorName = GetConstructorAccessorName(typeGenerationSpec);
+                    string accessorName = UnsafeAccessorEmitter.GetConstructorAccessorName(typeGenerationSpec.TypeInfoPropertyName);
                     sb = new($"static args => {accessorName}(");
                 }
                 else
@@ -2414,7 +2138,7 @@ namespace System.Text.Json.SourceGeneration
                     { IsValueTuple: true } => $"() => default({typeSpec.TypeRef.FullyQualifiedName})",
                     { ConstructionStrategy: ObjectConstructionStrategy.ParameterlessConstructor, ConstructorIsInaccessible: false } => $"() => new {typeSpec.TypeRef.FullyQualifiedName}()",
                     { ConstructionStrategy: ObjectConstructionStrategy.ParameterlessConstructor, ConstructorIsInaccessible: true } =>
-                        $"static () => {GetConstructorAccessorName(typeSpec)}()",
+                        $"static () => {UnsafeAccessorEmitter.GetConstructorAccessorName(typeSpec.TypeInfoPropertyName)}()",
                     _ => "null",
                 };
             }

--- a/src/libraries/System.Text.Json/gen/System.Text.Json.SourceGeneration.targets
+++ b/src/libraries/System.Text.Json/gen/System.Text.Json.SourceGeneration.targets
@@ -35,6 +35,7 @@
     <Compile Include="$(CommonPath)\SourceGenerators\SourceWriter.cs" Link="Common\SourceGenerators\SourceWriter.cs" />
     <Compile Include="$(CommonPath)\SourceGenerators\TypeModelHelper.cs" Link="Common\SourceGenerators\TypeModelHelper.cs" />
     <Compile Include="$(CommonPath)\SourceGenerators\TypeRef.cs" Link="Common\SourceGenerators\TypeRef.cs" />
+    <Compile Include="$(CommonPath)\SourceGenerators\UnsafeAccessorEmitter.cs" Link="Common\SourceGenerators\UnsafeAccessorEmitter.cs" />
     <Compile Include="..\Common\JsonCamelCaseNamingPolicy.cs" Link="Common\System\Text\Json\JsonCamelCaseNamingPolicy.cs" />
     <Compile Include="..\Common\JsonNamingPolicy.cs" Link="Common\System\Text\Json\JsonNamingPolicy.cs" />
     <Compile Include="..\Common\JsonPascalCaseNamingPolicy.cs" Link="Common\System\Text\Json\JsonPascalCaseNamingPolicy.cs" />


### PR DESCRIPTION
## Summary

Extracts the System.Text.Json source generator's accessor-emission machinery into a new shared helper, `src/libraries/Common/src/SourceGenerators/UnsafeAccessorEmitter.cs`, so that other source generators can reuse it.

This is a pure refactoring with no behavior change — it is a preparatory step for giving the `Microsoft.Extensions.Configuration.Binder` source generator the same `[UnsafeAccessor]`-based accessor support (including generic-type support), which will come in a follow-up PR stacked on top of this one.

## What moved

The shared helper now owns:

- UnsafeAccessor-based property/field get/set accessors and the generic wrapper-class accessors used for members on generic types (.NET 9+).
- The inaccessible-constructor accessor (UnsafeAccessor + reflection fallback).
- The reflection fallback for older TFMs (`net462`), including the cached `MemberInfo`/`ConstructorInfo` wrappers.
- Accessor naming, using STJ's existing scheme, parameterized by a "type-friendly name" so a different generator can supply its own identifier source.

The helper works over neutral, primitive-only spec types (`UnsafeAccessorMemberSpec`, `UnsafeAccessorConstructorSpec`, `UnsafeAccessorParameterSpec`) rather than STJ's own model types.

STJ's `GenerateMemberAccessors` and `GenerateConstructorAccessor` are now thin adapters that build the neutral specs and delegate to the helper. The value-type-setter/reflection-fallback contract (the `ValueTypeSetter<,>` delegate and `BindingFlags` const the emitted code references) is documented on the helper and remains emitted by the consuming generator, exactly as STJ already does.

> [!NOTE]
> This PR description was generated by GitHub Copilot.
