### PR TITLE
JIT: Model promoted struct definitions through visitors

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1570,10 +1570,10 @@ void AsyncTransformation::CreateLiveSetForSuspension(BasicBlock*                
     // by the call appears live when its result is used. Its previous value is
     // overwritten on normal flow and only needs to be preserved if it is live
     // into an EH successor.
-    auto visitDef = [&](const LocalDef& def) {
-        if (def.IsEntire)
+    auto visitDef = [&](const auto& def) {
+        if (def.IsEntire(m_compiler))
         {
-            unsigned lclNum = def.Def->GetLclNum();
+            unsigned lclNum = def.GetLclNum();
             if (IsCallDefLiveInEHSucc(block, lclNum))
             {
                 JITDUMP("  V%02u is fully defined but live into an EH successor\n", lclNum);

--- a/src/coreclr/jit/asyncanalysis.cpp
+++ b/src/coreclr/jit/asyncanalysis.cpp
@@ -181,6 +181,13 @@ static void UpdateMutatedLocal(Compiler* compiler, GenTree* node, VARSET_TP& mut
         {
             return;
         }
+
+        auto visitDef = [&](const auto& def) {
+            MarkMutatedVarDsc(compiler, compiler->lvaGetDesc(def.GetLclNum()), mutated);
+            return GenTree::VisitResult::Continue;
+        };
+        node->VisitLocalDefs(compiler, visitDef);
+        return;
     }
     else if (node->OperIs(GT_LCL_ADDR))
     {
@@ -345,13 +352,21 @@ static void MarkMutatedLocal(Compiler* compiler, GenTree* node, VARSET_TP& mutat
 {
     if (node->IsCall())
     {
-        auto visitDef = [&](GenTreeLclVarCommon* lcl) {
-            MarkMutatedVarDsc(compiler, compiler->lvaGetDesc(lcl), mutated);
+        auto visitDef = [&](const auto& def) {
+            MarkMutatedVarDsc(compiler, compiler->lvaGetDesc(def.GetLclNum()), mutated);
             return GenTree::VisitResult::Continue;
         };
-        node->VisitLocalDefNodes(compiler, visitDef);
+        node->VisitLocalDefs(compiler, visitDef);
     }
-    else if (node->OperIsLocalStore() || node->OperIs(GT_LCL_ADDR))
+    else if (node->OperIsLocalStore())
+    {
+        auto visitDef = [&](const auto& def) {
+            MarkMutatedVarDsc(compiler, compiler->lvaGetDesc(def.GetLclNum()), mutated);
+            return GenTree::VisitResult::Continue;
+        };
+        node->VisitLocalDefs(compiler, visitDef);
+    }
+    else if (node->OperIs(GT_LCL_ADDR))
     {
         MarkMutatedVarDsc(compiler, compiler->lvaGetDesc(node->AsLclVarCommon()), mutated);
     }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6503,12 +6503,9 @@ public:
     // tree node).
     PhaseStatus fgValueNumber();
 
-    void fgValueNumberLocalStore(GenTree*             storeNode,
-                                 GenTreeLclVarCommon* lclDefNode,
-                                 ssize_t              offset,
-                                 ValueSize            storeSize,
-                                 ValueNumPair         value,
-                                 bool                 normalize = true);
+    template <typename TDef>
+    void fgValueNumberLocalStore(
+        GenTree* storeNode, const TDef& def, ValueNumPair value, bool normalize = true);
 
     void fgValueNumberArrayElemLoad(GenTree* loadTree, VNFuncApp* addrFunc);
 
@@ -8062,7 +8059,10 @@ public:
                      LclNumToLiveDefsMap* curSsaName);
     void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToLiveDefsMap* curSsaName);
     bool optBlockCopyProp(BasicBlock* block, LclNumToLiveDefsMap* curSsaName);
-    void optCopyPropPushDef(GenTreeLclVarCommon* lclNode, LclNumToLiveDefsMap* curSsaName);
+    void optCopyPropPushDef(GenTreeLclVarCommon* lclNode,
+                            unsigned             lclNum,
+                            unsigned             ssaNum,
+                            LclNumToLiveDefsMap* curSsaName);
     int optCopyProp_LclVarScore(const LclVarDsc* lclVarDsc, const LclVarDsc* copyVarDsc, bool preferOp2);
     PhaseStatus optVnCopyProp();
     INDEBUG(void optDumpCopyPropStack(LclNumToLiveDefsMap* curSsaName));

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4450,12 +4450,464 @@ GenTree::VisitResult GenTree::VisitOperandUses(TVisitor visitor)
     }
 }
 
+template <typename TDerived>
+struct LocalDefProvider
+{
+    bool HasMultiDefIndex() const
+    {
+        return static_cast<const TDerived*>(this)->GetMultiDefIndex() != BAD_VAR_NUM;
+    }
+
+    unsigned GetSsaNum(Compiler* compiler) const
+    {
+        const TDerived* derived = static_cast<const TDerived*>(this);
+        unsigned        index   = derived->GetMultiDefIndex();
+        return index == BAD_VAR_NUM ? derived->GetDefNode()->GetSsaNum()
+                                    : derived->GetDefNode()->GetSsaNum(compiler, index);
+    }
+
+    void SetSsaNum(Compiler* compiler, unsigned ssaNum) const
+    {
+        const TDerived* derived = static_cast<const TDerived*>(this);
+        unsigned        index   = derived->GetMultiDefIndex();
+        if (index == BAD_VAR_NUM)
+        {
+            derived->GetDefNode()->SetSsaNum(ssaNum);
+        }
+        else
+        {
+            derived->GetDefNode()->SetSsaNum(compiler, index, ssaNum);
+        }
+    }
+};
+
+struct StoreLclVarDef : LocalDefProvider<StoreLclVarDef>
+{
+    GenTreeLclVarCommon* m_def;
+
+    explicit StoreLclVarDef(GenTreeLclVarCommon* def)
+        : m_def(def)
+    {
+    }
+
+    GenTreeLclVarCommon* GetDefNode() const
+    {
+        return m_def;
+    }
+
+    unsigned GetLclNum() const
+    {
+        return m_def->GetLclNum();
+    }
+
+    unsigned GetMultiDefIndex() const
+    {
+        return BAD_VAR_NUM;
+    }
+
+    bool IsEntire(Compiler* compiler) const
+    {
+        return true;
+    }
+
+    ssize_t GetOffset(Compiler* compiler) const
+    {
+        return 0;
+    }
+
+    ValueSize GetSize(Compiler* compiler) const
+    {
+        return GetStoreSize(compiler);
+    }
+
+    ssize_t GetValueOffset(Compiler* compiler) const
+    {
+        return 0;
+    }
+
+    ValueSize GetStoreSize(Compiler* compiler) const
+    {
+        return compiler->lvaLclValueSize(GetLclNum());
+    }
+};
+
+struct PromotedStoreLclVarDef : LocalDefProvider<PromotedStoreLclVarDef>
+{
+    GenTreeLclVarCommon* m_def;
+    unsigned             m_lclNum;
+    uint8_t              m_index;
+
+    PromotedStoreLclVarDef(GenTreeLclVarCommon* def, unsigned lclNum, unsigned index)
+        : m_def(def)
+        , m_lclNum(lclNum)
+        , m_index(static_cast<uint8_t>(index))
+    {
+        assert(index < UINT8_MAX);
+    }
+
+    GenTreeLclVarCommon* GetDefNode() const
+    {
+        return m_def;
+    }
+
+    unsigned GetLclNum() const
+    {
+        return m_lclNum;
+    }
+
+    unsigned GetMultiDefIndex() const
+    {
+        return m_index;
+    }
+
+    bool IsEntire(Compiler* compiler) const
+    {
+        return true;
+    }
+
+    ssize_t GetOffset(Compiler* compiler) const
+    {
+        return 0;
+    }
+
+    ValueSize GetSize(Compiler* compiler) const
+    {
+        return compiler->lvaGetDesc(m_lclNum)->lvValueSize();
+    }
+
+    ssize_t GetValueOffset(Compiler* compiler) const
+    {
+        return compiler->lvaGetDesc(m_lclNum)->lvFldOffset;
+    }
+
+    ValueSize GetStoreSize(Compiler* compiler) const
+    {
+        return compiler->lvaLclValueSize(m_def->GetLclNum());
+    }
+};
+
+struct StoreLclFldDef : LocalDefProvider<StoreLclFldDef>
+{
+    GenTreeLclFld* m_def;
+
+    explicit StoreLclFldDef(GenTreeLclFld* def)
+        : m_def(def)
+    {
+    }
+
+    GenTreeLclVarCommon* GetDefNode() const
+    {
+        return m_def;
+    }
+
+    unsigned GetLclNum() const
+    {
+        return m_def->GetLclNum();
+    }
+
+    unsigned GetMultiDefIndex() const
+    {
+        return BAD_VAR_NUM;
+    }
+
+    bool IsEntire(Compiler* compiler) const
+    {
+        return !m_def->IsPartialLclFld(compiler);
+    }
+
+    ssize_t GetOffset(Compiler* compiler) const
+    {
+        return m_def->GetLclOffs();
+    }
+
+    ValueSize GetSize(Compiler* compiler) const
+    {
+        return m_def->GetValueSize();
+    }
+
+    ssize_t GetValueOffset(Compiler* compiler) const
+    {
+        return 0;
+    }
+
+    ValueSize GetStoreSize(Compiler* compiler) const
+    {
+        return m_def->GetValueSize();
+    }
+};
+
+struct CallLocalDef : LocalDefProvider<CallLocalDef>
+{
+    GenTreeLclVarCommon* m_def;
+    ssize_t              m_offset;
+    ValueSize            m_size;
+    bool                 m_isEntire;
+
+    CallLocalDef(GenTreeLclVarCommon* def, bool isEntire, ssize_t offset, ValueSize size)
+        : m_def(def)
+        , m_offset(offset)
+        , m_size(size)
+        , m_isEntire(isEntire)
+    {
+    }
+
+    GenTreeLclVarCommon* GetDefNode() const
+    {
+        return m_def;
+    }
+
+    unsigned GetLclNum() const
+    {
+        return m_def->GetLclNum();
+    }
+
+    unsigned GetMultiDefIndex() const
+    {
+        return BAD_VAR_NUM;
+    }
+
+    bool IsEntire(Compiler* compiler) const
+    {
+        return m_isEntire;
+    }
+
+    ssize_t GetOffset(Compiler* compiler) const
+    {
+        return m_offset;
+    }
+
+    ValueSize GetSize(Compiler* compiler) const
+    {
+        return m_size;
+    }
+
+    ssize_t GetValueOffset(Compiler* compiler) const
+    {
+        return 0;
+    }
+
+    ValueSize GetStoreSize(Compiler* compiler) const
+    {
+        return m_size;
+    }
+};
+
+struct PromotedRangeLocalDef : LocalDefProvider<PromotedRangeLocalDef>
+{
+    GenTreeLclVarCommon* m_def;
+    unsigned             m_lclNum;
+    uint8_t              m_index;
+    bool                 m_isEntire;
+    ssize_t              m_offset;
+    ValueSize            m_size;
+    ssize_t              m_valueOffset;
+    ValueSize            m_storeSize;
+
+    PromotedRangeLocalDef(GenTreeLclVarCommon* def,
+                          unsigned             lclNum,
+                          unsigned             index,
+                          bool                 isEntire,
+                          ssize_t              offset,
+                          ValueSize            size,
+                          ssize_t              valueOffset,
+                          ValueSize            storeSize)
+        : m_def(def)
+        , m_lclNum(lclNum)
+        , m_index(static_cast<uint8_t>(index))
+        , m_isEntire(isEntire)
+        , m_offset(offset)
+        , m_size(size)
+        , m_valueOffset(valueOffset)
+        , m_storeSize(storeSize)
+    {
+        assert(index < UINT8_MAX);
+    }
+
+    GenTreeLclVarCommon* GetDefNode() const
+    {
+        return m_def;
+    }
+
+    unsigned GetLclNum() const
+    {
+        return m_lclNum;
+    }
+
+    unsigned GetMultiDefIndex() const
+    {
+        return m_index;
+    }
+
+    bool IsEntire(Compiler* compiler) const
+    {
+        return m_isEntire;
+    }
+
+    ssize_t GetOffset(Compiler* compiler) const
+    {
+        return m_offset;
+    }
+
+    ValueSize GetSize(Compiler* compiler) const
+    {
+        return m_size;
+    }
+
+    ssize_t GetValueOffset(Compiler* compiler) const
+    {
+        return m_valueOffset;
+    }
+
+    ValueSize GetStoreSize(Compiler* compiler) const
+    {
+        return m_storeSize;
+    }
+};
+
+template <typename TVisitor>
+GenTree::VisitResult VisitPromotedRangeLocalDefs(
+    Compiler* comp, GenTreeLclVarCommon* def, LclVarDsc* varDsc, ssize_t offset, ValueSize storeSize, TVisitor visitor)
+{
+    unsigned fieldLclNum = comp->lvaGetFieldLocal(varDsc, static_cast<unsigned>(offset));
+    if (fieldLclNum != BAD_VAR_NUM)
+    {
+        LclVarDsc* fieldVarDsc = comp->lvaGetDesc(fieldLclNum);
+        if (fieldVarDsc->lvValueSize() == storeSize)
+        {
+            unsigned index = fieldLclNum - varDsc->lvFieldLclStart;
+            return visitor(PromotedRangeLocalDef(def, fieldLclNum, index, /* isEntire */ true,
+                                                 /* offset */ 0, storeSize, /* valueOffset */ 0, storeSize));
+        }
+    }
+
+    for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
+    {
+        fieldLclNum            = varDsc->lvFieldLclStart + index;
+        LclVarDsc* fieldVarDsc = comp->lvaGetDesc(fieldLclNum);
+
+        ssize_t   fieldStoreOffset;
+        ValueSize fieldStoreSize;
+        if (!comp->gtStoreMayDefineField(fieldVarDsc, offset, storeSize, &fieldStoreOffset, &fieldStoreSize))
+        {
+            continue;
+        }
+
+        bool    isEntire    = (fieldStoreOffset == 0) && (fieldStoreSize == fieldVarDsc->lvValueSize());
+        ssize_t valueOffset = max(static_cast<ssize_t>(fieldVarDsc->lvFldOffset), offset) - offset;
+        if (visitor(PromotedRangeLocalDef(def, fieldLclNum, index, isEntire, fieldStoreOffset, fieldStoreSize,
+                                          valueOffset, storeSize)) == GenTree::VisitResult::Abort)
+        {
+            return GenTree::VisitResult::Abort;
+        }
+    }
+
+    return GenTree::VisitResult::Continue;
+}
+
 //------------------------------------------------------------------------
-// VisitLocalDefs: Visit locals being defined by this node.
+// IsEntireLocalDef: Check whether a physical local definition entirely
+// defines its local.
+//
+// Arguments:
+//   comp - the compiler instance
+//   def  - the physical definition
+//
+// Return Value:
+//   True if it does.
+//
+inline bool GenTree::IsEntireLocalDef(Compiler* comp, GenTreeLclVarCommon* def)
+{
+    if (OperIs(GT_STORE_LCL_VAR))
+    {
+        return true;
+    }
+
+    if (OperIs(GT_STORE_LCL_FLD))
+    {
+        return !def->IsPartialLclFld(comp);
+    }
+
+    assert(OperIs(GT_CALL));
+    GenTreeCall* call = AsCall();
+    if (def == comp->gtCallGetDefinedAsyncResumedLclAddr(call))
+    {
+        return comp->lvaLclExactSize(def->GetLclNum()) == TARGET_POINTER_SIZE;
+    }
+
+    assert(def == comp->gtCallGetDefinedRetBufLclAddr(call));
+    ValueSize storeSize(comp->typGetObjLayout(call->gtRetClsHnd)->GetSize());
+    return comp->IsEntireAccess(def->GetLclNum(), def->GetLclOffs(), storeSize);
+}
+
+//------------------------------------------------------------------------
+// VisitLocalDef: Visit the logical locals represented by one physical definition.
 //
 // Arguments:
 //   comp    - the compiler instance
-//   visitor - Functor of type GenTree::VisitResult(LocalDef)
+//   def     - the physical definition
+//   visitor - generic functor accepting a local definition provider
+//
+// Return Value:
+//   VisitResult::Abort if the functor aborted; otherwise VisitResult::Continue.
+//
+template <typename TVisitor>
+GenTree::VisitResult GenTree::VisitLocalDef(Compiler* comp, GenTreeLclVarCommon* def, TVisitor visitor)
+{
+    assert(OperIs(GT_STORE_LCL_VAR));
+
+    unsigned   lclNum = def->GetLclNum();
+    LclVarDsc* varDsc = comp->lvaGetDesc(lclNum);
+    if (!varDsc->lvPromoted)
+    {
+        return visitor(StoreLclVarDef(def));
+    }
+
+    for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
+    {
+        unsigned fieldLclNum = varDsc->lvFieldLclStart + index;
+        RETURN_IF_ABORT(visitor(PromotedStoreLclVarDef(def, fieldLclNum, index)));
+    }
+
+    return VisitResult::Continue;
+}
+
+//------------------------------------------------------------------------
+// VisitLocalDef: Visit the logical locals represented by one physical call
+// definition.
+//
+// Arguments:
+//   comp          - the compiler instance
+//   def           - the physical definition
+//   isEntire      - whether the physical store entirely defines its local
+//   offset        - offset of the store relative to the physical local
+//   size          - size of the store
+//   visitor       - generic functor accepting a local definition provider
+//
+// Return Value:
+//   VisitResult::Abort if the functor aborted; otherwise VisitResult::Continue.
+//
+template <typename TVisitor>
+GenTree::VisitResult GenTree::VisitLocalDef(
+    Compiler* comp, GenTreeLclVarCommon* def, bool isEntire, ssize_t offset, ValueSize size, TVisitor visitor)
+{
+    assert(OperIs(GT_CALL));
+
+    unsigned   lclNum = def->GetLclNum();
+    LclVarDsc* varDsc = comp->lvaGetDesc(lclNum);
+    if (!varDsc->lvPromoted)
+    {
+        return visitor(CallLocalDef(def, isEntire, offset, size));
+    }
+
+    return VisitPromotedRangeLocalDefs(comp, def, varDsc, offset, size, visitor);
+}
+
+//------------------------------------------------------------------------
+// VisitLocalDefs: Visit logical locals being defined by this node.
+//
+// Arguments:
+//   comp    - the compiler instance
+//   visitor - generic functor accepting a local definition provider
 //
 // Return Value:
 //   VisitResult::Abort if the functor aborted; otherwise VisitResult::Continue.
@@ -4470,13 +4922,18 @@ GenTree::VisitResult GenTree::VisitLocalDefs(Compiler* comp, TVisitor visitor)
 {
     if (OperIs(GT_STORE_LCL_VAR))
     {
-        ValueSize size = comp->lvaLclValueSize(AsLclVarCommon()->GetLclNum());
-        return visitor(LocalDef(AsLclVarCommon(), /* isEntire */ true, 0, size));
+        return VisitLocalDef(comp, AsLclVarCommon(), visitor);
     }
     if (OperIs(GT_STORE_LCL_FLD))
     {
-        GenTreeLclFld* fld = AsLclFld();
-        return visitor(LocalDef(fld, !fld->IsPartialLclFld(comp), fld->GetLclOffs(), fld->GetValueSize()));
+        GenTreeLclFld* fld    = AsLclFld();
+        LclVarDsc*     varDsc = comp->lvaGetDesc(fld);
+        if (!varDsc->lvPromoted)
+        {
+            return visitor(StoreLclFldDef(fld));
+        }
+
+        return VisitPromotedRangeLocalDefs(comp, fld, varDsc, fld->GetLclOffs(), fld->GetValueSize(), visitor);
     }
     if (OperIs(GT_CALL))
     {
@@ -4487,8 +4944,8 @@ GenTree::VisitResult GenTree::VisitLocalDefs(Compiler* comp, TVisitor visitor)
         {
             bool isEntire = comp->lvaLclExactSize(asyncResumedLclAddr->GetLclNum()) == TARGET_POINTER_SIZE;
 
-            RETURN_IF_ABORT(visitor(LocalDef(asyncResumedLclAddr, isEntire, asyncResumedLclAddr->GetLclOffs(),
-                                             ValueSize(TARGET_POINTER_SIZE))));
+            RETURN_IF_ABORT(VisitLocalDef(comp, asyncResumedLclAddr, isEntire, asyncResumedLclAddr->GetLclOffs(),
+                                          ValueSize(TARGET_POINTER_SIZE), visitor));
         }
 
         GenTreeLclVarCommon* retBufLclAddr = comp->gtCallGetDefinedRetBufLclAddr(call);
@@ -4499,7 +4956,8 @@ GenTree::VisitResult GenTree::VisitLocalDefs(Compiler* comp, TVisitor visitor)
             bool isEntire =
                 comp->IsEntireAccess(retBufLclAddr->GetLclNum(), retBufLclAddr->GetLclOffs(), ValueSize(storeSize));
 
-            return visitor(LocalDef(retBufLclAddr, isEntire, retBufLclAddr->GetLclOffs(), ValueSize(storeSize)));
+            return VisitLocalDef(comp, retBufLclAddr, isEntire, retBufLclAddr->GetLclOffs(), ValueSize(storeSize),
+                                 visitor);
         }
     }
 
@@ -4507,7 +4965,7 @@ GenTree::VisitResult GenTree::VisitLocalDefs(Compiler* comp, TVisitor visitor)
 }
 
 //------------------------------------------------------------------------
-// VisitLocalDefNodes: Visit GenTreeLclVarCommon nodes representing definitions in the specified node.
+// VisitLocalDefNodes: Visit physical GenTreeLclVarCommon nodes representing definitions in the specified node.
 //
 // Arguments:
 //   comp    - the compiler instance
@@ -4515,11 +4973,6 @@ GenTree::VisitResult GenTree::VisitLocalDefs(Compiler* comp, TVisitor visitor)
 //
 // Return Value:
 //   VisitResult::Abort if the functor aborted; otherwise VisitResult::Continue.
-//
-// Notes:
-//   This function is contractually bound to recognize a superset of stores
-//   that "LocalAddressVisitor" recognizes and transforms, as it is used to
-//   detect which trees can define tracked locals.
 //
 template <typename TVisitor>
 GenTree::VisitResult GenTree::VisitLocalDefNodes(Compiler* comp, TVisitor visitor)

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -51,26 +51,12 @@ void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToLiveDefsMap*
                 continue;
             }
 
-            auto visitDef = [=](GenTreeLclVarCommon* lcl) {
-                if (lcl->HasCompositeSsaName())
-                {
-                    LclVarDsc* varDsc = lvaGetDesc(lcl);
-                    assert(varDsc->lvPromoted);
-
-                    for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
-                    {
-                        popDef(varDsc->lvFieldLclStart + index, lcl->GetSsaNum(this, index));
-                    }
-                }
-                else
-                {
-                    popDef(lcl->GetLclNum(), lcl->GetSsaNum());
-                }
-
+            auto visitDef = [=](const auto& def) {
+                popDef(def.GetLclNum(), def.GetSsaNum(this));
                 return GenTree::VisitResult::Continue;
             };
 
-            tree->VisitLocalDefNodes(this, visitDef);
+            tree->VisitLocalDefs(this, visitDef);
         }
     }
 }
@@ -316,63 +302,44 @@ bool Compiler::optCopyProp(
 }
 
 //------------------------------------------------------------------------------
-// optCopyPropPushDef: Push the new live SSA def on the stack for "lclNode".
+// optCopyPropPushDef: Push the new live SSA def on the stack.
 //
 // Arguments:
 //    lclNode    - The local tree representing "the def"
+//    lclNum     - The logical local being defined
+//    ssaNum     - The SSA number of the definition
 //    curSsaName - The map of local numbers to stacks of their defs
 //
-void Compiler::optCopyPropPushDef(GenTreeLclVarCommon* lclNode, LclNumToLiveDefsMap* curSsaName)
+void Compiler::optCopyPropPushDef(GenTreeLclVarCommon* lclNode,
+                                  unsigned             lclNum,
+                                  unsigned             ssaNum,
+                                  LclNumToLiveDefsMap* curSsaName)
 {
-    unsigned lclNum = lclNode->GetLclNum();
-
     // Shadowed parameters are special: they will (at most) have one use, as values in a store
     // to their shadow, and we must not substitute them anywhere. So we'll not push any defs.
-    if ((gsShadowVarInfo != nullptr) && lvaGetDesc(lclNum)->lvIsParam &&
-        (gsShadowVarInfo[lclNum].shadowCopy != BAD_VAR_NUM))
+    unsigned nodeLclNum = lclNode->GetLclNum();
+    if ((gsShadowVarInfo != nullptr) && lvaGetDesc(nodeLclNum)->lvIsParam &&
+        (gsShadowVarInfo[nodeLclNum].shadowCopy != BAD_VAR_NUM))
     {
-        assert(!curSsaName->Lookup(lclNum));
+        assert(!curSsaName->Lookup(nodeLclNum));
         return;
     }
 
-    auto pushDef = [=](unsigned defLclNum, unsigned defSsaNum) {
-        // The default is "not available".
-        LclSsaVarDsc* ssaDef = nullptr;
-
-        if (defSsaNum != SsaConfig::RESERVED_SSA_NUM)
-        {
-            ssaDef = lvaGetDesc(defLclNum)->GetPerSsaData(defSsaNum);
-        }
-
-        CopyPropSsaDefStack* defStack;
-        if (!curSsaName->Lookup(defLclNum, &defStack))
-        {
-            defStack = new (curSsaName->GetAllocator()) CopyPropSsaDefStack(curSsaName->GetAllocator());
-            curSsaName->Set(defLclNum, defStack);
-        }
-
-        defStack->Push(CopyPropSsaDef(ssaDef, lclNode));
-    };
-
-    if (lclNode->HasCompositeSsaName())
+    if (ssaNum == SsaConfig::RESERVED_SSA_NUM)
     {
-        LclVarDsc* varDsc = lvaGetDesc(lclNum);
-        assert(varDsc->lvPromoted);
+        return;
+    }
 
-        for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
-        {
-            unsigned ssaNum = lclNode->GetSsaNum(this, index);
-            if (ssaNum != SsaConfig::RESERVED_SSA_NUM)
-            {
-                pushDef(varDsc->lvFieldLclStart + index, ssaNum);
-            }
-        }
-    }
-    else if (lclNode->HasSsaName())
+    LclSsaVarDsc* ssaDef = lvaGetDesc(lclNum)->GetPerSsaData(ssaNum);
+
+    CopyPropSsaDefStack* defStack;
+    if (!curSsaName->Lookup(lclNum, &defStack))
     {
-        unsigned ssaNum = lclNode->GetSsaNum();
-        pushDef(lclNum, ssaNum);
+        defStack = new (curSsaName->GetAllocator()) CopyPropSsaDefStack(curSsaName->GetAllocator());
+        curSsaName->Set(lclNum, defStack);
     }
+
+    defStack->Push(CopyPropSsaDef(ssaDef, lclNode));
 }
 
 //------------------------------------------------------------------------------
@@ -416,12 +383,12 @@ bool Compiler::optBlockCopyProp(BasicBlock* block, LclNumToLiveDefsMap* curSsaNa
 
             if (tree->OperIsSsaDef())
             {
-                auto visitDef = [=](GenTreeLclVarCommon* lcl) {
-                    optCopyPropPushDef(lcl, curSsaName);
+                auto visitDef = [=](const auto& def) {
+                    optCopyPropPushDef(def.GetDefNode(), def.GetLclNum(), def.GetSsaNum(this), curSsaName);
                     return GenTree::VisitResult::Continue;
                 };
 
-                tree->VisitLocalDefNodes(this, visitDef);
+                tree->VisitLocalDefs(this, visitDef);
             }
             else if (tree->OperIs(GT_LCL_VAR, GT_LCL_FLD) && tree->AsLclVarCommon()->HasSsaName())
             {
@@ -431,7 +398,7 @@ bool Compiler::optBlockCopyProp(BasicBlock* block, LclNumToLiveDefsMap* curSsaNa
                 // live definition. Since they are always live, we'll do it only once.
                 if ((lvaGetDesc(lclNum)->lvIsParam || (lclNum == info.compThisArg)) && !curSsaName->Lookup(lclNum))
                 {
-                    optCopyPropPushDef(tree->AsLclVarCommon(), curSsaName);
+                    optCopyPropPushDef(tree->AsLclVarCommon(), lclNum, tree->AsLclVarCommon()->GetSsaNum(), curSsaName);
                 }
 
                 // TODO-Review: EH successor/predecessor iteration seems broken.

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -4414,52 +4414,26 @@ public:
 
     void ProcessDefs(GenTree* tree)
     {
-        auto visitDef = [=](const LocalDef& def) {
-            const bool       isUse  = (def.Def->gtFlags & GTF_VAR_USEASG) != 0;
-            unsigned const   lclNum = def.Def->GetLclNum();
-            LclVarDsc* const varDsc = m_compiler->lvaGetDesc(lclNum);
+        auto visitDef = [=](const auto& def) {
+            GenTreeLclVarCommon* defNode = def.GetDefNode();
+            const bool           isUse   = (defNode->gtFlags & GTF_VAR_USEASG) != 0;
+            unsigned const       lclNum  = def.GetLclNum();
+            LclVarDsc* const     varDsc  = m_compiler->lvaGetDesc(lclNum);
 
-            assert(!(def.IsEntire && isUse));
+            assert(def.IsEntire(m_compiler) || isUse);
 
-            if (def.Def->HasCompositeSsaName())
+            unsigned const ssaNum = def.GetSsaNum(m_compiler);
+            ProcessDef(defNode, lclNum, ssaNum);
+
+            if (!def.IsEntire(m_compiler))
             {
-                for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
+                assert(isUse);
+                unsigned useSsaNum = SsaConfig::RESERVED_SSA_NUM;
+                if (ssaNum != SsaConfig::RESERVED_SSA_NUM)
                 {
-                    unsigned const   fieldLclNum = varDsc->lvFieldLclStart + index;
-                    LclVarDsc* const fieldVarDsc = m_compiler->lvaGetDesc(fieldLclNum);
-                    unsigned const   fieldSsaNum = def.Def->GetSsaNum(m_compiler, index);
-
-                    ssize_t   fieldStoreOffset;
-                    ValueSize fieldStoreSize;
-                    if (m_compiler->gtStoreMayDefineField(fieldVarDsc, def.Offset, def.Size, &fieldStoreOffset,
-                                                          &fieldStoreSize))
-                    {
-                        ProcessDef(def.Def, fieldLclNum, fieldSsaNum);
-
-                        if (!ValueNumStore::LoadStoreIsEntire(fieldVarDsc->lvValueSize(), fieldStoreOffset,
-                                                              fieldStoreSize))
-                        {
-                            assert(isUse);
-                            unsigned const fieldUseSsaNum = fieldVarDsc->GetPerSsaData(fieldSsaNum)->GetUseDefSsaNum();
-                            ProcessUse(def.Def, fieldLclNum, fieldUseSsaNum);
-                        }
-                    }
+                    useSsaNum = varDsc->GetPerSsaData(ssaNum)->GetUseDefSsaNum();
                 }
-            }
-            else
-            {
-                unsigned const ssaNum = def.Def->GetSsaNum();
-                ProcessDef(def.Def, lclNum, ssaNum);
-
-                if (isUse)
-                {
-                    unsigned useSsaNum = SsaConfig::RESERVED_SSA_NUM;
-                    if (ssaNum != SsaConfig::RESERVED_SSA_NUM)
-                    {
-                        useSsaNum = varDsc->GetPerSsaData(ssaNum)->GetUseDefSsaNum();
-                    }
-                    ProcessUse(def.Def, lclNum, useSsaNum);
-                }
+                ProcessUse(defNode, lclNum, useSsaNum);
             }
 
             return GenTree::VisitResult::Continue;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5474,7 +5474,7 @@ void FlowGraphNaturalLoops::Dump(FlowGraphNaturalLoops* loops)
 //   TFunc - Callback functor type
 //
 // Parameters:
-//   func - Callback functor that accepts a GenTreeLclVarCommon* and returns a
+//   func - Generic callback functor that accepts a local definition provider and returns a
 //   bool. On true, continue looking for defs; on false, abort.
 //
 // Returns:
@@ -5509,11 +5509,11 @@ bool FlowGraphNaturalLoop::VisitDefs(TFunc func)
                 return Compiler::WALK_SKIP_SUBTREES;
             }
 
-            auto visitDef = [=](GenTreeLclVarCommon* lcl) {
-                return m_func(lcl) ? GenTree::VisitResult::Continue : GenTree::VisitResult::Abort;
+            auto visitDef = [=](const auto& def) {
+                return m_func(def) ? GenTree::VisitResult::Continue : GenTree::VisitResult::Abort;
             };
 
-            if (tree->VisitLocalDefNodes(m_compiler, visitDef) == GenTree::VisitResult::Abort)
+            if (tree->VisitLocalDefs(m_compiler, visitDef) == GenTree::VisitResult::Abort)
             {
                 return Compiler::WALK_ABORT;
             }
@@ -5544,8 +5544,7 @@ bool FlowGraphNaturalLoop::VisitDefs(TFunc func)
 //   lclNum - The local.
 //
 // Returns:
-//   Tree that represents a def of the local, or a def of the parent local if
-//   the local is a field; nullptr if no def was found.
+//   Tree that represents a def of the local; nullptr if no def was found.
 //
 // Remarks:
 //   Does not support promoted struct locals, but does support fields of
@@ -5556,18 +5555,11 @@ GenTreeLclVarCommon* FlowGraphNaturalLoop::FindDef(unsigned lclNum)
     LclVarDsc* dsc = m_dfsTree->GetCompiler()->lvaGetDesc(lclNum);
     assert(!dsc->lvPromoted);
 
-    unsigned lclNum2 = BAD_VAR_NUM;
-
-    if (dsc->lvIsStructField)
-    {
-        lclNum2 = dsc->lvParentLcl;
-    }
-
     GenTreeLclVarCommon* result = nullptr;
-    VisitDefs([&result, lclNum, lclNum2](GenTreeLclVarCommon* def) {
-        if ((def->GetLclNum() == lclNum) || (def->GetLclNum() == lclNum2))
+    VisitDefs([&result, lclNum](const auto& def) {
+        if (def.GetLclNum() == lclNum)
         {
-            result = def;
+            result = def.GetDefNode();
             return false;
         }
 
@@ -5699,11 +5691,11 @@ bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info, bool allo
             continue;
         }
 
-        bool result = VisitDefs([=](GenTreeLclVarCommon* def) {
-            if ((def->GetLclNum() != iterVar) || (def == iterTree))
+        bool result = VisitDefs([=](const auto& def) {
+            if ((def.GetLclNum() != iterVar) || (def.GetDefNode() == iterTree))
                 return true;
 
-            JITDUMP("    Loop has extraneous def [%06u]\n", Compiler::dspTreeID(def));
+            JITDUMP("    Loop has extraneous def [%06u]\n", Compiler::dspTreeID(def.GetDefNode()));
             return false;
         });
 
@@ -6282,15 +6274,8 @@ bool FlowGraphNaturalLoop::HasDef(unsigned lclNum)
     // Currently does not handle promoted locals, only fields.
     assert(!dsc->lvPromoted);
 
-    unsigned defLclNum1 = lclNum;
-    unsigned defLclNum2 = BAD_VAR_NUM;
-    if (dsc->lvIsStructField)
-    {
-        defLclNum2 = dsc->lvParentLcl;
-    }
-
-    bool result = VisitDefs([=](GenTreeLclVarCommon* lcl) {
-        if ((lcl->GetLclNum() == defLclNum1) || (lcl->GetLclNum() == defLclNum2))
+    bool result = VisitDefs([=](const auto& def) {
+        if (def.GetLclNum() == lclNum)
         {
             return false;
         }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8136,24 +8136,21 @@ bool Compiler::gtTreeHasLocalStore(GenTree* tree, unsigned lclNum)
                 return WALK_SKIP_SUBTREES;
             }
 
-            auto visit = [&](GenTreeLclVarCommon* lclVar) {
-                if (lclVar->GetLclNum() == m_lclNum)
+            auto visit = [&](const auto& def) {
+                unsigned lclNum = def.GetLclNum();
+                if (lclNum == m_lclNum)
                 {
                     return GenTree::VisitResult::Abort;
                 }
-                if (m_lclDsc->lvIsStructField && (lclVar->GetLclNum() == m_lclDsc->lvParentLcl))
-                {
-                    return GenTree::VisitResult::Abort;
-                }
-                if (m_lclDsc->lvPromoted && (lclVar->GetLclNum() >= m_lclDsc->lvFieldLclStart) &&
-                    (lclVar->GetLclNum() < m_lclDsc->lvFieldLclStart + m_lclDsc->lvFieldCnt))
+                if (m_lclDsc->lvPromoted && (lclNum >= m_lclDsc->lvFieldLclStart) &&
+                    (lclNum < m_lclDsc->lvFieldLclStart + m_lclDsc->lvFieldCnt))
                 {
                     return GenTree::VisitResult::Abort;
                 }
                 return GenTree::VisitResult::Continue;
             };
 
-            if (node->VisitLocalDefNodes(m_compiler, visit) == GenTree::VisitResult::Abort)
+            if (node->VisitLocalDefs(m_compiler, visit) == GenTree::VisitResult::Abort)
             {
                 return WALK_ABORT;
             }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2170,6 +2170,15 @@ public:
     // is not the same size as the type of the GT_LCL_VAR.
     bool IsPartialLclFld(Compiler* comp);
 
+    bool IsEntireLocalDef(Compiler* comp, GenTreeLclVarCommon* def);
+
+    template <typename TVisitor>
+    VisitResult VisitLocalDef(Compiler* comp, GenTreeLclVarCommon* def, TVisitor visitor);
+
+    template <typename TVisitor>
+    VisitResult VisitLocalDef(
+        Compiler* comp, GenTreeLclVarCommon* def, bool isEntire, ssize_t offset, ValueSize size, TVisitor visitor);
+
     template <typename TVisitor>
     VisitResult VisitLocalDefs(Compiler* comp, TVisitor visitor);
 

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -271,30 +271,6 @@ LoopDefinitions::LocalDefinitionsMap* LoopDefinitions::GetOrCreateMap(FlowGraphN
 
             m_map->Set(lcl->GetLclNum(), true, LocalDefinitionsMap::Overwrite);
 
-            LclVarDsc* lclDsc = m_compiler->lvaGetDesc(lcl);
-            if (m_compiler->lvaIsImplicitByRefLocal(lcl->GetLclNum()) && lclDsc->lvPromoted)
-            {
-                // fgRetypeImplicitByRefArgs created a new promoted
-                // struct local to represent this arg. The stores will
-                // be rewritten by morph.
-                assert(lclDsc->lvFieldLclStart != 0);
-                m_map->Set(lclDsc->lvFieldLclStart, true, LocalDefinitionsMap::Overwrite);
-                lclDsc = m_compiler->lvaGetDesc(lclDsc->lvFieldLclStart);
-            }
-
-            if (lclDsc->lvPromoted)
-            {
-                for (unsigned i = 0; i < lclDsc->lvFieldCnt; i++)
-                {
-                    unsigned fieldLclNum = lclDsc->lvFieldLclStart + i;
-                    m_map->Set(fieldLclNum, true, LocalDefinitionsMap::Overwrite);
-                }
-            }
-            else if (lclDsc->lvIsStructField)
-            {
-                m_map->Set(lclDsc->lvParentLcl, true, LocalDefinitionsMap::Overwrite);
-            }
-
             return Compiler::WALK_CONTINUE;
         }
 

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -271,6 +271,30 @@ LoopDefinitions::LocalDefinitionsMap* LoopDefinitions::GetOrCreateMap(FlowGraphN
 
             m_map->Set(lcl->GetLclNum(), true, LocalDefinitionsMap::Overwrite);
 
+            LclVarDsc* lclDsc = m_compiler->lvaGetDesc(lcl);
+            if (m_compiler->lvaIsImplicitByRefLocal(lcl->GetLclNum()) && lclDsc->lvPromoted)
+            {
+                // fgRetypeImplicitByRefArgs created a new promoted
+                // struct local to represent this arg. The stores will
+                // be rewritten by morph.
+                assert(lclDsc->lvFieldLclStart != 0);
+                m_map->Set(lclDsc->lvFieldLclStart, true, LocalDefinitionsMap::Overwrite);
+                lclDsc = m_compiler->lvaGetDesc(lclDsc->lvFieldLclStart);
+            }
+
+            if (lclDsc->lvPromoted)
+            {
+                for (unsigned i = 0; i < lclDsc->lvFieldCnt; i++)
+                {
+                    unsigned fieldLclNum = lclDsc->lvFieldLclStart + i;
+                    m_map->Set(fieldLclNum, true, LocalDefinitionsMap::Overwrite);
+                }
+            }
+            else if (lclDsc->lvIsStructField)
+            {
+                m_map->Set(lclDsc->lvParentLcl, true, LocalDefinitionsMap::Overwrite);
+            }
+
             return Compiler::WALK_CONTINUE;
         }
 

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -1737,18 +1737,18 @@ GenTreeLclVarCommon* Liveness<TLiveness>::ComputeLifeCall(VARSET_TP&       life,
 
     GenTreeLclVarCommon* partialDef = nullptr;
 
-    auto visitDef = [&](const LocalDef& def) {
-        if (!def.IsEntire)
+    auto visitDef = [&](GenTreeLclVarCommon* def) {
+        if ((def->gtFlags & GTF_VAR_USEASG) != 0)
         {
             assert(partialDef == nullptr);
-            partialDef = def.Def;
+            partialDef = def;
         }
 
-        ComputeLifeLocal(life, keepAliveVars, def.Def);
+        ComputeLifeLocal(life, keepAliveVars, def);
         return GenTree::VisitResult::Continue;
     };
 
-    call->VisitLocalDefs(m_compiler, visitDef);
+    call->VisitLocalDefNodes(m_compiler, visitDef);
 
     return partialDef;
 }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -9188,12 +9188,12 @@ void Lowering::FindInducedParameterRegisterLocals()
     {
         hasRegisterKill |= node->IsCall();
 
-        auto visitDefs = [&](GenTreeLclVarCommon* lcl) {
-            storedToLocals.Emplace(lcl->GetLclNum(), true);
+        auto visitDefs = [&](const auto& def) {
+            storedToLocals.Emplace(def.GetLclNum(), true);
             return GenTree::VisitResult::Continue;
         };
 
-        node->VisitLocalDefNodes(m_compiler, visitDefs);
+        node->VisitLocalDefs(m_compiler, visitDefs);
 
         if (node->OperIs(GT_LCL_ADDR))
         {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6859,22 +6859,22 @@ GenTree* Compiler::fgMorphLeaf(GenTree* tree)
 
 void Compiler::fgAssignSetVarDef(GenTree* tree)
 {
-    auto visitDef = [=](const LocalDef& def) {
-        if (def.IsEntire)
+    auto visitDef = [=](GenTreeLclVarCommon* def) {
+        if (tree->IsEntireLocalDef(this, def))
         {
-            def.Def->gtFlags |= GTF_VAR_DEF;
+            def->gtFlags |= GTF_VAR_DEF;
         }
         else
         {
             // We consider partial definitions to be modeled as uses followed by definitions.
             // This captures the idea that precedings defs are not necessarily made redundant
             // by this definition.
-            def.Def->gtFlags |= (GTF_VAR_DEF | GTF_VAR_USEASG);
+            def->gtFlags |= (GTF_VAR_DEF | GTF_VAR_USEASG);
         }
         return GenTree::VisitResult::Continue;
     };
 
-    tree->VisitLocalDefs(this, visitDef);
+    tree->VisitLocalDefNodes(this, visitDef);
 }
 
 //------------------------------------------------------------------------------
@@ -13196,8 +13196,8 @@ void Compiler::fgMorphTreeDone(GenTree* tree, bool optAssertionPropDone DEBUGARG
     //
     if (optAssertionCount > 0)
     {
-        auto visitDef = [=](GenTreeLclVarCommon* lcl) {
-            fgKillDependentAssertions(lcl->GetLclNum() DEBUGARG(tree));
+        auto visitDef = [=](GenTreeLclVarCommon* def) {
+            fgKillDependentAssertions(def->GetLclNum() DEBUGARG(tree));
             return GenTree::VisitResult::Continue;
         };
 

--- a/src/coreclr/jit/promotionliveness.cpp
+++ b/src/coreclr/jit/promotionliveness.cpp
@@ -263,10 +263,10 @@ unsigned PromotionLiveness::GetSizeOfStructLocal(Statement* stmt, GenTreeLclVarC
         assert((data.parent != nullptr) && data.parent->IsCall());
 
         unsigned defSize = UINT_MAX;
-        auto     findDef = [&](const LocalDef& def) {
-            if (def.Def == lcl)
+        auto     findDef = [&](const auto& def) {
+            if (def.GetDefNode() == lcl)
             {
-                defSize = def.Size.GetExact();
+                defSize = def.GetStoreSize(m_compiler).GetExact();
                 return GenTree::VisitResult::Abort;
             }
 

--- a/src/coreclr/jit/sideeffects.cpp
+++ b/src/coreclr/jit/sideeffects.cpp
@@ -317,18 +317,37 @@ void AliasSet::AddNode(Compiler* compiler, GenTree* node)
     }
     if (nodeInfo.IsLclVarWrite())
     {
-        m_lclVarWrites.Add(compiler, nodeInfo.LclNum());
+        bool addedLocalDef = false;
+        auto visitDef      = [&](const auto& def) {
+            addedLocalDef   = true;
+            unsigned lclNum = def.GetLclNum();
+            m_lclVarWrites.Add(compiler, lclNum);
 
-        LclVarDsc* dsc = compiler->lvaGetDesc(nodeInfo.LclNum());
-        if (dsc->lvIsStructField)
-        {
-            m_lclVarWrites.Add(compiler, dsc->lvParentLcl);
-        }
-        else if (dsc->lvPromoted)
-        {
-            for (unsigned i = 0; i < dsc->lvFieldCnt; i++)
+            LclVarDsc* dsc = compiler->lvaGetDesc(lclNum);
+            if (dsc->lvIsStructField)
             {
-                m_lclVarWrites.Add(compiler, dsc->lvFieldLclStart + i);
+                m_lclVarWrites.Add(compiler, dsc->lvParentLcl);
+            }
+
+            return GenTree::VisitResult::Continue;
+        };
+        node->VisitLocalDefs(compiler, visitDef);
+
+        if (!addedLocalDef)
+        {
+            m_lclVarWrites.Add(compiler, nodeInfo.LclNum());
+
+            LclVarDsc* dsc = compiler->lvaGetDesc(nodeInfo.LclNum());
+            if (dsc->lvIsStructField)
+            {
+                m_lclVarWrites.Add(compiler, dsc->lvParentLcl);
+            }
+            else if (dsc->lvPromoted)
+            {
+                for (unsigned i = 0; i < dsc->lvFieldCnt; i++)
+                {
+                    m_lclVarWrites.Add(compiler, dsc->lvFieldLclStart + i);
+                }
             }
         }
     }

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -422,64 +422,36 @@ void SsaBuilder::RenameDef(GenTree* defNode, BasicBlock* block)
     assert(defNode->OperIsStore() || defNode->OperIs(GT_CALL));
 
     bool anyDefs  = false;
-    auto visitDef = [&](const LocalDef& def) {
-        anyDefs = true;
+    auto visitDef = [&](const auto& def) {
+        anyDefs                           = true;
+        GenTreeLclVarCommon* localDefNode = def.GetDefNode();
         // This should have been marked as definition.
-        assert(((def.Def->gtFlags & GTF_VAR_DEF) != 0) &&
-               (((def.Def->gtFlags & GTF_VAR_USEASG) != 0) == !def.IsEntire));
+        assert((localDefNode->gtFlags & GTF_VAR_DEF) != 0);
+        assert(def.IsEntire(m_compiler) || ((localDefNode->gtFlags & GTF_VAR_USEASG) != 0));
 
-        unsigned   lclNum = def.Def->GetLclNum();
+        unsigned   lclNum = def.GetLclNum();
         LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
 
         if (m_compiler->lvaInSsa(lclNum))
         {
-            def.Def->SetSsaNum(RenamePushDef(defNode, block, lclNum, def.IsEntire));
+            def.SetSsaNum(m_compiler, RenamePushDef(defNode, block, lclNum, def.IsEntire(m_compiler)));
             assert(!varDsc->IsAddressExposed()); // Cannot define SSA memory.
-            return GenTree::VisitResult::Continue;
-        }
-
-        if (varDsc->lvPromoted)
-        {
-            for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
-            {
-                unsigned   fieldLclNum = varDsc->lvFieldLclStart + index;
-                LclVarDsc* fieldVarDsc = m_compiler->lvaGetDesc(fieldLclNum);
-                if (m_compiler->lvaInSsa(fieldLclNum))
-                {
-                    ssize_t   fieldStoreOffset;
-                    ValueSize fieldStoreSize;
-                    unsigned  ssaNum = SsaConfig::RESERVED_SSA_NUM;
-
-                    // Fast-path the common case of an "entire" store.
-                    if (def.IsEntire)
-                    {
-                        ssaNum = RenamePushDef(defNode, block, fieldLclNum, /* defIsFull */ true);
-                    }
-                    else if (m_compiler->gtStoreMayDefineField(fieldVarDsc, def.Offset, def.Size, &fieldStoreOffset,
-                                                               &fieldStoreSize))
-                    {
-                        ssaNum = RenamePushDef(defNode, block, fieldLclNum,
-                                               ValueNumStore::LoadStoreIsEntire(fieldVarDsc->lvValueSize(),
-                                                                                fieldStoreOffset, fieldStoreSize));
-                    }
-
-                    if (ssaNum != SsaConfig::RESERVED_SSA_NUM)
-                    {
-                        def.Def->SetSsaNum(m_compiler, index, ssaNum);
-                    }
-                }
-            }
-        }
-
-        if (varDsc->IsAddressExposed())
-        {
-            RenamePushMemoryDef(def.Def, block);
         }
 
         return GenTree::VisitResult::Continue;
     };
 
     defNode->VisitLocalDefs(m_compiler, visitDef);
+
+    auto visitDefNode = [&](GenTreeLclVarCommon* lcl) {
+        if (m_compiler->lvaGetDesc(lcl)->IsAddressExposed())
+        {
+            RenamePushMemoryDef(lcl, block);
+        }
+
+        return GenTree::VisitResult::Continue;
+    };
+    defNode->VisitLocalDefNodes(m_compiler, visitDefNode);
 
     if (!anyDefs)
     {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6675,38 +6675,49 @@ ValueNum ValueNumStore::ExtendPtrVN(GenTree* opA, FieldSeq* fldSeq, ssize_t offs
 //
 // Arguments:
 //    storeNode  - The node performing the store
-//    lclDefNode - The local node representing the SSA definition
-//    offset     - The offset, relative to the local, of the target location
-//    storeSize  - The number of bytes being stored
-//    value      - (VN of) the value being stored
-//    normalize  - Whether "value" should be normalized to the local's type
-//                 (in case the store overwrites the entire variable) before
-//                 being written to the SSA descriptor
+//    def       - The local definition
+//    value     - (VN of) the value being stored
+//    normalize - Whether "value" should be normalized to the local's type
+//                (in case the store overwrites the entire variable) before
+//                being written to the SSA descriptor
 //
-void Compiler::fgValueNumberLocalStore(GenTree*             storeNode,
-                                       GenTreeLclVarCommon* lclDefNode,
-                                       ssize_t              offset,
-                                       ValueSize            storeSize,
-                                       ValueNumPair         value,
-                                       bool                 normalize)
+template <typename TDef>
+void Compiler::fgValueNumberLocalStore(GenTree* storeNode, const TDef& def, ValueNumPair value, bool normalize)
 {
     // Should not have been recorded as updating the GC heap.
     assert(!GetMemorySsaMap(GcHeap)->Lookup(storeNode));
 
-    auto processDef = [=](unsigned defLclNum, unsigned defSsaNum, ssize_t defOffset, ValueSize defSize,
-                          ValueNumPair defValue) {
-        LclVarDsc* defVarDsc = lvaGetDesc(defLclNum);
-
-        if (defSsaNum != SsaConfig::RESERVED_SSA_NUM)
+    GenTreeLclVarCommon* defNode   = def.GetDefNode();
+    unsigned             defLclNum = def.GetLclNum();
+    LclVarDsc*           defVarDsc = lvaGetDesc(defLclNum);
+    ValueNumPair         defValue  = value;
+    if (def.HasMultiDefIndex())
+    {
+        var_types defValueType = TYP_STRUCT;
+        if (def.IsEntire(this))
         {
-            ValueSize lclSize = defVarDsc->lvValueSize();
+            // Avoid redundant bitcasts for the common case of a full definition.
+            defValueType = defVarDsc->TypeGet();
+        }
 
-            ValueNumPair newLclValue;
-            if (vnStore->LoadStoreIsEntire(lclSize, defOffset, defSize))
-            {
-                newLclValue = defValue;
-            }
-            else if (defSize.IsUnknown())
+        defValue = vnStore->VNPairForLoad(value, def.GetStoreSize(this), defValueType, def.GetValueOffset(this),
+                                          def.GetSize(this));
+    }
+
+    unsigned defSsaNum = def.GetSsaNum(this);
+    if (defSsaNum != SsaConfig::RESERVED_SSA_NUM)
+    {
+        ValueSize lclSize = defVarDsc->lvValueSize();
+
+        ValueNumPair newLclValue;
+        if (def.IsEntire(this))
+        {
+            newLclValue = defValue;
+        }
+        else
+        {
+            ValueSize defSize = def.GetSize(this);
+            if (defSize.IsUnknown())
             {
                 JITDUMP("Tree [%06u] performs store to variable-sized local\n", dspTreeID(storeNode));
                 // We don't know the bounds of this store at compile time, so it's given a unique number.
@@ -6714,77 +6725,39 @@ void Compiler::fgValueNumberLocalStore(GenTree*             storeNode,
             }
             else
             {
-                assert((lclDefNode->gtFlags & GTF_VAR_USEASG) != 0);
+                assert((defNode->gtFlags & GTF_VAR_USEASG) != 0);
                 unsigned     oldDefSsaNum = defVarDsc->GetPerSsaData(defSsaNum)->GetUseDefSsaNum();
                 ValueNumPair oldLclValue  = defVarDsc->GetPerSsaData(oldDefSsaNum)->m_vnPair;
                 assert(oldLclValue.BothDefined() && defValue.BothDefined());
-                newLclValue = vnStore->VNPairForStore(oldLclValue, lclSize, defOffset, defSize, defValue);
+                newLclValue = vnStore->VNPairForStore(oldLclValue, lclSize, def.GetOffset(this), defSize, defValue);
             }
-
-            // Any out-of-bounds stores should have made the local address-exposed.
-            assert(newLclValue.BothDefined());
-
-            if (normalize)
-            {
-                // We normalize types stored in local locations because things outside VN itself look at them.
-                newLclValue = vnStore->VNPairForLoadStoreBitCast(newLclValue, defVarDsc->TypeGet(), lclSize);
-                assert((genActualType(vnStore->TypeOfVN(newLclValue.GetLiberal())) == genActualType(defVarDsc)));
-            }
-
-            defVarDsc->GetPerSsaData(defSsaNum)->m_vnPair = newLclValue;
-
-            JITDUMP("Tree [%06u] assigned VN to local var V%02u/%d: ", dspTreeID(storeNode), defLclNum, defSsaNum);
-            JITDUMPEXEC(vnpPrint(newLclValue, 1));
-            JITDUMP("\n");
         }
-        else if (defVarDsc->IsAddressExposed())
+
+        // Any out-of-bounds stores should have made the local address-exposed.
+        assert(newLclValue.BothDefined());
+
+        if (normalize)
         {
-            ValueNum heapVN = vnStore->VNForExpr(compCurBB, TYP_HEAP);
-            recordAddressExposedLocalStore(storeNode, heapVN DEBUGARG("local assign"));
+            // We normalize types stored in local locations because things outside VN itself look at them.
+            newLclValue = vnStore->VNPairForLoadStoreBitCast(newLclValue, defVarDsc->TypeGet(), lclSize);
+            assert((genActualType(vnStore->TypeOfVN(newLclValue.GetLiberal())) == genActualType(defVarDsc)));
         }
-        else
-        {
-            JITDUMP("Tree [%06u] assigns to non-address-taken local V%02u; excluded from SSA, so value not tracked\n",
-                    dspTreeID(storeNode), defLclNum);
-        }
-    };
 
-    if (lclDefNode->HasCompositeSsaName())
+        defVarDsc->GetPerSsaData(defSsaNum)->m_vnPair = newLclValue;
+
+        JITDUMP("Tree [%06u] assigned VN to local var V%02u/%d: ", dspTreeID(storeNode), defLclNum, defSsaNum);
+        JITDUMPEXEC(vnpPrint(newLclValue, 1));
+        JITDUMP("\n");
+    }
+    else if (defVarDsc->IsAddressExposed())
     {
-        LclVarDsc* varDsc = lvaGetDesc(lclDefNode);
-        assert(varDsc->lvPromoted);
-
-        for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
-        {
-            unsigned   fieldLclNum = varDsc->lvFieldLclStart + index;
-            LclVarDsc* fieldVarDsc = lvaGetDesc(fieldLclNum);
-
-            ssize_t   fieldStoreOffset;
-            ValueSize fieldStoreSize;
-            if (gtStoreMayDefineField(fieldVarDsc, offset, storeSize, &fieldStoreOffset, &fieldStoreSize))
-            {
-                // TYP_STRUCT can represent the general case where the value could be of any size.
-                var_types fieldStoreType = TYP_STRUCT;
-                if (vnStore->LoadStoreIsEntire(fieldVarDsc->lvValueSize(), fieldStoreOffset, fieldStoreSize))
-                {
-                    // Avoid redundant bitcasts for the common case of a full definition.
-                    fieldStoreType = fieldVarDsc->TypeGet();
-                }
-
-                // Calculate offset of this field's value, relative to the entire one.
-                ssize_t      fieldOffset      = fieldVarDsc->lvFldOffset;
-                ssize_t      fieldValueOffset = (fieldOffset < offset) ? 0 : (fieldOffset - offset);
-                ValueNumPair fieldStoreValue =
-                    vnStore->VNPairForLoad(value, storeSize, fieldStoreType, fieldValueOffset, fieldStoreSize);
-
-                processDef(fieldLclNum, lclDefNode->GetSsaNum(this, index), fieldStoreOffset, fieldStoreSize,
-                           fieldStoreValue);
-            }
-        }
+        ValueNum heapVN = vnStore->VNForExpr(compCurBB, TYP_HEAP);
+        recordAddressExposedLocalStore(storeNode, heapVN DEBUGARG("local assign"));
     }
     else
     {
-        processDef(lclDefNode->GetLclNum(), lclDefNode->GetSsaNum(), offset, storeSize, value);
+        JITDUMP("Tree [%06u] assigns to non-address-taken local V%02u; excluded from SSA, so value not tracked\n",
+                dspTreeID(storeNode), defLclNum);
     }
 }
 
@@ -12952,17 +12925,14 @@ void Compiler::fgValueNumberStore(GenTree* store)
     switch (store->OperGet())
     {
         case GT_STORE_LCL_VAR:
-        {
-            GenTreeLclVarCommon* lcl = store->AsLclVarCommon();
-            fgValueNumberLocalStore(store, lcl, 0, lvaLclValueSize(lcl->GetLclNum()), valueVNPair,
-                                    /* normalize */ false);
-        }
-        break;
-
         case GT_STORE_LCL_FLD:
         {
-            GenTreeLclFld* lclFld = store->AsLclFld();
-            fgValueNumberLocalStore(store, lclFld, lclFld->GetLclOffs(), lclFld->GetValueSize(), valueVNPair);
+            bool normalize = store->OperIs(GT_STORE_LCL_FLD);
+            auto visitDef  = [=](const auto& def) {
+                fgValueNumberLocalStore(store, def, valueVNPair, normalize);
+                return GenTree::VisitResult::Continue;
+            };
+            store->VisitLocalDefs(this, visitDef);
         }
         break;
 
@@ -14984,11 +14954,11 @@ void Compiler::fgValueNumberCall(GenTreeCall* call)
 
     // If the call generates any definitions, for example because it uses "return buffer", then VN the local
     // as well.
-    auto visitDef = [=](const LocalDef& def) {
+    auto visitDef = [=](const auto& def) {
         ValueNumPair storeValue;
-        storeValue.SetBoth(vnStore->VNForExpr(compCurBB, lvaGetDesc(def.Def->AsLclVarCommon())->TypeGet()));
+        storeValue.SetBoth(vnStore->VNForExpr(compCurBB, lvaGetDesc(def.GetDefNode())->TypeGet()));
 
-        fgValueNumberLocalStore(call, def.Def, def.Offset, def.Size, storeValue);
+        fgValueNumberLocalStore(call, def, storeValue);
         return GenTree::VisitResult::Continue;
     };
 


### PR DESCRIPTION
Teach `VisitLocalDefs` to report the logical field definitions represented by stores to promoted struct locals, including ranged `STORE_LCL_FLD` and call definitions. Use typed providers so definition properties are computed only when requested, while keeping `VisitLocalDefNodes` for consumers that need the physical IR nodes.

Update SSA, value numbering, copy propagation, async analysis, alias tracking, loop queries, and assertion invalidation to consume the appropriate visitor. This removes promotion-specific definition expansion from those consumers and prepares the IR for representing multiple local definitions explicitly with a new `STORE_LCL_VARS` node.