### PR TITLE
Exclude Runtime_129681 from WASM

### DIFF
--- a/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
+++ b/src/tests/GC/Regressions/Github/Runtime_129681/Runtime_129681.csproj
@@ -3,6 +3,9 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+    <!-- wasm32 doesn't support region GC, and its fully committed segments exceed
+         this test's hard limit during runtime startup. -->
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'">true</CLRTestTargetUnsupported>
     <!-- CrossGen2 reserves 6 GiB for regions which exceeds the 64 MiB hard limit - https://github.com/dotnet/runtime/issues/132062 -->
     <CrossGenTest>false</CrossGenTest>
 


### PR DESCRIPTION
Fixes #132871

## Summary

- Exclude `Runtime_129681` on wasm32 because the regression requires region GC, which wasm32 does not support.
- Keep the test enabled on supported CoreCLR targets.

## Testing

- Reproduced the browser-WASM startup failure with `0x8007000E` before the change.
- Confirmed the browser-WASM test build no longer compiles `Runtime_129681`.
- Built and ran the test on macOS arm64 Checked; it passed with exit code 100.

> [!NOTE]
> This PR description was generated with GitHub Copilot.
