### PR TITLE
Exclude job monitor stage when it is disabled in perf.yml

### DIFF
--- a/eng/pipelines/performance/perf.yml
+++ b/eng/pipelines/performance/perf.yml
@@ -56,11 +56,12 @@ extends:
     - stage: Build
       jobs:
 
-      - template: /eng/common/core-templates/job/helix-job-monitor.yml
-        parameters:
-          helixAccessToken: $(HelixApiAccessToken)
-          timeoutInMinutes: 540
-          allowNoHelixJobs: true
+      - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:
+        - template: /eng/common/core-templates/job/helix-job-monitor.yml
+          parameters:
+            helixAccessToken: $(HelixApiAccessToken)
+            timeoutInMinutes: 540
+            allowNoHelixJobs: true
 
       - template: /eng/pipelines/runtime-wasm-perf-jobs.yml@performance
         parameters:


### PR DESCRIPTION
Same as https://github.com/dotnet/runtime/pull/132884 but for perf.yml. This was missed in https://github.com/dotnet/runtime/pull/132807