### PR TITLE
Fix GC lifetime in ComWrappers cache cleanup test

### DIFF
--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -1692,10 +1692,10 @@ namespace ComWrappersTests
                 var wrapper = (ManualReleaseITestObjectWrapper)cw.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.None);
                 var reference = new WeakReference<object>(wrapper);
 
+                wrapper.FinalRelease();
+
                 Assert.True(ComWrappers.TryGetComInstance(wrapper, out IntPtr unknown));
                 Marshal.Release(unknown);
-
-                wrapper.FinalRelease();
 
                 GC.KeepAlive(wrapper);
 

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -1660,8 +1660,6 @@ namespace ComWrappersTests
             // the cache holds that handle, so the entry dies here rather than after finalization.
             Assert.False(first.TryGetTarget(out _));
 
-            // Verify the replacement is usable before the helper abandons its strong reference.
-            // Once only the weak reference remains, a GC may collect the wrapper at any time.
             WeakReference<object> second = CreateAndAbandonWrapper(cw, comWrapper);
 
             // Now let the wrapper finalizers run, which is what removes entries, and check the cache is
@@ -1694,8 +1692,7 @@ namespace ComWrappersTests
                 var wrapper = (ManualReleaseITestObjectWrapper)cw.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.None);
                 var reference = new WeakReference<object>(wrapper);
 
-                Assert.True(reference.TryGetTarget(out object? target));
-                Assert.True(ComWrappers.TryGetComInstance(target, out IntPtr unknown));
+                Assert.True(ComWrappers.TryGetComInstance(wrapper, out IntPtr unknown));
                 Marshal.Release(unknown);
 
                 wrapper.FinalRelease();

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -1660,12 +1660,9 @@ namespace ComWrappersTests
             // the cache holds that handle, so the entry dies here rather than after finalization.
             Assert.False(first.TryGetTarget(out _));
 
+            // Verify the replacement is usable before the helper abandons its strong reference.
+            // Once only the weak reference remains, a GC may collect the wrapper at any time.
             WeakReference<object> second = CreateAndAbandonWrapper(cw, comWrapper);
-
-            // The dead entry did not prevent a new RCW being created and cached for the same instance.
-            // Checked in a separate frame so that the strong reference it needs does not outlive it and
-            // keep the RCW alive through the collection below.
-            AssertUsableAndDrop(second);
 
             // Now let the wrapper finalizers run, which is what removes entries, and check the cache is
             // still able to hand out a working RCW afterwards.
@@ -1689,25 +1686,23 @@ namespace ComWrappersTests
 
             Marshal.Release(comWrapper);
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            static void AssertUsableAndDrop(WeakReference<object> reference)
-            {
-                Assert.True(reference.TryGetTarget(out object? target));
-                Assert.True(ComWrappers.TryGetComInstance(target, out IntPtr unknown));
-
-                Marshal.Release(unknown);
-            }
-
             // This wrapper type releases the interface pointer its constructor took by hand rather than
             // from a finalizer, so it is released here before the wrapper is dropped.
             [MethodImpl(MethodImplOptions.NoInlining)]
             static WeakReference<object> CreateAndAbandonWrapper(ComWrappers cw, IntPtr comWrapper)
             {
                 var wrapper = (ManualReleaseITestObjectWrapper)cw.GetOrCreateObjectForComInstance(comWrapper, CreateObjectFlags.None);
+                var reference = new WeakReference<object>(wrapper);
+
+                Assert.True(reference.TryGetTarget(out object? target));
+                Assert.True(ComWrappers.TryGetComInstance(target, out IntPtr unknown));
+                Marshal.Release(unknown);
 
                 wrapper.FinalRelease();
 
-                return new WeakReference<object>(wrapper);
+                GC.KeepAlive(wrapper);
+
+                return reference;
             }
         }
 


### PR DESCRIPTION
Fixes dotnet/runtime#133331.

`ValidateExternalWrapperCacheCleanUpWithoutFinalizer`, added in dotnet/runtime#133164, abandoned the wrapper's only strong reference before trying to recover it through a weak reference. A collection between those calls legitimately clears the target, making the usability assertion fail under GC stress.

Move the `TryGetComInstance` assertion into `CreateAndAbandonWrapper`, while the wrapper is still strongly rooted. Keep the helper non-inlined and preserve the collection and cache-cleanup assertions. This is a test-only change; the runtime implementation is unchanged.

> [!NOTE]
> This change and description were prepared with GitHub Copilot.