### PR TITLE
Enable supported UnmanagedCallersOnly tests on NativeAOT

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/UnmanagedCallingConventions.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/UnmanagedCallingConventions.cs
@@ -94,6 +94,10 @@ namespace Internal.TypeSystem
 
         public static UnmanagedCallingConventions GetUnmanagedCallersOnlyMethodCallingConventions(this MethodDesc method)
         {
+            // Generic methods and types are invalid here, but must not crash the compiler
+            // when reading the attribute from an instantiated method.
+            method = method.GetTypicalMethodDefinition();
+
             Debug.Assert(method.IsUnmanagedCallersOnly);
             CustomAttributeValue<TypeDesc> unmanagedCallersOnlyAttribute = ((EcmaMethod)method).GetDecodedCustomAttribute("System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute").Value;
             return GetUnmanagedCallingConventionFromAttribute(unmanagedCallersOnlyAttribute, method.Context) & ~UnmanagedCallingConventions.IsSuppressGcTransition;

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyNegativeTest.csproj
@@ -4,9 +4,9 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
-    <NativeAotIncompatible>true</NativeAotIncompatible>
     <CLRTestExitCode>134</CLRTestExitCode>
     <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true'">-2146233082</CLRTestExitCode>
+    <CLRTestExitCode Condition="'$(TestWrapperTargetsWindows)' == 'true' and '$(TestBuildMode)' == 'nativeaot'">-1073740286</CLRTestExitCode>
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">true</CLRTestTargetUnsupported>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
@@ -54,7 +54,8 @@ public unsafe class Program
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/57362", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoFULLAOT))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/64127", typeof(PlatformDetection), nameof(PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-    [Fact]
+    // On NativeAOT, this fails because the exception escapes the native UnmanagedCallersOnly transition.
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
     public static void NegativeTest_NonStaticMethod()
     {
         Console.WriteLine($"Running {nameof(NegativeTest_NonStaticMethod)}...");
@@ -72,7 +73,8 @@ public unsafe class Program
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/57362", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoFULLAOT))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/64127", typeof(PlatformDetection), nameof(PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-    [Fact]
+    // On NativeAOT, this fails because the exception escapes the native UnmanagedCallersOnly transition.
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
     public static void NegativeTest_NonBlittable()
     {
         Console.WriteLine($"Running {nameof(NegativeTest_NonBlittable)}...");
@@ -87,7 +89,8 @@ public unsafe class Program
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/57362", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoFULLAOT))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/64127", typeof(PlatformDetection), nameof(PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-    [Fact]
+    // On NativeAOT, this fails because the exception escapes the native UnmanagedCallersOnly transition.
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
     public static void NegativeTest_InstantiatedGenericArguments()
     {
         Console.WriteLine($"Running {nameof(NegativeTest_InstantiatedGenericArguments)}...");
@@ -99,7 +102,8 @@ public unsafe class Program
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/57362", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoFULLAOT))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/64127", typeof(PlatformDetection), nameof(PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-    [Fact]
+    // On NativeAOT, this fails because the exception escapes the native UnmanagedCallersOnly transition.
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
     public static void NegativeTest_FromInstantiatedGenericClass()
     {
         Console.WriteLine($"Running {nameof(NegativeTest_FromInstantiatedGenericClass)}...");
@@ -155,7 +159,8 @@ public unsafe class Program
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/57362", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoFULLAOT))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/64127", typeof(PlatformDetection), nameof(PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-    [Fact]
+    // On NativeAOT, calling a P/Invoke marked UnmanagedCallersOnly from managed code fails fast.
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
     public static void TestPInvokeMarkedWithUnmanagedCallersOnly()
     {
         Console.WriteLine($"Running {nameof(TestPInvokeMarkedWithUnmanagedCallersOnly)}...");
@@ -182,16 +187,21 @@ public unsafe class Program
         Assert.Equal(0, ((delegate* unmanaged<MaybeBlittable<nint>, int>)&MaybeBlittableGenericStruct)(new MaybeBlittable<nint>()));
 
 
-        Assert.Throws<InvalidProgramException>(()
-            => ((delegate* unmanaged<nint, int>)(void*)(delegate* unmanaged<NotBlittable<int>, int>)&InvalidGenericUnmanagedCallersOnlyParameters.GenericClass)((nint)1));
+        // On NativeAOT, this fails because the exception escapes the native UnmanagedCallersOnly transition.
+        if (TestLibrary.Utilities.IsNotNativeAot)
+        {
+            Assert.Throws<InvalidProgramException>(()
+                => ((delegate* unmanaged<nint, int>)(void*)(delegate* unmanaged<NotBlittable<int>, int>)&InvalidGenericUnmanagedCallersOnlyParameters.GenericClass)((nint)1));
 
-        Assert.Throws<InvalidProgramException>(()
-            => ((delegate* unmanaged<nint, int>)(void*)(delegate* unmanaged<MaybeBlittable<object>, int>)&InvalidGenericUnmanagedCallersOnlyParameters.GenericStructWithObjectField)((nint)1));
+            Assert.Throws<InvalidProgramException>(()
+                => ((delegate* unmanaged<nint, int>)(void*)(delegate* unmanaged<MaybeBlittable<object>, int>)&InvalidGenericUnmanagedCallersOnlyParameters.GenericStructWithObjectField)((nint)1));
+        }
     }
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/57362", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoFULLAOT))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/64127", typeof(PlatformDetection), nameof(PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-    [Fact]
+    // On NativeAOT, the Task-returning calli throws MarshalDirectiveException before validating UnmanagedCallersOnly.
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
     [SkipOnMono("Mono doesn't support runtime async and doesn't check the async bit.")]
     public static void TestUnmanagedCallersOnlyWithRuntimeAsync()
     {

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
@@ -3,11 +3,10 @@
     <!-- No test-specific corerun on wasm: the generator or the wasm linker rejects this test's
          native interop surface. Native-dependent tests skip instead. Tracked by https://github.com/dotnet/runtime/issues/131811 -->
     <WasmBuildTestCorerun Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'">false</WasmBuildTestCorerun>
-    <!-- Needed for NativeAotIncompatible, CMakeProjectReference -->
+    <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="UnmanagedCallersOnlyTest.cs" />


### PR DESCRIPTION
Normalize methods to their typical definitions before reading calling conventions to avoid compiler crashes on invalid generic declarations.

Replace project-wide exclusions with conditions on reproduced failing cases, preserve valid callback coverage, and set the NativeAOT-specific fatal exit code for the negative test.

The remaining disabled tests look like variations of https://github.com/dotnet/runtime/issues/130233 that I'm not sure why they're passing with CoreCLR.