### PR TITLE
Document the in-process crash reporter design.

### DIFF
--- a/docs/design/coreclr/botr/README.md
+++ b/docs/design/coreclr/botr/README.md
@@ -27,6 +27,7 @@ Below is a table of contents.
 - [ReadyToRun Overview](readytorun-overview.md)
 - [CLR ABI](clr-abi.md)
 - [Cross-platform Minidumps](xplat-minidump-generation.md)
+- [In-process Crash Reporting](in-process-crash-reporting.md)
 - [Mixed Mode Assemblies](mixed-mode.md)
 - [Guide For Porting](guide-for-porting.md)
 - [Vectors and Intrinsics](vectors-and-intrinsics.md)

--- a/docs/design/coreclr/botr/in-process-crash-reporting.md
+++ b/docs/design/coreclr/botr/in-process-crash-reporting.md
@@ -25,13 +25,13 @@ The reporter is implemented under `src/coreclr/debug/crashreport`. VM-specific t
 
 ## Activation and signal handling ##
 
-The reporter is enabled with `DOTNET_EnableCrashReport=1`. It registers a callback with the Platform Abstraction Layer (PAL), which invokes the callback from terminal fatal-signal paths such as `SIGSEGV`, `SIGBUS`, `SIGFPE`, `SIGILL`, `SIGABRT`, and `SIGTRAP`.
+The reporter is enabled with `DOTNET_EnableCrashReport=1`. `DOTNET_EnableCrashReportOnly=1` also enables the in-process reporter and has the same effect because the in-process reporter never generates a dump. The remainder of this document uses `DOTNET_EnableCrashReport` as the primary setting. The reporter registers a callback with the Platform Abstraction Layer (PAL), which invokes the callback from terminal fatal-signal paths such as `SIGSEGV`, `SIGBUS`, `SIGFPE`, `SIGILL`, `SIGABRT`, and `SIGTRAP`.
 
 The runtime coordinates concurrent crash-reporting attempts so that only one report is generated from the shared process state at a time.
 
 CoreCLR chooses the crash-reporting mechanism as follows:
 
-- On desktop Unix platforms, `DOTNET_DbgEnableMiniDump=1` uses _createdump_ for dump and crash-report generation.
+- On desktop Unix platforms where both mechanisms are available, enabling `DOTNET_DbgEnableMiniDump` selects _createdump_ and the in-process reporter is not initialized. `DOTNET_EnableCrashReport` instructs _createdump_ to produce a crash report in addition to the configured dump, while `DOTNET_EnableCrashReportOnly` instructs it to produce only the crash report.
 - On desktop Unix platforms without dump generation enabled, `DOTNET_EnableCrashReport=1` enables the in-process reporter.
 - On mobile platforms, `DOTNET_EnableCrashReport=1` enables the in-process reporter because _createdump_ is not available.
 

--- a/docs/design/coreclr/botr/in-process-crash-reporting.md
+++ b/docs/design/coreclr/botr/in-process-crash-reporting.md
@@ -1,6 +1,6 @@
 # Introduction #
 
-The .NET runtime can generate a compact crash report from inside a crashing process. The in-process crash reporter is intended for environments where launching and attaching an external dump-generation process is unavailable, restricted, or unnecessarily expensive. This is particularly important for mobile applications, but the reporter is supported by CoreCLR on Unix platforms that provide the required native fatal-signal process model.
+CoreCLR can generate a compact crash report from inside a crashing process. The in-process crash reporter is intended for environments where launching and attaching an external dump-generation process is unavailable, restricted, or unnecessarily expensive. This is particularly important for mobile applications, but the reporter is supported by CoreCLR on Unix platforms that provide the required native fatal-signal process model.
 
 The reporter complements the out-of-process _createdump_ utility described in [Cross-platform Minidumps](xplat-minidump-generation.md). It does not generate a memory dump. Instead, it records the most useful information that can be collected safely from the crashing process:
 
@@ -36,6 +36,8 @@ CoreCLR chooses the crash-reporting mechanism as follows:
 - On mobile platforms, `DOTNET_EnableCrashReport=1` enables the in-process reporter because _createdump_ is not available.
 
 The in-process reporter is not currently enabled on Windows, Browser, or WASI. Windows uses its existing dump and Windows Error Reporting mechanisms, while Browser and WASI do not provide the required native fatal-signal process model.
+
+The in-process reporter is also not supported by NativeAOT. NativeAOT represents managed frames using the platform ABI and unwind information, so platform crash reporting facilities such as Android tombstones and Apple crash reports already produce mixed call stacks containing both native and managed frames. On mobile platforms, an in-process NativeAOT reporter would not add enough information beyond those platform reports to justify a separate reporting mechanism. NativeAOT support can be reconsidered if the in-process reporter provides additional diagnostic information that is not available from the platform tooling.
 
 ## Signal chaining ##
 
@@ -146,6 +148,7 @@ Crash reports contain process, module, exception, and stack information and shou
 The in-process reporter trades completeness for availability on a damaged process path:
 
 - it is not a replacement for a memory dump and cannot support arbitrary postmortem memory inspection;
+- it is currently supported only by CoreCLR, not NativeAOT;
 - native frame symbolication is not performed in the crashing process;
 - only managed threads known to CoreCLR are enumerated;
 - other managed threads are omitted when the runtime cannot be suspended safely;

--- a/docs/design/coreclr/botr/in-process-crash-reporting.md
+++ b/docs/design/coreclr/botr/in-process-crash-reporting.md
@@ -25,7 +25,7 @@ The reporter is implemented under `src/coreclr/debug/crashreport`. VM-specific t
 
 ## Activation and signal handling ##
 
-The reporter is enabled with `DOTNET_EnableCrashReport=1`. `DOTNET_EnableCrashReportOnly=1` also enables the in-process reporter and has the same effect because the in-process reporter never generates a dump. The remainder of this document uses `DOTNET_EnableCrashReport` as the primary setting. The reporter registers a callback with the Platform Abstraction Layer (PAL), which invokes the callback from terminal fatal-signal paths such as `SIGSEGV`, `SIGBUS`, `SIGFPE`, `SIGILL`, `SIGABRT`, and `SIGTRAP`.
+When CoreCLR selects the in-process reporting path, either `DOTNET_EnableCrashReport=1` or `DOTNET_EnableCrashReportOnly=1` enables the reporter. Both settings have the same effect because the in-process reporter never generates a dump. The remainder of this document uses `DOTNET_EnableCrashReport` as the primary setting. The reporter registers a callback with the Platform Abstraction Layer (PAL), which invokes the callback from terminal fatal-signal paths such as `SIGSEGV`, `SIGBUS`, `SIGFPE`, `SIGILL`, `SIGABRT`, and `SIGTRAP`.
 
 The runtime coordinates concurrent crash-reporting attempts so that only one report is generated from the shared process state at a time.
 

--- a/docs/design/coreclr/botr/in-process-crash-reporting.md
+++ b/docs/design/coreclr/botr/in-process-crash-reporting.md
@@ -75,7 +75,7 @@ Initialization performs work that is unsuitable for a signal handler. This inclu
 
 The crash path does not allocate memory or load modules. Formatting uses bounded, fixed-size buffers and streams chunks through small JSON and console writers. File output uses operations such as `open`, `write`, `close`, `unlink`, and same-directory `rename`. The signal dispatcher preserves `errno` across report generation.
 
-The reporter deliberately tolerates missing information. Strings may be truncated to their fixed bounds, frames that cannot be classified remain native frames, and a failure to suspend the runtime limits collection to the crashing thread. An output failure stops or discards the affected output rather than attempting complex recovery from the crash path.
+The reporter deliberately tolerates missing information. Strings may be truncated to their fixed bounds, unavailable frame metadata is omitted, and a failure to suspend the runtime limits collection to the crashing thread. An output failure stops or discards the affected output rather than attempting complex recovery from the crash path.
 
 ## Thread enumeration and stack walking ##
 
@@ -83,7 +83,7 @@ The crashing managed thread is emitted first so that the most important diagnost
 
 Walking the remaining managed threads requires a completed runtime suspension. The reporter can either create its own suspension or reuse an existing one when the crashing thread owns it. This includes applicable Workstation and Server GC scenarios; a participating Server GC worker can also reuse the completed suspension. If no stable suspension can be used safely, the reporter includes only the information it can collect from the crashing thread.
 
-Each thread entry identifies whether it is managed and whether it is the crashing thread. The crashing thread begins with a native crash-site frame constructed from the signal's saved register context. Managed frames can include the method name, metadata token, IL offset, native offset, module name, module timestamp and size, and module MVID when those values are available.
+Each thread entry identifies whether it is managed and whether it is the crashing thread. In the JSON output, the crashing thread begins with a native crash-site entry constructed from the signal's saved register context. Managed frames can include the method name, metadata token, IL offset, native offset, module name, module timestamp and size, and module MVID when those values are available.
 
 The compact log uses a bounded module table so frames can refer to modules by a short numeric index. If the table is full or a module cannot be resolved, the frame includes the available module identity inline instead. The JSON output records the corresponding frame data directly.
 
@@ -139,7 +139,7 @@ The crash path sends a start notification before collection and a finish notific
 
 # Configuration/Policy #
 
-The following settings control reports triggered by fatal signals. On-demand reports do not require these settings:
+The following settings primarily control reports triggered by fatal signals. On-demand reports do not require any of these settings, although `DOTNET_CrashReportFrameLimitPerThread` also limits their compact-log output when it is set before explicit initialization:
 
 | Setting | Meaning |
 |---------|---------|
@@ -147,7 +147,7 @@ The following settings control reports triggered by fatal signals. On-demand rep
 | `DOTNET_CrashReportRootPath` | Existing absolute directory under which lifecycle-managed JSON reports are stored. If unset, only the compact log is emitted. |
 | `DOTNET_CrashReportMaxFileCount` | Maximum number of completed JSON reports to retain. The default is 32 and the value must be positive. |
 | `DOTNET_CrashReportTimeoutSeconds` | Watchdog timeout in seconds. The default is 30; `0` disables the watchdog. |
-| `DOTNET_CrashReportFrameLimitPerThread` | Maximum number of stack frames per thread in the compact log. The default is 32; `0` disables the limit. JSON frame collection is not limited by this setting. |
+| `DOTNET_CrashReportFrameLimitPerThread` | Maximum number of stack frames per thread in compact-log output, including on-demand compact logs. The default is 32; `0` disables the limit. JSON frame collection is not limited by this setting. |
 | `DOTNET_CrashReportBeforeSignalChaining` | When set to `1`, generates crash diagnostics before invoking a previously registered native signal handler. The default is to invoke the previous handler first. |
 | `System.Runtime.CrashReportBeforeSignalChaining` | Runtime configuration equivalent of `DOTNET_CrashReportBeforeSignalChaining`, specified as a Boolean in `runtimeconfig.json`. |
 

--- a/docs/design/coreclr/botr/in-process-crash-reporting.md
+++ b/docs/design/coreclr/botr/in-process-crash-reporting.md
@@ -155,14 +155,14 @@ Crash reports contain process, module, exception, and stack information and shou
 
 # Limitations #
 
-The in-process reporter trades completeness for availability on a damaged process path:
+Because the reporter runs inside the crashing process, it prioritizes producing a useful partial report over collecting every possible diagnostic detail. This results in the following limitations:
 
-- it is not a replacement for a memory dump and cannot support arbitrary postmortem memory inspection;
-- it is currently supported only by CoreCLR, not NativeAOT;
-- native frame symbolication is not performed in the crashing process;
-- only managed threads known to CoreCLR are enumerated;
-- other managed threads are omitted when the runtime cannot be suspended safely;
-- severe memory corruption can prevent stack walking or output; and
-- report generation after a fatal signal remains best-effort and may be terminated by the watchdog.
+- the report is not a memory dump and cannot be used for arbitrary postmortem memory inspection;
+- threads that are not attached to CoreCLR are not enumerated;
+- the reporter does not collect a native call stack or native module list; the JSON report records only the crashing thread's native register context and crash-site address;
+- when a completed runtime suspension cannot be created or safely reused, stack collection is limited to the crashing thread;
+- severe memory corruption can make stack information incomplete or prevent report generation;
+- a JSON output failure can leave only the compact log; and
+- the watchdog terminates the process if report generation after a fatal signal exceeds the configured timeout.
 
-When the environment permits launching and attaching _createdump_, a dump remains the more complete diagnostic artifact. The in-process report is aimed at reliably preserving a useful crash summary when _createdump_ is unavailable or has not been enabled.
+When the environment permits launching and attaching _createdump_, a dump remains the more complete diagnostic artifact. The in-process report is aimed at reliably preserving a useful crash summary when _createdump_ is unavailable.

--- a/docs/design/coreclr/botr/in-process-crash-reporting.md
+++ b/docs/design/coreclr/botr/in-process-crash-reporting.md
@@ -16,7 +16,7 @@ The report is emitted as a compact platform log and can also be written as a JSO
 
 An in-process crash reporter operates under different constraints than _createdump_. The external utility can attach to a stopped target, load the Data Access Component (DAC), allocate memory, and use general-purpose operating system and C++ runtime services. The in-process reporter runs while handling a fatal signal, when the process may have corrupted state, may hold runtime or allocator locks, and may have exhausted its stack.
 
-When crash reporting is enabled, the design divides the work into two phases:
+For reports triggered by fatal signals, the design divides the work into two phases:
 
 1. During normal runtime startup, after configuration has enabled the reporter, it allocates its fixed state, captures process and platform information, and initializes optional services such as file lifecycle management and the watchdog.
 2. If a terminal fatal signal subsequently reaches PAL while the reporter is enabled, the reporter uses only preallocated buffers and operations selected for that execution context. It streams output directly to the platform log and, when configured, to a temporary report file.
@@ -38,6 +38,16 @@ CoreCLR chooses the crash-reporting mechanism as follows:
 The in-process reporter is not currently enabled on Windows, Browser, or WASI. Windows uses its existing dump and Windows Error Reporting mechanisms, while Browser and WASI do not provide the required native fatal-signal process model.
 
 The in-process reporter is also not supported by NativeAOT. NativeAOT represents managed frames using the platform ABI and unwind information, so platform crash reporting facilities such as Android tombstones and Apple crash reports already produce mixed call stacks containing both native and managed frames. On mobile platforms, an in-process NativeAOT reporter would not add enough information beyond those platform reports to justify a separate reporting mechanism. NativeAOT support can be reconsidered if the in-process reporter provides additional diagnostic information that is not available from the platform tooling.
+
+## On-demand reports ##
+
+CoreCLR also provides the internal `InProcCrashReportCreateReport` API for generating an in-process crash report on demand. The reporter must be initialized before this API can be used. The normal startup path performs that initialization only when crash reporting is enabled through configuration, but an internal consumer can instead call `CrashReportInitialize` explicitly without setting `DOTNET_EnableCrashReport`.
+
+`CrashReportInitialize` initializes the reporter and its VM callbacks, but it does not register the reporter for fatal signals or start the additional crash-reporting services. The on-demand caller selects either the compact-log or JSON format and provides a callback that receives the generated report.
+
+On-demand reports use the same thread enumeration, stack walking, formatting, and serialization code as reports triggered by fatal signals. Once the reporter has been initialized, they can be generated multiple times during the lifetime of a process, although only one report can be generated at a time.
+
+The additional services used during fatal-signal reporting are not enabled for on-demand reports. The on-demand API does not start the watchdog or use the file lifecycle manager, report directory, temporary-file publishing, or retention limit. The caller receiving the output is responsible for storing or processing it.
 
 ## Signal chaining ##
 
@@ -99,7 +109,7 @@ The JSON output uses a createdump-shaped payload so crash-processing systems can
 
 For ordinary stack walks, the JSON report records every frame returned by the stack walker. `DOTNET_CrashReportFrameLimitPerThread` limits only the compact log because the JSON file is the more complete postmortem artifact and is streamed directly to disk. Stack-overflow reports are an exception: their preallocated trace snapshot is limited to 128 entries, and the JSON records when frames were truncated.
 
-JSON file output is enabled when `DOTNET_CrashReportRootPath` specifies an existing absolute directory. The reporter creates the following private subdirectories below that root:
+For reports triggered by fatal signals, JSON file output is enabled when `DOTNET_CrashReportRootPath` specifies an existing absolute directory. The reporter creates the following private subdirectories below that root:
 
 ```text
 <root>/.dotnet/crash-reports/
@@ -115,13 +125,13 @@ The report is streamed to a file with a `.tmp` suffix. After the JSON document h
 
 # Report lifecycle #
 
-Report directory setup and retention pruning run during normal startup, not during a crash. Startup removes stale temporary files and retains only the newest configured number of completed reports. If the directory is already at the retention limit, the oldest report path is cached so the crash path can remove it before publishing the next report without rescanning the directory.
+Report directory setup and retention pruning apply only to reports triggered by fatal signals. They run during normal startup, not during a crash. Startup removes stale temporary files and retains only the newest configured number of completed reports. If the directory is already at the retention limit, the oldest report path is cached so the crash path can remove it before publishing the next report without rescanning the directory.
 
 The reporter never creates the configured root itself. The root must already exist, be an absolute path, and be writable. If lifecycle initialization fails, JSON file output is disabled, but compact log output remains available.
 
 # Watchdog #
 
-Walking damaged process state can hang. Unless the watchdog is disabled through configuration, the reporter creates a detached watchdog thread and a non-blocking pipe during startup. The watchdog blocks the fatal signals handled by the runtime so a process-directed fatal signal is not delivered to the watchdog instead of an application thread.
+Walking damaged process state after a fatal signal can hang. Unless the watchdog is disabled through configuration, the reporter creates a detached watchdog thread and a non-blocking pipe during startup. The watchdog blocks the fatal signals handled by the runtime so a process-directed fatal signal is not delivered to the watchdog instead of an application thread. On-demand reports do not use this watchdog.
 
 Some platforms already provide watchdogs that monitor application responsiveness, such as whether the main thread continues to pump messages. Those watchdogs do not necessarily detect a crash reporter that hangs on another thread while the monitored thread remains responsive. The in-process crash reporter therefore uses its own watchdog, which monitors report generation regardless of which runtime thread encountered the crash.
 
@@ -129,7 +139,7 @@ The crash path sends a start notification before collection and a finish notific
 
 # Configuration/Policy #
 
-The following settings control the in-process reporter:
+The following settings control reports triggered by fatal signals. On-demand reports do not require these settings:
 
 | Setting | Meaning |
 |---------|---------|

--- a/docs/design/coreclr/botr/in-process-crash-reporting.md
+++ b/docs/design/coreclr/botr/in-process-crash-reporting.md
@@ -1,0 +1,155 @@
+# Introduction #
+
+The .NET runtime can generate a compact crash report from inside a crashing process. The in-process crash reporter is intended for environments where launching and attaching an external dump-generation process is unavailable, restricted, or unnecessarily expensive. This is particularly important for mobile applications, but the reporter is supported by CoreCLR on Unix platforms that provide the required native fatal-signal process model.
+
+The reporter complements the out-of-process _createdump_ utility described in [Cross-platform Minidumps](xplat-minidump-generation.md). It does not generate a memory dump. Instead, it records the most useful information that can be collected safely from the crashing process:
+
+- the process and runtime version;
+- the fatal signal and the native register context at the crash site;
+- managed threads and their stack frames, when the runtime can safely walk them;
+- the managed exception on the crashing thread, when available; and
+- module identities needed to interpret managed frames.
+
+The report is emitted as a compact platform log and can also be written as a JSON file. Report generation is best-effort: preserving process termination and avoiding another hang or fault take precedence over producing a complete report.
+
+# Design #
+
+An in-process crash reporter operates under different constraints than _createdump_. The external utility can attach to a stopped target, load the Data Access Component (DAC), allocate memory, and use general-purpose operating system and C++ runtime services. The in-process reporter runs while handling a fatal signal, when the process may have corrupted state, may hold runtime or allocator locks, and may have exhausted its stack.
+
+When crash reporting is enabled, the design divides the work into two phases:
+
+1. During normal runtime startup, after configuration has enabled the reporter, it allocates its fixed state, captures process and platform information, and initializes optional services such as file lifecycle management and the watchdog.
+2. If a terminal fatal signal subsequently reaches PAL while the reporter is enabled, the reporter uses only preallocated buffers and operations selected for that execution context. It streams output directly to the platform log and, when configured, to a temporary report file.
+
+The reporter is implemented under `src/coreclr/debug/crashreport`. VM-specific thread enumeration and managed stack walking are provided by `src/coreclr/vm/crashreportstackwalker.cpp`. This separation keeps the signal-safe formatting and output machinery independent of CoreCLR's internal thread and code-management types.
+
+## Activation and signal handling ##
+
+The reporter is enabled with `DOTNET_EnableCrashReport=1`. It registers a callback with the Platform Abstraction Layer (PAL), which invokes the callback from terminal fatal-signal paths such as `SIGSEGV`, `SIGBUS`, `SIGFPE`, `SIGILL`, `SIGABRT`, and `SIGTRAP`.
+
+The runtime coordinates concurrent crash-reporting attempts so that only one report is generated from the shared process state at a time.
+
+CoreCLR chooses the crash-reporting mechanism as follows:
+
+- On desktop Unix platforms, `DOTNET_DbgEnableMiniDump=1` uses _createdump_ for dump and crash-report generation.
+- On desktop Unix platforms without dump generation enabled, `DOTNET_EnableCrashReport=1` enables the in-process reporter.
+- On mobile platforms, `DOTNET_EnableCrashReport=1` enables the in-process reporter because _createdump_ is not available.
+
+The in-process reporter is not currently enabled on Windows, Browser, or WASI. Windows uses its existing dump and Windows Error Reporting mechanisms, while Browser and WASI do not provide the required native fatal-signal process model.
+
+## Signal chaining ##
+
+Applications, native hosts, and platforms can install signal handlers before CoreCLR starts. By default, PAL invokes a previously registered non-default handler before generating the crash report. If that handler terminates the process instead of returning, CoreCLR never gets an opportunity to produce the report.
+
+Android is an important example. Android installs its own crash handler, which is preserved as a chained signal handler when CoreCLR installs its handlers. The Android handler terminates the process after handling the crash, so invoking it first would prevent the in-process reporter from running.
+
+Setting `DOTNET_CrashReportBeforeSignalChaining=1` changes the order so PAL generates the crash report before invoking the previous signal handler. The same behavior can be selected through the runtime configuration property `System.Runtime.CrashReportBeforeSignalChaining`:
+
+```json
+{
+  "runtimeOptions": {
+    "configProperties": {
+      "System.Runtime.CrashReportBeforeSignalChaining": true
+    }
+  }
+}
+```
+
+The environment-style CLR configuration value takes precedence when both forms are specified. This setting changes only when crash diagnostics run relative to a previously registered handler; it does not enable the reporter by itself.
+
+## Signal safety ##
+
+Initialization performs work that is unsuitable for a signal handler. This includes allocating reporter state, resolving the process name, reading Apple platform information with `sysctl`, creating the watchdog thread, and scanning the report directory. Values needed during a crash are cached in fixed-size buffers.
+
+The crash path does not allocate memory or load modules. Formatting uses bounded, fixed-size buffers and streams chunks through small JSON and console writers. File output uses operations such as `open`, `write`, `close`, `unlink`, and same-directory `rename`. The signal dispatcher preserves `errno` across report generation.
+
+The reporter deliberately tolerates missing information. Strings may be truncated to their fixed bounds, frames that cannot be classified remain native frames, and a failure to suspend the runtime limits collection to the crashing thread. An output failure stops or discards the affected output rather than attempting complex recovery from the crash path.
+
+## Thread enumeration and stack walking ##
+
+The crashing managed thread is emitted first so that the most important diagnostic information remains present if collection later becomes incomplete. The reporter captures its managed exception type and HRESULT before attempting to suspend the runtime.
+
+Walking the remaining managed threads requires a completed runtime suspension. The reporter can either create its own suspension or reuse an existing one when the crashing thread owns it. This includes applicable Workstation and Server GC scenarios; a participating Server GC worker can also reuse the completed suspension. If no stable suspension can be used safely, the reporter includes only the information it can collect from the crashing thread.
+
+Each thread entry identifies whether it is managed and whether it is the crashing thread. The crashing thread begins with a native crash-site frame constructed from the signal's saved register context. Managed frames can include the method name, metadata token, IL offset, native offset, module name, module timestamp and size, and module MVID when those values are available.
+
+The compact log uses a bounded module table so frames can refer to modules by a short numeric index. If the table is full or a module cannot be resolved, the frame includes the available module identity inline instead. The JSON output records the corresponding frame data directly.
+
+## Stack overflow ##
+
+A stack overflow cannot rely on an ordinary stack walk from the crashing thread's exhausted stack. CoreCLR already constructs a compressed stack trace while handling a stack overflow. The in-process reporter snapshots that trace into preallocated storage before the process begins handling the fatal signal.
+
+When the crashing thread and the saved stack-overflow trace match, the reporter emits the captured managed frames and identifies the exception as `System.StackOverflowException`. Repeated frame sequences retain their repeat metadata in the JSON report. The snapshot is bounded; if it is unavailable or truncated, the report records the limitation rather than attempting an unsafe walk.
+
+# Output #
+
+The reporter has two output forms generated from the same collected data.
+
+## Compact log ##
+
+For reports triggered by a fatal signal, the compact log is always attempted. On Android, each logical line is written to logcat with the `DOTNET_CRASH` tag. On other supported platforms it is written to the runtime's standard error logging sink.
+
+The log begins with the report protocol version, runtime build, architecture, process name, process ID, and fatal signal. It then lists thread blocks and stack frames, followed by the module table used by managed frames. The number of frames written per thread can be bounded so a badly corrupted or unusually large stack does not produce unbounded log output.
+
+## JSON report ##
+
+The JSON output uses a createdump-shaped payload so crash-processing systems can consume a familiar structure. The document contains a `payload` object with configuration, process, thread, exception, and frame information, plus a `parameters` object containing the fatal signal and available platform information. The schema carries an explicit protocol version so readers can distinguish future revisions.
+
+For ordinary stack walks, the JSON report records every frame returned by the stack walker. `DOTNET_CrashReportFrameLimitPerThread` limits only the compact log because the JSON file is the more complete postmortem artifact and is streamed directly to disk. Stack-overflow reports are an exception: their preallocated trace snapshot is limited to 128 entries, and the JSON records when frames were truncated.
+
+JSON file output is enabled when `DOTNET_CrashReportRootPath` specifies an existing absolute directory. The reporter creates the following private subdirectories below that root:
+
+```text
+<root>/.dotnet/crash-reports/
+```
+
+Completed reports use names of the following form:
+
+```text
+report-<timestamp-in-nanoseconds>-<pid>.crashreport.json
+```
+
+The report is streamed to a file with a `.tmp` suffix. After the JSON document has been completed and the file has been closed successfully, a same-directory rename publishes the final report atomically. A failed or incomplete report is removed instead of being exposed as a completed report.
+
+# Report lifecycle #
+
+Report directory setup and retention pruning run during normal startup, not during a crash. Startup removes stale temporary files and retains only the newest configured number of completed reports. If the directory is already at the retention limit, the oldest report path is cached so the crash path can remove it before publishing the next report without rescanning the directory.
+
+The reporter never creates the configured root itself. The root must already exist, be an absolute path, and be writable. If lifecycle initialization fails, JSON file output is disabled, but compact log output remains available.
+
+# Watchdog #
+
+Walking damaged process state can hang. Unless the watchdog is disabled through configuration, the reporter creates a detached watchdog thread and a non-blocking pipe during startup. The watchdog blocks the fatal signals handled by the runtime so a process-directed fatal signal is not delivered to the watchdog instead of an application thread.
+
+Some platforms already provide watchdogs that monitor application responsiveness, such as whether the main thread continues to pump messages. Those watchdogs do not necessarily detect a crash reporter that hangs on another thread while the monitored thread remains responsive. The in-process crash reporter therefore uses its own watchdog, which monitors report generation regardless of which runtime thread encountered the crash.
+
+The crash path sends a start notification before collection and a finish notification when collection ends. If the finish notification does not arrive within the configured timeout, the watchdog aborts the process. The watchdog is best-effort: if its communication channel fails, it exits and leaves termination to the platform's normal fatal-signal handling.
+
+# Configuration/Policy #
+
+The following settings control the in-process reporter:
+
+| Setting | Meaning |
+|---------|---------|
+| `DOTNET_EnableCrashReport` | Enables crash reporting. When _createdump_ owns the crash path, it generates both its configured dump and crash report. Otherwise this enables the in-process reporter. |
+| `DOTNET_CrashReportRootPath` | Existing absolute directory under which lifecycle-managed JSON reports are stored. If unset, only the compact log is emitted. |
+| `DOTNET_CrashReportMaxFileCount` | Maximum number of completed JSON reports to retain. The default is 32 and the value must be positive. |
+| `DOTNET_CrashReportTimeoutSeconds` | Watchdog timeout in seconds. The default is 30; `0` disables the watchdog. |
+| `DOTNET_CrashReportFrameLimitPerThread` | Maximum number of stack frames per thread in the compact log. The default is 32; `0` disables the limit. JSON frame collection is not limited by this setting. |
+| `DOTNET_CrashReportBeforeSignalChaining` | When set to `1`, generates crash diagnostics before invoking a previously registered native signal handler. The default is to invoke the previous handler first. |
+| `System.Runtime.CrashReportBeforeSignalChaining` | Runtime configuration equivalent of `DOTNET_CrashReportBeforeSignalChaining`, specified as a Boolean in `runtimeconfig.json`. |
+
+Crash reports contain process, module, exception, and stack information and should be handled as diagnostic data. Applications are responsible for choosing an appropriately protected root directory and for collecting, uploading, or deleting reports according to their privacy and retention requirements.
+
+# Limitations #
+
+The in-process reporter trades completeness for availability on a damaged process path:
+
+- it is not a replacement for a memory dump and cannot support arbitrary postmortem memory inspection;
+- native frame symbolication is not performed in the crashing process;
+- only managed threads known to CoreCLR are enumerated;
+- other managed threads are omitted when the runtime cannot be suspended safely;
+- severe memory corruption can prevent stack walking or output; and
+- report generation after a fatal signal remains best-effort and may be terminated by the watchdog.
+
+When the environment permits launching and attaching _createdump_, a dump remains the more complete diagnostic artifact. The in-process report is aimed at reliably preserving a useful crash summary when _createdump_ is unavailable or has not been enabled.

--- a/docs/design/coreclr/botr/xplat-minidump-generation.md
+++ b/docs/design/coreclr/botr/xplat-minidump-generation.md
@@ -8,6 +8,8 @@ Our goal is to generate core dumps that are on par with WER (Windows Error Repor
 
 Our solution at this time is to intercept any unhandled exception in the PAL layer of the runtime and have coreclr itself trigger and generate a "mini" core dump.
 
+For platforms and configurations where launching an external dump-generation process is unavailable or not enabled, CoreCLR can instead generate a compact report from the crashing process. See [In-process Crash Reporting](in-process-crash-reporting.md) for its design and limitations.
+
 # Design #
 
 We looked at the existing technologies like Breakpad and its derivatives (e.g.: an internal MS version called _msbreakpad_ from the SQL team....). Breakpad generates Windows minidumps but they are not compatible with existing tools like Windbg, etc. Msbreakpad even more so. There is a minidump to Linux core conversion utility but it seems like a wasted extra step. _Breakpad_ does allow the minidump to be generated in-process inside the signal handlers. It restricts the APIs to what was allowed in a "async" signal handler (like SIGSEGV) and has a small subset of the C++ runtime that was also similarly constrained. We also need to add the set of memory regions for the "managed" state which requires loading and using the _DAC_'s (*) enumerate memory interfaces. Loading modules is not allowed in an async signal handler but forking/execve is allowed so launching an utility that loads the _DAC_, enumerates the list of memory regions and writes the dump is the only reasonable option. It would also allow uploading the dump to a server too.


### PR DESCRIPTION
Adds a Book of the Runtime document describing the design and current scope of the CoreCLR in-process crash reporter.

The document covers:

- activation and interaction with `createdump`;
- supported platforms;
- automatic and on-demand report generation;
- signal chaining and the Android crash-handler scenario;
- signal-safety constraints;
- managed thread enumeration, runtime suspension reuse, and stack walking;
- stack-overflow reporting;
- compact-log and JSON output;
- report lifecycle, retention, and watchdog behavior; and
- configuration and limitations.

The document is linked from the BOTR index and the existing cross-platform minidump documentation.