### PR TITLE
[browser] Validate npm 11.19.1 through Node and VMR packages

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -24,6 +24,7 @@
     <add key="dotnet12" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet12/nuget/v3/index.json" />
     <add key="dotnet12-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet12-transport/nuget/v3/index.json" />
     <add key="dotnet-diagnostics-tests" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-diagnostics-tests/nuget/v3/index.json" />
+    <add key="general-testing" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -33,9 +33,10 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.9.3-beta.26431.109</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>5.12.0-1.26431.109</MicrosoftNetCompilersToolsetPackageVersion>
-    <MicrosoftNETRuntimeEmscriptenInternalPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETRuntimeEmscriptenInternalPackageVersion>
+    <MicrosoftNETRuntimeEmscriptenInternalPackageVersion>12.0.0-alpha.1.26457.113</MicrosoftNETRuntimeEmscriptenInternalPackageVersion>
     <MicrosoftNETSdkILPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETSdkILPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportPackageVersion>11.0.100-rc.1.26431.109</MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportPackageVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest120100alpha1PackageVersion>12.0.100-alpha.1.26457.113</MicrosoftNETWorkloadEmscriptenCurrentManifest120100alpha1PackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreILAsmPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETCoreILAsmPackageVersion>
     <NuGetFrameworksPackageVersion>7.11.0-rc.43209</NuGetFrameworksPackageVersion>
@@ -80,14 +81,14 @@ This file should be imported by eng/Versions.props
     <runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkPackageVersion>23.1.0-alpha.1.26420.1</runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkPackageVersion>
     <runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsPackageVersion>23.1.0-alpha.1.26420.1</runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsPackageVersion>
     <!-- dotnet-node dependencies -->
-    <runtimelinuxarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26418.1</runtimelinuxarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
-    <runtimelinuxmuslarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26418.1</runtimelinuxmuslarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
-    <runtimelinuxmuslx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26418.1</runtimelinuxmuslx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
-    <runtimelinuxx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26418.1</runtimelinuxx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
-    <runtimeosxarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26418.1</runtimeosxarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
-    <runtimeosxx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26418.1</runtimeosxx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
-    <runtimewinarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26418.1</runtimewinarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
-    <runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26418.1</runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
+    <runtimelinuxarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26457.5</runtimelinuxarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
+    <runtimelinuxmuslarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26457.5</runtimelinuxmuslarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
+    <runtimelinuxmuslx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26457.5</runtimelinuxmuslx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
+    <runtimelinuxx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26457.5</runtimelinuxx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
+    <runtimeosxarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26457.5</runtimeosxarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
+    <runtimeosxx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26457.5</runtimeosxx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
+    <runtimewinarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26457.5</runtimewinarm64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
+    <runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>11.0.0-alpha.1.26457.5</runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
     <!-- dotnet-optimization dependencies -->
     <optimizationlinuxarm64MIBCRuntimePackageVersion>1.0.0-prerelease.26451.1</optimizationlinuxarm64MIBCRuntimePackageVersion>
     <optimizationlinuxx64MIBCRuntimePackageVersion>1.0.0-prerelease.26451.1</optimizationlinuxx64MIBCRuntimePackageVersion>
@@ -150,6 +151,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftNETRuntimeEmscriptenInternalVersion>$(MicrosoftNETRuntimeEmscriptenInternalPackageVersion)</MicrosoftNETRuntimeEmscriptenInternalVersion>
     <MicrosoftNETSdkILVersion>$(MicrosoftNETSdkILPackageVersion)</MicrosoftNETSdkILVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportPackageVersion)</MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportVersion>
+    <MicrosoftNETWorkloadEmscriptenCurrentManifest120100alpha1Version>$(MicrosoftNETWorkloadEmscriptenCurrentManifest120100alpha1PackageVersion)</MicrosoftNETWorkloadEmscriptenCurrentManifest120100alpha1Version>
     <MicrosoftNETCoreAppRefVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETCoreILAsmPackageVersion)</MicrosoftNETCoreILAsmVersion>
     <NuGetFrameworksVersion>$(NuGetFrameworksPackageVersion)</NuGetFrameworksVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -49,9 +49,13 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.Emscripten.Internal" Version="11.0.0-rc.1.26431.109">
+    <Dependency Name="Microsoft.NET.Runtime.Emscripten.Internal" Version="12.0.0-alpha.1.26457.113">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+      <Sha>3164ceae6856b7152b1ce6411c49605f2acd4755</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-12.0.100-alpha.1" Version="12.0.100-alpha.1.26457.113">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>3164ceae6856b7152b1ce6411c49605f2acd4755</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
@@ -377,37 +381,37 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26418.1">
+    <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26457.5">
       <Uri>https://github.com/dotnet/node</Uri>
-      <Sha>c11a7ade99acf4b7981546cde3ac1827b961afc1</Sha>
+      <Sha>9ed7febc29268b77525c4f71eef0598f126b0af6</Sha>
     </Dependency>
-    <Dependency Name="runtime.linux-musl-arm64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26418.1">
+    <Dependency Name="runtime.linux-musl-arm64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26457.5">
       <Uri>https://github.com/dotnet/node</Uri>
-      <Sha>c11a7ade99acf4b7981546cde3ac1827b961afc1</Sha>
+      <Sha>9ed7febc29268b77525c4f71eef0598f126b0af6</Sha>
     </Dependency>
-    <Dependency Name="runtime.linux-x64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26418.1">
+    <Dependency Name="runtime.linux-x64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26457.5">
       <Uri>https://github.com/dotnet/node</Uri>
-      <Sha>c11a7ade99acf4b7981546cde3ac1827b961afc1</Sha>
+      <Sha>9ed7febc29268b77525c4f71eef0598f126b0af6</Sha>
     </Dependency>
-    <Dependency Name="runtime.linux-musl-x64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26418.1">
+    <Dependency Name="runtime.linux-musl-x64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26457.5">
       <Uri>https://github.com/dotnet/node</Uri>
-      <Sha>c11a7ade99acf4b7981546cde3ac1827b961afc1</Sha>
+      <Sha>9ed7febc29268b77525c4f71eef0598f126b0af6</Sha>
     </Dependency>
-    <Dependency Name="runtime.osx-arm64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26418.1">
+    <Dependency Name="runtime.osx-arm64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26457.5">
       <Uri>https://github.com/dotnet/node</Uri>
-      <Sha>c11a7ade99acf4b7981546cde3ac1827b961afc1</Sha>
+      <Sha>9ed7febc29268b77525c4f71eef0598f126b0af6</Sha>
     </Dependency>
-    <Dependency Name="runtime.osx-x64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26418.1">
+    <Dependency Name="runtime.osx-x64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26457.5">
       <Uri>https://github.com/dotnet/node</Uri>
-      <Sha>c11a7ade99acf4b7981546cde3ac1827b961afc1</Sha>
+      <Sha>9ed7febc29268b77525c4f71eef0598f126b0af6</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-arm64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26418.1">
+    <Dependency Name="runtime.win-arm64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26457.5">
       <Uri>https://github.com/dotnet/node</Uri>
-      <Sha>c11a7ade99acf4b7981546cde3ac1827b961afc1</Sha>
+      <Sha>9ed7febc29268b77525c4f71eef0598f126b0af6</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-x64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26418.1">
+    <Dependency Name="runtime.win-x64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="11.0.0-alpha.1.26457.5">
       <Uri>https://github.com/dotnet/node</Uri>
-      <Sha>c11a7ade99acf4b7981546cde3ac1827b961afc1</Sha>
+      <Sha>9ed7febc29268b77525c4f71eef0598f126b0af6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.HostModel.TestData" Version="11.0.0-beta.26426.1">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -187,4 +187,10 @@
     <MicrosoftWixToolsetHeatVersion>6.0.3-dotnet.6</MicrosoftWixToolsetHeatVersion>
   </PropertyGroup>
 
+  <!-- Validation-only: use the VMR's manifest band without changing the existing .NET SDK host. -->
+  <PropertyGroup Condition="'$(MicrosoftNETWorkloadEmscriptenCurrentManifest120100alpha1PackageVersion)' == '12.0.100-alpha.1.26457.113'">
+    <SdkBandVersionForWorkload_FromRuntimeVersions>12.0.100-alpha.1</SdkBandVersionForWorkload_FromRuntimeVersions>
+    <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest120100alpha1PackageVersion)</MicrosoftNETRuntimeEmscriptenVersion>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
## Description

This validates the npm 11.19.1 update in dotnet/node#396 through the standard runtime WASM PR pipelines. It updates all eight Node transports to `11.0.0-alpha.1.26457.5` from BAR `330858` and consumes Emscripten packages from VMR BAR `330868` through `General Testing`. The validation-only manifest-band override selects the published .NET 12-branded workload packages while retaining the existing .NET 11 SDK host and leaving `global.json` unchanged.

The official Node build succeeds at https://dev.azure.com/dnceng/internal/_build/results?buildId=3068942 and the official VMR build succeeds at https://dev.azure.com/dnceng/internal/_build/results?buildId=3069115. Publication at https://dev.azure.com/dnceng/internal/_build/results?buildId=3069257 completes package and blob publication but fails while downloading an SDK PDB. All required Emscripten packs and workload manifests are available in the testing feed. BAR `330868` is assigned to `General Testing` without repeating artifact publication.

This draft is for CI validation only and must not merge while it references `General Testing`.

Contributes to dotnet/node#396

> [!NOTE]
> This pull request description and its changes were generated with GitHub Copilot.