### PR TITLE
Limit the size of SNI parsed from ClientHello

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
@@ -157,6 +157,7 @@ namespace System.Net.Security
 
         private const int UInt24Size = 3;
         private const int RandomSize = 32;
+        private const int MaxHostNameLength = 255;
         private const int ProtocolVersionMajorOffset = 0;
         private const int ProtocolVersionMinorOffset = 1;
         private const int ProtocolVersionSize = 2;
@@ -641,7 +642,7 @@ namespace System.Net.Security
             }
 
             invalid = false;
-            return DecodeString(hostName);
+            return hostNameLength <= MaxHostNameLength ? DecodeString(hostName) : null;
         }
 
         private static bool TryGetSupportedVersionsFromExtension(ReadOnlySpan<byte> extensionData, out SslProtocols protocols)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Authentication;
@@ -28,6 +29,20 @@ namespace System.Net.Security.Tests
         public void SniHelper_TruncatedData_Fails(int id, byte[] clientHello)
         {
             InvalidClientHello(clientHello, id, shouldPass: false);
+        }
+
+        [Theory]
+        [InlineData(255, true)]
+        [InlineData(256, false)]
+        public void SniHelper_HostNameLength_ValidatesMaximum(int hostNameLength, bool isValid)
+        {
+            string? expected = isValid ? new string('a', hostNameLength) : null;
+            byte[] clientHello = CreateClientHello(hostNameLength);
+            TlsFrameHelper.TlsFrameInfo info = default;
+
+            Assert.True(TlsFrameHelper.TryGetFrameInfo(clientHello, ref info));
+            Assert.Equal(expected, info.TargetName);
+            Assert.Equal(expected, TlsFrameHelper.GetServerName(clientHello));
         }
 
         private void InvalidClientHello(byte[] clientHello, int id, bool shouldPass)
@@ -157,6 +172,39 @@ namespace System.Net.Security.Tests
                 id++;
                 yield return new object[] { id, Convert.FromBase64String(invalidClientHello) };
             }
+        }
+
+        private static byte[] CreateClientHello(int hostNameLength)
+        {
+            const int HostNameOffset = 61;
+            byte[] clientHello = new byte[HostNameOffset + hostNameLength];
+
+            clientHello[0] = (byte)TlsContentType.Handshake;
+            clientHello[1] = 3;
+            clientHello[2] = 3;
+            BinaryPrimitives.WriteUInt16BigEndian(clientHello.AsSpan(3), checked((ushort)(clientHello.Length - TlsFrameHelper.HeaderSize)));
+            clientHello[5] = (byte)TlsHandshakeType.ClientHello;
+            int handshakeLength = clientHello.Length - 9;
+            clientHello[6] = (byte)(handshakeLength >> 16);
+            clientHello[7] = (byte)(handshakeLength >> 8);
+            clientHello[8] = (byte)handshakeLength;
+            clientHello[9] = 3;
+            clientHello[10] = 3;
+            clientHello[43] = 0; // Session ID length
+            BinaryPrimitives.WriteUInt16BigEndian(clientHello.AsSpan(44), 2);
+            clientHello[46] = 0x13;
+            clientHello[47] = 0x01;
+            clientHello[48] = 1;
+            clientHello[49] = 0;
+            BinaryPrimitives.WriteUInt16BigEndian(clientHello.AsSpan(50), checked((ushort)(hostNameLength + 9)));
+            BinaryPrimitives.WriteUInt16BigEndian(clientHello.AsSpan(52), (ushort)ExtensionType.ServerName);
+            BinaryPrimitives.WriteUInt16BigEndian(clientHello.AsSpan(54), checked((ushort)(hostNameLength + 5)));
+            BinaryPrimitives.WriteUInt16BigEndian(clientHello.AsSpan(56), checked((ushort)(hostNameLength + 3)));
+            clientHello[58] = 0;
+            BinaryPrimitives.WriteUInt16BigEndian(clientHello.AsSpan(59), checked((ushort)hostNameLength));
+            clientHello.AsSpan(HostNameOffset).Fill((byte)'a');
+
+            return clientHello;
         }
 
         private static byte[] s_validClientHello = new byte[] {


### PR DESCRIPTION
ClientHello SNI payloads carry a 16-bit length, but DNS hostnames are limited to 255 encoded bytes. Decoding larger peer-controlled values creates unnecessary managed strings for malformed input.

Cap managed SNI decoding at 255 bytes and treat larger values as unavailable SNI. The frame remains classified as complete so `TlsSession` does not incorrectly wait for more input. Boundary tests cover accepted 255-byte and rejected 256-byte payloads, including frame-completeness behavior.

Tests:
- `TlsFrameHelperTests`: 4,060 passed
- `System.Net.Security.Unit.Tests`: 117 passed, 4 skipped

Fixes: #133348

> [!NOTE]
> This pull request description was generated by GitHub Copilot.