### PR TITLE
[wasm] Isolate unsupported struct callback test

### DIFF
--- a/src/tests/JIT/Methodical/structs/systemvbringup/structpasstest.cs
+++ b/src/tests/JIT/Methodical/structs/systemvbringup/structpasstest.cs
@@ -8,7 +8,6 @@ namespace structinreg
 {
     public class Program
     {
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123946", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
         [Fact]
         [OuterLoop]
         public static int TestEntryPoint()
@@ -33,12 +32,6 @@ namespace structinreg
                     return ret;
                 }
 
-                ret = Program3.Main1();
-                if (ret != 100)
-                {
-                    return ret;
-                }
-
                 ret = Program4.Main1();
                 if (ret != 100)
                 {
@@ -50,6 +43,15 @@ namespace structinreg
                 Console.WriteLine(e.ToString());
             }
             return 100;
+        }
+
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/123946", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/133565", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsBrowser), nameof(TestLibrary.PlatformDetection.IsCoreCLR))]
+        [Fact]
+        [OuterLoop]
+        public static int TestPInvokeCallbacks()
+        {
+            return Program3.Main1();
         }
     }
 

--- a/src/tests/JIT/Methodical/structs/systemvbringup/structpasstest.cs
+++ b/src/tests/JIT/Methodical/structs/systemvbringup/structpasstest.cs
@@ -46,7 +46,7 @@ namespace structinreg
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/123946", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/133565", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsBrowser), nameof(TestLibrary.PlatformDetection.IsCoreCLR))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/133565", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsWasm), nameof(TestLibrary.PlatformDetection.IsCoreCLR))]
         [Fact]
         [OuterLoop]
         public static int TestPInvokeCallbacks()


### PR DESCRIPTION
Fixes #133565.

`structinreg.Program.TestEntryPoint` combined four managed struct-passing groups with a P/Invoke callback group. Once #133367 linked the test's native archive into the browser-wasm corerun, the callback group began running and failed before entering native code: marshaling its first delegate requires a dynamic unmanaged entrypoint, and CoreCLR wasm builds use `FEATURE_PORTABLE_ENTRYPOINTS`, which deliberately throws `PlatformNotSupported_DynamicEntrypoint` for that operation.

Split the callback group into its own outer-loop fact. The new fact retains the existing native-assets gate and is active-issued only when both `PlatformDetection.IsWasm` and `PlatformDetection.IsCoreCLR` are true. The managed struct-passing groups remain enabled on browser-wasm and WASI, while all callback and struct P/Invoke coverage continues to run on supported CoreCLR targets.

## Validation

- Clean checked CoreCLR/runtime-test baseline succeeded.
- Negative control on browser-wasm CoreCLR reproduced `global::structinreg.Program.TestEntryPoint()` with expected `100`, actual `-1`, and `Dynamic entrypoint allocation is not supported in the current environment.`
- After the change, browser-wasm CoreCLR passes `TestEntryPoint`; the generated results record only `TestPInvokeCallbacks` as skipped for #133565.
- WASI checked CoreCLR passes `TestEntryPoint` and records `TestPInvokeCallbacks` as skipped. WASI does not currently link test-specific native assets, so the existing #123946 gate would also skip it today; the wasm-wide predicate keeps the test correct if that support is added.
- macOS arm64 checked CoreCLR passes both `TestEntryPoint` and `TestPInvokeCallbacks`, including all native callback cases.
- `Methodical_others` remains explicitly R2R-incompatible for CoreCLR wasm under #132855, so there is no applicable R2R execution path changed here.

> [!NOTE]
> This pull request description was generated with the help of GitHub Copilot.