### PR TITLE
[wasm] Align the runtime-test call-helper generator override

### DIFF
--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -699,16 +699,16 @@
          the wasm-tools workload acquires, which sets $(Crossgen2ToolPath) from its Sdk.props. -->
     <PropertyGroup>
       <_PortableCallHelpersGeneratorExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_PortableCallHelpersGeneratorExeSuffix>
-      <PortableCallHelpersGeneratorPath Condition="'$(PortableCallHelpersGeneratorPath)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_PortableCallHelpersGeneratorExeSuffix)'))</PortableCallHelpersGeneratorPath>
-      <PortableCallHelpersGeneratorPath Condition="'$(PortableCallHelpersGeneratorPath)' == ''">$(Crossgen2ToolPath)</PortableCallHelpersGeneratorPath>
+      <Crossgen2Path Condition="'$(Crossgen2Path)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_PortableCallHelpersGeneratorExeSuffix)'))</Crossgen2Path>
+      <Crossgen2Path Condition="'$(Crossgen2Path)' == ''">$(Crossgen2ToolPath)</Crossgen2Path>
     </PropertyGroup>
 
-    <Error Condition="'$(PortableCallHelpersGeneratorPath)' == ''"
-           Text="crossgen2 was not found, so the portable call helpers cannot be generated. Install the 'wasm-tools' workload, or set %24(PortableCallHelpersGeneratorPath) to a crossgen2 executable." />
-    <Error Condition="'$([System.IO.Path]::GetExtension(`$(PortableCallHelpersGeneratorPath)`))' == '.dll'"
-           Text="%24(PortableCallHelpersGeneratorPath) is '$(PortableCallHelpersGeneratorPath)'. It has to name a crossgen2 executable; an IL assembly cannot be launched directly." />
-    <Error Condition="!Exists('$(PortableCallHelpersGeneratorPath)')"
-           Text="%24(PortableCallHelpersGeneratorPath) is '$(PortableCallHelpersGeneratorPath)', which does not exist. In the repo, build crossgen2 first; outside it, install the 'wasm-tools' workload." />
+    <Error Condition="'$(Crossgen2Path)' == ''"
+           Text="crossgen2 was not found, so the portable call helpers cannot be generated. Install the 'wasm-tools' workload, or set %24(Crossgen2Path) to a crossgen2 executable." />
+    <Error Condition="'$([System.IO.Path]::GetExtension(`$(Crossgen2Path)`))' == '.dll'"
+           Text="%24(Crossgen2Path) is '$(Crossgen2Path)'. It has to name a crossgen2 executable; an IL assembly cannot be launched directly." />
+    <Error Condition="!Exists('$(Crossgen2Path)')"
+           Text="%24(Crossgen2Path) is '$(Crossgen2Path)', which does not exist. In the repo, build crossgen2 first; outside it, install the 'wasm-tools' workload." />
 
     <PropertyGroup>
       <_PortableCallHelpersGeneratorRsp>$(_WasmIntermediateOutputPath)callhelpers-generator.rsp</_PortableCallHelpersGeneratorRsp>
@@ -724,7 +724,7 @@
 
     <WriteLinesToFile File="$(_PortableCallHelpersGeneratorRsp)" Lines="@(_PortableCallHelpersGeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
-    <Exec Command="&quot;$(PortableCallHelpersGeneratorPath)&quot; &quot;@$(_PortableCallHelpersGeneratorRsp)&quot;" />
+    <Exec Command="&quot;$(Crossgen2Path)&quot; &quot;@$(_PortableCallHelpersGeneratorRsp)&quot;" />
 
     <ItemGroup>
       <FileWrites Include="$(_PortableCallHelpersGeneratorRsp);$(_WasmPInvokeTablePath);$(_WasmReversePInvokeTablePath);$(_WasmInterpToNativeTablePath)" />

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -698,8 +698,8 @@
          In the repo it comes from the build output; outside it, from the crossgen2 pack
          the wasm-tools workload acquires, which sets $(Crossgen2ToolPath) from its Sdk.props. -->
     <PropertyGroup>
-      <_PortableCallHelpersGeneratorExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_PortableCallHelpersGeneratorExeSuffix>
-      <Crossgen2Path Condition="'$(Crossgen2Path)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_PortableCallHelpersGeneratorExeSuffix)'))</Crossgen2Path>
+      <_Crossgen2ExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_Crossgen2ExeSuffix>
+      <Crossgen2Path Condition="'$(Crossgen2Path)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_Crossgen2ExeSuffix)'))</Crossgen2Path>
       <Crossgen2Path Condition="'$(Crossgen2Path)' == ''">$(Crossgen2ToolPath)</Crossgen2Path>
     </PropertyGroup>
 
@@ -711,23 +711,23 @@
            Text="%24(Crossgen2Path) is '$(Crossgen2Path)', which does not exist. In the repo, build crossgen2 first; outside it, install the 'wasm-tools' workload." />
 
     <PropertyGroup>
-      <_PortableCallHelpersGeneratorRsp>$(_WasmIntermediateOutputPath)callhelpers-generator.rsp</_PortableCallHelpersGeneratorRsp>
+      <_Crossgen2GeneratorRsp>$(_WasmIntermediateOutputPath)callhelpers-generator.rsp</_Crossgen2GeneratorRsp>
     </PropertyGroup>
 
     <ItemGroup>
-      <_PortableCallHelpersGeneratorArg Include="--targetos:browser" />
-      <_PortableCallHelpersGeneratorArg Include="--targetarch:wasm" />
-      <_PortableCallHelpersGeneratorArg Include="--generate-portable-callhelpers:$(_WasmIntermediateOutputPath)" />
-      <_PortableCallHelpersGeneratorArg Include="@(_WasmPInvokeModules->'--directpinvoke:%(Identity)')" />
-      <_PortableCallHelpersGeneratorArg Include="@(_WasmManagedAssemblies->'%(FullPath)')" />
+      <_Crossgen2GeneratorArg Include="--targetos:browser" />
+      <_Crossgen2GeneratorArg Include="--targetarch:wasm" />
+      <_Crossgen2GeneratorArg Include="--generate-portable-callhelpers:$(_WasmIntermediateOutputPath)" />
+      <_Crossgen2GeneratorArg Include="@(_WasmPInvokeModules->'--directpinvoke:%(Identity)')" />
+      <_Crossgen2GeneratorArg Include="@(_WasmManagedAssemblies->'%(FullPath)')" />
     </ItemGroup>
 
-    <WriteLinesToFile File="$(_PortableCallHelpersGeneratorRsp)" Lines="@(_PortableCallHelpersGeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(_Crossgen2GeneratorRsp)" Lines="@(_Crossgen2GeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
-    <Exec Command="&quot;$(Crossgen2Path)&quot; &quot;@$(_PortableCallHelpersGeneratorRsp)&quot;" />
+    <Exec Command="&quot;$(Crossgen2Path)&quot; &quot;@$(_Crossgen2GeneratorRsp)&quot;" />
 
     <ItemGroup>
-      <FileWrites Include="$(_PortableCallHelpersGeneratorRsp);$(_WasmPInvokeTablePath);$(_WasmReversePInvokeTablePath);$(_WasmInterpToNativeTablePath)" />
+      <FileWrites Include="$(_Crossgen2GeneratorRsp);$(_WasmPInvokeTablePath);$(_WasmReversePInvokeTablePath);$(_WasmInterpToNativeTablePath)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/mono/wasi/build/WasiApp.CoreCLR.targets
+++ b/src/mono/wasi/build/WasiApp.CoreCLR.targets
@@ -158,8 +158,8 @@
          today, so out-of-repo wasi relink needs $(Crossgen2Path) or
          $(Crossgen2ToolPath) to be set explicitly. -->
     <PropertyGroup>
-      <_PortableCallHelpersGeneratorExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_PortableCallHelpersGeneratorExeSuffix>
-      <Crossgen2Path Condition="'$(Crossgen2Path)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_PortableCallHelpersGeneratorExeSuffix)'))</Crossgen2Path>
+      <_Crossgen2ExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_Crossgen2ExeSuffix>
+      <Crossgen2Path Condition="'$(Crossgen2Path)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_Crossgen2ExeSuffix)'))</Crossgen2Path>
       <Crossgen2Path Condition="'$(Crossgen2Path)' == ''">$(Crossgen2ToolPath)</Crossgen2Path>
     </PropertyGroup>
 
@@ -171,23 +171,23 @@
            Text="%24(Crossgen2Path) is '$(Crossgen2Path)', which does not exist. In the repo, build crossgen2 first; outside it, set it to a crossgen2 executable." />
 
     <PropertyGroup>
-      <_PortableCallHelpersGeneratorRsp>$(_WasiRelinkObjDir)callhelpers-generator.rsp</_PortableCallHelpersGeneratorRsp>
+      <_Crossgen2GeneratorRsp>$(_WasiRelinkObjDir)callhelpers-generator.rsp</_Crossgen2GeneratorRsp>
     </PropertyGroup>
 
     <ItemGroup>
-      <_PortableCallHelpersGeneratorArg Include="--targetos:wasi" />
-      <_PortableCallHelpersGeneratorArg Include="--targetarch:wasm" />
-      <_PortableCallHelpersGeneratorArg Include="--generate-portable-callhelpers:$(_WasiRelinkObjDir)" />
-      <_PortableCallHelpersGeneratorArg Include="@(_WasiPInvokeModules->'--directpinvoke:%(Identity)')" />
-      <_PortableCallHelpersGeneratorArg Include="@(_WasiManagedAssemblies->'%(FullPath)')" />
+      <_Crossgen2GeneratorArg Include="--targetos:wasi" />
+      <_Crossgen2GeneratorArg Include="--targetarch:wasm" />
+      <_Crossgen2GeneratorArg Include="--generate-portable-callhelpers:$(_WasiRelinkObjDir)" />
+      <_Crossgen2GeneratorArg Include="@(_WasiPInvokeModules->'--directpinvoke:%(Identity)')" />
+      <_Crossgen2GeneratorArg Include="@(_WasiManagedAssemblies->'%(FullPath)')" />
     </ItemGroup>
 
-    <WriteLinesToFile File="$(_PortableCallHelpersGeneratorRsp)" Lines="@(_PortableCallHelpersGeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(_Crossgen2GeneratorRsp)" Lines="@(_Crossgen2GeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
-    <Exec Command="&quot;$(Crossgen2Path)&quot; &quot;@$(_PortableCallHelpersGeneratorRsp)&quot;" />
+    <Exec Command="&quot;$(Crossgen2Path)&quot; &quot;@$(_Crossgen2GeneratorRsp)&quot;" />
 
     <ItemGroup>
-      <FileWrites Include="$(_PortableCallHelpersGeneratorRsp);$(_WasiPInvokeTablePath);$(_WasiReversePInvokeTablePath);$(_WasiInterpToNativeTablePath)" />
+      <FileWrites Include="$(_Crossgen2GeneratorRsp);$(_WasiPInvokeTablePath);$(_WasiReversePInvokeTablePath);$(_WasiInterpToNativeTablePath)" />
     </ItemGroup>
 
     <!-- 2. Compile the three generated callhelper sources with the wasi-sdk clang.

--- a/src/mono/wasi/build/WasiApp.CoreCLR.targets
+++ b/src/mono/wasi/build/WasiApp.CoreCLR.targets
@@ -155,20 +155,20 @@
     <!-- crossgen2 has the type system that knows the wasm ABI, so it generates the helpers itself.
          In the repo it comes from the build output; outside it, from a crossgen2 pack
          that sets $(Crossgen2ToolPath). The wasi-experimental workload does not acquire that pack
-         today, so out-of-repo wasi relink needs $(PortableCallHelpersGeneratorPath) or
+         today, so out-of-repo wasi relink needs $(Crossgen2Path) or
          $(Crossgen2ToolPath) to be set explicitly. -->
     <PropertyGroup>
       <_PortableCallHelpersGeneratorExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_PortableCallHelpersGeneratorExeSuffix>
-      <PortableCallHelpersGeneratorPath Condition="'$(PortableCallHelpersGeneratorPath)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_PortableCallHelpersGeneratorExeSuffix)'))</PortableCallHelpersGeneratorPath>
-      <PortableCallHelpersGeneratorPath Condition="'$(PortableCallHelpersGeneratorPath)' == ''">$(Crossgen2ToolPath)</PortableCallHelpersGeneratorPath>
+      <Crossgen2Path Condition="'$(Crossgen2Path)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_PortableCallHelpersGeneratorExeSuffix)'))</Crossgen2Path>
+      <Crossgen2Path Condition="'$(Crossgen2Path)' == ''">$(Crossgen2ToolPath)</Crossgen2Path>
     </PropertyGroup>
 
-    <Error Condition="'$(PortableCallHelpersGeneratorPath)' == ''"
-           Text="crossgen2 was not found, so the portable call helpers cannot be generated. Set %24(PortableCallHelpersGeneratorPath) to a crossgen2 executable." />
-    <Error Condition="'$([System.IO.Path]::GetExtension(`$(PortableCallHelpersGeneratorPath)`))' == '.dll'"
-           Text="%24(PortableCallHelpersGeneratorPath) is '$(PortableCallHelpersGeneratorPath)'. It has to name a crossgen2 executable; an IL assembly cannot be launched directly." />
-    <Error Condition="!Exists('$(PortableCallHelpersGeneratorPath)')"
-           Text="%24(PortableCallHelpersGeneratorPath) is '$(PortableCallHelpersGeneratorPath)', which does not exist. In the repo, build crossgen2 first; outside it, set it to a crossgen2 executable." />
+    <Error Condition="'$(Crossgen2Path)' == ''"
+           Text="crossgen2 was not found, so the portable call helpers cannot be generated. Set %24(Crossgen2Path) to a crossgen2 executable." />
+    <Error Condition="'$([System.IO.Path]::GetExtension(`$(Crossgen2Path)`))' == '.dll'"
+           Text="%24(Crossgen2Path) is '$(Crossgen2Path)'. It has to name a crossgen2 executable; an IL assembly cannot be launched directly." />
+    <Error Condition="!Exists('$(Crossgen2Path)')"
+           Text="%24(Crossgen2Path) is '$(Crossgen2Path)', which does not exist. In the repo, build crossgen2 first; outside it, set it to a crossgen2 executable." />
 
     <PropertyGroup>
       <_PortableCallHelpersGeneratorRsp>$(_WasiRelinkObjDir)callhelpers-generator.rsp</_PortableCallHelpersGeneratorRsp>
@@ -184,7 +184,7 @@
 
     <WriteLinesToFile File="$(_PortableCallHelpersGeneratorRsp)" Lines="@(_PortableCallHelpersGeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
-    <Exec Command="&quot;$(PortableCallHelpersGeneratorPath)&quot; &quot;@$(_PortableCallHelpersGeneratorRsp)&quot;" />
+    <Exec Command="&quot;$(Crossgen2Path)&quot; &quot;@$(_PortableCallHelpersGeneratorRsp)&quot;" />
 
     <ItemGroup>
       <FileWrites Include="$(_PortableCallHelpersGeneratorRsp);$(_WasiPInvokeTablePath);$(_WasiReversePInvokeTablePath);$(_WasiInterpToNativeTablePath)" />

--- a/src/tests/Common/CLRTest.WasmCorerun.targets
+++ b/src/tests/Common/CLRTest.WasmCorerun.targets
@@ -323,15 +323,15 @@ against CORE_ROOT, and no SDK is involved. Only the generator task assembly is s
 
     <PropertyGroup>
       <_WasmCorerunGeneratorExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_WasmCorerunGeneratorExeSuffix>
-      <PortableCallHelpersGeneratorPath Condition="'$(PortableCallHelpersGeneratorPath)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_WasmCorerunGeneratorExeSuffix)'))</PortableCallHelpersGeneratorPath>
+      <Crossgen2Path Condition="'$(Crossgen2Path)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_WasmCorerunGeneratorExeSuffix)'))</Crossgen2Path>
     </PropertyGroup>
 
-    <Error Condition="'$(PortableCallHelpersGeneratorPath)' == ''"
-           Text="crossgen2 was not found. Build the 'clr' subset or set %24(PortableCallHelpersGeneratorPath) to a crossgen2 executable." />
-    <Error Condition="!Exists('$(PortableCallHelpersGeneratorPath)')"
-           Text="crossgen2 executable not found: '$(PortableCallHelpersGeneratorPath)'. Build the 'clr' subset or correct %24(PortableCallHelpersGeneratorPath)." />
-    <Error Condition="'$([System.IO.Path]::GetExtension(`$(PortableCallHelpersGeneratorPath)`))' == '.dll'"
-           Text="Set %24(PortableCallHelpersGeneratorPath) to a crossgen2 executable, not the DLL '$(PortableCallHelpersGeneratorPath)'." />
+    <Error Condition="'$(Crossgen2Path)' == ''"
+           Text="crossgen2 was not found. Build the 'clr' subset or set %24(Crossgen2Path) to a crossgen2 executable." />
+    <Error Condition="!Exists('$(Crossgen2Path)')"
+           Text="crossgen2 executable not found: '$(Crossgen2Path)'. Build the 'clr' subset or correct %24(Crossgen2Path)." />
+    <Error Condition="'$([System.IO.Path]::GetExtension(`$(Crossgen2Path)`))' == '.dll'"
+           Text="Set %24(Crossgen2Path) to a crossgen2 executable, not the DLL '$(Crossgen2Path)'." />
 
     <ItemGroup>
       <!-- This file is only imported for browser, so $(TargetOS) is that; naming it rather than
@@ -345,7 +345,7 @@ against CORE_ROOT, and no SDK is involved. Only the generator task assembly is s
 
     <WriteLinesToFile File="$(_WasmCorerunGeneratorRsp)" Lines="@(_WasmCorerunGeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
-    <Exec Command="&quot;$(PortableCallHelpersGeneratorPath)&quot; &quot;@$(_WasmCorerunGeneratorRsp)&quot;" />
+    <Exec Command="&quot;$(Crossgen2Path)&quot; &quot;@$(_WasmCorerunGeneratorRsp)&quot;" />
 
     <ItemGroup>
       <FileWrites Include="$(_WasmCorerunGeneratorRsp)" />

--- a/src/tests/Common/CLRTest.WasmCorerun.targets
+++ b/src/tests/Common/CLRTest.WasmCorerun.targets
@@ -323,15 +323,15 @@ against CORE_ROOT, and no SDK is involved. Only the generator task assembly is s
 
     <PropertyGroup>
       <_WasmCorerunGeneratorExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_WasmCorerunGeneratorExeSuffix>
-      <_WasmCorerunGeneratorPath Condition="'$(_WasmCorerunGeneratorPath)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_WasmCorerunGeneratorExeSuffix)'))</_WasmCorerunGeneratorPath>
+      <PortableCallHelpersGeneratorPath Condition="'$(PortableCallHelpersGeneratorPath)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_WasmCorerunGeneratorExeSuffix)'))</PortableCallHelpersGeneratorPath>
     </PropertyGroup>
 
-    <Error Condition="'$(_WasmCorerunGeneratorPath)' == ''"
-           Text="crossgen2 was not found, so the test's portable call helpers cannot be generated. It is built by the 'clr' subset, or set %24(_WasmCorerunGeneratorPath) to a crossgen2 executable." />
-    <Error Condition="!Exists('$(_WasmCorerunGeneratorPath)')"
-           Text="crossgen2 was not found at '$(_WasmCorerunGeneratorPath)', so the test's portable call helpers cannot be generated. It is built by the 'clr' subset." />
-    <Error Condition="'$([System.IO.Path]::GetExtension(`$(_WasmCorerunGeneratorPath)`))' == '.dll'"
-           Text="%24(_WasmCorerunGeneratorPath) is '$(_WasmCorerunGeneratorPath)'. It has to name a crossgen2 executable; an IL assembly cannot be launched directly." />
+    <Error Condition="'$(PortableCallHelpersGeneratorPath)' == ''"
+           Text="crossgen2 was not found. Build the 'clr' subset or set %24(PortableCallHelpersGeneratorPath) to a crossgen2 executable." />
+    <Error Condition="!Exists('$(PortableCallHelpersGeneratorPath)')"
+           Text="crossgen2 executable not found: '$(PortableCallHelpersGeneratorPath)'. Build the 'clr' subset or correct %24(PortableCallHelpersGeneratorPath)." />
+    <Error Condition="'$([System.IO.Path]::GetExtension(`$(PortableCallHelpersGeneratorPath)`))' == '.dll'"
+           Text="Set %24(PortableCallHelpersGeneratorPath) to a crossgen2 executable, not the DLL '$(PortableCallHelpersGeneratorPath)'." />
 
     <ItemGroup>
       <!-- This file is only imported for browser, so $(TargetOS) is that; naming it rather than
@@ -345,7 +345,7 @@ against CORE_ROOT, and no SDK is involved. Only the generator task assembly is s
 
     <WriteLinesToFile File="$(_WasmCorerunGeneratorRsp)" Lines="@(_WasmCorerunGeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
-    <Exec Command="&quot;$(_WasmCorerunGeneratorPath)&quot; &quot;@$(_WasmCorerunGeneratorRsp)&quot;" />
+    <Exec Command="&quot;$(PortableCallHelpersGeneratorPath)&quot; &quot;@$(_WasmCorerunGeneratorRsp)&quot;" />
 
     <ItemGroup>
       <FileWrites Include="$(_WasmCorerunGeneratorRsp)" />

--- a/src/tests/Common/CLRTest.WasmCorerun.targets
+++ b/src/tests/Common/CLRTest.WasmCorerun.targets
@@ -189,7 +189,7 @@ against CORE_ROOT, and no SDK is involved. Only the generator task assembly is s
            and corerun.wasm below belong in the output directory. -->
       <_WasmCorerunDir>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'wasm-corerun'))</_WasmCorerunDir>
       <_WasmCorerunInputManifest>$(_WasmCorerunDir)inputs.txt</_WasmCorerunInputManifest>
-      <_WasmCorerunGeneratorRsp>$(_WasmCorerunDir)callhelpers-generator.rsp</_WasmCorerunGeneratorRsp>
+      <_Crossgen2GeneratorRsp>$(_WasmCorerunDir)callhelpers-generator.rsp</_Crossgen2GeneratorRsp>
 
       <!-- Consumed straight out of the kit: the paths in them are relative to the kit directory,
            which is why both em++ invocations below run from there. -->
@@ -322,8 +322,8 @@ against CORE_ROOT, and no SDK is involved. Only the generator task assembly is s
     </FilterManagedAssemblies>
 
     <PropertyGroup>
-      <_WasmCorerunGeneratorExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_WasmCorerunGeneratorExeSuffix>
-      <Crossgen2Path Condition="'$(Crossgen2Path)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_WasmCorerunGeneratorExeSuffix)'))</Crossgen2Path>
+      <_Crossgen2ExeSuffix Condition="'$(OS)' == 'Windows_NT'">.exe</_Crossgen2ExeSuffix>
+      <Crossgen2Path Condition="'$(Crossgen2Path)' == '' and '$(Crossgen2InBuildDir)' != ''">$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(_Crossgen2ExeSuffix)'))</Crossgen2Path>
     </PropertyGroup>
 
     <Error Condition="'$(Crossgen2Path)' == ''"
@@ -336,19 +336,19 @@ against CORE_ROOT, and no SDK is involved. Only the generator task assembly is s
     <ItemGroup>
       <!-- This file is only imported for browser, so $(TargetOS) is that; naming it rather than
            repeating the literal keeps the two from drifting if wasi ever links a test corerun. -->
-      <_WasmCorerunGeneratorArg Include="--targetos:$(TargetOS)" />
-      <_WasmCorerunGeneratorArg Include="--targetarch:wasm" />
-      <_WasmCorerunGeneratorArg Include="--generate-portable-callhelpers:$(_WasmCorerunDir)" />
-      <_WasmCorerunGeneratorArg Include="@(_WasmCorerunPInvokeModule->'--directpinvoke:%(Identity)')" />
-      <_WasmCorerunGeneratorArg Include="@(_WasmCorerunManagedAssembly->'%(FullPath)')" />
+      <_Crossgen2GeneratorArg Include="--targetos:$(TargetOS)" />
+      <_Crossgen2GeneratorArg Include="--targetarch:wasm" />
+      <_Crossgen2GeneratorArg Include="--generate-portable-callhelpers:$(_WasmCorerunDir)" />
+      <_Crossgen2GeneratorArg Include="@(_WasmCorerunPInvokeModule->'--directpinvoke:%(Identity)')" />
+      <_Crossgen2GeneratorArg Include="@(_WasmCorerunManagedAssembly->'%(FullPath)')" />
     </ItemGroup>
 
-    <WriteLinesToFile File="$(_WasmCorerunGeneratorRsp)" Lines="@(_WasmCorerunGeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(_Crossgen2GeneratorRsp)" Lines="@(_Crossgen2GeneratorArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
-    <Exec Command="&quot;$(Crossgen2Path)&quot; &quot;@$(_WasmCorerunGeneratorRsp)&quot;" />
+    <Exec Command="&quot;$(Crossgen2Path)&quot; &quot;@$(_Crossgen2GeneratorRsp)&quot;" />
 
     <ItemGroup>
-      <FileWrites Include="$(_WasmCorerunGeneratorRsp)" />
+      <FileWrites Include="$(_Crossgen2GeneratorRsp)" />
       <FileWrites Include="@(_WasmCorerunGeneratedSource)" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Addresses [review feedback on #131877](https://github.com/dotnet/runtime/pull/131877#discussion_r3932627852).

Use `PortableCallHelpersGeneratorPath` for runtime-test corerun generation and diagnostics, matching browser/WASI app builds. Keep the existing in-repo generator fallback.

## Validation

Seven target-level cases covered override precedence, fallback resolution, and diagnostics. Built a test-specific corerun and ran the native `NestedStruct` test on browser-wasm.

> [!NOTE]
> This PR description was drafted with GitHub Copilot.
