### PR TITLE
[release/11.0] JIT: fix range assertions for bypassed phi blocks

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1930,9 +1930,7 @@ Range RangeCheck::GetRangeFromType(var_types type)
 }
 
 // Compute the range for a local var definition.
-Range RangeCheck::ComputeRangeForLocalDef(BasicBlock*          block,
-                                          GenTreeLclVarCommon* lcl,
-                                          bool monIncreasing   DEBUGARG(int indent))
+Range RangeCheck::ComputeRangeForLocalDef(GenTreeLclVarCommon* lcl, bool monIncreasing DEBUGARG(int indent))
 {
     LclSsaVarDsc* ssaDef = GetSsaDefStore(lcl);
     if (ssaDef == nullptr)
@@ -1947,17 +1945,7 @@ Range RangeCheck::ComputeRangeForLocalDef(BasicBlock*          block,
         JITDUMP("----------------------------------------------------\n");
     }
 #endif
-    Range range = GetRangeWorker(ssaDef->GetBlock(), ssaDef->GetDefNode()->Data(), monIncreasing DEBUGARG(indent));
-    if (!BitVecOps::MayBeUninit(block->bbAssertionIn) && (m_compiler->GetAssertionCount() > 0))
-    {
-        JITDUMP("Merge assertions from " FMT_BB ": ", block->bbNum);
-        Compiler::optDumpAssertionIndices(block->bbAssertionIn, " ");
-        JITDUMP("for definition [%06d]\n", Compiler::dspTreeID(ssaDef->GetDefNode()))
-
-        MergeEdgeAssertions(ssaDef->GetDefNode(), block->bbAssertionIn, &range);
-        JITDUMP("done merging\n");
-    }
-    return range;
+    return GetRangeWorker(ssaDef->GetBlock(), ssaDef->GetDefNode()->Data(), monIncreasing DEBUGARG(indent));
 }
 
 // Get the limit's maximum possible value.
@@ -2311,7 +2299,8 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreas
     // If local, find the definition from the def map and evaluate the range for rhs.
     else if (expr->IsLocal())
     {
-        range = ComputeRangeForLocalDef(block, expr->AsLclVarCommon(), monIncreasing DEBUGARG(indent + 1));
+        range = ComputeRangeForLocalDef(expr->AsLclVarCommon(), monIncreasing DEBUGARG(indent + 1));
+        // Phi arguments need edge assertions, not the assertions of a block that jump threading may have bypassed.
         MergeAssertion(block, expr, &range DEBUGARG(indent + 1));
     }
     // compute the range for binary operation

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -882,7 +882,7 @@ private:
 
     // Given the local variable, first find the definition of the local and find the range of the rhs.
     // Helper for GetRangeWorker.
-    Range ComputeRangeForLocalDef(BasicBlock* block, GenTreeLclVarCommon* lcl, bool monIncreasing DEBUGARG(int indent));
+    Range ComputeRangeForLocalDef(GenTreeLclVarCommon* lcl, bool monIncreasing DEBUGARG(int indent));
 
     // Compute the range, rather than retrieve a cached value. Helper for GetRangeWorker.
     Range ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreasing DEBUGARG(int indent));

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133267/Runtime_133267.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133267/Runtime_133267.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_133267
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Equal(4, Test(new object[4], [1, 1, 1, 1]));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int Test(object[] key, int[] fields)
+    {
+        int c = key != null ? key.Length : 0;
+        if (key is null || c <= 0 || fields.Length != c)
+        {
+            throw new ArgumentException();
+        }
+
+        int sum = 0;
+        for (int i = 0; i < key.Length; i++)
+        {
+            sum += fields[i];
+        }
+        return sum;
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -66,6 +66,7 @@
     <Compile Include="JitBlue\Runtime_61359\Runtime_61359.cs" />
     <Compile Include="JitBlue\Runtime_620\Runtime_620.cs" />
     <Compile Include="JitBlue\Runtime_62597\Runtime_62597.cs" />
+    <Compile Include="JitBlue\Runtime_133267\Runtime_133267.cs" />
     <Compile Include="JitBlue\Runtime_65937\Runtime_65937.cs" />
     <Compile Include="JitBlue\Runtime_66578\Runtime_66578.cs" />
     <Compile Include="JitBlue\Runtime_75832\Runtime_75832.cs" />


### PR DESCRIPTION
Backport of #133268 to release/11.0

## Customer Impact

- [ ] Customer reported
- [x] Found internally

The JIT may merge range assertions from a block bypassed by jump threading, then optimize based on stale facts. Valid optimized code can take an impossible error path and throw unexpectedly.

## Regression

- [x] Yes
- [ ] No

Introduced during .NET 11 development. Reproduces on .NET 11 RC1 and does not reproduce on .NET 10.0.12.

## Testing

Regression test added. Built the Checked JIT and verified the repro returns the expected value (`4`) with the backported JIT.

## Risk

Low. The change stops merging potentially stale block assertions into local definitions and uses the existing edge-aware assertion merge at the use.