### PR TITLE
Fix MIME encoded-word decoding

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/ContentDisposition.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/ContentDisposition.cs
@@ -223,8 +223,7 @@ namespace System.Net.Mime
 
         private static void EncodeToBuffer(string value, StringBuilder builder, bool allowUnicode)
         {
-            Encoding? encoding = MimeBasePart.DecodeEncoding(value);
-            if (encoding != null) // Manually encoded elsewhere, pass through
+            if (MimeBasePart.IsFullyEncoded(value)) // Manually encoded elsewhere, pass through
             {
                 builder.Append('"').Append(value).Append('"');
             }
@@ -236,7 +235,7 @@ namespace System.Net.Mime
             else
             {
                 // MIME Encoding required
-                encoding = Encoding.GetEncoding(MimeBasePart.DefaultCharSet);
+                Encoding encoding = Encoding.GetEncoding(MimeBasePart.DefaultCharSet);
                 builder.Append('"').Append(MimeBasePart.EncodeHeaderValue(value, encoding, MimeBasePart.ShouldUseBase64Encoding(encoding))).Append('"');
             }
         }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/ContentType.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/ContentType.cs
@@ -191,8 +191,7 @@ namespace System.Net.Mime
 
         private static void EncodeToBuffer(string value, StringBuilder builder, bool allowUnicode)
         {
-            Encoding? encoding = MimeBasePart.DecodeEncoding(value);
-            if (encoding != null) // Manually encoded elsewhere, pass through
+            if (MimeBasePart.IsFullyEncoded(value)) // Manually encoded elsewhere, pass through
             {
                 builder.Append('\"').Append(value).Append('"');
             }
@@ -204,7 +203,7 @@ namespace System.Net.Mime
             else
             {
                 // MIME Encoding required
-                encoding = Encoding.GetEncoding(MimeBasePart.DefaultCharSet);
+                Encoding encoding = Encoding.GetEncoding(MimeBasePart.DefaultCharSet);
                 builder.Append('"').Append(MimeBasePart.EncodeHeaderValue(value, encoding, MimeBasePart.ShouldUseBase64Encoding(encoding))).Append('"');
             }
         }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
@@ -43,8 +43,6 @@ namespace System.Net.Mime
             return stream.GetEncodedString();
         }
 
-        private static readonly char[] s_headerValueSplitChars = new char[] { '\r', '\n', ' ' };
-
         internal static string DecodeHeaderValue(string? value)
         {
             if (string.IsNullOrEmpty(value))
@@ -52,45 +50,60 @@ namespace System.Net.Mime
                 return string.Empty;
             }
 
-            string newValue = string.Empty;
+            StringBuilder decodedValue = new StringBuilder(value.Length);
+            ReadOnlySpan<char> valueSpan = value;
+            bool decodedAny = false;
+            bool previousTokenWasEncoded = false;
+            int current = 0;
 
-            //split strings, they may be folded.  If they are, decode one at a time and append the results
-            string[] substringsToDecode = value.Split(s_headerValueSplitChars, StringSplitOptions.RemoveEmptyEntries);
-
-            foreach (string foldedSubString in substringsToDecode)
+            while (current < valueSpan.Length)
             {
-                //an encoded string has as specific format in that it must start and end with an
-                //'=' char and contains five parts, separated by '?' chars.
-                //the first and last part are therefore '=', the second part is the byte encoding (B or Q)
-                //the third is the unicode encoding type, and the fourth is encoded message itself.  '?' is not valid inside of
-                //an encoded string other than as a separator for these five parts.
-                //If this check fails, the string is either not encoded or cannot be decoded by this method
-                string[] subStrings = foldedSubString.Split('?');
-                if ((subStrings.Length != 5 || subStrings[0] != "=" || subStrings[4] != "="))
+                int whitespaceStart = current;
+                while (current < valueSpan.Length && IsLinearWhiteSpace(valueSpan[current]))
                 {
-                    return value;
+                    current++;
                 }
 
-                string charSet = subStrings[1];
-                bool base64Encoding = (subStrings[2] == "B");
-                byte[] buffer = Encoding.ASCII.GetBytes(subStrings[3]);
-                int newLength;
+                int tokenStart = current;
+                while (current < valueSpan.Length && !IsLinearWhiteSpace(valueSpan[current]))
+                {
+                    current++;
+                }
 
-                IEncodableStream s = EncodedStreamFactory.GetEncoderForHeader(Encoding.GetEncoding(charSet), base64Encoding, 0);
+                if (tokenStart == current)
+                {
+                    decodedValue.Append(valueSpan[whitespaceStart..current]);
+                    break;
+                }
 
-                newLength = s.DecodeBytes(buffer);
+                ReadOnlySpan<char> token = valueSpan[tokenStart..current];
+                if (TryDecodeHeaderValue(token, out string decodedToken))
+                {
+                    if (!previousTokenWasEncoded)
+                    {
+                        decodedValue.Append(valueSpan[whitespaceStart..tokenStart]);
+                    }
 
-                Encoding encoding = Encoding.GetEncoding(charSet);
-                newValue += encoding.GetString(buffer, 0, newLength);
+                    decodedValue.Append(decodedToken);
+                    decodedAny = true;
+                    previousTokenWasEncoded = true;
+                }
+                else
+                {
+                    decodedValue.Append(valueSpan[whitespaceStart..tokenStart]);
+                    decodedValue.Append(token);
+                    previousTokenWasEncoded = false;
+                }
             }
-            return newValue;
+
+            return decodedAny ? decodedValue.ToString() : value;
         }
 
         // Detect the encoding: "=?encoding?BorQ?content?="
         // "=?utf-8?B?RmlsZU5hbWVf55CG0Y3Qq9C60I5jw4TRicKq0YIM0Y1hSsSeTNCy0Klh?="; // 3.5
         // With the addition of folding in 4.0, there may be multiple lines with encoding, only detect the first:
         // "=?utf-8?B?RmlsZU5hbWVf55CG0Y3Qq9C60I5jw4TRicKq0YIM0Y1hSsSeTNCy0Klh?=\r\n =?utf-8?B??=";
-        internal static unsafe Encoding? DecodeEncoding(string? value)
+        internal static Encoding? DecodeEncoding(string? value)
         {
             if (string.IsNullOrEmpty(value))
             {
@@ -98,16 +111,100 @@ namespace System.Net.Mime
             }
 
             ReadOnlySpan<char> valueSpan = value;
-            Span<Range> subStrings = stackalloc Range[6];
-            if (valueSpan.SplitAny(subStrings, "?\r\n") < 5 ||
-                valueSpan[subStrings[0]] is not "=" ||
-                valueSpan[subStrings[4]] is not "=")
+            int current = 0;
+
+            while (current < valueSpan.Length)
             {
-                return null;
+                while (current < valueSpan.Length && IsLinearWhiteSpace(valueSpan[current]))
+                {
+                    current++;
+                }
+
+                int tokenStart = current;
+                while (current < valueSpan.Length && !IsLinearWhiteSpace(valueSpan[current]))
+                {
+                    current++;
+                }
+
+                ReadOnlySpan<char> token = valueSpan[tokenStart..current];
+                if (TryParseEncodedWord(token, out Range charSet, out _, out _))
+                {
+                    return Encoding.GetEncoding(token[charSet].ToString());
+                }
             }
 
-            return Encoding.GetEncoding(value[subStrings[1]]);
+            return null;
         }
+
+        private static bool TryDecodeHeaderValue(ReadOnlySpan<char> value, out string decodedValue)
+        {
+            decodedValue = string.Empty;
+            if (!TryParseEncodedWord(value, out Range charSetRange, out bool base64Encoding, out Range encodedTextRange))
+            {
+                return false;
+            }
+
+            Encoding encoding = Encoding.GetEncoding(value[charSetRange].ToString());
+            ReadOnlySpan<char> encodedText = value[encodedTextRange];
+            byte[] buffer = new byte[encodedText.Length];
+            Encoding.ASCII.GetBytes(encodedText, buffer);
+            IEncodableStream stream = EncodedStreamFactory.GetEncoderForHeader(encoding, base64Encoding, 0);
+            int decodedLength = stream.DecodeBytes(buffer);
+            decodedValue = encoding.GetString(buffer, 0, decodedLength);
+            return true;
+        }
+
+        private static bool TryParseEncodedWord(
+            ReadOnlySpan<char> value,
+            out Range charSet,
+            out bool base64Encoding,
+            out Range encodedText)
+        {
+            charSet = default;
+            base64Encoding = false;
+            encodedText = default;
+
+            if (value.Length is < 7 or > 75 || !value.StartsWith("=?") || !value.EndsWith("?="))
+            {
+                return false;
+            }
+
+            int charSetEnd = value[2..].IndexOf('?');
+            if (charSetEnd <= 0)
+            {
+                return false;
+            }
+            charSetEnd += 2;
+
+            int encodingEnd = value[(charSetEnd + 1)..].IndexOf('?');
+            if (encodingEnd != 1)
+            {
+                return false;
+            }
+            encodingEnd += charSetEnd + 1;
+
+            char encodingIdentifier = value[charSetEnd + 1];
+            if (encodingIdentifier is 'B' or 'b')
+            {
+                base64Encoding = true;
+            }
+            else if (encodingIdentifier is not ('Q' or 'q'))
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> encodedTextValue = value[(encodingEnd + 1)..^2];
+            if (encodedTextValue.Contains('?'))
+            {
+                return false;
+            }
+
+            charSet = 2..charSetEnd;
+            encodedText = (encodingEnd + 1)..^2;
+            return true;
+        }
+
+        private static bool IsLinearWhiteSpace(char value) => value is ' ' or '\t' or '\r' or '\n';
 
         internal static bool IsAscii(string value, bool permitCROrLF)
         {

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MimeBasePart.cs
@@ -50,6 +50,11 @@ namespace System.Net.Mime
                 return string.Empty;
             }
 
+            if (!value.Contains("=?", StringComparison.Ordinal))
+            {
+                return value;
+            }
+
             StringBuilder decodedValue = new StringBuilder(value.Length);
             ReadOnlySpan<char> valueSpan = value;
             bool decodedAny = false;
@@ -129,11 +134,59 @@ namespace System.Net.Mime
                 ReadOnlySpan<char> token = valueSpan[tokenStart..current];
                 if (TryParseEncodedWord(token, out Range charSet, out _, out _))
                 {
-                    return Encoding.GetEncoding(token[charSet].ToString());
+                    Encoding? encoding = TryGetEncoding(token[charSet]);
+                    if (encoding is not null)
+                    {
+                        return encoding;
+                    }
                 }
             }
 
             return null;
+        }
+
+        internal static bool IsFullyEncoded(string value)
+        {
+            ReadOnlySpan<char> valueSpan = value;
+            bool encodedAny = false;
+            int current = 0;
+
+            while (current < valueSpan.Length)
+            {
+                int whitespaceStart = current;
+                while (current < valueSpan.Length && IsLinearWhiteSpace(valueSpan[current]))
+                {
+                    current++;
+                }
+
+                if (!IsValidHeaderWhiteSpace(valueSpan[whitespaceStart..current]))
+                {
+                    return false;
+                }
+
+                int tokenStart = current;
+                while (current < valueSpan.Length && !IsLinearWhiteSpace(valueSpan[current]))
+                {
+                    current++;
+                }
+
+                if (tokenStart == current)
+                {
+                    break;
+                }
+
+                ReadOnlySpan<char> token = valueSpan[tokenStart..current];
+                if (!TryParseEncodedWord(token, out Range charSet, out _, out _) ||
+                    TryGetEncoding(token[charSet]) is null ||
+                    token.ContainsAny('"', '\\'))
+                {
+                    return false;
+                }
+
+                encodedAny = true;
+            }
+
+            return encodedAny;
         }
 
         private static bool TryDecodeHeaderValue(ReadOnlySpan<char> value, out string decodedValue)
@@ -144,7 +197,12 @@ namespace System.Net.Mime
                 return false;
             }
 
-            Encoding encoding = Encoding.GetEncoding(value[charSetRange].ToString());
+            Encoding? encoding = TryGetEncoding(value[charSetRange]);
+            if (encoding is null)
+            {
+                return false;
+            }
+
             ReadOnlySpan<char> encodedText = value[encodedTextRange];
             byte[] buffer = new byte[encodedText.Length];
             Encoding.ASCII.GetBytes(encodedText, buffer);
@@ -164,9 +222,17 @@ namespace System.Net.Mime
             base64Encoding = false;
             encodedText = default;
 
-            if (value.Length is < 7 or > 75 || !value.StartsWith("=?") || !value.EndsWith("?="))
+            if (value.Length < 7 || !value.StartsWith("=?") || !value.EndsWith("?="))
             {
                 return false;
+            }
+
+            foreach (char c in value)
+            {
+                if (c is < '!' or > '~')
+                {
+                    return false;
+                }
             }
 
             int charSetEnd = value[2..].IndexOf('?');
@@ -201,6 +267,45 @@ namespace System.Net.Mime
 
             charSet = 2..charSetEnd;
             encodedText = (encodingEnd + 1)..^2;
+            return true;
+        }
+
+        private static Encoding? TryGetEncoding(ReadOnlySpan<char> charSet)
+        {
+            try
+            {
+                return Encoding.GetEncoding(charSet.ToString());
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+            catch (NotSupportedException)
+            {
+                return null;
+            }
+        }
+
+        private static bool IsValidHeaderWhiteSpace(ReadOnlySpan<char> value)
+        {
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (value[i] is ' ' or '\t')
+                {
+                    continue;
+                }
+
+                if (value[i] != '\r' ||
+                    i + 2 >= value.Length ||
+                    value[i + 1] != '\n' ||
+                    value[i + 2] is not (' ' or '\t'))
+                {
+                    return false;
+                }
+
+                i += 2;
+            }
+
             return true;
         }
 

--- a/src/libraries/System.Net.Mail/tests/Functional/ContentDispositionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/ContentDispositionTest.cs
@@ -93,6 +93,17 @@ namespace System.Net.Mime.Tests
         }
 
         [Fact]
+        public static void ToString_EncodedWordWithinInvalidParameterValue_DoesNotBypassEncoding()
+        {
+            var cd = new ContentDisposition();
+            cd.FileName = "report\r\nX-Test: injected =?utf-8?B?YQ?=";
+
+            string value = cd.ToString();
+
+            Assert.DoesNotContain("\r\nX-Test:", value, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public static void Inline_Roundtrip()
         {
             var cd = new ContentDisposition();

--- a/src/libraries/System.Net.Mail/tests/Functional/ContentTypeTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/ContentTypeTest.cs
@@ -150,6 +150,17 @@ namespace System.Net.Mime.Tests
             Assert.Empty(ct.Parameters);
         }
 
+        [Theory]
+        [InlineData("=?utf-8?B?Y2Fmw6kudHh0?=", "caf\u00e9.txt")]
+        [InlineData("=?utf-8?b?Y2Fmw6kudHh0?=", "caf\u00e9.txt")]
+        [InlineData("Report =?utf-8?B?Y2Fmw6kudHh0?=", "Report caf\u00e9.txt")]
+        public static void Name_EncodedWords_AreDecoded(string value, string expected)
+        {
+            var ct = new ContentType($"application/octet-stream; name=\"{value}\"");
+
+            Assert.Equal(expected, ct.Name);
+        }
+
         [Fact]
         public static void MediaType_Set_InvalidArgs_Throws()
         {

--- a/src/libraries/System.Net.Mail/tests/Functional/ContentTypeTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/ContentTypeTest.cs
@@ -154,11 +154,35 @@ namespace System.Net.Mime.Tests
         [InlineData("=?utf-8?B?Y2Fmw6kudHh0?=", "caf\u00e9.txt")]
         [InlineData("=?utf-8?b?Y2Fmw6kudHh0?=", "caf\u00e9.txt")]
         [InlineData("Report =?utf-8?B?Y2Fmw6kudHh0?=", "Report caf\u00e9.txt")]
+        [InlineData("Report =?utf-99?B?Y2Fmw6kudHh0?=", "Report =?utf-99?B?Y2Fmw6kudHh0?=")]
+        [InlineData("Report =?utf-7?B?Y2Fmw6kudHh0?=", "Report =?utf-7?B?Y2Fmw6kudHh0?=")]
         public static void Name_EncodedWords_AreDecoded(string value, string expected)
         {
             var ct = new ContentType($"application/octet-stream; name=\"{value}\"");
 
             Assert.Equal(expected, ct.Name);
+        }
+
+        [Fact]
+        public static void ToString_EncodedWordWithinInvalidParameterValue_DoesNotBypassEncoding()
+        {
+            var ct = new ContentType();
+            ct.Name = "report\r\nX-Test: injected =?utf-8?B?YQ?=";
+
+            string value = ct.ToString();
+
+            Assert.DoesNotContain("\r\nX-Test:", value, StringComparison.Ordinal);
+            Assert.Contains("=?utf-8?B?", value, StringComparison.Ordinal);
+            Assert.Equal("report\r\nX-Test: injected =?utf-8?B?YQ?=", new ContentType(value).Name);
+        }
+
+        [Fact]
+        public static void ToString_EntireEncodedWordParameter_IsPassedThrough()
+        {
+            var ct = new ContentType();
+            ct.Name = "=?utf-8?B?Y2Fmw6kudHh0?=";
+
+            Assert.Equal("application/octet-stream; name=\"=?utf-8?B?Y2Fmw6kudHh0?=\"", ct.ToString());
         }
 
         [Fact]

--- a/src/libraries/System.Net.Mail/tests/Unit/ByteEncodingTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/ByteEncodingTest.cs
@@ -45,6 +45,27 @@ namespace System.Net.Mime.Tests
         }
 
         [Theory]
+        [InlineData("B")]
+        [InlineData("b")]
+        public void DecodeHeaderValue_Base64EncodingIdentifier_IsCaseInsensitive(string encodingIdentifier)
+        {
+            Assert.Equal("caf\u00e9.txt", MimeBasePart.DecodeHeaderValue($"=?utf-8?{encodingIdentifier}?Y2Fmw6kudHh0?="));
+        }
+
+        [Theory]
+        [InlineData("Report =?utf-8?B?Y2Fmw6kudHh0?=", "Report caf\u00e9.txt")]
+        [InlineData("=?utf-8?B?Y2Fmw6kudHh0?= attached", "caf\u00e9.txt attached")]
+        [InlineData("Report =?utf-8?B?Y2Fmw6kudHh0?= attached", "Report caf\u00e9.txt attached")]
+        [InlineData(" =?utf-8?B?Y2Fmw6kudHh0?= ", " caf\u00e9.txt ")]
+        [InlineData("=?utf-8?B?Y2Fm?= \r\n\t=?utf-8?B?w6kudHh0?=", "caf\u00e9.txt")]
+        [InlineData("Report =?utf-8?X?Y2Fmw6kudHh0?=", "Report =?utf-8?X?Y2Fmw6kudHh0?=")]
+        [InlineData("Report=?utf-8?B?Y2Fmw6kudHh0?=", "Report=?utf-8?B?Y2Fmw6kudHh0?=")]
+        public void DecodeHeaderValue_MixedAsciiAndEncodedWords_DecodesTokens(string value, string expected)
+        {
+            Assert.Equal(expected, MimeBasePart.DecodeHeaderValue(value));
+        }
+
+        [Theory]
         [InlineData("some test header to base64", 1)]
         [InlineData("some test header to base64asdf \xE9\xE5 encode that contains some unicode \xE5 \xF8\xEE asdf\xE9\xE5 and is really really long and stuff ", 3)]
         public void EncoderAndDecoder_WithQEncodedString_AndNoUnicode_AndShortHeader_ShouldEncodeAndDecode(

--- a/src/libraries/System.Net.Mail/tests/Unit/ByteEncodingTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/ByteEncodingTest.cs
@@ -45,11 +45,13 @@ namespace System.Net.Mime.Tests
         }
 
         [Theory]
-        [InlineData("B")]
-        [InlineData("b")]
-        public void DecodeHeaderValue_Base64EncodingIdentifier_IsCaseInsensitive(string encodingIdentifier)
+        [InlineData("B", "Y2Fmw6kgZmlsZS50eHQ=?=")]
+        [InlineData("b", "Y2Fmw6kgZmlsZS50eHQ=?=")]
+        [InlineData("Q", "caf=C3=A9_file.txt?=")]
+        [InlineData("q", "caf=C3=A9_file.txt?=")]
+        public void DecodeHeaderValue_EncodingIdentifier_IsCaseInsensitive(string encodingIdentifier, string encodedText)
         {
-            Assert.Equal("caf\u00e9.txt", MimeBasePart.DecodeHeaderValue($"=?utf-8?{encodingIdentifier}?Y2Fmw6kudHh0?="));
+            Assert.Equal("caf\u00e9 file.txt", MimeBasePart.DecodeHeaderValue($"=?utf-8?{encodingIdentifier}?{encodedText}"));
         }
 
         [Theory]
@@ -60,8 +62,42 @@ namespace System.Net.Mime.Tests
         [InlineData("=?utf-8?B?Y2Fm?= \r\n\t=?utf-8?B?w6kudHh0?=", "caf\u00e9.txt")]
         [InlineData("Report =?utf-8?X?Y2Fmw6kudHh0?=", "Report =?utf-8?X?Y2Fmw6kudHh0?=")]
         [InlineData("Report=?utf-8?B?Y2Fmw6kudHh0?=", "Report=?utf-8?B?Y2Fmw6kudHh0?=")]
+        [InlineData("=?utf-99?B?eA?= =?utf-8?B?YQ?=", "=?utf-99?B?eA?= a")]
+        [InlineData("=?utf-7?B?eA?= =?utf-8?B?YQ?=", "=?utf-7?B?eA?= a")]
         public void DecodeHeaderValue_MixedAsciiAndEncodedWords_DecodesTokens(string value, string expected)
         {
+            Assert.Equal(expected, MimeBasePart.DecodeHeaderValue(value));
+        }
+
+        [Fact]
+        public void DecodeEncoding_UnknownCharsetBeforeKnownCharset_ReturnsKnownEncoding()
+        {
+            Assert.Equal(Encoding.Latin1, MimeBasePart.DecodeEncoding("=?utf-99?B?eA?= =?iso-8859-1?Q?a?="));
+        }
+
+        [Theory]
+        [InlineData("=?utf-8?B?YQ?=", true)]
+        [InlineData(" =?utf-8?B?YQ?= ", true)]
+        [InlineData("=?utf-8?B?YQ?= =?iso-8859-1?Q?a?=", true)]
+        [InlineData("=?utf-8?B?YQ?=\r\n\t=?utf-8?Q?a?=", true)]
+        [InlineData("=?utf-8?Q?a\"b?=", false)]
+        [InlineData("=?utf-8?Q?a\\b?=", false)]
+        [InlineData("=?utf-8?Q?caf\u00e9?=", false)]
+        [InlineData("=?utf-8?B?YQ?=\r\n", false)]
+        [InlineData("Report =?utf-8?B?YQ?=", false)]
+        [InlineData("", false)]
+        public void IsFullyEncoded_ValidatesEntireParameterValue(string value, bool expected)
+        {
+            Assert.Equal(expected, MimeBasePart.IsFullyEncoded(value));
+        }
+
+        [Fact]
+        public void DecodeHeaderValue_OverlongEncodedWord_Decodes()
+        {
+            string expected = new string('a', 60);
+            string value = $"=?utf-8?B?{Convert.ToBase64String(Encoding.UTF8.GetBytes(expected))}?=";
+            Assert.True(value.Length > 75);
+
             Assert.Equal(expected, MimeBasePart.DecodeHeaderValue(value));
         }
 

--- a/src/libraries/System.Net.Mail/tests/Unit/MessageTests/MessageHeaderBehaviorTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/MessageTests/MessageHeaderBehaviorTest.cs
@@ -212,12 +212,14 @@ namespace System.Net.Mail.Tests
             Assert.Equal("Report caf\u00e9.txt", _message.Subject);
         }
 
-        [Fact]
-        public void MessageSubject_UnknownEncodingEncodedUnicode_Accepted()
+        [Theory]
+        [InlineData("utf-99")]
+        [InlineData("utf-7")]
+        public void MessageSubject_UnknownEncodingEncodedUnicode_Accepted(string charset)
         {
             _message.From = new MailAddress("from@example.com");
 
-            string input = "=?utf-99?B?SGkgw5wgQm9i?=";
+            string input = $"=?{charset}?B?SGkgw5wgQm9i?=";
             _message.Subject = input;
 
             Assert.Null(_message.SubjectEncoding);

--- a/src/libraries/System.Net.Mail/tests/Unit/MessageTests/MessageHeaderBehaviorTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/MessageTests/MessageHeaderBehaviorTest.cs
@@ -202,6 +202,17 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        public void MessageSubject_MixedAsciiAndEncodedUnicode_Accepted()
+        {
+            _message.From = new MailAddress("from@example.com");
+
+            _message.Subject = "Report =?utf-8?B?Y2Fmw6kudHh0?=";
+
+            Assert.Equal(Encoding.UTF8, _message.SubjectEncoding);
+            Assert.Equal("Report caf\u00e9.txt", _message.Subject);
+        }
+
+        [Fact]
         public void MessageSubject_UnknownEncodingEncodedUnicode_Accepted()
         {
             _message.From = new MailAddress("from@example.com");


### PR DESCRIPTION
## Summary

- decode RFC 2047 encoded-words token by token when mixed with ordinary ASCII text
- treat `B`/`Q` encoding identifiers case-insensitively
- preserve linear whitespace around ordinary text while suppressing it between adjacent encoded-words
- recognize mixed encoded-word values in `MailMessage.Subject` and `ContentType.Name`
- preserve literal text for tokens that are not valid encoded-words and retain existing malformed-payload behavior

## Testing

- `System.Net.Mail.csproj` build: 0 warnings, 0 errors
- `ByteEncodingTest`: 25 passed
- `MessageHeaderBehaviorTest`: 15 passed
- `ContentTypeTest`: 30 passed

> [!NOTE]
> This pull request description was generated with GitHub Copilot.