### PR TITLE
Handle unresolved TypeMap attribute types in Crossgen2

### DIFF
--- a/src/coreclr/tools/Common/Compiler/TypeMapMetadata.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeMapMetadata.cs
@@ -442,8 +442,6 @@ namespace ILCompiler
                         continue;
                     }
 
-                    CustomAttributeValue<TypeWithSerializedName> attrValue = attr.DecodeValue(new TypeMapCustomAttributeTypeProvider(currentAssembly));
-
                     TypeDesc typeMapGroup = type.Instantiation[0];
 
                     Map typeMapState;
@@ -483,6 +481,8 @@ namespace ILCompiler
 
                     try
                     {
+                        CustomAttributeValue<TypeWithSerializedName> attrValue = attr.DecodeValue(new TypeMapCustomAttributeTypeProvider(currentAssembly));
+
                         switch (attrKind)
                         {
                             case TypeMapAttributeKind.TypeMapAssemblyTarget:


### PR DESCRIPTION
Decode TypeMap attribute values within the existing TypeSystemException try/catch so unresolved serialized type names use runtime fallback instead of terminating Crossgen2.

I must have been using stale bits for https://github.com/dotnet/runtime/pull/133038 locally and the TypeMap test failures didn't show up in the AzDO Tests tab because the crossgen build failed before the test could run.