### PR TITLE
Probe {riscv,loongarch,arm}64 virtual memory address

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1028,7 +1028,7 @@ size_t GCToOSInterface::GetVirtualMemoryLimit()
     return GetVirtualMemoryMaxAddress();
 }
 
-#if defined(TARGET_LINUX) && (defined(TARGET_ARM64) || defined(TARGET_RISCV64))
+#if defined(TARGET_LINUX) && (defined(TARGET_ARM64) || defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64))
 #ifndef MAP_FIXED_NOREPLACE
 #define MAP_FIXED_NOREPLACE 0x100000
 #endif
@@ -1057,7 +1057,7 @@ static bool IsUserVirtualAddressSpaceAtLeast(int vaBits)
     // so the mapping may have been placed elsewhere. Trust only an exact match.
     return result == probe;
 }
-#endif // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64)
+#endif // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64 || TARGET_LOONGARCH64)
 
 // Return the maximum address of the virtual address space of this process.
 // Return:
@@ -1065,7 +1065,7 @@ static bool IsUserVirtualAddressSpaceAtLeast(int vaBits)
 size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
 {
 #ifdef HOST_64BIT
-#if defined(TARGET_LINUX) && (defined(TARGET_ARM64) || defined(TARGET_RISCV64))
+#if defined(TARGET_LINUX) && (defined(TARGET_ARM64) || defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64))
     // The size of the user virtual address space is a kernel configuration choice on these
     // architectures, so discover it at run time by probing the candidates from the largest to
     // the smallest one. The smallest candidate is assumed without probing.
@@ -1073,15 +1073,15 @@ size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
     if (s_maxAddress == 0)
     {
 #if defined(TARGET_ARM64)
-        // CONFIG_ARM64_VA_BITS can be 52, 48, 47, 42, 39 or 36 and the user address space is
-        // 1 << CONFIG_ARM64_VA_BITS. Android kernels typically use 39 bits.
         static const int candidates[] = { 52, 48, 47, 42, 39 };
         const int minVaBits = 36;
-#else // TARGET_ARM64
-        // The user address space is the lower half of the Sv57 / Sv48 / Sv39 virtual address space.
+#elif defined(TARGET_RISCV64)
         static const int candidates[] = { 56, 47 };
         const int minVaBits = 38;
-#endif // TARGET_ARM64
+#else // TARGET_LOONGARCH64
+        static const int candidates[] = { 47, 39 };
+        const int minVaBits = 36;
+#endif
 
         size_t maxAddress = ((size_t)1) << minVaBits;
         for (size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++)
@@ -1096,14 +1096,14 @@ size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
         s_maxAddress = maxAddress;
     }
     return s_maxAddress;
-#else // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64)
+#else // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64 || TARGET_LOONGARCH64)
     // There is no API to get the total virtual address space size on
     // Unix, so we use a constant value representing 128TB, which is
     // the approximate size of total user virtual address space on
     // the currently supported Unix systems.
     static const uint64_t _128TB = (1ull << 47);
     return _128TB;
-#endif // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64)
+#endif // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64 || TARGET_LOONGARCH64)
 #else
     return (size_t)-1;
 #endif

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1068,22 +1068,19 @@ size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
 #if defined(TARGET_LINUX) && (defined(TARGET_ARM64) || defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64))
     // The size of the user virtual address space is a kernel configuration choice on these
     // architectures, so discover it at run time by probing the candidates from the largest to
-    // the smallest one. The smallest candidate is assumed without probing.
+    // the smallest one.
     static volatile size_t s_maxAddress = 0;
     if (s_maxAddress == 0)
     {
 #if defined(TARGET_ARM64)
-        static const int candidates[] = { 52, 48, 47, 42, 39 };
-        const int minVaBits = 36;
+        static const int candidates[] = { 52, 48, 47, 42, 39, 36 };
 #elif defined(TARGET_RISCV64)
-        static const int candidates[] = { 56, 47 };
-        const int minVaBits = 38;
+        static const int candidates[] = { 56, 47, 38 };
 #else // TARGET_LOONGARCH64
-        static const int candidates[] = { 47, 39 };
-        const int minVaBits = 36;
+        static const int candidates[] = { 47, 39, 36 };
 #endif
 
-        size_t maxAddress = ((size_t)1) << minVaBits;
+        size_t maxAddress = 0;
         for (size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++)
         {
             if (IsUserVirtualAddressSpaceAtLeast(candidates[i]))
@@ -1093,14 +1090,16 @@ size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
             }
         }
 
+        // Not even the smallest candidate could be probed, so the probing itself does not work
+        // in this environment (e.g. mmap is blocked). Report the failure to the caller.
+        assert(maxAddress != 0);
         s_maxAddress = maxAddress;
     }
     return s_maxAddress;
 #else // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64 || TARGET_LOONGARCH64)
-    // There is no API to get the total virtual address space size on
-    // Unix, so we use a constant value representing 128TB, which is
-    // the approximate size of total user virtual address space on
-    // the currently supported Unix systems.
+    // The remaining platforms do not provide an API to get the size of the user virtual
+    // address space either, so use a constant representing 128TB (47 bits), which is
+    // the size on x64 and a close enough approximation on the other supported systems.
     static const uint64_t _128TB = (1ull << 47);
     return _128TB;
 #endif // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64 || TARGET_LOONGARCH64)

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1029,6 +1029,10 @@ size_t GCToOSInterface::GetVirtualMemoryLimit()
 }
 
 #if defined(TARGET_LINUX) && (defined(TARGET_ARM64) || defined(TARGET_RISCV64))
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
 // Check whether the user virtual address space of this process extends up to (1 << vaBits)
 // by trying to map the last page below that boundary at a fixed address.
 // Parameters:

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1028,23 +1028,61 @@ size_t GCToOSInterface::GetVirtualMemoryLimit()
     return GetVirtualMemoryMaxAddress();
 }
 
-// Return the maximum address of the of the virtual address space of this process.
+// Return the maximum address of the virtual address space of this process.
 // Return:
 //  non zero if it has succeeded, 0 if it has failed
 size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
 {
 #ifdef HOST_64BIT
-#ifndef TARGET_RISCV64
+#ifdef TARGET_RISCV64
+    // Run-time lookup isolated for RISC-V 64-bit to handle Sv39/Sv48/Sv57 MMU modes.
+    static volatile size_t max_address = 0;
+    if (max_address == 0)
+    {
+        size_t discovered = 0;
+
+        // 1. Probe for Sv57 capability (64 PB user ceiling).
+        // Per Linux kernel spec, the opt-in hint address must be >= 1ULL << 56.
+        void* ptr57 = mmap((void*)(1ULL << 56), 4096, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE, -1, 0);
+        if (ptr57 != MAP_FAILED)
+        {
+            munmap(ptr57, 4096);
+            discovered = (1ULL << 56); // Sv57 max user address (64 PB)
+        }
+
+        // 2. Probe for Sv48 capability (128 TB user ceiling) if Sv57 failed.
+        if (discovered == 0)
+        {
+            // Per Linux kernel spec, the opt-in hint address must be >= 1ULL << 47.
+            void* ptr48 = mmap((void*)(1ULL << 47), 4096, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE, -1, 0);
+            if (ptr48 != MAP_FAILED)
+            {
+                munmap(ptr48, 4096);
+                discovered = (1ULL << 47); // Sv48 max user address (128 TB)
+            }
+        }
+
+        // 3. Fallback to Sv39 if both high address capabilities failed.
+        if (discovered == 0)
+        {
+            void* ptr39 = mmap(NULL, 4096, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+            if (ptr39 != MAP_FAILED)
+            {
+                munmap(ptr39, 4096);
+                discovered = (1ULL << 38); // Sv39 max user address (256 GB)
+            }
+        }
+
+        max_address = discovered;
+    }
+    return max_address;
+#else // TARGET_RISCV64
     // There is no API to get the total virtual address space size on
     // Unix, so we use a constant value representing 128TB, which is
     // the approximate size of total user virtual address space on
     // the currently supported Unix systems.
     static const uint64_t _128TB = (1ull << 47);
     return _128TB;
-#else // TARGET_RISCV64
-    // For RISC-V Linux Kernel SV39 virtual memory limit is 256gb.
-    static const uint64_t _256GB = (1ull << 38);
-    return _256GB;
 #endif // TARGET_RISCV64
 #else
     return (size_t)-1;

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1028,70 +1028,78 @@ size_t GCToOSInterface::GetVirtualMemoryLimit()
     return GetVirtualMemoryMaxAddress();
 }
 
+#if defined(TARGET_LINUX) && (defined(TARGET_ARM64) || defined(TARGET_RISCV64))
+// Check whether the user virtual address space of this process extends up to (1 << vaBits)
+// by trying to map the last page below that boundary at a fixed address.
+// Parameters:
+//  vaBits - number of bits of the user virtual address space to probe for
+// Return:
+//  true if the boundary is within the user virtual address space, false otherwise
+static bool IsUserVirtualAddressSpaceAtLeast(int vaBits)
+{
+    size_t pageSize = OS_PAGE_SIZE;
+    void* probe = (void*)((((size_t)1) << vaBits) - pageSize);
+    void* result = mmap(probe, pageSize, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE, -1, 0);
+    if (result == MAP_FAILED)
+    {
+        // EEXIST means the page is already mapped, so the address is valid.
+        // Anything else (typically ENOMEM) means the address is outside of the user address space.
+        return errno == EEXIST;
+    }
+
+    munmap(result, pageSize);
+
+    // Kernels older than 4.17 ignore MAP_FIXED_NOREPLACE and treat the address as a hint,
+    // so the mapping may have been placed elsewhere. Trust only an exact match.
+    return result == probe;
+}
+#endif // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64)
+
 // Return the maximum address of the virtual address space of this process.
 // Return:
 //  non zero if it has succeeded, 0 if it has failed
 size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
 {
 #ifdef HOST_64BIT
-#ifdef TARGET_RISCV64
-    // Run-time lookup isolated for RISC-V 64-bit to handle Sv39/Sv48/Sv57 MMU modes.
-    static volatile size_t max_address = 0;
-    if (max_address == 0)
+#if defined(TARGET_LINUX) && (defined(TARGET_ARM64) || defined(TARGET_RISCV64))
+    // The size of the user virtual address space is a kernel configuration choice on these
+    // architectures, so discover it at run time by probing the candidates from the largest to
+    // the smallest one. The smallest candidate is assumed without probing.
+    static volatile size_t s_maxAddress = 0;
+    if (s_maxAddress == 0)
     {
-        size_t discovered = 0;
+#if defined(TARGET_ARM64)
+        // CONFIG_ARM64_VA_BITS can be 52, 48, 47, 42, 39 or 36 and the user address space is
+        // 1 << CONFIG_ARM64_VA_BITS. Android kernels typically use 39 bits.
+        static const int candidates[] = { 52, 48, 47, 42, 39 };
+        const int minVaBits = 36;
+#else // TARGET_ARM64
+        // The user address space is the lower half of the Sv57 / Sv48 / Sv39 virtual address space.
+        static const int candidates[] = { 56, 47 };
+        const int minVaBits = 38;
+#endif // TARGET_ARM64
 
-        // 1. Probe for Sv57 capability (64 PB user ceiling).
-        // Per Linux kernel spec, the opt-in hint address must be >= 1ULL << 56.
-        void* ptr57 = mmap((void*)(1ULL << 56), 4096, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE, -1, 0);
-        if (ptr57 != MAP_FAILED)
+        size_t maxAddress = ((size_t)1) << minVaBits;
+        for (size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++)
         {
-            munmap(ptr57, 4096);
-            discovered = (1ULL << 56); // Sv57 max user address (64 PB)
-        }
-        else if (errno == EEXIST)
-        {
-            discovered = (1ULL << 56); // Tier is supported but page is occupied.
-        }
-
-        // 2. Probe for Sv48 capability (128 TB user ceiling) if Sv57 failed.
-        if (discovered == 0)
-        {
-            // Per Linux kernel spec, the opt-in hint address must be >= 1ULL << 47.
-            void* ptr48 = mmap((void*)(1ULL << 47), 4096, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE, -1, 0);
-            if (ptr48 != MAP_FAILED)
+            if (IsUserVirtualAddressSpaceAtLeast(candidates[i]))
             {
-                munmap(ptr48, 4096);
-                discovered = (1ULL << 47); // Sv48 max user address (128 TB)
-            }
-            else if (errno == EEXIST)
-            {
-                discovered = (1ULL << 47); // Tier is supported but page is occupied.
+                maxAddress = ((size_t)1) << candidates[i];
+                break;
             }
         }
 
-        // 3. Fallback to Sv39 if both high address capabilities failed.
-        if (discovered == 0)
-        {
-            void* ptr39 = mmap(NULL, 4096, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-            if (ptr39 != MAP_FAILED)
-            {
-                munmap(ptr39, 4096);
-                discovered = (1ULL << 38); // Sv39 max user address (256 GB)
-            }
-        }
-
-        max_address = discovered;
+        s_maxAddress = maxAddress;
     }
-    return max_address;
-#else // TARGET_RISCV64
+    return s_maxAddress;
+#else // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64)
     // There is no API to get the total virtual address space size on
     // Unix, so we use a constant value representing 128TB, which is
     // the approximate size of total user virtual address space on
     // the currently supported Unix systems.
     static const uint64_t _128TB = (1ull << 47);
     return _128TB;
-#endif // TARGET_RISCV64
+#endif // TARGET_LINUX && (TARGET_ARM64 || TARGET_RISCV64)
 #else
     return (size_t)-1;
 #endif

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1049,6 +1049,10 @@ size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
             munmap(ptr57, 4096);
             discovered = (1ULL << 56); // Sv57 max user address (64 PB)
         }
+        else if (errno == EEXIST)
+        {
+            discovered = (1ULL << 56); // Tier is supported but page is occupied.
+        }
 
         // 2. Probe for Sv48 capability (128 TB user ceiling) if Sv57 failed.
         if (discovered == 0)
@@ -1059,6 +1063,10 @@ size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
             {
                 munmap(ptr48, 4096);
                 discovered = (1ULL << 47); // Sv48 max user address (128 TB)
+            }
+            else if (errno == EEXIST)
+            {
+                discovered = (1ULL << 47); // Tier is supported but page is occupied.
             }
         }
 


### PR DESCRIPTION
Modern riscv64 systems are using sv48 and GC remains limited to sv39. PR probes it at run-time.