### PR TITLE
[release/11.0] JIT: guard negative-offset bounds inference against underflow

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1202,11 +1202,11 @@ void RangeCheck::MergeEdgeAssertionsWorker(Compiler*                        comp
                     limit      = Limit(Limit::keBinOpArray, preferredBoundVN, -addOpCns);
                     isUnsigned = false;
                 }
-                else if (addOpCns > INT32_MIN)
+                else if ((addOpCns > INT32_MIN) && pRange->LowerLimit().IsConstant() &&
+                         !IntAddOverflows(pRange->LowerLimit().GetConstant(), addOpCns))
                 {
-                    // (normalLclVN + negConst) u< bound, with bound non-negative.
-                    // Since the comparison is unsigned, (normalLclVN + negConst) must not have wrapped,
-                    // which means normalLclVN >= -negConst.
+                    // The known lower bound rules out underflow. Otherwise a negative index could
+                    // wrap to a nonnegative value and pass the unsigned comparison.
                     cmpOper    = GT_GE;
                     limit      = Limit(Limit::keConstant, -addOpCns);
                     isUnsigned = false;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133271/Runtime_133271.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133271/Runtime_133271.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_133271
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Throws<IndexOutOfRangeException>(() => Test(new int[4], int.MinValue));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int Test(int[] array, int index)
+    {
+        if ((uint)(index - int.MaxValue) < (uint)array.Length && index < array.Length)
+        {
+            ref int unused = ref array[index];
+            return 1;
+        }
+        return 0;
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -95,6 +95,7 @@
     <Compile Include="JitBlue\Runtime_125169\Runtime_125169.cs" />
     <Compile Include="JitBlue\Runtime_125301\Runtime_125301.cs" />
     <Compile Include="JitBlue\Runtime_125328\Runtime_125328.cs" />
+    <Compile Include="JitBlue\Runtime_133271\Runtime_133271.cs" />
     <Compile Include="JitBlue\Runtime_125431\Runtime_125431.cs" />
     <Compile Include="JitBlue\Runtime_126060\Runtime_126060.cs" />
     <Compile Include="JitBlue\Runtime_127260\Runtime_127260.cs" />


### PR DESCRIPTION
Backport of #133272 to release/11.0

## Customer Impact

- [ ] Customer reported
- [x] Found internally

The JIT may incorrectly infer a lower bound from an unsigned comparison whose negative offset underflows. It can then remove an array bounds check and let an invalid negative index proceed instead of throwing `IndexOutOfRangeException`.

## Regression

- [x] Yes
- [ ] No

Introduced by #125235. Reproduces on .NET 11 RC1 and does not reproduce on .NET 10.0.12.

## Testing

Regression test added. Built the Checked JIT and verified the repro throws `IndexOutOfRangeException` with the backported JIT.

## Risk

Low. The change only enables the range inference when a known constant lower bound proves the subtraction cannot underflow.