### PR TITLE
Quote script paths in eng/build.sh

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -166,7 +166,7 @@ bootstrap=0
 bootstrapConfig='Debug'
 dynamiccodecompiled=""
 
-source $scriptroot/common/native/init-os-and-arch.sh
+source "$scriptroot"/common/native/init-os-and-arch.sh
 
 hostArch=$arch
 
@@ -644,7 +644,7 @@ if [[ "$bootstrap" == "1" ]]; then
   done
 
   # Set a different path for prebuilt usage tracking for the bootstrap build.
-  "$scriptroot/common/build.sh" ${bootstrapArguments[@]+"${bootstrapArguments[@]}"} /p:Subset=bootstrap /p:TrackPrebuiltUsageReportFile=$scriptroot/../artifacts/log/bootstrap-prebuilt-usage.xml -bl:$scriptroot/../artifacts/log/$bootstrapConfig/bootstrap.binlog
+  "$scriptroot/common/build.sh" ${bootstrapArguments[@]+"${bootstrapArguments[@]}"} /p:Subset=bootstrap /p:TrackPrebuiltUsageReportFile="$scriptroot/../artifacts/log/bootstrap-prebuilt-usage.xml" -bl:"$scriptroot/../artifacts/log/$bootstrapConfig/bootstrap.binlog"
 
   # Remove artifacts from the bootstrap build so the product build is a "clean" build.
   echo "Cleaning up artifacts from bootstrap build..."

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -254,7 +254,7 @@ function Build {
     properties+=("/p:Projects=$projects")
   fi
 
-  local bl=""
+  local bl=()
   if [[ "$binary_log" == true ]]; then
     local binary_log_path=""
     if [[ -z "$binary_log_name" ]]; then
@@ -266,7 +266,7 @@ function Build {
     fi
 
     mkdir -p "$(dirname "$binary_log_path")"
-    bl="/bl:\"$binary_log_path\""
+    bl=("/bl:$binary_log_path")
   fi
 
   local check=""
@@ -274,8 +274,8 @@ function Build {
     check="/check"
   fi
 
-  MSBuild $_InitializeToolset \
-    $bl \
+  MSBuild "$_InitializeToolset" \
+    ${bl[@]+"${bl[@]}"} \
     $check \
     /p:Configuration=$configuration \
     /p:RepoRoot="$repo_root" \
@@ -299,7 +299,7 @@ function Build {
 
 if [[ "$clean" == true ]]; then
   if [ -d "$artifacts_dir" ]; then
-    rm -rf $artifacts_dir
+    rm -rf "$artifacts_dir"
     echo "Artifacts directory deleted."
   fi
   exit 0


### PR DESCRIPTION
Contributes to #73327.

Two unquoted path expansions in `eng/build.sh` break the build when the repo path contains a space.

Line 169 word splits when sourcing `init-os-and-arch.sh`, so every invocation dies immediately:

```
eng/build.sh: line 169: /home/user/space: No such file or directory
```

Line 647 passes `TrackPrebuiltUsageReportFile` and `-bl` unquoted, so `-bootstrap` hands MSBuild a truncated property and a stray switch (MSB1008). Independent of the above, and still fails once it is fixed.

Every other use of `$scriptroot` in the file is already quoted, so these two look like oversights.

The arcade side of this is dotnet/arcade#17509. Both are needed to get past the shell layer. The CMake layer still fails after that, and I am handling it separately in the future.

Tested at a path with a space on linux-x64 and macos-arm64. Clean `clr.native+libs.native` builds at a space free path before and after are identical, so this is inert on normal paths.