### PR TITLE
Fix cpu affinity set size to have minimal size

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -184,13 +184,14 @@ bool GCToOSInterface::Initialize()
 
     {
         // Use a dynamically allocated cpu_set_t to support systems with more than CPU_SETSIZE (typically 1024) CPUs.
-        cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
+        int cpusToAllocate = std::max(configuredCpuCount, CPU_SETSIZE);
+        cpu_set_t* pCpuSet = CPU_ALLOC(cpusToAllocate);
         if (pCpuSet == nullptr)
         {
             return false;
         }
 
-        size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
+        size_t cpuSetSize = CPU_ALLOC_SIZE(cpusToAllocate);
         CPU_ZERO_S(cpuSetSize, pCpuSet);
 
         int st = sched_getaffinity(getpid(), cpuSetSize, pCpuSet);
@@ -900,8 +901,9 @@ bool GCToOSInterface::SetThreadAffinity(uint16_t procNo)
 {
 #if HAVE_SCHED_SETAFFINITY || HAVE_PTHREAD_SETAFFINITY_NP
 
-    size_t cpuSetSize = CPU_ALLOC_SIZE(g_configuredCpuCount);
-    cpu_set_t* pCpuSet = CPU_ALLOC(g_configuredCpuCount);
+    uint32_t cpusToAllocate = std::max(g_configuredCpuCount, (uint32_t)CPU_SETSIZE);
+    size_t cpuSetSize = CPU_ALLOC_SIZE(cpusToAllocate);
+    cpu_set_t* pCpuSet = CPU_ALLOC(cpusToAllocate);
     if (pCpuSet == nullptr)
     {
         return false;

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -211,6 +211,11 @@ bool GCToOSInterface::Initialize()
             // We should not get any of the errors that the sched_getaffinity can return since none
             // of them applies for the current thread, so this is an unexpected kind of failure.
             assert(false);
+            // Fallback: if sched_getaffinity fails, assume all CPUs are available.
+            for (int i = 0; i < configuredCpuCount; i++)
+            {
+                g_processAffinitySet.Add(i);
+            }
         }
 
         CPU_FREE(pCpuSet);

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <cwchar>
+#include <algorithm> 
 #include <sal.h>
 #include "config.h"
 #include <pthread.h>
@@ -481,16 +482,17 @@ void InitializeCurrentProcessCpuCount()
             configuredCpuCount = CPU_SETSIZE;
         }
 
-        cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
+        int cpusToAllocate = std::max(configuredCpuCount, CPU_SETSIZE);
+        cpu_set_t* pCpuSet = CPU_ALLOC(cpusToAllocate);
         if (pCpuSet != nullptr)
         {
-            size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
+            size_t cpuSetSize = CPU_ALLOC_SIZE(cpusToAllocate);
             CPU_ZERO_S(cpuSetSize, pCpuSet);
 
             int st = sched_getaffinity(getpid(), cpuSetSize, pCpuSet);
             if (st == 0)
             {
-                count = (uint32_t)CPU_COUNT_S(CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
+                count = (uint32_t)CPU_COUNT_S(cpuSetSize, pCpuSet);
             }
             else
             {

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <cwchar>
-#include <algorithm> 
+#include <algorithm>
 #include <sal.h>
 #include "config.h"
 #include <pthread.h>

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -173,16 +173,18 @@ PAL_GetLogicalCpuCountFromOS()
             configuredCpuCount = CPU_SETSIZE;
         }
 
-        cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
+        int cpusToAllocate = std::max(configuredCpuCount, CPU_SETSIZE);
+
+        cpu_set_t* pCpuSet = CPU_ALLOC(cpusToAllocate);
         if (pCpuSet != nullptr)
         {
-            size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
+            size_t cpuSetSize = CPU_ALLOC_SIZE(cpusToAllocate);
             CPU_ZERO_S(cpuSetSize, pCpuSet);
 
             int st = sched_getaffinity(gPID, cpuSetSize, pCpuSet);
             if (st == 0)
             {
-                nrcpus = CPU_COUNT_S(CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
+                nrcpus = CPU_COUNT_S(cpuSetSize, pCpuSet);
             }
             else
             {

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1421,7 +1421,8 @@ CPalThread::ThreadEntry(
             configuredCpuCount = CPU_SETSIZE;
         }
 
-        cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
+        int cpusToAllocate = std::max(configuredCpuCount, CPU_SETSIZE);
+        cpu_set_t* pCpuSet = CPU_ALLOC(cpusToAllocate);
         if (pCpuSet == nullptr)
         {
             ASSERT("CPU_ALLOC failed!\n");
@@ -1429,13 +1430,13 @@ CPalThread::ThreadEntry(
             goto fail;
         }
 
-        size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
+        size_t cpuSetSize = CPU_ALLOC_SIZE(cpusToAllocate);
         CPU_ZERO_S(cpuSetSize, pCpuSet);
 
         st = sched_getaffinity(gPID, cpuSetSize, pCpuSet);
         if (st == 0)
         {
-            st = sched_setaffinity(0, CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
+            st = sched_setaffinity(0, cpuSetSize, pCpuSet);
             if (st != 0)
             {
                 if (errno == EPERM || errno == EACCES)


### PR DESCRIPTION
There is a problem when the /sys/devices/system/cpu/possible reports less CPUs than the kernel keeps as `nr_cpu_ids`. My recent change has made the CPU set size dynamic based on the possible CPU count. In the problematic case, kernel returns failure from the sched_getaffinity syscall, since it requires the passed in CPU set size to be >= `nr_cpu_ids`.

This change fixes it by always using CPU_SETSIZE as the minimum size allocated, which is the default size when the CPU set is not allocated dynamically and which was used before my recent fix.

Close #133449