### PR TITLE
Skip Runtime_133101 on Windows Mono MiniJIT

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_133101/Runtime_133101.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133101/Runtime_133101.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using TestLibrary;
 using Xunit;
 
 namespace Runtime_133101;
 
 public class Runtime_133101
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/133442", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsX64Process), nameof(PlatformDetection.IsMonoMiniJIT))]
     [Fact]
     public static void TestEntryPoint()
     {

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -139,7 +139,9 @@
     <Compile Include="JitBlue\Runtime_132785\Runtime_132785.cs" />
     <Compile Include="JitBlue\Runtime_132902\Runtime_132902.cs" />
     <Compile Include="JitBlue\Runtime_133022\Runtime_133022.cs" />
-    <Compile Include="JitBlue\Runtime_133101\Runtime_133101.cs" />
+    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/133442 -->
+    <Compile Include="JitBlue\Runtime_133101\Runtime_133101.cs"
+             Condition="'$(TargetsWindows)' != 'true' or '$(TargetArchitecture)' != 'x64' or '$(RuntimeFlavor)' != 'mono' or '$(RuntimeVariant)' != 'minijit'" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -139,9 +139,7 @@
     <Compile Include="JitBlue\Runtime_132785\Runtime_132785.cs" />
     <Compile Include="JitBlue\Runtime_132902\Runtime_132902.cs" />
     <Compile Include="JitBlue\Runtime_133022\Runtime_133022.cs" />
-    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/133442 -->
-    <Compile Include="JitBlue\Runtime_133101\Runtime_133101.cs"
-             Condition="!('$(TargetsWindows)' == 'true' and '$(TargetArchitecture)' == 'x64' and '$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'minijit')" />
+    <Compile Include="JitBlue\Runtime_133101\Runtime_133101.cs" />
     <Compile Include="JitBlue\Runtime_133207\Runtime_133207.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -139,12 +139,10 @@
     <Compile Include="JitBlue\Runtime_132785\Runtime_132785.cs" />
     <Compile Include="JitBlue\Runtime_132902\Runtime_132902.cs" />
     <Compile Include="JitBlue\Runtime_133022\Runtime_133022.cs" />
-    <Compile Include="JitBlue\Runtime_133101\Runtime_133101.cs" />
+    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/133442 -->
+    <Compile Include="JitBlue\Runtime_133101\Runtime_133101.cs"
+             Condition="!('$(TargetsWindows)' == 'true' and '$(TargetArchitecture)' == 'x64' and '$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'minijit')" />
     <Compile Include="JitBlue\Runtime_133207\Runtime_133207.cs" />
-  </ItemGroup>
-  <!-- ActiveIssue https://github.com/dotnet/runtime/issues/133442 -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetArchitecture)' == 'x64' and '$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'minijit'">
-    <Compile Remove="JitBlue\Runtime_133101\Runtime_133101.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Fixes #133442

## Summary

Mark `Runtime_133101` with an `[ActiveIssue]` condition for Windows x64 Mono MiniJIT. The test remains compiled and runs normally for all other runtime, OS, and architecture configurations.

The affected leg consistently terminates `corerun` with Windows access violation `0xC0000005` while starting this test:

```
Running test: global::Runtime_133101.Runtime_133101.TestEntryPoint()
Exit Code: -1073741819
Expected: 100
Actual: -1073741819
```

Build Analysis cannot match a sufficiently specific KBE because the crash produces no TRX and its indexed error contains only the generic failed-work-item result, so the test uses a source-level `ActiveIssue` condition instead.

## Validation

- Confirmed the test remains compiled in the Windows x64 Mono MiniJIT merged project.
- Built `Regression_ro_2` on macOS arm64 Checked.
- Ran the merged test suite on macOS arm64 Checked; `Runtime_133101` and `Runtime_133207` executed and passed.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.