### PR TITLE
Add auxiliary symbol enumeration to cDAC

### DIFF
--- a/docs/design/datacontracts/AuxiliarySymbols.md
+++ b/docs/design/datacontracts/AuxiliarySymbols.md
@@ -7,6 +7,9 @@ This contract provides name resolution for helper functions. It may include othe
 ## APIs of contract
 
 ``` csharp
+// Enumerates all known auxiliary symbols and their code addresses.
+IEnumerable<(TargetCodePointer Address, string Name)> EnumerateAuxiliarySymbols();
+
 // Attempts to resolve a code address to a helper function name.
 // Returns true if the address matches a known helper, with the name in symbolName.
 // Returns false if the address does not match any known helper.
@@ -40,15 +43,10 @@ bool TryGetAuxiliarySymbolName(TargetPointer ip, out string symbolName);
 
 
 ``` csharp
-bool TryGetAuxiliarySymbolName(TargetPointer ip, out string? symbolName)
+IEnumerable<(TargetCodePointer Address, string Name)> EnumerateAuxiliarySymbols()
 {
-    symbolName = null;
-
-    TargetCodePointer codePointer = CodePointerFromAddress(ip);
-
     TargetPointer helperArray = target.ReadGlobalPointer("AuxiliarySymbols");
     uint count = target.Read<uint>(target.ReadGlobalPointer("AuxiliarySymbolCount"));
-
     uint entrySize = /* AuxiliarySymbolInfo size */;
 
     for (uint i = 0; i < count; i++)
@@ -57,9 +55,21 @@ bool TryGetAuxiliarySymbolName(TargetPointer ip, out string? symbolName)
         TargetCodePointer address = target.ReadCodePointer(entryAddr + /* AuxiliarySymbolInfo::Address offset */);
         TargetPointer namePointer = target.ReadPointer(entryAddr + /* AuxiliarySymbolInfo::Name offset */);
 
-        if (address == codePointer && namePointer != TargetPointer.Null)
+        if (namePointer != TargetPointer.Null)
+            yield return (address, target.ReadUtf8String(namePointer));
+    }
+}
+
+bool TryGetAuxiliarySymbolName(TargetPointer ip, out string? symbolName)
+{
+    symbolName = null;
+    TargetCodePointer codePointer = CodePointerFromAddress(ip);
+
+    foreach ((TargetCodePointer address, string name) in EnumerateAuxiliarySymbols())
+    {
+        if (address == codePointer)
         {
-            symbolName = target.ReadUtf8String(namePointer);
+            symbolName = name;
             return true;
         }
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IAuxiliarySymbols.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IAuxiliarySymbols.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
@@ -9,6 +10,7 @@ namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 public interface IAuxiliarySymbols : IContract
 {
     static string IContract.Name { get; } = nameof(AuxiliarySymbols);
+    IEnumerable<(TargetCodePointer Address, string Name)> EnumerateAuxiliarySymbols() => throw new NotImplementedException();
     bool TryGetAuxiliarySymbolName(TargetPointer ip, [NotNullWhen(true)] out string? symbolName) => throw new NotImplementedException();
 }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/AuxiliarySymbols_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/AuxiliarySymbols_1.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
@@ -14,15 +15,31 @@ internal readonly struct AuxiliarySymbols_1 : IAuxiliarySymbols
         _target = target;
     }
 
+    IEnumerable<(TargetCodePointer Address, string Name)> IAuxiliarySymbols.EnumerateAuxiliarySymbols()
+        => EnumerateAuxiliarySymbols();
+
     bool IAuxiliarySymbols.TryGetAuxiliarySymbolName(TargetPointer ip, [NotNullWhen(true)] out string? symbolName)
     {
         symbolName = null;
 
         TargetCodePointer codePointer = CodePointerUtils.CodePointerFromAddress(ip, _target);
 
+        foreach ((TargetCodePointer address, string name) in EnumerateAuxiliarySymbols())
+        {
+            if (address == codePointer)
+            {
+                symbolName = name;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private IEnumerable<(TargetCodePointer Address, string Name)> EnumerateAuxiliarySymbols()
+    {
         TargetPointer helperArrayPtr = _target.ReadGlobalPointer(Constants.Globals.AuxiliarySymbols);
         uint helperCount = _target.Read<uint>(_target.ReadGlobalPointer(Constants.Globals.AuxiliarySymbolCount));
-
         uint entrySize = Data.AuxiliarySymbolInfo.GetSize(_target);
 
         for (uint i = 0; i < helperCount; i++)
@@ -30,18 +47,8 @@ internal readonly struct AuxiliarySymbols_1 : IAuxiliarySymbols
             TargetPointer entryAddr = helperArrayPtr + (ulong)(i * entrySize);
             Data.AuxiliarySymbolInfo entry = _target.ProcessedData.GetOrAdd<Data.AuxiliarySymbolInfo>(entryAddr);
 
-            if (entry.CodeAddress == codePointer)
-            {
-                if (entry.Name != TargetPointer.Null)
-                {
-                    symbolName = _target.ReadUtf8String(entry.Name);
-                    return true;
-                }
-
-                return false;
-            }
+            if (entry.Name != TargetPointer.Null)
+                yield return (entry.CodeAddress, _target.ReadUtf8String(entry.Name));
         }
-
-        return false;
     }
 }

--- a/src/native/managed/cdac/tests/UnitTests/AuxiliarySymbolsTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/AuxiliarySymbolsTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.TestInfrastructure;
@@ -92,6 +93,23 @@ public class AuxiliarySymbolsTests
             .AddMockContract<IPlatformMetadata>(Mock.Of<IPlatformMetadata>(p => p.GetCodePointerFlags() == default(CodePointerFlags)))
             .AddContract<IAuxiliarySymbols>(version: "c1")
             .Build();
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void EnumerateAuxiliarySymbols_ReturnsAllSymbols(MockTarget.Architecture arch)
+    {
+        (ulong Address, string Name)[] helpers =
+        [
+            (0x7FFF_0100, "@WriteBarrier"),
+            (0x7FFF_0200, "@CheckedWriteBarrier"),
+        ];
+        Target target = CreateTarget(arch, helpers);
+
+        Assert.Equal(
+            helpers.Select(helper => (new TargetCodePointer(helper.Address), helper.Name)),
+            target.Contracts.AuxiliarySymbols.EnumerateAuxiliarySymbols());
+        Assert.Empty(CreateTarget(arch, []).Contracts.AuxiliarySymbols.EnumerateAuxiliarySymbols());
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- add `IAuxiliarySymbols.EnumerateAuxiliarySymbols()` to expose every populated auxiliary symbol and code address
- share the enumeration with `TryGetAuxiliarySymbolName`
- document the c1 contract algorithm and add unit coverage across target architectures

This is a standalone prerequisite for cDAC dump enumeration. The dump collector needs to proactively traverse the auxiliary symbol table so heap dumps capture the table entries and UTF-8 names before later diagnostic operations request symbol resolution.

This addresses the auxiliary symbol table concern raised in [Rachel's review comment on #132584](https://github.com/dotnet/runtime/pull/132584#issuecomment-5593548606). The corresponding dump-collection usage remains in #132584.

## Testing

- `dotnet.cmd test src\native\managed\cdac\tests\UnitTests\Microsoft.Diagnostics.DataContractReader.Tests.csproj --filter "FullyQualifiedName~AuxiliarySymbolsTests" -c Debug -p:RuntimeConfiguration=Debug -p:LibrariesConfiguration=Release` (16 passed)

> [!NOTE]
> This pull request description was generated with GitHub Copilot.