### PR TITLE
Reject WinRT metadata types in compiler type validation

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
@@ -321,6 +321,11 @@ namespace ILCompiler
                 // Validate classes, structs, enums, interfaces, and delegates
                 Debug.Assert(type.IsDefType);
 
+                if (type.IsWindowsRuntime)
+                {
+                    ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+                }
+
                 // Don't validate generic definitions much other than by checking for illegal recursion.
                 if (type.IsGenericDefinition)
                 {

--- a/src/tests/Interop/WinRT/Program.cs
+++ b/src/tests/Interop/WinRT/Program.cs
@@ -18,11 +18,9 @@ namespace WinRT
 
         [Fact]
         [SkipOnMono("WinRT interop was never supported on Mono, so blocking loading WinRT types was never added.")]
-        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/182", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
         public static void CannotLoadWinRTType()
         {
             Assert.Throws<TypeLoadException>(() => ObjectIsI(new object()));
         }
     }
 }
-


### PR DESCRIPTION
This is a trivial fix and lets us get rid of native AOT special casing (that I'm auditing for right now and might do that in the future too).

Match CoreCLR's TypeLoadException rejection of WindowsRuntime types and enable the NativeAOT WinRT regression test.

Resolves https://github.com/dotnet/runtimelab/issues/182