### PR TITLE
Fix duplicate fake authentication success response

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.FakeServer.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.FakeServer.cs
@@ -22,12 +22,13 @@ namespace System.Net.Http.Functional.Tests
 
         private static NetworkCredential s_testCredentialRight = new NetworkCredential("rightusername", "rightpassword");
 
-        internal static async Task HandleAuthenticationRequestWithFakeServer(LoopbackServer.Connection connection, bool useNtlm)
+        internal static async Task<int> HandleAuthenticationRequestWithFakeServer(LoopbackServer.Connection connection, bool useNtlm)
         {
             HttpRequestData request = await connection.ReadRequestDataAsync();
             FakeNtlmServer? fakeNtlmServer = null;
             FakeNegotiateServer? fakeNegotiateServer = null;
             string authHeader = null;
+            int successfulResponseCount = 0;
 
             foreach (HttpHeaderData header in request.Headers)
             {
@@ -99,20 +100,31 @@ namespace System.Net.Http.Functional.Tests
                 if (outBlob != null)
                 {
                     authHeader = $"WWW-Authenticate: {tokens[0]} {Convert.ToBase64String(outBlob)}\r\n";
+                    if (isAuthenticated)
+                    {
+                        authHeader += "Connection: close\r\n";
+                        successfulResponseCount++;
+                    }
+
                     await connection.SendResponseAsync(isAuthenticated ? HttpStatusCode.OK : HttpStatusCode.Unauthorized, authHeader);
-                    connection.CompleteRequestProcessing();
 
                     if (!isAuthenticated)
                     {
+                        connection.CompleteRequestProcessing();
                         request = await connection.ReadRequestDataAsync();
                     }
+                }
+                else if (isAuthenticated)
+                {
+                    successfulResponseCount++;
+                    await connection.SendResponseAsync(HttpStatusCode.OK, "Connection: close\r\n");
                 }
             }
             while (!isAuthenticated);
 
             fakeNtlmServer?.Dispose();
 
-            await connection.SendResponseAsync(HttpStatusCode.OK);
+            return successfulResponseCount;
         }
 
         private static HttpAgnosticOptions CreateHttpAgnosticOptions() => new HttpAgnosticOptions
@@ -307,10 +319,11 @@ namespace System.Net.Http.Functional.Tests
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         Assert.IsType<LoopbackServer.Connection>(connection);
-                        await HandleAuthenticationRequestWithFakeServer((LoopbackServer.Connection)connection, useNtlm);
+                        int successfulResponseCount = await HandleAuthenticationRequestWithFakeServer((LoopbackServer.Connection)connection, useNtlm);
+                        Assert.Equal(1, successfulResponseCount);
                     });
 
-                    // Third connection: HTTP/1.1 for second request (no auth needed, new connection).
+                    // Third connection: HTTP/1.1 for second request after the authenticated connection was closed.
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         Assert.IsType<LoopbackServer.Connection>(connection);


### PR DESCRIPTION
Fixes #133125.

The fake NTLM/Negotiate server sent a successful response containing the final Negotiate token and then unconditionally sent another `200 OK`. Depending on connection timing, the extra response could be consumed by the subsequent request while the loopback server waited for a new connection, causing the Android timeout.

This change:
- emits exactly one terminal authentication response
- preserves the final Negotiate output token when required
- adds `Connection: close` to the terminal response so the subsequent request uses the expected fresh HTTP/1.1 connection
- strengthens the existing subsequent-request theory to assert that authentication emitted exactly one successful response

Validation:
- Android arm64 A/B regression check: old behavior failed the Negotiate case with `Expected: 1, Actual: 2`; fixed behavior passed both NTLM and Negotiate cases
- Android 16 arm64: targeted theory passed, 2/2
- macOS arm64: all `NtAuthTests` passed, 18/18
- `./build.sh clr+libs -rc release`
- Android arm64 CoreCLR and libraries build

> [!NOTE]
> This pull request description was generated with GitHub Copilot.