### PR TITLE
Fix missing Helix queue variables in SuperPMI replay pipelines

### DIFF
--- a/eng/pipelines/coreclr/superpmi-replay-apx.yml
+++ b/eng/pipelines/coreclr/superpmi-replay-apx.yml
@@ -10,6 +10,7 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - template: /eng/pipelines/helix-platforms.yml
 
 extends:
   template:  /eng/pipelines/coreclr/templates/jit-replay-pipeline.yml

--- a/eng/pipelines/coreclr/superpmi-replay-wasm.yml
+++ b/eng/pipelines/coreclr/superpmi-replay-wasm.yml
@@ -10,6 +10,7 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - template: /eng/pipelines/helix-platforms.yml
 
 extends:
   template:  /eng/pipelines/coreclr/templates/jit-replay-pipeline.yml

--- a/eng/pipelines/coreclr/superpmi-replay.yml
+++ b/eng/pipelines/coreclr/superpmi-replay.yml
@@ -21,6 +21,7 @@ schedules:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - template: /eng/pipelines/helix-platforms.yml
 
 extends:
   template:  /eng/pipelines/coreclr/templates/jit-replay-pipeline.yml


### PR DESCRIPTION
Import helix-platforms.yml in the standard, APX, and WASM replay pipelines so shared queue selection can resolve the Windows queue aliases.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>