### PR TITLE
JIT: keep volatile accesses in order across call arguments

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -737,6 +737,62 @@ void CallArg::Dump(Compiler* comp)
 #endif
 
 //------------------------------------------------------------------------
+// ArgHasVolatileAccess: Check whether an argument tree contains a volatile
+//    memory access.
+//
+// Parameters:
+//   comp - The compiler object.
+//   argx - The argument tree.
+//
+// Returns:
+//   True if the tree contains a volatile load or store.
+//
+// Remarks:
+//   Volatile accesses must not be reordered with respect to other memory
+//   accesses, which constrains the order in which arguments may be evaluated.
+//   Other users of GTF_ORDER_SIDEEFF (bounds checks, null checks and the
+//   address computations tied to them) only need to preserve their ordering
+//   within a single argument tree, so they are not interesting here.
+//
+static bool ArgHasVolatileAccess(Compiler* comp, GenTree* argx)
+{
+    if ((argx->gtFlags & GTF_ORDER_SIDEEFF) == 0)
+    {
+        return false;
+    }
+
+    struct Visitor : GenTreeVisitor<Visitor>
+    {
+        enum
+        {
+            DoPreOrder = true,
+        };
+
+        bool HasVolatileAccess = false;
+
+        Visitor(Compiler* comp)
+            : GenTreeVisitor(comp)
+        {
+        }
+
+        fgWalkResult PreOrderVisit(GenTree** use, GenTree* user)
+        {
+            if ((*use)->OperIsIndir() && (*use)->AsIndir()->IsVolatile())
+            {
+                HasVolatileAccess = true;
+                return Compiler::WALK_ABORT;
+            }
+
+            return Compiler::WALK_CONTINUE;
+        }
+    };
+
+    Visitor visitor(comp);
+    visitor.WalkTree(&argx, nullptr);
+    return visitor.HasVolatileAccess;
+}
+
+//------------------------------------------------------------------------
 // ArgsComplete: Make final decisions on which arguments to evaluate into temporaries.
 //
 void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
@@ -748,6 +804,8 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
     // Exceptions previous tree with GTF_EXCEPT may throw (computed lazily, may
     // be empty)
     ExceptionSetFlags prevExceptionFlags = ExceptionSetFlags::None;
+    // Whether we have seen an argument with a volatile memory access
+    bool hasVolatileAccess = false;
 
     for (CallArg& arg : Args())
     {
@@ -811,6 +869,41 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
 
                 if (((prevArg.GetEarlyNode()->gtFlags & GTF_ALL_EFFECT) != 0) ||
                     comp->gtMayHaveStoreInterference(argx, prevArg.GetEarlyNode()))
+                {
+                    SetNeedsTemp(&prevArg);
+                }
+            }
+        }
+
+        // Volatile accesses must not be reordered with respect to other memory accesses.
+        // Once we have seen one, every argument that accesses memory - before or after it -
+        // forces all preceding memory-accessing arguments into temps so that the sort below
+        // cannot reorder them.
+        //
+        if (ArgHasVolatileAccess(comp, argx))
+        {
+            hasVolatileAccess = true;
+        }
+
+        if (hasVolatileAccess && ((argx->gtFlags & GTF_ALL_EFFECT) != 0))
+        {
+            for (CallArg& prevArg : Args())
+            {
+                if (&prevArg == &arg)
+                {
+                    break;
+                }
+
+#if !FEATURE_FIXED_OUT_ARGS
+                if (!prevArg.AbiInfo.HasAnyRegisterSegment())
+                {
+                    // All stack args are already evaluated and placed in order
+                    // in this case.
+                    continue;
+                }
+#endif
+
+                if ((prevArg.GetEarlyNode() != nullptr) && ((prevArg.GetEarlyNode()->gtFlags & GTF_ALL_EFFECT) != 0))
                 {
                     SetNeedsTemp(&prevArg);
                 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133524/Runtime_133524.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133524/Runtime_133524.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Xunit;
+
+// Call arguments were sorted purely by cost, which could evaluate a later argument's
+// volatile read before an earlier one's. With a monotonically increasing value the
+// first read can never observe a larger value than the second, so any such observation
+// means the two acquire loads were reordered.
+public class Runtime_133524
+{
+    private static int s_value;
+    private static int s_stop;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool ReadsReversed(ref int value) =>
+        Sink(Volatile.Read(ref value), Volatile.Read(ref value) + 1);
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool Sink(int first, int secondPlusOne) => first > secondPlusOne - 1;
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Thread publisher = new Thread(static () =>
+        {
+            for (int i = 1; (i <= 100_000_000) && (Volatile.Read(ref s_stop) == 0); i++)
+            {
+                Volatile.Write(ref s_value, i);
+            }
+        });
+
+        publisher.IsBackground = true;
+        publisher.Start();
+
+        int reversed = 0;
+        for (int i = 0; i < 2_000_000; i++)
+        {
+            if (ReadsReversed(ref s_value))
+            {
+                reversed++;
+            }
+        }
+
+        Volatile.Write(ref s_stop, 1);
+        publisher.Join();
+
+        Assert.Equal(0, reversed);
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -130,6 +130,7 @@
     <Compile Include="JitBlue\GitHub_131472\GitHub_131472.cs" />
     <Compile Include="JitBlue\Runtime_122237\Runtime_122237.cs" />
     <Compile Include="JitBlue\Runtime_131716\Runtime_131716.cs" />
+    <Compile Include="JitBlue\Runtime_133524\Runtime_133524.cs" />
     <Compile Include="JitBlue\Runtime_132268\Runtime_132268.cs" />
     <Compile Include="JitBlue\Runtime_132370\Runtime_132370.cs" />
     <Compile Include="JitBlue\Runtime_132243\Runtime_132243.cs" />


### PR DESCRIPTION
Fixes #133524

`CallArgs::ArgsComplete` forces arguments into temps for stores (`GTF_ASG`), calls (`GTF_CALL`) and differing exception sets (`GTF_EXCEPT`), but has no notion of ordering side effects. Two volatile loads were therefore left free-floating and `SortArgs` reordered them by cost:

```asm
mov edx, dword ptr [rdx] ; read for the SECOND argument
inc edx
mov ecx, dword ptr [rcx] ; read for the FIRST argument
call Sink
```

Once an argument contains a volatile access, all preceding memory-accessing arguments are now evaluated into temps. Temp setups live in the early arg list, which is sequenced in original argument order ahead of all late args, so this restores the program order.

Keying on `GTF_ORDER_SIDEEFF` directly would also catch bounds checks, null checks and non-faulting indirections, which only need their ordering preserved within a single argument tree (+7,539 bytes in benchmarks.run). Narrowing to actual volatile indirections costs +54 bytes over 8 contexts.