### PR TITLE
Prevent dual-mode accept tests from hanging

### DIFF
--- a/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
+++ b/src/libraries/Common/tests/System/Net/Sockets/SocketTestExtensions.cs
@@ -94,8 +94,8 @@ namespace System.Net.Sockets.Tests
     }
 
     /// <summary>
-    /// A utility to create and bind a socket while blocking it's port for both IPv4 and IPv6
-    /// by also creating and binding a "shadow" socket of the opposite address family.
+    /// A utility to create and bind a socket while blocking its port for both IPv4 and IPv6
+    /// by also creating and binding a "shadow" socket.
     /// </summary>
     internal class PortBlocker : IDisposable
     {
@@ -106,7 +106,7 @@ namespace System.Net.Sockets.Tests
 
         public int Port;
 
-        public PortBlocker(Func<Socket> socketFactory)
+        public PortBlocker(Func<Socket> socketFactory, IPAddress? shadowAddress = null)
         {
             bool success = false;
             for (int i = 0; i < MaxAttempts; i++)
@@ -118,15 +118,14 @@ namespace System.Net.Sockets.Tests
                     throw new Exception($"{nameof(socketFactory)} is expected create and bind the socket.");
                 }
 
-                IPAddress shadowAddress = MainSocket.AddressFamily == AddressFamily.InterNetwork ?
-                        IPAddress.IPv6Loopback :
-                        IPAddress.Loopback;
+                IPAddress address = shadowAddress ??
+                    (MainSocket.AddressFamily == AddressFamily.InterNetwork ? IPAddress.IPv6Loopback : IPAddress.Loopback);
                 int port = ((IPEndPoint)MainSocket.LocalEndPoint).Port;
-                IPEndPoint shadowEndPoint = new IPEndPoint(shadowAddress, port);
+                IPEndPoint shadowEndPoint = new IPEndPoint(address, port);
 
                 try
                 {
-                    _shadowSocket = new Socket(shadowAddress.AddressFamily, MainSocket.SocketType, MainSocket.ProtocolType);
+                    _shadowSocket = new Socket(address.AddressFamily, MainSocket.SocketType, MainSocket.ProtocolType);
                     success = TryBindWithoutReuseAddress(_shadowSocket, shadowEndPoint, out _);
 
                     if (success)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -797,13 +797,28 @@ namespace System.Net.Sockets.Tests
 
         private async Task Accept_Helper_Failing(IPAddress listenOn, IPAddress connectTo)
         {
-            using Socket serverSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            int port = serverSocket.BindToAnonymousPort(listenOn);
+            using PortBlocker portBlocker = new PortBlocker(() =>
+            {
+                Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                socket.BindToAnonymousPort(listenOn);
+                return socket;
+            }, connectTo);
+
+            Socket serverSocket = portBlocker.MainSocket;
             serverSocket.Listen(1);
-            _ = AcceptAsync(serverSocket);
 
             using Socket client = new Socket(connectTo.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            await Assert.ThrowsAsync<SocketException>(() => client.ConnectAsync(connectTo, port));
+            Assert.False(client.TryConnect(new IPEndPoint(connectTo, portBlocker.Port), TestSettings.FailingTestTimeout));
+
+            IPAddress validConnectTo = listenOn.AddressFamily == AddressFamily.InterNetwork ? IPAddress.Loopback : IPAddress.IPv6Loopback;
+            using Socket validClient = new Socket(validConnectTo.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            await validClient.ConnectAsync(validConnectTo, portBlocker.Port).WaitAsync(TestSettings.PassingTestTimeout);
+
+            using Socket accepted = await AcceptAsync(serverSocket).WaitAsync(TestSettings.PassingTestTimeout);
+            var clientEndPoint = (IPEndPoint)validClient.LocalEndPoint;
+            var acceptedRemoteEndPoint = (IPEndPoint)accepted.RemoteEndPoint;
+            Assert.Equal(clientEndPoint.Port, acceptedRemoteEndPoint.Port);
+            Assert.Equal(clientEndPoint.Address.MapToIPv6(), acceptedRemoteEndPoint.Address.MapToIPv6());
         }
 
         protected static void AssertDualModeEnabled(Socket socket, IPAddress listenOn)


### PR DESCRIPTION
The negative dual-mode accept tests start an accept operation and then expect a mismatched-address-family connection to fail immediately. On macOS, `DualModeAcceptSync.AcceptV6BoundToAnyV4_CantConnect` can instead leave both operations pending indefinitely: the worker remains blocked in native `accept`, while the connect never completes.

This is the same class of problem historically discussed in #16265. These tests were later re-enabled as part of #1481 / #80715, but the shared negative helper still has unbounded operations.

This change:

- extends `PortBlocker` to accept an explicit shadow address, since the socket address family does not identify the bound endpoint family for dual-mode sockets;
- bounds the expected failed connection with the existing `TryConnect` helper;
- queues a valid same-family connection before invoking the accept implementation, so synchronous accept completes normally rather than relying on socket disposal for cancellation; and
- verifies that accept returned the valid client, normalizing IPv4 and IPv4-mapped IPv6 addresses.

The change is test-only and covers the shared Sync, APM, EAP, and Task implementations.

Validation:

```text
System.Net.Sockets.Tests  Total: 32, Errors: 0, Failed: 0, Skipped: 0
```

A full libraries baseline was not run; the focused `System.Net.Sockets` test project built successfully while running the affected classes.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.