### PR TITLE
Address Wasm unboxing stub review feedback

### DIFF
--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -1592,13 +1592,7 @@ void* GetPortableEntryPointToInterpreterThunk(MethodDesc *pMD)
 
 void* GetUnboxingStub(MethodDesc* pMD, MethodDesc** ppTargetMethodDesc, PCODE* pTargetEntryPoint)
 {
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
+    STANDARD_VM_CONTRACT;
 
     _ASSERTE(pMD->IsUnboxingStub());
     _ASSERTE(ppTargetMethodDesc != nullptr);
@@ -1638,15 +1632,15 @@ void* GetUnboxingStub(MethodDesc* pMD, MethodDesc** ppTargetMethodDesc, PCODE* p
             return nullptr;
     }
 
-    PCODE unboxingStub = LookupPregeneratedThunkByString(keyBuffer);
-    if (unboxingStub == (PCODE)NULL)
+    void* unboxingStub = LookupPortableEntryPointThunk(keyBuffer);
+    if (unboxingStub == nullptr)
     {
         return nullptr;
     }
 
     *ppTargetMethodDesc = pTargetMethodDesc;
     *pTargetEntryPoint = pTargetMD->GetMultiCallableAddrOfCode(CORINFO_ACCESS_ANY);
-    return (void*)unboxingStub;
+    return unboxingStub;
 }
 
 void* GetUnmanagedCallersOnlyThunk(MethodDesc* pMD)


### PR DESCRIPTION
## Summary

- use `STANDARD_VM_CONTRACT` for `GetUnboxingStub`
- keep the generated unboxing stub typed as `void*` by reusing `LookupPortableEntryPointThunk`
- address the remaining minor review feedback from #133218

## Validation

- `build.cmd clr -c release -os browser`
- focused `WasmVirtualMethodGenerics` ReadyToRun tests: 2 passed

> [!NOTE]
> This pull request description was generated with GitHub Copilot.