### PR TITLE
Fix optimizations of explicitly rounded hardware intrinsics

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -1424,21 +1424,16 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
     {
         size_t   numArgs = node->GetOperandCount();
         GenTree* lastOp  = node->Op(numArgs);
-        uint8_t  mode    = 0xFF;
 
         if (lastOp->IsCnsIntOrI())
         {
             // Mark the constant as contained since it's specially encoded
             MakeSrcContained(node, lastOp);
-
-            mode = static_cast<uint8_t>(lastOp->AsIntCon()->IconValue());
         }
 
-        if ((mode & 0x03) != 0x00)
-        {
-            // Embedded rounding only works for register-to-register operations, so skip containment
-            return node->gtNext;
-        }
+        // Codegen consumes the rounding operand. The remaining lowering and containment
+        // expect the ordinary operand count, even when the rounding mode is implicit.
+        return node->gtNext;
     }
 
     bool       isScalar = false;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9905,6 +9905,12 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
                 break;
             }
 
+            if (node->GetOperandCount() != 2)
+            {
+                // These simplifications are not worth specializing for explicit rounding modes.
+                break;
+            }
+
             double multiplier = op2Cns->ToScalarFloating(simdBaseType);
 
             if (multiplier == -1.0)
@@ -9987,7 +9993,7 @@ GenTree* Compiler::fgOptimizeHWIntrinsic(GenTreeHWIntrinsic* node)
                 ExtractEffectiveOp(GT_NEG, node, /* destroyNodes */ true);
                 return result;
             }
-            else if ((op1Oper == GT_MUL) || (op1Oper == GT_DIV))
+            else if (((op1Oper == GT_MUL) || (op1Oper == GT_DIV)) && (op1Intrin->GetOperandCount() == 2))
             {
                 GenTree* op2 = op1Intrin->Op(2);
 

--- a/src/tests/JIT/HardwareIntrinsics/X86_Avx512/Avx512F/EmbeddedRounding.Double.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86_Avx512/Avx512F/EmbeddedRounding.Double.cs
@@ -13,6 +13,17 @@ namespace IntelHardwareIntrinsicTest._Avx512F
 {
     public partial class Program
     {
+        [ConditionalTheory(typeof(Avx512F), nameof(Avx512F.IsSupported))]
+        [InlineData(0x3FF0000000000001ul)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void NegateEmbeddedRounding_Double(ulong bits)
+        {
+            Vector512<double> value = Vector512.Create(BitConverter.UInt64BitsToDouble(bits));
+
+            Assert.Equal(Vector512.Create(0xBFF8000000000002ul), (-Avx512F.Multiply(value, Vector512.Create(1.5), FloatRoundingMode.ToPositiveInfinity)).AsUInt64());
+            Assert.Equal(Vector512.Create(0xBFC2492492492494ul), (-Avx512F.Divide(value, Vector512.Create(7.0), FloatRoundingMode.ToPositiveInfinity)).AsUInt64());
+        }
+
         [Fact]
         public static unsafe void ConvertToInt32EmbeddedRounding_Double()
         {

--- a/src/tests/JIT/HardwareIntrinsics/X86_Avx512/Avx512F/EmbeddedRounding.Single.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86_Avx512/Avx512F/EmbeddedRounding.Single.cs
@@ -13,6 +13,41 @@ namespace IntelHardwareIntrinsicTest._Avx512F
 {
     public partial class Program
     {
+        [ConditionalTheory(typeof(Avx512F), nameof(Avx512F.IsSupported))]
+        [InlineData(0x3F800001u)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void NegateEmbeddedRounding_Single(uint bits)
+        {
+            Vector512<float> value = Vector512.Create(BitConverter.UInt32BitsToSingle(bits));
+
+            Assert.Equal(Vector512.Create(0xBFC00002u), (-Avx512F.Multiply(value, Vector512.Create(1.5f), FloatRoundingMode.ToPositiveInfinity)).AsUInt32());
+            Assert.Equal(Vector512.Create(0xBE124926u), (-Avx512F.Divide(value, Vector512.Create(7.0f), FloatRoundingMode.ToPositiveInfinity)).AsUInt32());
+        }
+
+        [ConditionalTheory(typeof(Avx512F), nameof(Avx512F.IsSupported))]
+        [InlineData(float.MaxValue)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void MultiplyConstantEmbeddedRounding_Single(float scalar)
+        {
+            // Reusing the vector keeps the multiply's input local, enabling the multiply-to-add rewrite.
+            Vector512<float> value = Vector512.Create(scalar);
+            Vector512<float> doubled = Avx512F.Multiply(value, Vector512.Create(2.0f), FloatRoundingMode.ToZero);
+            Assert.Equal(Vector512<float>.Zero, doubled - value);
+        }
+
+        [ConditionalTheory(typeof(Avx512F), nameof(Avx512F.IsSupported))]
+        [InlineData(1.25f)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ToEvenEmbeddedRounding_Single(float scalar)
+        {
+            Vector512<float> left = Vector512.Create(scalar);
+            Vector512<float> right = Vector512.Create(1.5f);
+            Vector512<float> addend = Vector512.Create(1.0f);
+
+            Assert.Equal(Vector512.Create(2.75f), Avx512F.Add(left, right, FloatRoundingMode.ToEven));
+            Assert.Equal(Vector512.Create(2.875f), Avx512F.FusedMultiplyAdd(left, right, addend, FloatRoundingMode.ToEven));
+        }
+
         [Fact]
         public static unsafe void ConvertToInt32EmbeddedRounding_Single()
         {


### PR DESCRIPTION
Skip morph simplifications that move negation through an explicitly rounded multiply/divide or replace a rounded multiply with an operation that drops its rounding mode.

Also keep explicit-rounding nodes out of ordinary lowering and containment, which expect no rounding operand. This fixes operand-count assertions for `ToEven` arithmetic and FMA. Add focused regression coverage for both issues.

Fixes dotnet/runtime#133519

> [!NOTE]
> This PR was prepared with GitHub Copilot.