### PR TITLE
Narrow NativeAOT interop test exclusions

### DIFF
--- a/src/tests/Interop/BestFitMapping/BestFitMapping.cs
+++ b/src/tests/Interop/BestFitMapping/BestFitMapping.cs
@@ -912,7 +912,11 @@ public class BestFitMapping
 
         //Cdecl Delegate
         DoCCallBack_LPSTR_In(new CCallBackIn(TestMethod_CCallBackIn));
-        DoCCallBack_LPSTR_Out(new CCallBackOut(TestMethod_CCallBackOut));
+        // https://github.com/dotnet/runtime/issues/123529
+        if (!Utilities.IsNativeAot)
+        {
+            DoCCallBack_LPSTR_Out(new CCallBackOut(TestMethod_CCallBackOut));
+        }
         DoCCallBack_LPSTR_InOut(new CCallBackInOut(TestMethod_CCallBackInOut));
 
         DoCCallBack_LPSTR_InByRef(new CCallBackInByRef(TestMethod_CCallBackInByRef));
@@ -922,7 +926,11 @@ public class BestFitMapping
 
         //Stdcall Delegate
         DoSCallBack_LPSTR_In(new SCallBackIn(TestMethod_SCallBackIn));
-        DoSCallBack_LPSTR_Out(new SCallBackOut(TestMethod_SCallBackOut));
+        // https://github.com/dotnet/runtime/issues/123529
+        if (!Utilities.IsNativeAot)
+        {
+            DoSCallBack_LPSTR_Out(new SCallBackOut(TestMethod_SCallBackOut));
+        }
         DoSCallBack_LPSTR_InOut(new SCallBackInOut(TestMethod_SCallBackInOut));
 
         DoSCallBack_LPSTR_InByRef(new SCallBackInByRef(TestMethod_SCallBackInByRef));

--- a/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
+++ b/src/tests/Interop/BestFitMapping/BestFitMapping.csproj
@@ -8,8 +8,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- https://github.com/dotnet/runtimelab/issues/180 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
@@ -70,7 +70,11 @@ public class Managed
         RunMarshalSeqStructAsParamByValInOut();
         RunMarshalSeqStructAsParamByRefInOut();
         RunMarshalSeqStructAsReturn();
-        RunMarshalSeqStructDelegateField();
+        // System.Delegate fields: https://github.com/dotnet/runtime/issues/69919
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            RunMarshalSeqStructDelegateField();
+        }
 
         if (failures > 0)
         {
@@ -2433,8 +2437,12 @@ public class Managed
 #endif
         MarshalStructAsParam_AsSeqByVal(StructID.StringStructSequentialAnsiId);
         MarshalStructAsParam_AsSeqByVal(StructID.StringStructSequentialUnicodeId);
-        MarshalStructAsParam_AsSeqByVal(StructID.S8Id);
-        MarshalStructAsParam_AsSeqByVal(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            MarshalStructAsParam_AsSeqByVal(StructID.S8Id);
+            MarshalStructAsParam_AsSeqByVal(StructID.S9Id);
+        }
         MarshalStructAsParam_AsSeqByVal(StructID.IncludeOuterIntegerStructSequentialId);
         MarshalStructAsParam_AsSeqByVal(StructID.S11Id);
         MarshalStructAsParam_AsSeqByVal(StructID.AutoStringId);
@@ -2466,8 +2474,12 @@ public class Managed
 #endif
         MarshalStructAsParam_AsSeqByRef(StructID.StringStructSequentialAnsiId);
         MarshalStructAsParam_AsSeqByRef(StructID.StringStructSequentialUnicodeId);
-        MarshalStructAsParam_AsSeqByRef(StructID.S8Id);
-        MarshalStructAsParam_AsSeqByRef(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            MarshalStructAsParam_AsSeqByRef(StructID.S8Id);
+            MarshalStructAsParam_AsSeqByRef(StructID.S9Id);
+        }
         MarshalStructAsParam_AsSeqByRef(StructID.IncludeOuterIntegerStructSequentialId);
         MarshalStructAsParam_AsSeqByRef(StructID.S11Id);
     }
@@ -2489,8 +2501,12 @@ public class Managed
 #endif
         MarshalStructAsParam_AsSeqByValIn(StructID.StringStructSequentialAnsiId);
         MarshalStructAsParam_AsSeqByValIn(StructID.StringStructSequentialUnicodeId);
-        MarshalStructAsParam_AsSeqByValIn(StructID.S8Id);
-        MarshalStructAsParam_AsSeqByValIn(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            MarshalStructAsParam_AsSeqByValIn(StructID.S8Id);
+            MarshalStructAsParam_AsSeqByValIn(StructID.S9Id);
+        }
         MarshalStructAsParam_AsSeqByValIn(StructID.IncludeOuterIntegerStructSequentialId);
         MarshalStructAsParam_AsSeqByValIn(StructID.S11Id);
     }
@@ -2512,8 +2528,12 @@ public class Managed
 #endif
         MarshalStructAsParam_AsSeqByRefIn(StructID.StringStructSequentialAnsiId);
         MarshalStructAsParam_AsSeqByRefIn(StructID.StringStructSequentialUnicodeId);
-        MarshalStructAsParam_AsSeqByRefIn(StructID.S8Id);
-        MarshalStructAsParam_AsSeqByRefIn(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            MarshalStructAsParam_AsSeqByRefIn(StructID.S8Id);
+            MarshalStructAsParam_AsSeqByRefIn(StructID.S9Id);
+        }
         MarshalStructAsParam_AsSeqByRefIn(StructID.IncludeOuterIntegerStructSequentialId);
         MarshalStructAsParam_AsSeqByRefIn(StructID.S11Id);
     }
@@ -2535,8 +2555,12 @@ public class Managed
 #endif
         MarshalStructAsParam_AsSeqByValOut(StructID.StringStructSequentialAnsiId);
         MarshalStructAsParam_AsSeqByValOut(StructID.StringStructSequentialUnicodeId);
-        MarshalStructAsParam_AsSeqByValOut(StructID.S8Id);
-        MarshalStructAsParam_AsSeqByValOut(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            MarshalStructAsParam_AsSeqByValOut(StructID.S8Id);
+            MarshalStructAsParam_AsSeqByValOut(StructID.S9Id);
+        }
         MarshalStructAsParam_AsSeqByValOut(StructID.IncludeOuterIntegerStructSequentialId);
         MarshalStructAsParam_AsSeqByValOut(StructID.S11Id);
     }
@@ -2558,8 +2582,12 @@ public class Managed
 #endif
         MarshalStructAsParam_AsSeqByRefOut(StructID.StringStructSequentialAnsiId);
         MarshalStructAsParam_AsSeqByRefOut(StructID.StringStructSequentialUnicodeId);
-        MarshalStructAsParam_AsSeqByRefOut(StructID.S8Id);
-        MarshalStructAsParam_AsSeqByRefOut(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            MarshalStructAsParam_AsSeqByRefOut(StructID.S8Id);
+            MarshalStructAsParam_AsSeqByRefOut(StructID.S9Id);
+        }
         MarshalStructAsParam_AsSeqByRefOut(StructID.IncludeOuterIntegerStructSequentialId);
         MarshalStructAsParam_AsSeqByRefOut(StructID.S11Id);
     }
@@ -2581,8 +2609,12 @@ public class Managed
 #endif
         MarshalStructAsParam_AsSeqByValInOut(StructID.StringStructSequentialAnsiId);
         MarshalStructAsParam_AsSeqByValInOut(StructID.StringStructSequentialUnicodeId);
-        MarshalStructAsParam_AsSeqByValInOut(StructID.S8Id);
-        MarshalStructAsParam_AsSeqByValInOut(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            MarshalStructAsParam_AsSeqByValInOut(StructID.S8Id);
+            MarshalStructAsParam_AsSeqByValInOut(StructID.S9Id);
+        }
         MarshalStructAsParam_AsSeqByValInOut(StructID.IncludeOuterIntegerStructSequentialId);
         MarshalStructAsParam_AsSeqByValInOut(StructID.S11Id);
     }
@@ -2604,8 +2636,12 @@ public class Managed
 #endif
         MarshalStructAsParam_AsSeqByRefInOut(StructID.StringStructSequentialAnsiId);
         MarshalStructAsParam_AsSeqByRefInOut(StructID.StringStructSequentialUnicodeId);
-        MarshalStructAsParam_AsSeqByRefInOut(StructID.S8Id);
-        MarshalStructAsParam_AsSeqByRefInOut(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            MarshalStructAsParam_AsSeqByRefInOut(StructID.S8Id);
+            MarshalStructAsParam_AsSeqByRefInOut(StructID.S9Id);
+        }
         MarshalStructAsParam_AsSeqByRefInOut(StructID.IncludeOuterIntegerStructSequentialId);
         MarshalStructAsParam_AsSeqByRefInOut(StructID.S11Id);
     }

--- a/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
+++ b/src/tests/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.csproj
@@ -6,8 +6,6 @@
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/runtimelab/issues/180 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MarshalStructAsLayoutSeq.cs" />

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.cs
@@ -1348,8 +1348,12 @@ public class MarshalStructTest
         TestMethod_DelegatePInvoke_MarshalByRef_Cdecl(StructID.S5Id);
         TestMethod_DelegatePInvoke_MarshalByRef_Cdecl(StructID.StringStructSequentialAnsiId);
         TestMethod_DelegatePInvoke_MarshalByRef_Cdecl(StructID.StringStructSequentialUnicodeId);
-        TestMethod_DelegatePInvoke_MarshalByRef_Cdecl(StructID.S8Id);
-        TestMethod_DelegatePInvoke_MarshalByRef_Cdecl(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!Utilities.IsNativeAot)
+        {
+            TestMethod_DelegatePInvoke_MarshalByRef_Cdecl(StructID.S8Id);
+            TestMethod_DelegatePInvoke_MarshalByRef_Cdecl(StructID.S9Id);
+        }
         TestMethod_DelegatePInvoke_MarshalByRef_Cdecl(StructID.IncludeOuterIntegerStructSequentialId);
         TestMethod_DelegatePInvoke_MarshalByRef_Cdecl(StructID.S11Id);
     }
@@ -1366,8 +1370,12 @@ public class MarshalStructTest
         TestMethod_DelegatePInvoke_MarshalByRef_StdCall(StructID.S5Id);
         TestMethod_DelegatePInvoke_MarshalByRef_StdCall(StructID.StringStructSequentialAnsiId);
         TestMethod_DelegatePInvoke_MarshalByRef_StdCall(StructID.StringStructSequentialUnicodeId);
-        TestMethod_DelegatePInvoke_MarshalByRef_StdCall(StructID.S8Id);
-        TestMethod_DelegatePInvoke_MarshalByRef_StdCall(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!Utilities.IsNativeAot)
+        {
+            TestMethod_DelegatePInvoke_MarshalByRef_StdCall(StructID.S8Id);
+            TestMethod_DelegatePInvoke_MarshalByRef_StdCall(StructID.S9Id);
+        }
         TestMethod_DelegatePInvoke_MarshalByRef_StdCall(StructID.IncludeOuterIntegerStructSequentialId);
         TestMethod_DelegatePInvoke_MarshalByRef_StdCall(StructID.S11Id);
     }
@@ -1388,8 +1396,12 @@ public class MarshalStructTest
         TestMethod_DelegatePInvoke_MarshalByVal_Cdecl(StructID.S5Id);
         TestMethod_DelegatePInvoke_MarshalByVal_Cdecl(StructID.StringStructSequentialAnsiId);
         TestMethod_DelegatePInvoke_MarshalByVal_Cdecl(StructID.StringStructSequentialUnicodeId);
-        TestMethod_DelegatePInvoke_MarshalByVal_Cdecl(StructID.S8Id);
-        TestMethod_DelegatePInvoke_MarshalByVal_Cdecl(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!Utilities.IsNativeAot)
+        {
+            TestMethod_DelegatePInvoke_MarshalByVal_Cdecl(StructID.S8Id);
+            TestMethod_DelegatePInvoke_MarshalByVal_Cdecl(StructID.S9Id);
+        }
         TestMethod_DelegatePInvoke_MarshalByVal_Cdecl(StructID.IncludeOuterIntegerStructSequentialId);
         TestMethod_DelegatePInvoke_MarshalByVal_Cdecl(StructID.S11Id);
     }
@@ -1406,8 +1418,12 @@ public class MarshalStructTest
         TestMethod_DelegatePInvoke_MarshalByVal_StdCall(StructID.S5Id);
         TestMethod_DelegatePInvoke_MarshalByVal_StdCall(StructID.StringStructSequentialAnsiId);
         TestMethod_DelegatePInvoke_MarshalByVal_StdCall(StructID.StringStructSequentialUnicodeId);
-        TestMethod_DelegatePInvoke_MarshalByVal_StdCall(StructID.S8Id);
-        TestMethod_DelegatePInvoke_MarshalByVal_StdCall(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!Utilities.IsNativeAot)
+        {
+            TestMethod_DelegatePInvoke_MarshalByVal_StdCall(StructID.S8Id);
+            TestMethod_DelegatePInvoke_MarshalByVal_StdCall(StructID.S9Id);
+        }
         TestMethod_DelegatePInvoke_MarshalByVal_StdCall(StructID.IncludeOuterIntegerStructSequentialId);
         TestMethod_DelegatePInvoke_MarshalByVal_StdCall(StructID.S11Id);
     }

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest.csproj
@@ -6,8 +6,6 @@
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/runtimelab/issues/180 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DelegatePInvokeTest.cs" />

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest.csproj
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest.csproj
@@ -6,8 +6,6 @@
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- https://github.com/dotnet/runtimelab/issues/180 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ReversePInvokeTest_.cs" />

--- a/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest_.cs
+++ b/src/tests/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke/ReversePInvokeTest_.cs
@@ -1606,8 +1606,12 @@ public class MarshalStructTest
         TestMethod_DoCallBack_MarshalStructByRef_Cdecl(StructID.S5Id);
         TestMethod_DoCallBack_MarshalStructByRef_Cdecl(StructID.StringStructSequentialAnsiId);
         TestMethod_DoCallBack_MarshalStructByRef_Cdecl(StructID.StringStructSequentialUnicodeId);
-        TestMethod_DoCallBack_MarshalStructByRef_Cdecl(StructID.S8Id);
-        TestMethod_DoCallBack_MarshalStructByRef_Cdecl(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!Utilities.IsNativeAot)
+        {
+            TestMethod_DoCallBack_MarshalStructByRef_Cdecl(StructID.S8Id);
+            TestMethod_DoCallBack_MarshalStructByRef_Cdecl(StructID.S9Id);
+        }
         TestMethod_DoCallBack_MarshalStructByRef_Cdecl(StructID.IncludeOuterIntegerStructSequentialId);
         TestMethod_DoCallBack_MarshalStructByRef_Cdecl(StructID.S11Id);
     }
@@ -1624,8 +1628,12 @@ public class MarshalStructTest
         TestMethod_DoCallBack_MarshalStructByRef_StdCall(StructID.S5Id);
         TestMethod_DoCallBack_MarshalStructByRef_StdCall(StructID.StringStructSequentialAnsiId);
         TestMethod_DoCallBack_MarshalStructByRef_StdCall(StructID.StringStructSequentialUnicodeId);
-        TestMethod_DoCallBack_MarshalStructByRef_StdCall(StructID.S8Id);
-        TestMethod_DoCallBack_MarshalStructByRef_StdCall(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!Utilities.IsNativeAot)
+        {
+            TestMethod_DoCallBack_MarshalStructByRef_StdCall(StructID.S8Id);
+            TestMethod_DoCallBack_MarshalStructByRef_StdCall(StructID.S9Id);
+        }
         TestMethod_DoCallBack_MarshalStructByRef_StdCall(StructID.IncludeOuterIntegerStructSequentialId);
         TestMethod_DoCallBack_MarshalStructByRef_StdCall(StructID.S11Id);
     }
@@ -1797,8 +1805,12 @@ public class MarshalStructTest
         TestMethod_DoCallBack_MarshalStructByVal_Cdecl(StructID.S5Id);
         TestMethod_DoCallBack_MarshalStructByVal_Cdecl(StructID.StringStructSequentialAnsiId);
         TestMethod_DoCallBack_MarshalStructByVal_Cdecl(StructID.StringStructSequentialUnicodeId);
-        TestMethod_DoCallBack_MarshalStructByVal_Cdecl(StructID.S8Id);
-        TestMethod_DoCallBack_MarshalStructByVal_Cdecl(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!Utilities.IsNativeAot)
+        {
+            TestMethod_DoCallBack_MarshalStructByVal_Cdecl(StructID.S8Id);
+            TestMethod_DoCallBack_MarshalStructByVal_Cdecl(StructID.S9Id);
+        }
         TestMethod_DoCallBack_MarshalStructByVal_Cdecl(StructID.IncludeOuterIntegerStructSequentialId);
         TestMethod_DoCallBack_MarshalStructByVal_Cdecl(StructID.S11Id);
         // Windows X86 has a long standing X86_ONLY logic that causes 3, 5,6,7 byte structure returns to behave incorrectly.
@@ -1820,8 +1832,12 @@ public class MarshalStructTest
         TestMethod_DoCallBack_MarshalStructByVal_StdCall(StructID.S5Id);
         TestMethod_DoCallBack_MarshalStructByVal_StdCall(StructID.StringStructSequentialAnsiId);
         TestMethod_DoCallBack_MarshalStructByVal_StdCall(StructID.StringStructSequentialUnicodeId);
-        TestMethod_DoCallBack_MarshalStructByVal_StdCall(StructID.S8Id);
-        TestMethod_DoCallBack_MarshalStructByVal_StdCall(StructID.S9Id);
+        // UnmanagedType.Error: https://github.com/dotnet/runtime/issues/69919
+        if (!Utilities.IsNativeAot)
+        {
+            TestMethod_DoCallBack_MarshalStructByVal_StdCall(StructID.S8Id);
+            TestMethod_DoCallBack_MarshalStructByVal_StdCall(StructID.S9Id);
+        }
         TestMethod_DoCallBack_MarshalStructByVal_StdCall(StructID.IncludeOuterIntegerStructSequentialId);
         TestMethod_DoCallBack_MarshalStructByVal_StdCall(StructID.S11Id);
         // Windows X86 has a long standing X86_ONLY logic that causes 3, 5,6,7 byte structure returns to behave incorrectly.


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtimelab/issues/180.

Replace project-wide exclusions with inline guards for UnmanagedType.Error, System.Delegate fields, and unsupported StringBuilder callbacks, retaining unrelated marshalling coverage.

We should run all interop testing we can run. We may never implement the things triggering the disablement.