### PR TITLE
Enable NativeAOT delegate function-pointer tests

### DIFF
--- a/src/tests/Interop/PInvoke/Delegate/DelegateTest.cs
+++ b/src/tests/Interop/PInvoke/Delegate/DelegateTest.cs
@@ -12,7 +12,6 @@ using TestLibrary;
 [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
 public class DelegateTest
 {
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/176: IDispatch", typeof(Utilities), nameof(Utilities.IsNativeAot))]
     [Fact]
     public static void TestFunctionPointer()
     {


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtimelab/issues/176.

Remove the misplaced IDispatch exclusion from TestFunctionPointer.