### PR TITLE
Add option to configure optimistic R2R instruction sets

### DIFF
--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -18,7 +18,7 @@ namespace System.CommandLine
     internal static partial class Helpers
     {
         public static InstructionSetSupport ConfigureInstructionSetSupport(string instructionSet, int maxVectorTBitWidth, bool isVectorTOptimistic, TargetArchitecture targetArchitecture, TargetOS targetOS,
-            string mustNotBeMessage, string invalidImplicationMessage, Logger logger, bool allowOptimistic, bool isReadyToRun)
+            string mustNotBeMessage, string invalidImplicationMessage, Logger logger, bool allowOptimistic, bool isReadyToRun, string optimisticInstructionSetOverrides = null)
         {
             InstructionSetSupportBuilder instructionSetSupportBuilder = new(targetArchitecture);
 
@@ -219,6 +219,7 @@ namespace System.CommandLine
             // the optimistic set would be missing the explicitly unsupported sets. So we effectively clone the list and
             // tack on the additional optimistic bits after. This ensures the optimistic set remains an accurate superset
             InstructionSetSupportBuilder optimisticInstructionSetSupportBuilder = new InstructionSetSupportBuilder(instructionSetSupportBuilder);
+            InstructionSetSupportBuilder optimisticInstructionSetOverrideBuilder = new(targetArchitecture);
 
             // Optimistically assume some instruction sets are present.
             if (allowOptimistic && targetArchitecture is TargetArchitecture.X86 or TargetArchitecture.X64)
@@ -283,9 +284,24 @@ namespace System.CommandLine
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("sha2");
             }
 
+            if (optimisticInstructionSetOverrides != null)
+            {
+                string[] optimisticInstructionSetOverrideParams = optimisticInstructionSetOverrides.Split(',');
+                for (int i = 0; i < optimisticInstructionSetOverrideParams.Length; i++)
+                {
+                    string instructionSetSpecifier = NormalizeInstructionSetSpecifier(optimisticInstructionSetOverrideParams[i], mustNotBeMessage);
+                    ApplyInstructionSetSpecifier(optimisticInstructionSetOverrideBuilder, instructionSetSpecifier, mustNotBeMessage);
+                }
+            }
+
             // Vector<T> can always be part of the optimistic set, we only want to optionally exclude it from the supported set
             optimisticInstructionSetSupportBuilder.ComputeInstructionSetFlags(maxVectorTBitWidth, skipAddingVectorT: false, out var optimisticInstructionSet, out _,
                 (string specifiedInstructionSet, string impliedInstructionSet) => throw new NotSupportedException());
+            optimisticInstructionSetOverrideBuilder.ComputeInstructionSetFlags(maxVectorTBitWidth, skipAddingVectorT: true, out var supportedOptimisticInstructionSetOverride, out var unsupportedOptimisticInstructionSetOverride,
+                (string specifiedInstructionSet, string impliedInstructionSet) =>
+                    throw new CommandLineException(string.Format(invalidImplicationMessage, specifiedInstructionSet, impliedInstructionSet)));
+            optimisticInstructionSet.Add(supportedOptimisticInstructionSetOverride);
+            optimisticInstructionSet.Remove(unsupportedOptimisticInstructionSetOverride);
             optimisticInstructionSet.Remove(unsupportedInstructionSet);
             optimisticInstructionSet.Add(supportedInstructionSet);
 

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -174,17 +174,7 @@ namespace System.CommandLine
                 // Normalize instruction set format to include implied +.
                 for (int i = 0; i < instructionSetParamsInput.Length; i++)
                 {
-                    instructionSet = instructionSetParamsInput[i].Trim();
-
-                    if (string.IsNullOrEmpty(instructionSet))
-                        throw new CommandLineException(string.Format(mustNotBeMessage, ""));
-
-                    char firstChar = instructionSet[0];
-
-                    if ((firstChar != '+') && (firstChar != '-'))
-                    {
-                        instructionSet = "+" + instructionSet;
-                    }
+                    instructionSet = NormalizeInstructionSetSpecifier(instructionSetParamsInput[i], mustNotBeMessage);
 
                     if (instructionSet == "+optimistic")
                     {
@@ -202,19 +192,7 @@ namespace System.CommandLine
 
                 foreach (string instructionSetSpecifier in instructionSetParams)
                 {
-                    instructionSet = instructionSetSpecifier.Substring(1);
-
-                    bool enabled = instructionSetSpecifier[0] == '+' ? true : false;
-                    if (enabled)
-                    {
-                        if (!instructionSetSupportBuilder.AddSupportedInstructionSet(instructionSet))
-                            throw new CommandLineException(string.Format(mustNotBeMessage, instructionSet));
-                    }
-                    else
-                    {
-                        if (!instructionSetSupportBuilder.RemoveInstructionSetSupport(instructionSet))
-                            throw new CommandLineException(string.Format(mustNotBeMessage, instructionSet));
-                    }
+                    ApplyInstructionSetSpecifier(instructionSetSupportBuilder, instructionSetSpecifier, mustNotBeMessage);
                 }
             }
 
@@ -347,6 +325,40 @@ namespace System.CommandLine
                 optimisticInstructionSet,
                 InstructionSetSupportBuilder.GetNonSpecifiableInstructionSetsForArch(targetArchitecture),
                 targetArchitecture);
+        }
+
+        private static string NormalizeInstructionSetSpecifier(string instructionSet, string mustNotBeMessage)
+        {
+            instructionSet = instructionSet.Trim();
+
+            if (string.IsNullOrEmpty(instructionSet))
+                throw new CommandLineException(string.Format(mustNotBeMessage, ""));
+
+            char firstChar = instructionSet[0];
+
+            if ((firstChar != '+') && (firstChar != '-'))
+            {
+                instructionSet = "+" + instructionSet;
+            }
+
+            return instructionSet;
+        }
+
+        private static void ApplyInstructionSetSpecifier(InstructionSetSupportBuilder instructionSetSupportBuilder, string instructionSetSpecifier, string mustNotBeMessage)
+        {
+            string instructionSet = instructionSetSpecifier.Substring(1);
+
+            bool enabled = instructionSetSpecifier[0] == '+' ? true : false;
+            if (enabled)
+            {
+                if (!instructionSetSupportBuilder.AddSupportedInstructionSet(instructionSet))
+                    throw new CommandLineException(string.Format(mustNotBeMessage, instructionSet));
+            }
+            else
+            {
+                if (!instructionSetSupportBuilder.RemoveInstructionSetSupport(instructionSet))
+                    throw new CommandLineException(string.Format(mustNotBeMessage, instructionSet));
+            }
         }
 
         // Produces an InstructionSetSupport where the instruction sets are fixed at compile time: every

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -24,6 +24,8 @@ namespace ILCompiler
             new("--reference", "-r") { CustomParser = result => Helpers.BuildPathDictionary(result.Tokens, false), DefaultValueFactory = result => Helpers.BuildPathDictionary(result.Tokens, false), Description = SR.ReferenceFiles };
         public Option<string> InstructionSet { get; } =
             new("--instruction-set") { Description = SR.InstructionSets };
+        public Option<string> OptimisticInstructionSetOverrides { get; } =
+            new("--optimistic-instruction-set") { Description = SR.OptimisticInstructionSets };
         public Option<int> MaxVectorTBitWidth { get; } =
             new("--max-vectort-bitwidth") { Description = SR.MaxVectorTBitWidths };
         public Option<string[]> MibcFilePaths { get; } =
@@ -168,6 +170,7 @@ namespace ILCompiler
             Options.Add(UnrootedInputFilePaths);
             Options.Add(ReferenceFilePaths);
             Options.Add(InstructionSet);
+            Options.Add(OptimisticInstructionSetOverrides);
             Options.Add(MaxVectorTBitWidth);
             Options.Add(MibcFilePaths);
             Options.Add(OutputFilePath);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -99,7 +99,8 @@ namespace ILCompiler
             InstructionSetSupport instructionSetSupport = Helpers.ConfigureInstructionSetSupport(Get(_command.InstructionSet), Get(_command.MaxVectorTBitWidth), isVectorTOptimistic, targetArchitecture, targetOS,
                 SR.InstructionSetMustNotBe, SR.InstructionSetInvalidImplication, logger,
                 allowOptimistic: allowOptimistic,
-                isReadyToRun: true);
+                isReadyToRun: true,
+                optimisticInstructionSetOverrides: Get(_command.OptimisticInstructionSetOverrides));
             if (!targetAllowsRuntimeCodeGeneration)
             {
                 instructionSetSupport = Helpers.GetFixedInstructionSetSupport(instructionSetSupport);

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -189,6 +189,9 @@
   <data name="InstructionSetInvalidImplication" xml:space="preserve">
     <value>Instruction set '{0}' implies support for instruction set '{1}'</value>
   </data>
+  <data name="OptimisticInstructionSets" xml:space="preserve">
+    <value>Instruction set(s) to add to or remove from optimistic compilation without changing baseline requirements</value>
+  </data>
   <data name="MaxVectorTBitWidths" xml:space="preserve">
     <value>The maximum width, in bits, for System.Numerics.Vector&lt;T&gt;. For example '128', '256', or '512'.</value>
   </data>


### PR DESCRIPTION
R2R allowed expanding the baseline instruction set via `--instruction-set:+insset` or adding unsupported sets via `--instruction-set:-insset`. The optimistic set could only be disabled completely via `--instruction-set:-optimistic`.

This PR adds the option to configure explicitly the optimistic set via a new flag: ex: `--optimistic-instruction-set:avx512,-waitpkg`. This is done in the second commit of the PR, where we add/remove the flags from this override set over the default set.

For context, https://github.com/dotnet/android/pull/12722 noted that a lot of r2r code was excluded on older devices because some instruction set was included by default in the optimistic set, which was not available at runtime. This resulted in various r2r code being rejected. While we could hardcode the new default optimistic set for android inside crossgen2, it seems like a better approach is to allow custom configuration of this by android build (and even users themselvs via `PublishReadyToRunCrossgen2ExtraArgs`)