### PR TITLE
Retry peer-reset timeouts in socket disposal tests on BSD/Apple

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -1139,12 +1139,13 @@ namespace System.Net.Sockets.Tests
                                 peerSocketError = se.SocketErrorCode;
                                 break;
                             }
-                            catch (TimeoutException) when (!receiveOrSend && (PlatformDetection.IsApplePlatform || PlatformDetection.IsFreeBSD))
+                            catch (TimeoutException ex) when (!receiveOrSend && (PlatformDetection.IsApplePlatform || PlatformDetection.IsFreeBSD))
                             {
                                 // BSD TCP stacks may reject a valid reset when sent data has not yet
                                 // been acknowledged. Retry with fresh sockets, not another receive.
                                 const string Message = "Timed out waiting for the peer to observe the connection reset, retry.";
                                 _output?.WriteLine(Message);
+                                _output?.WriteLine(ex.ToString());
                                 Assert.Fail(Message);
                             }
                         }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -1059,6 +1059,7 @@ namespace System.Net.Sockets.Tests
                 (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair(ipv6Server, dualModeClient);
                 using SafeSocketHandle? owner = ReplaceWithNonOwning(ref socket1, owning);
 
+                using (socket1)
                 using (socket2)
                 {
                     Task socketOperation;
@@ -1137,6 +1138,14 @@ namespace System.Net.Sockets.Tests
                             {
                                 peerSocketError = se.SocketErrorCode;
                                 break;
+                            }
+                            catch (TimeoutException) when (!receiveOrSend && (PlatformDetection.IsApplePlatform || PlatformDetection.IsFreeBSD))
+                            {
+                                // BSD TCP stacks may reject a valid reset when sent data has not yet
+                                // been acknowledged. Retry with fresh sockets, not another receive.
+                                const string Message = "Timed out waiting for the peer to observe the connection reset, retry.";
+                                _output?.WriteLine(Message);
+                                Assert.Fail(Message);
                             }
                         }
 


### PR DESCRIPTION
Fixes #131990.

`TcpReceiveSendGetsCanceledByDispose` can time out waiting for the peer
to observe a reset after local cancellation has succeeded. This is
consistent with the documented BSD TCP reset-validation issue:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=296594

The existing retry loop handles assertion failures, but not
`TimeoutException`. Convert only peer-receive timeouts on Apple/FreeBSD
send paths into logged assertion failures, allowing the existing
eight-attempt loop to retry with fresh sockets.

This preserves the peer-reset assertion. Timeouts waiting for local
cancellation or disposal still fail immediately. Also ensure the sending
socket is disposed on exceptional exits.

### Validation

- Linux functional suite: 2,418 passed, 24 skipped, zero failures.
- Linux inline-completion test: passed.
- Helix macOS 27 ARM64: 174 iterations, 18,792 cases passed, zero skips.
  Iteration 174 encountered a peer-reset timeout in `SendReceive_Apm`;
  the same test then passed after retry, exercising the recovery path.

[Helix results and captured retry](https://helix.dot.net/api/2019-06-17/jobs/22f21270-e3a7-40ce-82dc-f942e2fdb3e1/workitems/SocketCancellation.Retries/console)

> [!NOTE]
> This change and description were prepared with GitHub Copilot.