### PR TITLE
[release/11.0][PERF] Add release/11.0 to trigger branches in perf.yml

### DIFF
--- a/eng/pipelines/performance/perf.yml
+++ b/eng/pipelines/performance/perf.yml
@@ -8,6 +8,7 @@ trigger:
   branches:
     include:
     - main
+    - release/11.0
     - release/10.0
     - release/9.0
     - release/8.0


### PR DESCRIPTION
# Description

Enables release/11.0 branch automatic runs in the .NET Perf Lab.

# Testing

This matches previous updates of a similar goal: https://github.com/dotnet/runtime/pull/117994

# Risk

If this is incorrect, we will get more errors in our automatic runs and may need to remove this update.