### PR TITLE
Resolve WASM NativeAOT object relocations

### DIFF
--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -300,7 +300,7 @@ void emitter::emitIns_Call(const EmitCallParams& params)
     {
         case EC_FUNC_TOKEN:
             ins = params.isJump ? INS_return_call : INS_call;
-            id  = emitNewInstrSC(EA_HANDLE_CNS_RELOC, 0 /* FIXME-WASM: function index reloc */);
+            id  = emitNewInstrSC(EA_HANDLE_CNS_RELOC, (cnsval_ssize_t)params.addr);
             id->idIns(ins);
             id->idInsFmt(IF_FUNCIDX);
             break;

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmDataSection.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmDataSection.cs
@@ -101,7 +101,7 @@ namespace ILCompiler.ObjectWriter
         /// Assign the layout of segments within the data section, padding segments for file alignment, and placing
         /// active segments at the appropriate memory offsets.
         /// </summary>
-        private void AssignSegmentLayout()
+        public void AssignSegmentLayout()
         {
             if (_layoutAssigned)
                 return;

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -144,7 +144,15 @@ namespace ILCompiler.ObjectWriter
         private protected override void RecordMethodDeclaration(INodeWithTypeSignature node)
         {
             WriteSignatureIndexForFunction(node);
-            RegisterFunctionSymbol(new Utf8String(node.GetMangledName(_nodeFactory.NameMangler)));
+            Utf8String methodName = new(node.GetMangledName(_nodeFactory.NameMangler));
+            RegisterFunctionSymbol(methodName);
+
+            Utf8String alternateName = _nodeFactory.GetSymbolAlternateName(node, out _);
+            if (!alternateName.IsNull)
+            {
+                _wasmSymbolManager.AddAlias(ExternCName(alternateName), methodName);
+            }
+
             if (node is INodeWithFunclets nodeWithFunclets)
             {
                 RecordFunclets(nodeWithFunclets);
@@ -361,13 +369,13 @@ namespace ILCompiler.ObjectWriter
             IDictionary<Utf8String, SymbolDefinition> definedSymbols,
             SortedSet<Utf8String> undefinedSymbols)
         {
+            // Register defined symbols for future use during relocation resolution.
+            _definedSymbols = new Dictionary<Utf8String, SymbolDefinition>(definedSymbols);
+
             WriteImports();
             WriteGlobalSection();
             WriteExports();
             WriteElements();
-
-            // Register defined symbols for future use during relocation resolution.
-            _definedSymbols = new Dictionary<Utf8String, SymbolDefinition>(definedSymbols);
         }
 
         private protected abstract void WriteImports();

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -369,13 +369,13 @@ namespace ILCompiler.ObjectWriter
             IDictionary<Utf8String, SymbolDefinition> definedSymbols,
             SortedSet<Utf8String> undefinedSymbols)
         {
-            // Register defined symbols for future use during relocation resolution.
-            _definedSymbols = new Dictionary<Utf8String, SymbolDefinition>(definedSymbols);
-
             WriteImports();
             WriteGlobalSection();
-            WriteExports();
             WriteElements();
+
+            // Register defined symbols for use during when resolving exports and relocations.
+            _definedSymbols = new Dictionary<Utf8String, SymbolDefinition>(definedSymbols);
+            WriteExports();
         }
 
         private protected abstract void WriteImports();

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -373,7 +373,7 @@ namespace ILCompiler.ObjectWriter
             WriteGlobalSection();
             WriteElements();
 
-            // Register defined symbols for use during when resolving exports and relocations.
+            // Register defined symbols for use when resolving exports and relocations.
             _definedSymbols = new Dictionary<Utf8String, SymbolDefinition>(definedSymbols);
             WriteExports();
         }

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -17,7 +17,7 @@ using Internal.TypeSystem;
 namespace ILCompiler.ObjectWriter
 {
     /// <summary>
-    /// Base class for WebAssembly object file format writers.
+    /// Base class for WebAssembly object writers.
     /// </summary>
     internal abstract partial class WasmObjectWriter : ObjectWriter
     {
@@ -382,9 +382,12 @@ namespace ILCompiler.ObjectWriter
             _sections.GetSection<WasmExternallyCountedSection>(ObjectNodeSection.WasmCodeSection.Name)
                 .SetEntryCount(MethodCount);
 
-            Debug.Assert(_sections.GetSection<WasmFunctionSection>(WasmObjectNodeSection.FunctionSection.Name).EntryCount == MethodCount);
-            Debug.Assert(_sections.GetSection<WasmImportSection>(WasmObjectNodeSection.ImportSection.Name).EntryCount == _wasmSymbolManager.GetImportCount());
-            Debug.Assert(_sections.GetSection<WasmGlobalSection>(WasmObjectNodeSection.GlobalSection.Name).EntryCount == _wasmSymbolManager.GetDefinitionCount(WasmIndexSpace.Global));
+            Debug.Assert(!_sections.Contains(WasmObjectNodeSection.FunctionSection.Name)
+                || _sections.GetSection<WasmFunctionSection>(WasmObjectNodeSection.FunctionSection.Name).EntryCount == MethodCount);
+            Debug.Assert(!_sections.Contains(WasmObjectNodeSection.ImportSection.Name)
+                || _sections.GetSection<WasmImportSection>(WasmObjectNodeSection.ImportSection.Name).EntryCount == _wasmSymbolManager.GetImportCount());
+            Debug.Assert(!_sections.Contains(WasmObjectNodeSection.GlobalSection.Name)
+                || _sections.GetSection<WasmGlobalSection>(WasmObjectNodeSection.GlobalSection.Name).EntryCount == _wasmSymbolManager.GetDefinitionCount(WasmIndexSpace.Global));
         }
     }
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
@@ -60,6 +60,7 @@ namespace ILCompiler.ObjectWriter
             Debug.Assert(outputFileStream.CanSeek, $"EmitObjectFile requires seekable output stream");
 
             FinalizeSectionEntryCounts();
+            _dataSection?.AssignSegmentLayout();
             ResolveSectionRelocations();
 
             EmitWasmHeader(outputFileStream);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
@@ -112,6 +112,7 @@ namespace ILCompiler.ObjectWriter
 
         private unsafe void ResolveRelocations(int sectionIndex, MemoryStream sectionStream, List<SymbolicRelocation> relocs, long sectionStart = 0)
         {
+            // TODO: We also need to emit relocations in the reloc section for the linker to resolve.
             byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
 
             foreach (SymbolicRelocation reloc in relocs)
@@ -158,12 +159,25 @@ namespace ILCompiler.ObjectWriter
                             Relocation.WriteValue(reloc.Type, pData, symbol.Index + addend);
                             break;
                         }
+                        case RelocType.IMAGE_REL_BASED_HIGHLOW:
+                        {
+                            if (_sections[definedSymbol.SectionIndex] is WasmDataSegmentEmitter segment)
+                            {
+                                int targetOffsetFromMemoryBase = segment.GetMemoryAddressOfOffset((int)(definedSymbol.Value + addend));
+                                Relocation.WriteValue(reloc.Type, pData, targetOffsetFromMemoryBase);
+                            }
+                            else
+                            {
+                                throw new NotImplementedException();
+                            }
+                            break;
+                        }
 
                         default:
                             // TODO-WASM: add other cases as needed;
                             // ignoring other reloc types for now
                             throw new NotSupportedException($"Relocation type {reloc.Type} for symbol '{reloc.SymbolName}' at "
-                                + $"offset 0x{reloc.Offset:X} in section {sectionIndex} not yet implemented");
+                                + $"offset 0x{reloc.Offset:X} in section {_sections[sectionIndex].SectionName} not yet implemented");
 
                     }
 
@@ -185,6 +199,9 @@ namespace ILCompiler.ObjectWriter
                 sectionStream.Write(new Span<byte>(pData, Relocation.GetSize(reloc.Type)));
             }
         }
+
+        // TODO: This is a temporary workaround for the fact that we don't yet emit a COMDAT section (or any reloc / linking sections)
+        private protected override bool UsesSubsectionsViaSymbols => true;
 
         private protected override SectionDataEmitter CreateDataSection(
             ObjectNodeSection section,
@@ -245,6 +262,14 @@ namespace ILCompiler.ObjectWriter
 
         private protected override void WriteExports()
         {
+            // TODO-WASM: Handle exports better (e.g., only export public methods, etc.)
+            IEnumerable<WasmSymbol> functionSymbols = _wasmSymbolManager.GetDefinitions(
+                WasmIndexSpace.Function,
+                Comparer<WasmSymbol>.Create(static (x, y) => x.Name.CompareTo(y.Name)));
+            foreach (WasmSymbol symbol in functionSymbols)
+            {
+                WriteFunctionExport(symbol.Name.ToString(), symbol.Index);
+            }
         }
 
         private protected override void WriteElements()

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
@@ -10,6 +10,7 @@ using Internal.JitInterface;
 using Internal.Text;
 using Internal.TypeSystem.TypesDebugInfo;
 using ILCompiler.DependencyAnalysis.Wasm;
+using System.Linq;
 
 namespace ILCompiler.ObjectWriter
 {
@@ -262,20 +263,23 @@ namespace ILCompiler.ObjectWriter
 
         private protected override void WriteExports()
         {
-            // TODO-WASM: Handle exports better (e.g., only export public methods, etc.)
-            IEnumerable<WasmSymbol> functionSymbols = _wasmSymbolManager.GetDefinitions(
-                WasmIndexSpace.Function,
-                Comparer<WasmSymbol>.Create(static (x, y) => x.Name.CompareTo(y.Name)));
-            foreach (WasmSymbol symbol in functionSymbols)
+            WasmSection codeSection = GetOrCreateSection<WasmSection>(ObjectNodeSection.WasmCodeSection, out _);
+            int codeSectionIndex = codeSection.SectionIndex;
+            foreach (var symbol in _definedSymbols)
             {
-                WriteFunctionExport(symbol.Name.ToString(), symbol.Index);
+                // We only export methods for now
+                if (!symbol.Value.Global || symbol.Value.SectionIndex != codeSectionIndex)
+                    continue;
+
+                WasmSymbol methodEntry = _wasmSymbolManager.GetSymbol(symbol.Key);
+                Debug.Assert(methodEntry.IndexSpace == WasmIndexSpace.Function);
+                WriteFunctionExport(symbol.Key.ToString(), methodEntry.Index);
             }
         }
 
         private protected override void WriteElements()
         {
         }
-
 
         // ObjectWriter.Aot.cs methods
         private protected override void EmitUnwindInfo(SectionWriter sectionWriter, INodeWithCodeInfo nodeWithCodeInfo, Utf8String currentSymbolName)

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
@@ -165,8 +165,8 @@ namespace ILCompiler.ObjectWriter
                         {
                             if (_sections[definedSymbol.SectionIndex] is WasmDataSegmentEmitter segment)
                             {
-                                int targetOffsetFromMemoryBase = segment.GetMemoryAddressOfOffset((int)(definedSymbol.Value + addend));
-                                Relocation.WriteValue(reloc.Type, pData, targetOffsetFromMemoryBase);
+long targetAddress = segment.GetMemoryAddressOfOffset((int)(definedSymbol.Value + addend)) + reloc.Addend;
+                                Relocation.WriteValue(reloc.Type, pData, targetAddress);
                             }
                             else
                             {

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmSymbolManager.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmSymbolManager.cs
@@ -56,6 +56,7 @@ internal sealed class WasmSymbolManager
     }
 
     private readonly Dictionary<Utf8String, Entry> _entries = new();
+    private readonly Dictionary<Utf8String, Entry> _aliases = new();
     private IndexSpaceArray<int> _importCounts = new IndexSpaceArray<int>();
     private IndexSpaceArray<int> _definitionCounts = new IndexSpaceArray<int>();
     private IndexSpaceArray<bool> _importsFrozen = new IndexSpaceArray<bool>();
@@ -76,14 +77,23 @@ internal sealed class WasmSymbolManager
         _definitionCounts[indexSpace]++;
     }
 
+    public void AddAlias(Utf8String alias, Utf8String target)
+    {
+        Debug.Assert(!_entries.ContainsKey(alias), "Alias symbol name must not already exist.");
+        Debug.Assert(_entries.ContainsKey(target), "Target symbol name must exist before adding an alias.");
+        Entry entry = _entries[target];
+        _aliases.Add(alias, entry with { Name = alias });
+    }
+
     public WasmSymbol GetSymbol(Utf8String name)
     {
-        return ResolveAndFreeze(_entries[name]);
+        return ResolveAndFreeze(GetEntry(name));
     }
 
     public bool TryGetSymbol(Utf8String name, out WasmSymbol symbol)
     {
-        if (!_entries.TryGetValue(name, out Entry entry))
+        if (!_entries.TryGetValue(name, out Entry entry) &&
+            !_aliases.TryGetValue(name, out entry))
         {
             symbol = default;
             return false;
@@ -92,6 +102,9 @@ internal sealed class WasmSymbolManager
         symbol = ResolveAndFreeze(entry);
         return true;
     }
+
+    private Entry GetEntry(Utf8String name) =>
+        _entries.TryGetValue(name, out Entry entry) ? entry : _aliases[name];
 
     public int GetImportCount() => _importCounts.Values.Sum();
 


### PR DESCRIPTION
Adds support for resolving IMAGE_REL_BASED_HIGHLOW relocations in the NativeAOT WASM object writer. This is only supported when the target is in a data segment that corresponds directly to an ObjectNodeSection (which most, if not all, will).

Also adds emission of export entries and handling of symbol aliases.