### PR TITLE
Remove ActiveIssue attribute from TypeTests

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/TypeTests.Get.CornerCases.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/TypeTests.Get.CornerCases.cs
@@ -282,7 +282,6 @@ namespace System.Reflection.Tests
             Assert.Equal(0, properties.Length);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/865", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Fact]
         public static void HideDetectionHappensAfterPrivateInBaseClassChecks()
         {


### PR DESCRIPTION
This seems to be passing.

Resolves dotnet/runtimelab#865