### PR TITLE
Track NativeAOT BestFitMapping failures with a dedicated issue

### DIFF
--- a/src/tests/Interop/PInvoke/BestFitMapping/Program.cs
+++ b/src/tests/Interop/PInvoke/BestFitMapping/Program.cs
@@ -13,7 +13,7 @@ public class Program
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Mono doesn't support interop BestFitMapping and ThrowOnUnmappableChar attributes")]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/155", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/133395", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
     public static void TestEntryPoint()
     {


### PR DESCRIPTION
This test looks to be hitting some legit bugs (not just throwing the "Marshalling not supported").
