### PR TITLE
Fix cgroup v2 memory limit traversal at hierarchy root

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs
+++ b/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs
@@ -117,15 +117,23 @@ internal static partial class Interop
         /// <returns>true if the limit was read successfully; otherwise, false.</returns>
         internal static bool TryGetMemoryLimitV2(out ulong limit)
         {
+            return TryGetMemoryLimitV2(s_cgroupMemoryPath, s_cgroupMemoryHierarchyMountPath, out limit);
+        }
+
+        /// <summary>Tries to read the memory limit from a cgroup v2 path hierarchy.</summary>
+        /// <param name="currentCGroupMemoryPath">The current cgroup memory path.</param>
+        /// <param name="cgroupMemoryHierarchyMountPath">The cgroup memory hierarchy mount path.</param>
+        /// <param name="limit">The read limit, or 0 if it couldn't be read.</param>
+        /// <returns>true if the limit was read successfully; otherwise, false.</returns>
+        internal static bool TryGetMemoryLimitV2(string? currentCGroupMemoryPath, string? cgroupMemoryHierarchyMountPath, out ulong limit)
+        {
             bool foundAnyLimit = false;
             ulong minLimit = ulong.MaxValue;
-            string? currentCGroupMemoryPath = s_cgroupMemoryPath;
-            string? cgroupMemoryHierarchyMountPath = s_cgroupMemoryHierarchyMountPath;
             if (currentCGroupMemoryPath != null && cgroupMemoryHierarchyMountPath != null)
             {
                 // Iterate over the directory hierarchy representing the cgroup hierarchy until reaching the
-                // mount directory. The mount directory doesn't contain the memory.max.
-                do
+                // mount directory. The mount directory can contain memory.max when it is not the global root.
+                while (currentCGroupMemoryPath != null && IsPathAtOrBelowMount(currentCGroupMemoryPath, cgroupMemoryHierarchyMountPath))
                 {
                     if (TryReadMemoryValueFromFile(currentCGroupMemoryPath + "/memory.max", out ulong currentLevelLimit))
                     {
@@ -135,14 +143,28 @@ internal static partial class Interop
                             minLimit = currentLevelLimit;
                         }
                     }
+                    if (string.Equals(currentCGroupMemoryPath, cgroupMemoryHierarchyMountPath, StringComparison.Ordinal))
+                    {
+                        break;
+                    }
+
                     currentCGroupMemoryPath = Path.GetDirectoryName(currentCGroupMemoryPath);
                 }
-                while (currentCGroupMemoryPath!.Length != cgroupMemoryHierarchyMountPath.Length);
             }
 
             limit = minLimit;
 
             return foundAnyLimit;
+        }
+
+        private static bool IsPathAtOrBelowMount(string path, string mount)
+        {
+            if (string.Equals(path, mount, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            return mount == "/" || path.StartsWith(mount + "/", StringComparison.Ordinal);
         }
 
         /// <summary>Tries to parse a memory limit from the specified file.</summary>

--- a/src/libraries/Common/tests/Tests/Interop/cgroupsTests.cs
+++ b/src/libraries/Common/tests/Tests/Interop/cgroupsTests.cs
@@ -34,9 +34,39 @@ namespace Common.Tests
         [Theory]
         [InlineData("/sys/fs/cgroup/cpu/my_cgroup", "/docker/1234", "/sys/fs/cgroup/cpu", "/docker/1234/my_cgroup")]
         [InlineData("/sys/fs/cgroup/cpu/my_cgroup", "/", "/sys/fs/cgroup/cpu", "/my_cgroup")]
+        [InlineData("/sys/fs/cgroup", "/some/container", "/sys/fs/cgroup", "/some/container")]
         public void ValidateFindCGroupPath(string expectedResult, string hierarchyRoot, string hierarchyMount, string cgroupPathRelativeToMount)
         {
             Assert.Equal(expectedResult, Interop.cgroups.FindCGroupPath(hierarchyRoot, hierarchyMount, cgroupPathRelativeToMount));
+        }
+
+        [Fact]
+        public void ValidateTryGetMemoryLimitV2AtHierarchyMount()
+        {
+            string testRoot = GetTestFilePath();
+            string hierarchyMount = Path.Combine(testRoot, "mount");
+            Directory.CreateDirectory(hierarchyMount);
+            File.WriteAllText(Path.Combine(hierarchyMount, "memory.max"), "1");
+
+            Assert.True(Interop.cgroups.TryGetMemoryLimitV2(hierarchyMount, hierarchyMount, out ulong limit));
+            Assert.Equal(1UL, limit);
+        }
+
+        [Fact]
+        public void ValidateTryGetMemoryLimitV2StopsAtHierarchyMount()
+        {
+            string testRoot = GetTestFilePath();
+            string hierarchyMount = Path.Combine(testRoot, "mount");
+            string parentCGroup = Path.Combine(hierarchyMount, "a");
+            string currentCGroup = Path.Combine(parentCGroup, "b");
+            Directory.CreateDirectory(currentCGroup);
+            File.WriteAllText(Path.Combine(hierarchyMount, "memory.max"), "20");
+            File.WriteAllText(Path.Combine(parentCGroup, "memory.max"), "20");
+            File.WriteAllText(Path.Combine(currentCGroup, "memory.max"), "10");
+            File.WriteAllText(Path.Combine(testRoot, "memory.max"), "2");
+
+            Assert.True(Interop.cgroups.TryGetMemoryLimitV2(currentCGroup, hierarchyMount, out ulong limit));
+            Assert.Equal(10UL, limit);
         }
 
         [Theory]


### PR DESCRIPTION
Related to #130092

Fixes https://github.com/dotnet/runtime/issues/133470


Fix managed cgroup v2 memory limit traversal when the current cgroup is exactly the hierarchy mount root.

The previous `do/while` loop moved to the parent directory before checking whether the mount root had been reached. This could walk outside the cgroup hierarchy and eventually dereference a null path.

The traversal now stops before reading or moving above the hierarchy mount root. Path equality uses ordinal string comparison.
