### PR TITLE
Enable NativeAOT callback stress coverage without SEH interop

### DIFF
--- a/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest.cs
+++ b/src/tests/Interop/NativeLibrary/Callback/CallbackStressTest.cs
@@ -37,7 +37,7 @@ public class CallbackStressTest
                         throw new ArgumentException();
                     }
 
-                    return NativeLibrary.Load(NativeLibraryToLoad.Name, asm, null);
+                    return NativeLibrary.Load(NativeLibraryToLoad.GetFullPath(), asm, null);
                 }
 
                 return IntPtr.Zero;
@@ -108,7 +108,7 @@ public class CallbackStressTest
     public static void ManualRaiseException()
     {
 #if WINDOWS
-        if (!TestLibrary.Utilities.IsMonoRuntime && !TestLibrary.Utilities.IsCoreClrInterpreter)
+        if (TestLibrary.PlatformDetection.IsExceptionInteropSupported)
         {
             try
             {
@@ -118,7 +118,7 @@ public class CallbackStressTest
         }
         else
         {
-            // SEH exception handling not supported on Mono.
+            // SEH exception handling is not supported on this runtime.
             s_SEHExceptionCatchCalled++;
         }
 #else
@@ -127,7 +127,6 @@ public class CallbackStressTest
 #endif
     }
 
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/166", typeof(Utilities), nameof(Utilities.IsNativeAot))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/64127", typeof(PlatformDetection), nameof(PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
     [ActiveIssue("Needs coreclr build", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoFULLAOT))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/54905", TestPlatforms.Android)]


### PR DESCRIPTION
Gate native exception propagation on IsExceptionInteropSupported instead of skipping the whole test. Use the existing native-library path helper so the resolver works with the NativeAOT test layout.