### PR TITLE
Align NativeAOT generic marshalling rejection with CoreCLR

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -247,6 +247,7 @@ namespace Internal.TypeSystem.Interop
                     // Allow ref returning blittable structs for IJW
                     if (type.IsValueType &&
                         (nativeType == NativeTypeKind.Struct || nativeType == NativeTypeKind.Default) &&
+                        IsValidForGenericMarshalling(type, isField) &&
                         MarshalUtils.IsBlittableType(type))
                     {
                         return MarshallerKind.BlittableValueClassByRefReturn;
@@ -665,6 +666,12 @@ namespace Internal.TypeSystem.Interop
             }
             else if (type.IsInterface)
             {
+                if (type.HasInstantiation)
+                {
+                    // Generic types cannot be marshaled.
+                    return MarshallerKind.Invalid;
+                }
+
                 if (context.Target.IsWindows)
                     return MarshallerKind.ComInterface;
                 else

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceB.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceB.cs
@@ -28,7 +28,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestIComInterfaceB()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetIComInterfaceB());

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceC.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceC.cs
@@ -28,7 +28,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestIComInterfaceC()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetIComInterfaceC());

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceD.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceD.cs
@@ -28,7 +28,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestIComInterfaceD()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetIComInterfaceD());

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceF.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceF.cs
@@ -28,7 +28,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestIComInterfaceF()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetIComInterfaceF());

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceL.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceL.cs
@@ -28,7 +28,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestIComInterfaceL()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetIComInterfaceL());

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceU.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.IComInterfaceU.cs
@@ -28,7 +28,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestIComInterfaceU()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetIComInterfaceU());

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.ReadOnlySpanD.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.ReadOnlySpanD.cs
@@ -26,7 +26,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestReadOnlySpanD()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetReadOnlySpanD(1.0));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.ReadOnlySpanF.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.ReadOnlySpanF.cs
@@ -26,7 +26,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestReadOnlySpanF()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetReadOnlySpanF(1.0f));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.ReadOnlySpanL.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.ReadOnlySpanL.cs
@@ -26,7 +26,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestReadOnlySpanL()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetReadOnlySpanL(1L));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.ReadOnlySpanU.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.ReadOnlySpanU.cs
@@ -26,7 +26,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestReadOnlySpanU()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetReadOnlySpanU(1u));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.SpanD.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.SpanD.cs
@@ -26,7 +26,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestSpanD()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetSpanD(1.0));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.SpanF.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.SpanF.cs
@@ -26,7 +26,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestSpanF()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetSpanF(1.0f));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.SpanL.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.SpanL.cs
@@ -26,7 +26,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestSpanL()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetSpanL(1L));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.SpanU.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.SpanU.cs
@@ -26,7 +26,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestSpanU()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetSpanU(1u));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128B.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128B.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector128B()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector128B(true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128C.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128C.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector128C()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector128C('0', '1', '2', '3', '4', '5', '6', '7'));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128D.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128D.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector128D()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector128D(1.0, 2.0));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128F.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128F.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector128F()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector128F(1.0f, 2.0f, 3.0f, 4.0f));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128L.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128L.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector128L()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector128L(1L, 2L));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128U.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector128U.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector128U()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector128U(1u, 2u, 3u, 4u));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256B.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256B.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsXArch))]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector256B()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector256B(true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false, true, false));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256C.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256C.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsXArch))]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector256C()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector256C('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256D.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256D.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsXArch))]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector256D()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector256D(1.0, 2.0, 3.0, 4.0));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256F.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256F.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsXArch))]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector256F()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector256F(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256L.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256L.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsXArch))]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector256L()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector256L(1L, 2L, 3L, 4L));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256U.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector256U.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsXArch))]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector256U()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector256U(1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64B.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64B.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector64B()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector64B(true, false, true, false, true, false, true, false));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64C.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64C.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector64C()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector64C('0', '1', '2', '3'));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64D.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64D.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector64D()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector64D(1.0));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64F.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64F.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector64F()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector64F(1.0f, 2.0f));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64L.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64L.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector64L()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector64L(1L));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64U.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.Vector64U.cs
@@ -39,7 +39,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVector64U()
     {
         Assert.Throws<MarshalDirectiveException>(() => GenericsNative.GetVector64U(1u, 2u));

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorB.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorB.cs
@@ -66,7 +66,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVectorB()
     {
         if (Vector<byte>.Count == 64)

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorC.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorC.cs
@@ -66,7 +66,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVectorC()
     {
         if (Vector<short>.Count == 32)

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorD.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorD.cs
@@ -66,7 +66,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVectorD()
     {
         if (Vector<double>.Count == 8)

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorF.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorF.cs
@@ -66,7 +66,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVectorF()
     {
         if (Vector<float>.Count == 16)

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorL.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorL.cs
@@ -66,7 +66,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVectorL()
     {
         if (Vector<long>.Count == 8)

--- a/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorU.cs
+++ b/src/tests/Interop/PInvoke/Generics/GenericsTest.VectorU.cs
@@ -66,7 +66,6 @@ unsafe partial class GenericsNative
 public unsafe partial class GenericsTest
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/177", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void TestVectorU()
     {
         if (Vector<uint>.Count == 16)


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtimelab/issues/177.

This was another wide disablement that got copypasted into tests that have nothing to do with COM. We should run them.

Reject generic interfaces and validate generic types before accepting blittable byref returns. Re-enable all 38 affected NativeAOT Generics tests.