### PR TITLE
JIT: expand all stack array allocations in a statement

### DIFF
--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -2805,25 +2805,34 @@ PhaseStatus Compiler::fgExpandStackArrayAllocations()
     {
         for (Statement* const stmt : block->Statements())
         {
-            if ((stmt->GetRootNode()->gtFlags & GTF_CALL) == 0)
-            {
-                continue;
-            }
+            // A single statement can contain more than one allocation. Expanding one splits
+            // the statement's tree and leaves the remainder (which may hold further
+            // allocations) in "stmt", so keep rescanning it until nothing is left to expand.
+            //
+            bool expanded = true;
 
-            for (GenTree* const tree : stmt->TreeList())
+            while (expanded)
             {
-                if (!tree->IsCall())
+                expanded = false;
+
+                if ((stmt->GetRootNode()->gtFlags & GTF_CALL) == 0)
                 {
-                    continue;
+                    break;
                 }
 
-                if (fgExpandStackArrayAllocation(block, stmt, tree->AsCall()))
+                for (GenTree* const tree : stmt->TreeList())
                 {
-                    // If we expand, we split the statement's tree
-                    // so will be done with this statment.
-                    //
-                    modified = true;
-                    break;
+                    if (!tree->IsCall())
+                    {
+                        continue;
+                    }
+
+                    if (fgExpandStackArrayAllocation(block, stmt, tree->AsCall()))
+                    {
+                        modified = true;
+                        expanded = true;
+                        break;
+                    }
                 }
             }
         }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133523/Runtime_133523.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133523/Runtime_133523.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+// Forward substitution can put several stack-allocated array allocations into a single
+// statement. The stack array expansion phase used to expand only the first one of them,
+// leaving the rest as malformed NEWARR helper calls (still carrying the StackArrayLocal
+// arg), which crashed the process.
+public class Runtime_133523
+{
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int TwoArrays(int index)
+    {
+        int[] first = new int[3];
+        int[] second = new int[3];
+        return first[second[index]];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int ThreeArrays(int index)
+    {
+        int[] a = new int[3];
+        int[] b = new int[3];
+        int[] c = new int[3];
+        a[2] = 42;
+        return a[b[c[index]]] + a[2];
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Equal(0, TwoArrays(0));
+        Assert.Equal(42, ThreeArrays(0));
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -102,6 +102,7 @@
     <Compile Include="JitBlue\Runtime_127446\Runtime_127446.cs" />
     <Compile Include="JitBlue\Runtime_128062\Runtime_128062.cs" />
     <Compile Include="JitBlue\Runtime_128392\Runtime_128392.cs" />
+    <Compile Include="JitBlue\Runtime_133523\Runtime_133523.cs" />
     <Compile Include="JitBlue\Runtime_128631\Runtime_128631.cs" />
     <Compile Include="JitBlue\Runtime_128801\Runtime_128801.cs" />
     <Compile Include="JitBlue\Runtime_129076\Runtime_129076.cs" />


### PR DESCRIPTION
Fixes #133523

`fgExpandStackArrayAllocations` stopped after expanding the first allocation in a statement. `gtSplitTree` only moves the part of the tree evaluated *before* the split point into new statements, so any further `NEWARR` helper calls stayed in the statement and were never expanded - leaving a helper call with a bogus `StackArrayLocal` arg (asserts in lowering, AVs in release).

No SPMI asm diffs.