### PR TITLE
Add fallbacks to some intrinsics that are skipped on r2r

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -663,7 +663,7 @@ namespace System
         public static TInteger ConvertToIntegerNative<TInteger>(double value)
             where TInteger : IBinaryInteger<TInteger>
         {
-            if (typeof(TInteger).IsPrimitive)
+            if (typeof(TInteger).IsPrimitive && RuntimeFeature.IsDynamicCodeCompiled)
             {
                 // We need this to be recursive so indirect calls (delegates
                 // for example) produce the same result as direct invocation
@@ -1219,7 +1219,9 @@ namespace System
 #if MONO
             return (left * right) + addend;
 #else
-            return MultiplyAddEstimate(left, right, addend);
+            return RuntimeFeature.IsDynamicCodeCompiled
+                ? MultiplyAddEstimate(left, right, addend)
+                : (left * right) + addend;
 #endif
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1270,7 +1270,9 @@ namespace System
 #if MONO
             return 1.0 / d;
 #else
-            return ReciprocalEstimate(d);
+            return RuntimeFeature.IsDynamicCodeCompiled
+                ? ReciprocalEstimate(d)
+                : 1.0 / d;
 #endif
         }
 
@@ -1287,7 +1289,9 @@ namespace System
 #if MONO || TARGET_LOONGARCH64
             return 1.0 / Sqrt(d);
 #else
-            return ReciprocalSqrtEstimate(d);
+            return RuntimeFeature.IsDynamicCodeCompiled
+                ? ReciprocalSqrtEstimate(d)
+                : 1.0 / Sqrt(d);
 #endif
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -317,7 +317,9 @@ namespace System
 #if MONO
             return 1.0f / x;
 #else
-            return ReciprocalEstimate(x);
+            return RuntimeFeature.IsDynamicCodeCompiled
+                ? ReciprocalEstimate(x)
+                : 1.0f / x;
 #endif
         }
 
@@ -335,7 +337,9 @@ namespace System
 #if MONO || TARGET_LOONGARCH64
             return 1.0f / Sqrt(x);
 #else
-            return ReciprocalSqrtEstimate(x);
+            return RuntimeFeature.IsDynamicCodeCompiled
+                ? ReciprocalSqrtEstimate(x)
+                : 1.0f / Sqrt(x);
 #endif
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -656,7 +656,7 @@ namespace System
         public static TInteger ConvertToIntegerNative<TInteger>(float value)
             where TInteger : IBinaryInteger<TInteger>
         {
-            if (typeof(TInteger).IsPrimitive)
+            if (typeof(TInteger).IsPrimitive && RuntimeFeature.IsDynamicCodeCompiled)
             {
                 // We need this to be recursive so indirect calls (delegates
                 // for example) produce the same result as direct invocation
@@ -1236,7 +1236,9 @@ namespace System
 #if MONO
             return (left * right) + addend;
 #else
-            return MultiplyAddEstimate(left, right, addend);
+            return RuntimeFeature.IsDynamicCodeCompiled
+                ? MultiplyAddEstimate(left, right, addend)
+                : (left * right) + addend;
 #endif
         }
 


### PR DESCRIPTION
These intrinsics might not produce identical results between the cross compiled r2r version and the jit at runtime, therefore they were simply skipped from r2r compilation (via `BlockNonDeterministicIntrinsics`). This is problematic for ios/wasm where this means we would always have to fallback to interpreter which is orders of magnitude slower. As a simple workaround, on platforms where we don't have jit available at run-time, simply use explicit implementations of these API's that don't make use of any special instruction sets. The performance should be good enough for now.