### PR TITLE
JIT: preserve recursive tail call flag during inlining

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -481,7 +481,8 @@ enum BasicBlockFlags : uint64_t
     // have actually copied one of these type of tree nodes, but if we only copy a portion of the block's statements,
     // we don't know (unless we actually pay close attention during the copy).
 
-    BBF_COPY_PROPAGATE = BBF_HAS_NEWOBJ | BBF_HAS_NEWARR | BBF_HAS_MDARRAYREF | BBF_MAY_HAVE_BOUNDS_CHECKS,
+    BBF_COPY_PROPAGATE = BBF_HAS_NEWOBJ | BBF_HAS_NEWARR | BBF_HAS_MDARRAYREF | BBF_MAY_HAVE_BOUNDS_CHECKS | \
+                         BBF_RECURSIVE_TAILCALL,
 };
 
 FORCEINLINE

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -497,7 +497,7 @@ private:
             {
                 // IR may potentially contain nodes that requires mandatory BB flags to be set.
                 // Propagate those flags from the containing BB.
-                m_compiler->compCurBB->CopyFlags(inlineeBB, BBF_COPY_PROPAGATE);
+                m_compiler->compCurBB->CopyFlags(inlineeBB, BBF_COPY_PROPAGATE | BBF_RECURSIVE_TAILCALL);
             }
         }
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -497,7 +497,7 @@ private:
             {
                 // IR may potentially contain nodes that requires mandatory BB flags to be set.
                 // Propagate those flags from the containing BB.
-                m_compiler->compCurBB->CopyFlags(inlineeBB, BBF_COPY_PROPAGATE | BBF_RECURSIVE_TAILCALL);
+                m_compiler->compCurBB->CopyFlags(inlineeBB, BBF_COPY_PROPAGATE);
             }
         }
 


### PR DESCRIPTION
Fixes #133352.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>