### PR TITLE
Add MemoryExtensions.CommonSuffixLength

### DIFF
--- a/src/libraries/System.Memory/ref/System.Memory.cs
+++ b/src/libraries/System.Memory/ref/System.Memory.cs
@@ -270,6 +270,8 @@ namespace System
         public static int CommonPrefixLength<T>(this System.Span<T> span, System.ReadOnlySpan<T> other, System.Collections.Generic.IEqualityComparer<T>? comparer) { throw null; }
         public static int CommonPrefixLength<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> other) { throw null; }
         public static int CommonPrefixLength<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> other, System.Collections.Generic.IEqualityComparer<T>? comparer) { throw null; }
+        public static int CommonSuffixLength<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> other) { throw null; }
+        public static int CommonSuffixLength<T>(this System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> other, System.Collections.Generic.IEqualityComparer<T>? comparer) { throw null; }
         public static int CompareTo(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> other, System.StringComparison comparisonType) { throw null; }
         public static bool Contains(this System.ReadOnlySpan<char> span, System.ReadOnlySpan<char> value, System.StringComparison comparisonType) { throw null; }
         public static bool Contains<T>(this System.ReadOnlySpan<T> span, T value) where T : System.IEquatable<T>? { throw null; }

--- a/src/libraries/System.Memory/tests/Span/CommonSuffixLength.T.cs
+++ b/src/libraries/System.Memory/tests/Span/CommonSuffixLength.T.cs
@@ -1,0 +1,266 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.SpanTests;
+
+public static class CommonSuffixLengthTests
+{
+    public static IEnumerable<object[]> Lengths()
+    {
+        for (int length = 0; length <= 33; length++)
+        {
+            yield return new object[] { length };
+        }
+
+        foreach (int length in new[] { 63, 64, 65, 127, 128, 129, 257 })
+        {
+            yield return new object[] { length };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Lengths))]
+    public static void EveryMismatchPosition(int length)
+    {
+        ValidatePositions(length, i => (byte)(i == 0 ? 0 : i % 251 + 1));
+        ValidatePositions(length, i => (char)i);
+        ValidatePositions(length, i => (short)i);
+        ValidatePositions(length, i => i);
+        ValidatePositions(length, i => (long)i);
+        ValidatePositions(length, i => (ulong)i);
+        ValidatePositions(length, i => (DayOfWeek)i);
+        ValidatePositions(length, i => (int?)i);
+        ValidatePositions(length, i => new EquatableValue(i));
+    }
+
+    private static void ValidatePositions<T>(int length, Func<int, T> create)
+    {
+        T[] first = new T[length + 3];
+        T[] second = new T[length + 5];
+        for (int i = 0; i < first.Length; i++)
+        {
+            first[i] = create(i + 1);
+        }
+
+        first.AsSpan(1, length).CopyTo(second.AsSpan(3, length));
+        for (int suffix = 0; suffix <= length; suffix++)
+        {
+            T[] changed = (T[])second.Clone();
+            if (suffix < length)
+            {
+                changed[3 + length - suffix - 1] = create(0);
+            }
+
+            Validate<T>(first.AsSpan(1, length), changed.AsSpan(3, length), suffix);
+            Validate<T>(first.AsSpan(1, length), changed.AsSpan(1, length + 2), suffix);
+            Validate<T>(changed.AsSpan(1, length + 2), first.AsSpan(1, length), suffix);
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(8)]
+    public static void Empty(int length)
+    {
+        ReadOnlySpan<int> empty = default;
+        ReadOnlySpan<int> nullBacked = new ReadOnlySpan<int>((int[])null);
+        ReadOnlySpan<int> values = new int[length];
+        Validate(empty, values, 0);
+        Validate(values, empty, 0);
+        Validate(nullBacked, values, 0);
+        Validate(values, nullBacked, 0);
+        Validate(values.Slice(length), values, 0);
+
+        EqualityComparer<int> comparer = EqualityComparer<int>.Create((x, y) => throw new InvalidOperationException());
+        Assert.Equal(0, empty.CommonSuffixLength(values, comparer));
+        Assert.Equal(0, values.CommonSuffixLength(nullBacked, comparer));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(5)]
+    public static void SameAndOverlappingMemory(int offset)
+    {
+        ReadOnlySpan<int> values = new[] { 1, 2, 1, 2, 1 };
+        Validate(values, values, values.Length);
+        Validate(values.Slice(offset), values, values.Length - offset);
+        Validate(values, values.Slice(offset), values.Length - offset);
+        Validate(values.Slice(0, 3), values.Slice(2), 3);
+
+        int calls = 0;
+        EqualityComparer<int> comparer = EqualityComparer<int>.Create((x, y) => { calls++; return false; });
+        Assert.Equal(0, values.CommonSuffixLength(values, comparer));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public static void DefaultEquality()
+    {
+        Validate<string>(new[] { "x", "a", null, "b" }, new[] { "y", "a", null, "b" }, 3);
+        Validate<string>(new[] { "a", null }, new[] { "a", "b" }, 0);
+        Validate<int?>(new int?[] { 1, null, 2 }, new int?[] { 0, 1, null, 2 }, 3);
+        Validate<int?>(new int?[] { 1, null }, new int?[] { 1, 0 }, 0);
+        Validate<NonEquatableValue>(
+            new[] { new NonEquatableValue(1), new NonEquatableValue(2) },
+            new[] { new NonEquatableValue(3), new NonEquatableValue(2) }, 1);
+        Validate<EqualityObject>(
+            new[] { new EqualityObject(1), null, new EqualityObject(2) },
+            new[] { new EqualityObject(3), null, new EqualityObject(2) }, 2);
+        object instance = new object();
+        Validate<object>(new[] { new object(), instance }, new[] { new object(), instance }, 1);
+    }
+
+    [Fact]
+    public static void FloatingPointEquality()
+    {
+        float nan1 = BitConverter.Int32BitsToSingle(unchecked((int)0x7FC00001));
+        float nan2 = BitConverter.Int32BitsToSingle(unchecked((int)0xFFC00002));
+        Validate<float>(new[] { 1f, nan1, -0f, float.PositiveInfinity, float.NegativeInfinity },
+            new[] { 2f, nan2, +0f, float.PositiveInfinity, float.NegativeInfinity }, 4);
+        double doubleNan1 = BitConverter.Int64BitsToDouble(0x7FF8000000000001);
+        double doubleNan2 = BitConverter.Int64BitsToDouble(unchecked((long)0xFFF8000000000002));
+        Validate<double>(new[] { 1d, doubleNan1, -0d, double.PositiveInfinity, double.NegativeInfinity },
+            new[] { 2d, doubleNan2, +0d, double.PositiveInfinity, double.NegativeInfinity }, 4);
+        Validate<float>(new[] { float.PositiveInfinity }, new[] { float.NegativeInfinity }, 0);
+        Validate<double>(new[] { double.NaN }, new[] { 1d }, 0);
+    }
+
+    [Fact]
+    public static void CustomEquality()
+    {
+        ReadOnlySpan<string> first = new[] { "x", "a", null, "b" };
+        ReadOnlySpan<string> second = new[] { "y", "A", null, "B" };
+        Assert.Equal(3, first.CommonSuffixLength(second, StringComparer.OrdinalIgnoreCase));
+        Assert.Equal(0, first.CommonSuffixLength(second));
+
+        ReadOnlySpan<int> integers = new[] { 1, 2, -3, 4 };
+        EqualityComparer<int> comparer = EqualityComparer<int>.Create((x, y) => Math.Abs(x) == Math.Abs(y));
+        Assert.Equal(3, integers.CommonSuffixLength(new[] { 0, -2, 3, -4 }, comparer));
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(0, 1)]
+    [InlineData(0, 4)]
+    [InlineData(1, 0)]
+    [InlineData(1, 1)]
+    [InlineData(1, 4)]
+    [InlineData(2, 0)]
+    [InlineData(2, 1)]
+    [InlineData(2, 4)]
+    public static void ComparerOrderAndStopping(int longer, int suffix)
+    {
+        int[] first = longer == 1 ? new[] { 99, 1, 2, 3, 4 } : new[] { 1, 2, 3, 4 };
+        int[] second = longer == 2 ? new[] { 99, 11, 12, 13, 14 } : new[] { 11, 12, 13, 14 };
+        var calls = new List<(int, int)>();
+        EqualityComparer<int> comparer = EqualityComparer<int>.Create((x, y) =>
+        {
+            calls.Add((x, y));
+            return x + 10 == y && calls.Count <= suffix;
+        });
+        Assert.Equal(suffix, ((ReadOnlySpan<int>)first).CommonSuffixLength(second, comparer));
+        int expectedCalls = Math.Min(suffix + 1, 4);
+        Assert.Equal(expectedCalls, calls.Count);
+        for (int i = 0; i < expectedCalls; i++)
+        {
+            Assert.Equal((4 - i, 14 - i), calls[i]);
+        }
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    public static void ComparerException(int throwOnCall)
+    {
+        int calls = 0;
+        var exception = new InvalidOperationException();
+        EqualityComparer<int> comparer = EqualityComparer<int>.Create((x, y) =>
+        {
+            if (++calls == throwOnCall)
+            {
+                throw exception;
+            }
+
+            return true;
+        });
+        int[] values = new[] { 1, 2, 3 };
+        Assert.Same(exception, Assert.Throws<InvalidOperationException>(
+            () => ((ReadOnlySpan<int>)values).CommonSuffixLength(values, comparer)));
+        Assert.Equal(throwOnCall, calls);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(42)]
+    public static void Differential(int seed)
+    {
+        var random = new Random(seed);
+        EqualityComparer<int> comparer = EqualityComparer<int>.Create((x, y) => Math.Abs(x) == Math.Abs(y));
+        for (int iteration = 0; iteration < 300; iteration++)
+        {
+            int[] first = new int[random.Next(150)];
+            int[] second = new int[random.Next(150)];
+            for (int i = 0; i < first.Length; i++)
+            {
+                first[i] = random.Next(-3, 4);
+            }
+
+            for (int i = 0; i < second.Length; i++)
+            {
+                second[i] = random.Next(-3, 4);
+            }
+
+            int copyLength = random.Next(Math.Min(first.Length, second.Length) + 1);
+            first.AsSpan(first.Length - copyLength).CopyTo(second.AsSpan(second.Length - copyLength));
+            Validate<int>(first, second, Oracle(first, second, EqualityComparer<int>.Default));
+            Assert.Equal(Oracle(first, second, comparer), ((ReadOnlySpan<int>)first).CommonSuffixLength(second, comparer));
+        }
+    }
+
+    private static int Oracle(int[] first, int[] second, IEqualityComparer<int> comparer)
+    {
+        int run = 0;
+        int offset = second.Length - first.Length;
+        // Scan forwards, resetting the matching run at each mismatch.
+        for (int i = Math.Max(0, -offset); i < first.Length; i++)
+        {
+            run = comparer.Equals(first[i], second[i + offset]) ? run + 1 : 0;
+        }
+
+        return run;
+    }
+
+    private static void Validate<T>(ReadOnlySpan<T> first, ReadOnlySpan<T> second, int expected)
+    {
+        Assert.Equal(expected, first.CommonSuffixLength(second));
+        Assert.Equal(expected, first.CommonSuffixLength(second, null));
+        Assert.Equal(expected, first.CommonSuffixLength(second, EqualityComparer<T>.Default));
+        EqualityComparer<T> comparer = EqualityComparer<T>.Create((x, y) => EqualityComparer<T>.Default.Equals(x, y));
+        Assert.Equal(expected, first.CommonSuffixLength(second, comparer));
+    }
+
+    private readonly struct NonEquatableValue(int value)
+    {
+        public readonly int Value = value;
+    }
+
+    private readonly struct EquatableValue(int value) : IEquatable<EquatableValue>
+    {
+        private readonly int _value = value;
+        public bool Equals(EquatableValue other) => _value == other._value;
+        public override bool Equals(object obj) => obj is EquatableValue other && Equals(other);
+        public override int GetHashCode() => _value;
+    }
+
+    private sealed class EqualityObject(int value)
+    {
+        private readonly int _value = value;
+        public override bool Equals(object obj) => obj is EqualityObject other && _value == other._value;
+        public override int GetHashCode() => _value;
+    }
+}

--- a/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Span\Fill.cs" />
     <Compile Include="Span\Clear.cs" />
     <Compile Include="Span\CommonPrefixLength.T.cs" />
+    <Compile Include="Span\CommonSuffixLength.T.cs" />
     <Compile Include="Span\Contains.T.cs" />
     <Compile Include="Span\CopyTo.cs" />
     <Compile Include="Span\CtorArray.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -5006,6 +5006,58 @@ namespace System
             return span.Length;
         }
 
+        /// <summary>Finds the length of any common suffix shared between <paramref name="span"/> and <paramref name="other"/>.</summary>
+        /// <typeparam name="T">The type of the elements in the spans.</typeparam>
+        /// <param name="span">The first sequence to compare.</param>
+        /// <param name="other">The second sequence to compare.</param>
+        /// <returns>The length of the common suffix shared by the two spans, or 0 if there is no shared suffix.</returns>
+        public static int CommonSuffixLength<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other)
+        {
+            int length = Math.Min(span.Length, other.Length);
+            span = span.Slice(span.Length - length);
+            other = other.Slice(other.Length - length);
+
+            for (int i = length - 1; i >= 0; i--)
+            {
+                if (!EqualityComparer<T>.Default.Equals(span[i], other[i]))
+                {
+                    return length - i - 1;
+                }
+            }
+
+            return length;
+        }
+
+        /// <summary>Finds the length of any common suffix shared between <paramref name="span"/> and <paramref name="other"/>.</summary>
+        /// <typeparam name="T">The type of the elements in the spans.</typeparam>
+        /// <param name="span">The first sequence to compare.</param>
+        /// <param name="other">The second sequence to compare.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to use the default <see cref="IEqualityComparer{T}"/> for the type of an element.</param>
+        /// <returns>The length of the common suffix shared by the two spans, or 0 if there is no shared suffix.</returns>
+        public static int CommonSuffixLength<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other, IEqualityComparer<T>? comparer)
+        {
+            // Use the default comparer directly for value types to enable devirtualization.
+            if (typeof(T).IsValueType && (comparer is null || comparer == EqualityComparer<T>.Default))
+            {
+                return CommonSuffixLength(span, other);
+            }
+
+            int length = Math.Min(span.Length, other.Length);
+            span = span.Slice(span.Length - length);
+            other = other.Slice(other.Length - length);
+
+            comparer ??= EqualityComparer<T>.Default;
+            for (int i = length - 1; i >= 0; i--)
+            {
+                if (!comparer.Equals(span[i], other[i]))
+                {
+                    return length - i - 1;
+                }
+            }
+
+            return length;
+        }
+
         /// <summary>Determines if one span is longer than the other, and slices the longer one to match the length of the shorter.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SliceLongerSpanToMatchShorterLength<T>(ref ReadOnlySpan<T> span, ref ReadOnlySpan<T> other)


### PR DESCRIPTION
Fixes #127630.

Implements the [two approved overloads](https://github.com/dotnet/runtime/issues/127630#issuecomment-5590096005), with no generic constraints or optional comparer argument.

- Compares end-aligned spans backwards using default or supplied equality.
- Keeps the implementation scalar and safe; no temporary buffers, reversed copies, SIMD helper, or changes to CommonPrefixLength.
- Adds tests for unequal lengths, empty/overlapping spans, boundary positions, nullable/non-IEquatable types, floating-point equality, and custom-comparer behavior.

### Validation

Windows x64:
- Untouched checked CoreCLR/libraries baseline and modified checked/Release builds succeeded.
- System.Memory source/ref and GenAPI validation succeeded; unrelated generated drift was excluded.
- Targeted suffix/prefix tests: 82 passed (63 suffix, 19 prefix).
- Full System.Memory suite: 52,992 passed with checked runtime/Debug libraries and 52,992 with Release runtime/libraries.
- New test formatting and diff whitespace checks passed. Whole-file format checks reproduced 20 pre-existing diagnostics on unmodified HEAD.

Normal test filtering excludes outerloop and known-failing categories. Unix, ARM64, Mono, NativeAOT and Browser/WASM were not run.

### Performance evidence

BenchmarkDotNet 0.16.0 nightly, Windows x64 Hyper-V on AMD EPYC 7763; new API versus a simple user scalar loop on the **same modified Release runtime**, not an old runtime without the API. Setup is outside timing; methods return one result.

80 cases covered int, char, string references and an absolute-value int comparer; lengths 0/1/8/512/1024; no/one/half/full suffix; and unequal lengths in both orientations. A 40-case repeat used eight 500ms measurement iterations.

Selected repeated results, nanoseconds:

| Case | Scalar | API | API/scalar |
|---|---:|---:|---:|
| int empty | 2.830 | 3.170 | 1.12 |
| custom comparer empty | 4.083 | 4.732 | 1.16 |
| int, 512 elements, 256 suffix | 226.975 | 172.203 | 0.76 |
| int, 1024 elements, full suffix | 881.905 | 334.843 | 0.38 |
| char, 1024 elements, full suffix | 878.232 | 336.322 | 0.38 |
| references, 1024 elements, full suffix | 3230.978 | 2589.691 | 0.80 |
| custom comparer, 1024 elements, full suffix | 1943.958 | 1300.775 | 0.67 |

No managed allocation was reported in these measured scenarios. Matched reference entries used identical string instances. Default equality/comparers for arbitrary types can have their own allocation costs.

Small fixed overhead is retained rather than adding special-case complexity. One reference mismatch measurement varied between runs (1.04 then 1.33 ratio); a focused two-launch repeat measured 8.186ns scalar versus 8.490ns API (1.04). These virtualized microbenchmarks are bounded evidence, not a universal speedup claim.

> [!NOTE]
> This implementation, tests, measurements summary, and PR description were prepared with GitHub Copilot assistance.