### PR TITLE
Update SerialStream.Windows.cs to avoid unnecessary thread queuing and scheduling

### DIFF
--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1677,6 +1677,8 @@ namespace System.IO.Ports
 
             private void CallEvents(int nativeEvents)
             {
+                SerialStream stream = (SerialStream)streamWeakReference.Target;
+                
                 // EV_ERR includes only CE_FRAME, CE_OVERRUN, and CE_RXPARITY
                 // To catch errors such as CE_RXOVER, we need to call CleanCommErrors bit more regularly.
                 // EV_RXCHAR is perhaps too loose an event to look for overflow errors but a safe side to err...
@@ -1708,7 +1710,7 @@ namespace System.IO.Ports
                     // TODO: what about other error conditions not covered by the enum?  Should those produce some other error?
 
                     // if error events occurred and an event handler exists to handle them, queue a work item to handle them
-                    if (errors != 0 && stream.ErrorReceived != null)
+                    if (errors != 0 && stream?.ErrorReceived != null)
                     {
                         ThreadPool.QueueUserWorkItem(callErrorEvents, errors);
                     }
@@ -1717,13 +1719,13 @@ namespace System.IO.Ports
                 // now look for pin changed and received events.
 
                 // if pin changed events occurred and an event handler exists to handle them, queue a work item to handle them
-                if ((nativeEvents & PinChangedEvents) != 0 && stream.PinChanged != null)
+                if ((nativeEvents & PinChangedEvents) != 0 && stream?.PinChanged != null)
                 {
                     ThreadPool.QueueUserWorkItem(callPinEvents, nativeEvents);
                 }
 
                 // if receive events occurred and an event handler exists to handle them, queue a work item to handle them
-                if ((nativeEvents & ReceivedEvents) != 0 && stream.DataReceived != null)
+                if ((nativeEvents & ReceivedEvents) != 0 && stream?.DataReceived != null)
                 {
                     ThreadPool.QueueUserWorkItem(callReceiveEvents, nativeEvents);
                 }

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1678,7 +1678,7 @@ namespace System.IO.Ports
             private void CallEvents(int nativeEvents)
             {
                 SerialStream stream = (SerialStream)streamWeakReference.Target;
-                
+
                 // EV_ERR includes only CE_FRAME, CE_OVERRUN, and CE_RXPARITY
                 // To catch errors such as CE_RXOVER, we need to call CleanCommErrors bit more regularly.
                 // EV_RXCHAR is perhaps too loose an event to look for overflow errors but a safe side to err...

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1707,19 +1707,23 @@ namespace System.IO.Ports
                     //       but CE_BREAK is returned from ClreaCommError.
                     // TODO: what about other error conditions not covered by the enum?  Should those produce some other error?
 
-                    if (errors != 0)
+                    // if error events occurred and an event handler exists to handle them, queue a work item to handle them
+                    if (errors != 0 && stream.ErrorReceived != null)
                     {
                         ThreadPool.QueueUserWorkItem(callErrorEvents, errors);
                     }
                 }
 
                 // now look for pin changed and received events.
-                if ((nativeEvents & PinChangedEvents) != 0)
+
+                // if pin changed events occurred and an event handler exists to handle them, queue a work item to handle them
+                if ((nativeEvents & PinChangedEvents) != 0 && stream.PinChanged != null)
                 {
                     ThreadPool.QueueUserWorkItem(callPinEvents, nativeEvents);
                 }
 
-                if ((nativeEvents & ReceivedEvents) != 0)
+                // if receive events occurred and an event handler exists to handle them, queue a work item to handle them
+                if ((nativeEvents & ReceivedEvents) != 0 && stream.DataReceived != null)
                 {
                     ThreadPool.QueueUserWorkItem(callReceiveEvents, nativeEvents);
                 }


### PR DESCRIPTION
Fixes issue 134346. Currently, a ThreadPool user work item is queued unconditionally, and the queued callback simply checks whether the corresponding event handler is non-null; if it is null, it returns. This is unnecessary queuing. For serial ports, events can arrive faster than the ThreadPool can drain them once the backlog exceeds the minimum worker-thread count (defaults to the core count), so items whose only job is to return still accumulate in the queue. This is inefficient and taxes the scheduler for no benefit. The null checks on the handlers should happen before the work item is queued.