### PR TITLE
Remove RCPC2 from the optimistic set on arm64

### DIFF
--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -299,7 +299,6 @@ namespace System.CommandLine
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("dotprod");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("lse");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("rcpc");
-                optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("rcpc2");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("rdma");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("sha1");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("sha2");

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -299,6 +299,8 @@ namespace System.CommandLine
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("dotprod");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("lse");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("rcpc");
+                // RCPC2 is intentionally excluded from the optimistic set since it is not universally available
+                // on supported ARM64 hardware yet, and many methods take an opportunistic dependency on it.
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("rdma");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("sha1");
                 optimisticInstructionSetSupportBuilder.AddSupportedInstructionSet("sha2");


### PR DESCRIPTION
Testing on android (https://github.com/dotnet/android/pull/12722) showed that older devices don't have rcpc2 instruction set available which leads to significant r2r code rejection. This is a simpler, cross platform fix for the issue, compared to exposing knobs to tweak the optimistic set (https://github.com/dotnet/runtime/pull/133514) and have dotnet/android use them.