### PR TITLE
Make browser WASM R2R runtime tests blocking

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1965,9 +1965,6 @@ extends:
           - browser_wasm
           helixQueueGroup: pr
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          # Keep known failures visible without blocking the runtime pipeline.
-          # Tracked by https://github.com/dotnet/runtime/issues/133305.
-          shouldContinueOnError: true
           jobParameters:
             testGroup: innerloop
             readyToRun: true
@@ -1975,8 +1972,7 @@ extends:
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: CoreCLR_ReleaseLibraries_BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_hostedOs)_$(_BuildConfig)
             unifiedBuildNameSuffix: CoreCLR_ReleaseLibraries
-            # The shared monitor would turn this non-blocking lane into a pipeline failure.
-            useHelixMonitor: false
+            useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
             extraBuildArgs: -os browser -p:HostConfiguration=Release
             condition: >-
               or(


### PR DESCRIPTION
Follow-up to #133305 and #133463.

#133463 restored the browser-wasm CoreCLR `R2R_CG2` runtime-test lane as non-blocking while the known failures were addressed. With no remaining failures observed, this change makes the lane follow the normal blocking browser-wasm convention by:

- removing `shouldContinueOnError`
- using the shared Helix job monitor through `${{ variables.enableHelixJobMonitor }}`

Validation:

- parsed `eng/pipelines/runtime.yml` successfully with Ruby Psych
- `git diff --check`

> [!NOTE]
> This pull request description was drafted with GitHub Copilot.