### PR TITLE
Enable I2C linking via PR description

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,7 @@ For markdown (`.md`) files, ensure there is no trailing whitespace at the end of
 ## Pull Requests
 
 - **One concern per PR.** Split large or mixed changes. Do large refactorings and mechanical renames in their own PR, separate from logic changes.
-- **Enable automatic resolved-issue linking in the PR description.** On any PR intended to close an issue, incldue the fully qualified `Resolves owner/repository#123` format at the end of the PR description.
+- **Enable automatic resolved-issue linking in the PR description.** On any PR intended to close an issue, include the fully qualified `Resolves owner/repository#123` format at the end of the PR description.
 - **New public API requires an approved proposal before submission** — PRs adding unapproved API will be closed. Use the `api-proposal` skill; until approval lands the API stays `internal` in any submitted PR. A proposal's prototype branch is exempt and keeps its surface public — it's evidence, not a submission.
 - **Core component changes should start with an issue.** Changes to the host, VM, or JIT need a GitHub issue describing the problem and motivation first.
 - **Put the measurements in the description** for performance changes — BenchmarkDotNet results, or codegen and instruction-count evidence for low-level work.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,7 @@ For markdown (`.md`) files, ensure there is no trailing whitespace at the end of
 ## Pull Requests
 
 - **One concern per PR.** Split large or mixed changes. Do large refactorings and mechanical renames in their own PR, separate from logic changes.
-- **Enable automatic Idea2Customer (I2C) linking in the PR description.** For I2C work (or any PR intended to close an issue), use the fully qualified `Resolves owner/repository#123` format; GitHub will close the referenced issue when the PR is merged into the default branch.
+- **Enable automatic resolved-issue linking in the PR description.** On any PR intended to close an issue, incldue the fully qualified `Resolves owner/repository#123` format at the end of the PR description.
 - **New public API requires an approved proposal before submission** — PRs adding unapproved API will be closed. Use the `api-proposal` skill; until approval lands the API stays `internal` in any submitted PR. A proposal's prototype branch is exempt and keeps its surface public — it's evidence, not a submission.
 - **Core component changes should start with an issue.** Changes to the host, VM, or JIT need a GitHub issue describing the problem and motivation first.
 - **Put the measurements in the description** for performance changes — BenchmarkDotNet results, or codegen and instruction-count evidence for low-level work.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,7 @@ For markdown (`.md`) files, ensure there is no trailing whitespace at the end of
 ## Pull Requests
 
 - **One concern per PR.** Split large or mixed changes. Do large refactorings and mechanical renames in their own PR, separate from logic changes.
-- **Link CloudMine Idea-to-Customer (I2C) work in the PR description.** Always use the fully qualified `Resolves owner/repository#123` format; merging into the default branch automatically closes the linked issue.
+- **Enable automatic Idea2Customer (I2C) linking in the PR description.** Always use the fully qualified `Resolves owner/repository#123` format; merging into the default branch automatically closes the linked issue.
 - **New public API requires an approved proposal before submission** — PRs adding unapproved API will be closed. Use the `api-proposal` skill; until approval lands the API stays `internal` in any submitted PR. A proposal's prototype branch is exempt and keeps its surface public — it's evidence, not a submission.
 - **Core component changes should start with an issue.** Changes to the host, VM, or JIT need a GitHub issue describing the problem and motivation first.
 - **Put the measurements in the description** for performance changes — BenchmarkDotNet results, or codegen and instruction-count evidence for low-level work.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,7 @@ For markdown (`.md`) files, ensure there is no trailing whitespace at the end of
 ## Pull Requests
 
 - **One concern per PR.** Split large or mixed changes. Do large refactorings and mechanical renames in their own PR, separate from logic changes.
-- **Enable automatic resolved-issue linking in the PR description.** On any PR intended to close an issue, include the fully qualified `Resolves owner/repository#123` format at the end of the PR description.
+- **Enable automatic resolved-issue linking in the PR description.** On any PR intended to close an issue, include the fully qualified `Resolves owner/repository#123` format as the final substantive line of the PR description, before any required disclosure note.
 - **New public API requires an approved proposal before submission** — PRs adding unapproved API will be closed. Use the `api-proposal` skill; until approval lands the API stays `internal` in any submitted PR. A proposal's prototype branch is exempt and keeps its surface public — it's evidence, not a submission.
 - **Core component changes should start with an issue.** Changes to the host, VM, or JIT need a GitHub issue describing the problem and motivation first.
 - **Put the measurements in the description** for performance changes — BenchmarkDotNet results, or codegen and instruction-count evidence for low-level work.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,7 @@ For markdown (`.md`) files, ensure there is no trailing whitespace at the end of
 ## Pull Requests
 
 - **One concern per PR.** Split large or mixed changes. Do large refactorings and mechanical renames in their own PR, separate from logic changes.
+- **Link CloudMine Idea-to-Customer (I2C) work in the PR description.** Always use the fully qualified `Resolves owner/repository#123` format; merging into the default branch automatically closes the linked issue.
 - **New public API requires an approved proposal before submission** — PRs adding unapproved API will be closed. Use the `api-proposal` skill; until approval lands the API stays `internal` in any submitted PR. A proposal's prototype branch is exempt and keeps its surface public — it's evidence, not a submission.
 - **Core component changes should start with an issue.** Changes to the host, VM, or JIT need a GitHub issue describing the problem and motivation first.
 - **Put the measurements in the description** for performance changes — BenchmarkDotNet results, or codegen and instruction-count evidence for low-level work.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,7 @@ For markdown (`.md`) files, ensure there is no trailing whitespace at the end of
 ## Pull Requests
 
 - **One concern per PR.** Split large or mixed changes. Do large refactorings and mechanical renames in their own PR, separate from logic changes.
-- **Enable automatic Idea2Customer (I2C) linking in the PR description.** Always use the fully qualified `Resolves owner/repository#123` format; merging into the default branch automatically closes the linked issue.
+- **Enable automatic Idea2Customer (I2C) linking in the PR description.** For I2C work (or any PR intended to close an issue), use the fully qualified `Resolves owner/repository#123` format; GitHub will close the referenced issue when the PR is merged into the default branch.
 - **New public API requires an approved proposal before submission** — PRs adding unapproved API will be closed. Use the `api-proposal` skill; until approval lands the API stays `internal` in any submitted PR. A proposal's prototype branch is exempt and keeps its surface public — it's evidence, not a submission.
 - **Core component changes should start with an issue.** Changes to the host, VM, or JIT need a GitHub issue describing the problem and motivation first.
 - **Put the measurements in the description** for performance changes — BenchmarkDotNet results, or codegen and instruction-count evidence for low-level work.


### PR DESCRIPTION
## Summary

Ask agents to use the fully qualified `Resolves owner/repository#123` format in pull request descriptions

## Rationale

GitHub pull request issue metadata cannot currently be resolved for the I2C metric. Requiring a fully qualified closing keyword in the PR description is a temporary workaround that allows automatic Idea2Customer linking until that metadata can be resolved directly.

## Validation

- `git diff --check`
- verified the rule is in the canonical `Pull Requests` section of `.github/copilot-instructions.md`
- verified the instructions do not include the temporary-workaround implementation detail

> [!NOTE]
> This pull request description was generated with GitHub Copilot.