### PR TITLE
Fix configuration reload test race

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -840,7 +840,7 @@ IniKey1=IniValue2");
             _fileSystem.DeleteFile(_iniFile);
 
             await WaitForChange(
-                () => config["Key"] == "JsonValue1",
+                () => config["Key"] == "JsonValue1" && token.HasChanged,
                 "Notification failed for deleting ini file.");
 
             Assert.Equal("JsonValue1", config["Key"]);
@@ -850,7 +850,7 @@ IniKey1=IniValue2");
             _fileSystem.DeleteFile(_jsonFile);
 
             await WaitForChange(
-                () => config["Key"] == "XmlValue1",
+                () => config["Key"] == "XmlValue1" && token.HasChanged,
                 "Notification failed for deleting JSON file.");
 
             Assert.Equal("XmlValue1", config["Key"]);
@@ -860,7 +860,7 @@ IniKey1=IniValue2");
             _fileSystem.DeleteFile(_xmlFile);
 
             await WaitForChange(
-                () => config["Key"] == null,
+                () => config["Key"] is null && token.HasChanged,
                 "Notification failed for deleting XML file.");
 
             Assert.Null(config["Key"]);
@@ -870,7 +870,7 @@ IniKey1=IniValue2");
             _fileSystem.WriteFile(_jsonFile, @"{""Key"": ""JsonValue1""}");
 
             await WaitForChange(
-                () => config["Key"] == "JsonValue1",
+                () => config["Key"] == "JsonValue1" && token.HasChanged,
                 "Notification failed for re-creating JSON file.");
 
             Assert.Equal("JsonValue1", config["Key"]);
@@ -891,7 +891,7 @@ IniKey1=IniValue2");
             _fileSystem.WriteFile(_iniFile, @"Key = IniValue1");
 
             await WaitForChange(
-                () => config["Key"] == "IniValue1",
+                () => config["Key"] == "IniValue1" && token.HasChanged,
                 "Notification failed for re-creating ini file.");
 
             Assert.Equal("IniValue1", config["Key"]);


### PR DESCRIPTION
Fixes #132147.

The test waited for the expected configuration value before asserting that the root reload token had changed. `FileConfigurationProvider` updates its data before it raises its provider reload token, so the expected value could become visible while the root token was still unchanged.

Update each wait condition in `DeletingFilesThatRedefineKeysWithReload` to require both the expected value and the corresponding root reload token notification before the test continues.

## Testing

- `dotnet build src\libraries\Microsoft.Extensions.Configuration\tests\FunctionalTests\Microsoft.Extensions.Configuration.Functional.Tests.csproj /t:test /p:XunitMethodName=Microsoft.Extensions.Configuration.Test.ConfigurationTests.DeletingFilesThatRedefineKeysWithReload`
- 20 repeated runs of `DeletingFilesThatRedefineKeysWithReload` (40 theory cases)
- `dotnet build src\libraries\Microsoft.Extensions.Configuration\tests\FunctionalTests\Microsoft.Extensions.Configuration.Functional.Tests.csproj /t:test`

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
