### PR TITLE
[wasm][coreclr] Use NoWasmIntrinsics substitutions for interpreted-only library tests

### DIFF
--- a/eng/testing/tests.wasm.targets
+++ b/eng/testing/tests.wasm.targets
@@ -87,8 +87,14 @@
 
       So, set those parameters explicitly here.
       -->
-    <_ExtraTrimmerArgs Condition="'$(WasmEnableSIMD)' != 'false'">$(_ExtraTrimmerArgs) --substitutions "$(BrowserProjectRoot)build\ILLink.Substitutions.WasmIntrinsics.xml"</_ExtraTrimmerArgs>
-    <_ExtraTrimmerArgs Condition="'$(WasmEnableSIMD)' == 'false'">$(_ExtraTrimmerArgs) --substitutions "$(BrowserProjectRoot)build\ILLink.Substitutions.NoWasmIntrinsics.xml"</_ExtraTrimmerArgs>
+    <_WasmIntrinsicsSubstitutions Condition="'$(WasmEnableSIMD)' != 'false'">WasmIntrinsics</_WasmIntrinsicsSubstitutions>
+    <_WasmIntrinsicsSubstitutions Condition="'$(WasmEnableSIMD)' == 'false'">NoWasmIntrinsics</_WasmIntrinsicsSubstitutions>
+    <!-- WasmEnableSIMD is about native codegen, and CoreCLR browser-wasm forces it on, but the CoreCLR
+         interpreter maps every System.Runtime.Intrinsics arch intrinsic except get_IsSupported to
+         PlatformNotSupportedException. Only crossgen'd code can execute them, so without ReadyToRun stubbing
+         IsSupported to true leaves a guarded SIMD path unconditionally reachable and it throws at startup. -->
+    <_WasmIntrinsicsSubstitutions Condition="'$(RuntimeFlavor)' == 'CoreCLR' and '$(PublishReadyToRun)' != 'true'">NoWasmIntrinsics</_WasmIntrinsicsSubstitutions>
+    <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --substitutions "$(BrowserProjectRoot)build\ILLink.Substitutions.$(_WasmIntrinsicsSubstitutions).xml"</_ExtraTrimmerArgs>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

Trimmed CoreCLR browser-wasm library tests with `PublishReadyToRun=false` abort during startup and produce no test results. The failure is a `PlatformNotSupportedException` thrown from a class constructor, visible in the browser as:

```
InterpThrow(InterpMethodContextFrame*, int const*, RuntimeExceptionKind) (interpexec.cpp:875)
...
::ExecuteInterpretedMethodFromUnmanaged(...)  <- static constructor
```

`interpexec.cpp:4492` is `INTOP_THROW_PNSE`.

## Cause

The CoreCLR interpreter has no managed SIMD. [`src/coreclr/interpreter/intrinsics.cpp`](https://github.com/dotnet/runtime/blob/main/src/coreclr/interpreter/intrinsics.cpp) maps every arch-specific intrinsic except `get_IsSupported` to `PlatformNotSupportedException`:

```cpp
else if (HAS_PREFIX(namespaceName, "System.Runtime.Intrinsics"))
{
    if (!strcmp(methodName, "get_IsSupported"))
        return NI_IsSupported_False;
    // Every intrinsic except IsSupported is PNSE in interpreted-only mode.
    return NI_Throw_PlatformNotSupportedException;
}
```

But `eng/testing/tests.wasm.targets` selected the ILLink substitution file purely from `WasmEnableSIMD`, which `BrowserWasmApp.CoreCLR.targets` forces to `true` for CoreCLR browser-wasm (*"WasmEnableSIMD cannot be disabled for CoreCLR browser-wasm. The CoreCLR runtime requires SIMD."*). That baked into the trimmed CoreLib:

```xml
<method signature="System.Boolean get_IsSupported()" body="stub" value="true" />          <!-- PackedSimd -->
<method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="true" /> <!-- Vector128 -->
```

Trimming then removes the guard, so the SIMD branch becomes unconditionally reachable and throws.

`WasmEnableSIMD` governs **native** codegen and says nothing about whether the **managed** interpreter can execute those intrinsics — so it is the wrong signal on its own for CoreCLR.

## Fix

Select `NoWasmIntrinsics` when the runtime is CoreCLR and ReadyToRun is off. Mono and every ReadyToRun configuration are unchanged — with R2R, crossgen2 compiles those paths, so the intrinsics really are available.

Why the failure only appears in one cell:

| configuration | substitution | result |
|---|---|---|
| untrimmed, no R2R | none applied | interpreter reports `IsSupported=false` — passes |
| trimmed, R2R | `true` baked in | crossgen2 compiles the SIMD path — passes |
| **trimmed, no R2R** | `true` baked in | interpreter — **PNSE** |

## Coverage impact

> [!IMPORTANT]
> This narrows what the `PublishReadyToRun=false` configuration tests: SIMD paths become unreachable rather than exercised. That matches what the interpreter can actually run, but it does mean the R2R=false lane no longer covers managed SIMD.

## Validation

`System.Runtime.InteropServices.JavaScript.Tests`, browser + CoreCLR + trimmed, clean `obj`/`bin`:

```
Tests run: 476  Passed: 474  Failed: 0  Skipped: 2   —   WASM EXIT 0
```

Identical to the ReadyToRun configuration of the same suite. Before this change the app aborted during startup and reported no results.

`WasmEnableSIMD=false` is not a workaround — the SDK rejects it for CoreCLR browser-wasm.

> [!NOTE]
> This description and the change were produced with the assistance of GitHub Copilot.