### PR TITLE
JIT: Dispatch OSR resumptions in tail-await-only methods

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1134,6 +1134,15 @@ PhaseStatus AsyncTransformation::Run()
     if (awaits.NumNormalAwaits <= 0)
     {
         assert(continuationMemberOffsets.Empty());
+        if ((awaits.NumTailAwaits > 0) && m_compiler->doesMethodHavePatchpoints())
+        {
+            // Inlining a tail await can introduce non-tail awaits in the OSR version.
+            // Its continuations still resume through this method.
+            CreateResumptionSwitch(nullptr);
+            m_compiler->fgInvalidateDfsTree();
+            result = PhaseStatus::MODIFIED_EVERYTHING;
+        }
+
         return result;
     }
 
@@ -4974,6 +4983,30 @@ ContinuationLayoutBuilder* ContinuationLayoutBuilder::CreateSharedLayout(Compile
 }
 
 //------------------------------------------------------------------------
+// AsyncTransformation::CreateOSRJumpBB:
+//   Create a block that transfers control to the OSR version on resumption.
+//
+// Parameters:
+//   osrAddress - The address of the OSR version.
+//
+// Returns:
+//   The block containing the non-local jump.
+//
+BasicBlock* AsyncTransformation::CreateOSRJumpBB(GenTree* osrAddress)
+{
+    BasicBlock* jmpOSR = m_compiler->fgNewBBafter(BBJ_THROW, m_compiler->fgLastBBInMainFunction(), false);
+    jmpOSR->bbSetRunRarely();
+    jmpOSR->clearTryIndex();
+    jmpOSR->clearHndIndex();
+
+    JITDUMP("    Created " FMT_BB " for transitions back into OSR method\n", jmpOSR->bbNum);
+
+    GenTree* jmpOsr = m_compiler->gtNewOperNode(GT_NONLOCAL_JMP, TYP_VOID, osrAddress);
+    LIR::AsRange(jmpOSR).InsertAtEnd(LIR::SeqTree(m_compiler, jmpOsr));
+    return jmpOSR;
+}
+
+//------------------------------------------------------------------------
 // AsyncTransformation::CreateResumptionSwitch:
 //   Create the IR for the entry of the function that checks the continuation
 //   and dispatches on its state number.
@@ -4991,7 +5024,17 @@ void AsyncTransformation::CreateResumptionSwitch(GenTreeLclVarCommon* commonAsyn
 
     FlowEdge* resumingEdge;
 
-    if (m_states.size() == 1)
+    if (m_states.empty())
+    {
+        assert(m_compiler->doesMethodHavePatchpoints());
+
+        // Tier0 cannot create its own continuation, so a non-null continuation
+        // must belong to an OSR version that acquired awaits through inlining.
+        continuationArg     = m_compiler->gtNewLclvNode(m_compiler->lvaAsyncContinuationArg, TYP_REF);
+        GenTree* osrAddress = LoadFromOffset(continuationArg, OFFSETOF__CORINFO_Continuation__data, TYP_I_IMPL);
+        resumingEdge        = m_compiler->fgAddRefPred(CreateOSRJumpBB(osrAddress), newEntryBB);
+    }
+    else if (m_states.size() == 1)
     {
         JITDUMP("  Redirecting entry " FMT_BB " directly to " FMT_BB " as it is the only resumption block\n",
                 newEntryBB->bbNum, m_states[0].ResumptionBB->bbNum);
@@ -5084,16 +5127,13 @@ void AsyncTransformation::CreateResumptionSwitch(GenTreeLclVarCommon* commonAsyn
         StoreResumedDef(commonAsyncResumedDef, resumingEdge->getDestinationBlock());
     }
 
-    if (m_compiler->doesMethodHavePatchpoints())
+    if (m_compiler->doesMethodHavePatchpoints() && !m_states.empty())
     {
         JITDUMP("  Method has patch points...\n");
         // If we have patchpoints then first check if we need to resume in the OSR version.
-        BasicBlock* jmpOSR = m_compiler->fgNewBBafter(BBJ_THROW, m_compiler->fgLastBBInMainFunction(), false);
-        jmpOSR->bbSetRunRarely();
-        jmpOSR->clearTryIndex();
-        jmpOSR->clearHndIndex();
-
-        JITDUMP("    Created " FMT_BB " for transitions back into OSR method\n", jmpOSR->bbNum);
+        unsigned osrAddressLclNum = m_compiler->lvaGrabTemp(false DEBUGARG("OSR address for tier0 OSR method"));
+        m_compiler->lvaGetDesc(osrAddressLclNum)->lvType = TYP_I_IMPL;
+        BasicBlock* jmpOSR = CreateOSRJumpBB(m_compiler->gtNewLclvNode(osrAddressLclNum, TYP_I_IMPL));
 
         BasicBlock* onContinuationBB        = newEntryBB->GetTrueTarget();
         BasicBlock* checkOSRAddressOffsetBB = m_compiler->fgNewBBbefore(BBJ_COND, onContinuationBB, true);
@@ -5117,9 +5157,7 @@ void AsyncTransformation::CreateResumptionSwitch(GenTreeLclVarCommon* commonAsyn
         continuationArg                   = m_compiler->gtNewLclvNode(m_compiler->lvaAsyncContinuationArg, TYP_REF);
         unsigned offsetOfOSRAddressOffset = OFFSETOF__CORINFO_Continuation__data;
         GenTree* osrAddress               = LoadFromOffset(continuationArg, offsetOfOSRAddressOffset, TYP_I_IMPL);
-        unsigned osrAddressLclNum         = m_compiler->lvaGrabTemp(false DEBUGARG("OSR address for tier0 OSR method"));
-        m_compiler->lvaGetDesc(osrAddressLclNum)->lvType = TYP_I_IMPL;
-        GenTree* storeOsrAddress = m_compiler->gtNewStoreLclVarNode(osrAddressLclNum, osrAddress);
+        GenTree* storeOsrAddress          = m_compiler->gtNewStoreLclVarNode(osrAddressLclNum, osrAddress);
         LIR::AsRange(checkOSRAddressOffsetBB).InsertAtEnd(LIR::SeqTree(m_compiler, storeOsrAddress));
 
         osrAddress      = m_compiler->gtNewLclvNode(osrAddressLclNum, TYP_I_IMPL);
@@ -5127,11 +5165,6 @@ void AsyncTransformation::CreateResumptionSwitch(GenTreeLclVarCommon* commonAsyn
         GenTree* neZero = m_compiler->gtNewOperNode(GT_NE, TYP_INT, osrAddress, zero);
         GenTree* jtrue  = m_compiler->gtNewOperNode(GT_JTRUE, TYP_VOID, neZero);
         LIR::AsRange(checkOSRAddressOffsetBB).InsertAtEnd(osrAddress, zero, neZero, jtrue);
-
-        osrAddress = m_compiler->gtNewLclvNode(osrAddressLclNum, TYP_I_IMPL);
-
-        GenTree* jmpOsr = m_compiler->gtNewOperNode(GT_NONLOCAL_JMP, TYP_VOID, osrAddress);
-        LIR::AsRange(jmpOSR).InsertAtEnd(LIR::SeqTree(m_compiler, jmpOsr));
     }
     else if (m_compiler->opts.IsOSR())
     {

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -565,6 +565,7 @@ class AsyncTransformation
                                                               GenTree*                  syncContext);
     GenTreeLclVarCommon*      FindAndRemoveCommonAsyncResumedDef();
     const ContinuationLayout* CreateResumptionsAndSuspensions(ArrayStack<GenTree*>& continuationMemberOffsets);
+    BasicBlock*               CreateOSRJumpBB(GenTree* osrAddress);
     void                      CreateResumptionSwitch(GenTreeLclVarCommon* commonAsyncResumedDef);
 
     BasicBlock* CreateInlinedFrameSuspensionTail(BasicBlock*               callBlock,

--- a/src/tests/async/osr-inlined-contexts/osr-inlined-contexts.cs
+++ b/src/tests/async/osr-inlined-contexts/osr-inlined-contexts.cs
@@ -126,4 +126,34 @@ public class Async2OsrInlinedContexts
             SynchronizationContext.SetSynchronizationContext(original);
         }
     }
+
+    [Fact]
+    public static void TailAwaitOnlyMethodCanResumeInOsrCode()
+    {
+        Run().GetAwaiter().GetResult();
+
+        static async Task Run()
+        {
+            Assert.Equal(42, await LoopBeforeTailAwait(new[] { 42 }));
+        }
+    }
+
+    // NoInlining would prevent the Tier0 tail await and hide the missing dispatcher.
+    private static Task<int> LoopBeforeTailAwait(int[] value)
+    {
+        Assert.Equal(42, value[0]);
+        for (int i = 0; i < Iterations; i++)
+        {
+            Volatile.Write(ref s_sideEffect, i);
+        }
+
+        return ReadAfterYield(value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static async Task<int> ReadAfterYield(int[] value)
+    {
+        await Task.Yield();
+        return value[0];
+    }
 }


### PR DESCRIPTION
Tier0 async methods with only tail awaits can acquire non-tail awaits through inlining in their OSR versions. Emit resumption dispatch even without Tier0 suspension states so OSR continuations properly transfer control to the OSR method.

Add regression coverage to the existing async OSR tests.

Fix #132991
Fix #132992
Fix #133278