### PR TITLE
Exclude desktop certificate context test from mobile builds

### DIFF
--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -135,7 +135,7 @@
   </ItemGroup>
 
   <!-- Compiled on desktop only: crashes Apple-mobile CoreCLR at startup due to R2R IL-body stripping. -->
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows' or '$(TargetPlatformIdentifier)' == 'unix' or '$(TargetPlatformIdentifier)' == 'osx'">
+  <ItemGroup Condition="'$(TargetsMobile)' != 'true' and ('$(TargetPlatformIdentifier)' == 'windows' or '$(TargetPlatformIdentifier)' == 'unix' or '$(TargetPlatformIdentifier)' == 'osx')">
     <Compile Include="SslAuthenticationOptionsTests.Desktop.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
The desktop-only certificate-context ownership test is still compiled for tvOS because that build reports `TargetPlatformIdentifier=unix`. It then reaches an OpenSSL-specific path with an Apple ECDSA key and fails in runtime-extra-platforms.

Keep the existing desktop target-framework allowlist, but also require `TargetsMobile` to be false. This excludes tvOS and other mobile builds without broadening the test to iOS, Android, or browser inner builds.

Validation:
- Confirmed the file is included for the Windows desktop target.
- Confirmed the file is excluded for tvOS (`TargetsMobile=true`, `TargetPlatformIdentifier=unix`).
- Confirmed the file is excluded for an iOS inner build.
- `System.Net.Security.Unit.Tests`: 121 passed, 0 failed, 4 skipped.

Fixes: #133234

> [!NOTE]
> This pull request description was generated with GitHub Copilot.