### PR TITLE
Adjust contracts for frame chain to handle HandleManagedFault's calling state

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -5525,8 +5525,7 @@ AdjustContextForJITHelpers(
         //
         // Question: Why do we unwind before determining whether we will handle the exception or not?
         UnwindFrameChain(GetThread(), (Frame*)GetSP(pContext));
-        fShouldHandleManagedFault = ShouldHandleManagedFault(pExceptionRecord,pContext
-                               );
+        fShouldHandleManagedFault = ShouldHandleManagedFault(pExceptionRecord,pContext);
 
         if (fShouldHandleManagedFault)
         {
@@ -5936,8 +5935,7 @@ VEH_ACTION WINAPI CLRVectoredExceptionHandlerPhase2(PEXCEPTION_POINTERS pExcepti
     {
         CantAllocHolder caHolder;
         fShouldHandleManagedFault = ShouldHandleManagedFault(pExceptionInfo->ExceptionRecord,
-                                                             pExceptionInfo->ContextRecord
-                                                            );
+                                                             pExceptionInfo->ContextRecord);
     }
 
     if (fShouldHandleManagedFault)

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -5525,7 +5525,7 @@ AdjustContextForJITHelpers(
         //
         // Question: Why do we unwind before determining whether we will handle the exception or not?
         UnwindFrameChain(GetThread(), (Frame*)GetSP(pContext));
-        fShouldHandleManagedFault = ShouldHandleManagedFault(pExceptionRecord,pContext);
+        fShouldHandleManagedFault = ShouldHandleManagedFault(pExceptionRecord, pContext);
 
         if (fShouldHandleManagedFault)
         {

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -5639,11 +5639,6 @@ void FaultingExceptionFrame::InitAndLink(CONTEXT *pContext)
     WRAPPER_NO_CONTRACT;
 
     Init(pContext);
-
-    // We may enter here from preemptive mode with an unwalkable stack,
-    // so we can't transition to co-op mode reliably.
-    PERMANENT_CONTRACT_VIOLATION(ModeViolation);
-
     Push();
 }
 
@@ -5704,6 +5699,20 @@ bool ShouldHandleManagedFault(
 
         if (!ExecutionManager::IsManagedCode(GetIP(pContext)))
             return false;
+    }
+
+    Thread *pCurrentThread = pThread != nullptr ? pThread : GetThreadNULLOk();
+    if (pCurrentThread != nullptr &&
+        !pCurrentThread->PreemptiveGCDisabled() &&
+        InlinedCallFrame::FrameHasActiveCall(pCurrentThread->GetFrame()))
+    {
+        // If the user tries to call an invalid function pointer, some addresses on some architectures trigger a fault
+        // with the IP at the caller's address, not the invalid target address.
+        // If this case occurs after a GC transition to preemptive mode (ie a call to a function pointer with an unmanaged calling convention),
+        // we have semantically already left managed code.
+        // We will consider this a non-managed code address to align the "IP is caller's address" and "IP is callee's address"
+        // user experiences.
+        return false;
     }
 
     // caller should call HandleManagedFault and resume execution.

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -5640,6 +5640,10 @@ void FaultingExceptionFrame::InitAndLink(CONTEXT *pContext)
 
     Init(pContext);
 
+    // We may enter here from preemptive mode with an unwalkable stack,
+    // so we can't transition to co-op mode reliably.
+    PERMANENT_CONTRACT_VIOLATION(ModeViolation);
+
     Push();
 }
 

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -5525,9 +5525,7 @@ AdjustContextForJITHelpers(
         //
         // Question: Why do we unwind before determining whether we will handle the exception or not?
         UnwindFrameChain(GetThread(), (Frame*)GetSP(pContext));
-        fShouldHandleManagedFault = ShouldHandleManagedFault(pExceptionRecord,pContext,
-                               NULL, // establisher frame (x86 only)
-                               NULL  // pThread           (x86 only)
+        fShouldHandleManagedFault = ShouldHandleManagedFault(pExceptionRecord,pContext
                                );
 
         if (fShouldHandleManagedFault)
@@ -5645,9 +5643,7 @@ void FaultingExceptionFrame::InitAndLink(CONTEXT *pContext)
 
 bool ShouldHandleManagedFault(
                         EXCEPTION_RECORD*               pExceptionRecord,
-                        CONTEXT*                        pContext,
-                        EXCEPTION_REGISTRATION_RECORD*  pEstablisherFrame,
-                        Thread*                         pThread)
+                        CONTEXT*                        pContext)
 {
     CONTRACTL
     {
@@ -5701,7 +5697,7 @@ bool ShouldHandleManagedFault(
             return false;
     }
 
-    Thread *pCurrentThread = pThread != nullptr ? pThread : GetThreadNULLOk();
+    Thread *pCurrentThread = GetThreadNULLOk();
     if (pCurrentThread != nullptr &&
         !pCurrentThread->PreemptiveGCDisabled() &&
         InlinedCallFrame::FrameHasActiveCall(pCurrentThread->GetFrame()))
@@ -5940,9 +5936,7 @@ VEH_ACTION WINAPI CLRVectoredExceptionHandlerPhase2(PEXCEPTION_POINTERS pExcepti
     {
         CantAllocHolder caHolder;
         fShouldHandleManagedFault = ShouldHandleManagedFault(pExceptionInfo->ExceptionRecord,
-                                                             pExceptionInfo->ContextRecord,
-                                                             NULL, // establisher frame (x86 only)
-                                                             NULL  // pThread           (x86 only)
+                                                             pExceptionInfo->ContextRecord
                                                             );
     }
 

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -608,9 +608,7 @@ bool IsGcMarker(T_CONTEXT *pContext, EXCEPTION_RECORD *pExceptionRecord);
 
 bool ShouldHandleManagedFault(
                         EXCEPTION_RECORD*               pExceptionRecord,
-                        T_CONTEXT*                      pContext,
-                        EXCEPTION_REGISTRATION_RECORD*  pEstablisherFrame,
-                        Thread*                         pThread);
+                        T_CONTEXT*                      pContext);
 
 void HandleManagedFault(EXCEPTION_RECORD* pExceptionRecord, T_CONTEXT* pContext);
 

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -542,7 +542,7 @@ VOID Frame::Push()
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_ANY;
+        MODE_COOPERATIVE;
     }
     CONTRACTL_END;
 
@@ -555,7 +555,7 @@ VOID Frame::Push(Thread *pThread)
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_ANY;
+        MODE_COOPERATIVE;
     }
     CONTRACTL_END;
 
@@ -589,7 +589,7 @@ VOID Frame::Pop()
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_ANY;
+        MODE_COOPERATIVE;
     }
     CONTRACTL_END;
 
@@ -602,7 +602,7 @@ VOID Frame::Pop(Thread *pThread)
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_ANY;
+        MODE_COOPERATIVE;
     }
     CONTRACTL_END;
 
@@ -627,7 +627,7 @@ void Frame::PopIfChained()
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_ANY;
+        MODE_COOPERATIVE;
     }
     CONTRACTL_END;
 

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -542,7 +542,7 @@ VOID Frame::Push()
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_COOPERATIVE;
+        MODE_ANY;
     }
     CONTRACTL_END;
 
@@ -555,7 +555,7 @@ VOID Frame::Push(Thread *pThread)
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_COOPERATIVE;
+        MODE_ANY;
     }
     CONTRACTL_END;
 
@@ -589,7 +589,7 @@ VOID Frame::Pop()
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_COOPERATIVE;
+        MODE_ANY;
     }
     CONTRACTL_END;
 
@@ -602,7 +602,7 @@ VOID Frame::Pop(Thread *pThread)
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_COOPERATIVE;
+        MODE_ANY;
     }
     CONTRACTL_END;
 
@@ -627,7 +627,7 @@ void Frame::PopIfChained()
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_COOPERATIVE;
+        MODE_ANY;
     }
     CONTRACTL_END;
 


### PR DESCRIPTION
Fixes #133332

Alternatively, we could adjust HandleManagedFault to transition into cooperative, but that feels like a riskier option (we're already in a bad state, so a debug-only change vs an actual product feature change feels less risky to me).