### PR TITLE
[iOS] Avoid debugger patches in R2R code without dynamic code support

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -16,6 +16,9 @@
 #include "../inc/common.h"
 #include "eeconfig.h"
 
+#if defined(HOST_IOS)
+#include <TargetConditionals.h>
+#endif
 #include "../../vm/methoditer.h"
 #include "../../vm/tailcallhelp.h"
 
@@ -1840,7 +1843,7 @@ BOOL DebuggerController::CheckGetPatchedOpcode(CORDB_ADDRESS_TYPE *address,
     return res;
 }
 
-// void DebuggerController::ActivatePatch()  Place a breakpoint
+// bool DebuggerController::ActivatePatch()  Place a breakpoint
 // so that threads will trip over this patch.
 // If there any patches at the address already, then copy
 // their opcode into this one & return.  Otherwise,
@@ -1848,7 +1851,7 @@ BOOL DebuggerController::CheckGetPatchedOpcode(CORDB_ADDRESS_TYPE *address,
 // address by virtue of the fact that we can iterate through all the
 // patches in the patch with the same address.
 // DebuggerControllerPatch *patch:  The patch to activate
-/* static */ void DebuggerController::ActivatePatch(DebuggerControllerPatch *patch)
+/* static */ bool DebuggerController::ActivatePatch(DebuggerControllerPatch *patch)
 {
     _ASSERTE(g_patches != NULL);
     _ASSERTE(patch != NULL);
@@ -1857,6 +1860,16 @@ BOOL DebuggerController::CheckGetPatchedOpcode(CORDB_ADDRESS_TYPE *address,
 
     LOG((LF_CORDB|LF_ENC,LL_INFO1000,"DC::ActivatePatch: patchId:0x%zx\n", patch->patchId));
     patch->LogInstance();
+
+#if defined(HOST_IOS) && !TARGET_OS_SIMULATOR
+    if (ExecutionManager::IsReadyToRunCode(dac_cast<PCODE>(patch->address)))
+    {
+        LOG((LF_CORDB, LL_INFO10000,
+            "DC::ActivatePatch: R2R patch at %p is not supported on physical iOS\n",
+            patch->address));
+        return false;
+    }
+#endif
 
     bool fApply = true;
     //
@@ -1889,6 +1902,7 @@ BOOL DebuggerController::CheckGetPatchedOpcode(CORDB_ADDRESS_TYPE *address,
     }
 
     _ASSERTE(patch->IsActivated());
+    return true;
 }
 
 // void DebuggerController::DeactivatePatch()  Make sure that a
@@ -2042,12 +2056,9 @@ BOOL DebuggerController::AddBindAndActivateILReplicaPatch(DebuggerControllerPatc
         }
 #endif // FEATURE_INTERPRETER
 
-        INDEBUG(BOOL fOk = )
-            AddBindAndActivatePatchForMethodDesc(pMD, dji,
-                nativeOffset, PATCH_KIND_IL_REPLICA,
-                LEAF_MOST_FRAME, m_pAppDomain);
-        _ASSERTE(fOk);
-        result = TRUE;
+        result = AddBindAndActivatePatchForMethodDesc(pMD, dji,
+            nativeOffset, PATCH_KIND_IL_REPLICA,
+            LEAF_MOST_FRAME, m_pAppDomain);
     }
     else // bind by IL offset
     {
@@ -2074,13 +2085,9 @@ BOOL DebuggerController::AddBindAndActivateILReplicaPatch(DebuggerControllerPatc
                 continue;
             }
 
-            result = TRUE;
-
-            INDEBUG(BOOL fOk = )
-                AddBindAndActivatePatchForMethodDesc(pMD, dji,
-                    offsetNative, PATCH_KIND_IL_REPLICA,
-                    LEAF_MOST_FRAME, m_pAppDomain);
-            _ASSERTE(fOk);
+            result = AddBindAndActivatePatchForMethodDesc(pMD, dji,
+                offsetNative, PATCH_KIND_IL_REPLICA,
+                LEAF_MOST_FRAME, m_pAppDomain) || result;
         }
     }
 
@@ -2208,7 +2215,7 @@ BOOL DebuggerController::AddILPatch(AppDomain * pAppDomain, Module *module,
 // This is used by step-in.
 // Calls to new methods always go to the latest version, so EnC is not an issue here.
 // The method may be not yet jitted. Or it may be prejitted.
-void DebuggerController::AddPatchToStartOfLatestMethod(MethodDesc * fd)
+BOOL DebuggerController::AddPatchToStartOfLatestMethod(MethodDesc * fd)
 {
     CONTRACTL
     {
@@ -2225,7 +2232,7 @@ void DebuggerController::AddPatchToStartOfLatestMethod(MethodDesc * fd)
     Module* pModule = fd->GetModule();
     mdToken defToken = fd->GetMemberDef();
     DebuggerMethodInfo* pDMI = g_pDebugger->GetOrCreateMethodInfo(pModule, defToken);
-    DebuggerController::AddILPatch(GetAppDomain(), pModule, defToken, fd, pDMI->GetCurrentEnCVersion(), 0, FALSE);
+    return DebuggerController::AddILPatch(GetAppDomain(), pModule, defToken, fd, pDMI->GetCurrentEnCVersion(), 0, FALSE);
 }
 
 
@@ -2273,7 +2280,6 @@ BOOL DebuggerController::AddBindAndActivatePatchForMethodDesc(MethodDesc *fd,
     }
     CONTRACTL_END;
 
-    BOOL ok = FALSE;
     ControllerLockHolder ch;
 
     LOG((LF_CORDB|LF_ENC,LL_INFO10000,"DC::ABAAPFMD: Add to %s::%s, at offs 0x%zx kind:%d fp:%p AD:%p\n",
@@ -2292,13 +2298,18 @@ BOOL DebuggerController::AddBindAndActivatePatchForMethodDesc(MethodDesc *fd,
                             0,
                             dji);
 
-    if (DebuggerController::BindPatch(patch, fd, NULL))
+    if (!DebuggerController::BindPatch(patch, fd, NULL))
     {
-        DebuggerController::ActivatePatch(patch);
-        ok = TRUE;
+        return patch->IsActivated();
     }
 
-    return ok;
+    if (!DebuggerController::ActivatePatch(patch))
+    {
+        g_patches->RemovePatch(patch);
+        return FALSE;
+    }
+
+    return TRUE;
 }
 
 
@@ -2334,7 +2345,11 @@ DebuggerControllerPatch *DebuggerController::AddAndActivateNativePatchForAddress
                             DebuggerPatchTable::DCP_PATCHID_INVALID,
                             traceType);
 
-    ActivatePatch(patch);
+    if (!ActivatePatch(patch))
+    {
+        g_patches->RemovePatch(patch);
+        return NULL;
+    }
 
     return patch;
 }
@@ -2526,11 +2541,10 @@ bool DebuggerController::PatchTrace(TraceDestination *trace,
 
         if (fStopInUnmanaged && !_AddrIsJITHelper(trace->GetAddress()))
         {
-            AddAndActivateNativePatchForAddress((CORDB_ADDRESS_TYPE *)trace->GetAddress(),
-                     fp,
-                     FALSE,
-                     trace->GetTraceType());
-            return true;
+            return AddAndActivateNativePatchForAddress((CORDB_ADDRESS_TYPE *)trace->GetAddress(),
+                       fp,
+                       FALSE,
+                       trace->GetTraceType()) != NULL;
         }
         else
         {
@@ -2542,6 +2556,15 @@ bool DebuggerController::PatchTrace(TraceDestination *trace,
     case TRACE_MANAGED:
         LOG((LF_CORDB, LL_INFO10000,
              "Setting managed trace patch at 0x%p(%p)\n", (void*)trace->GetAddress(), fp.GetSPValue()));
+
+#if defined(HOST_IOS) && !TARGET_OS_SIMULATOR
+        // Resolving debug information can recursively bind pending patches. Reject
+        // unpatchable R2R code before entering that path.
+        if (ExecutionManager::IsReadyToRunCode(trace->GetAddress()))
+        {
+            return false;
+        }
+#endif
 
         MethodDesc *fd;
         fd = g_pEEInterface->GetNativeCodeMethodDesc(trace->GetAddress());
@@ -2562,15 +2585,10 @@ bool DebuggerController::PatchTrace(TraceDestination *trace,
         // out of that jitted code.
         if (nativeOffset == 0)
         {
-            AddPatchToStartOfLatestMethod(fd);
-        }
-        else
-        {
-            AddBindAndActivateNativeManagedPatch(fd, dji, nativeOffset, fp, NULL);
+            return AddPatchToStartOfLatestMethod(fd);
         }
 
-
-        return true;
+        return AddBindAndActivateNativeManagedPatch(fd, dji, nativeOffset, fp, NULL);
 
     case TRACE_UNJITTED_METHOD:
         // trace->address is actually a MethodDesc* of the method that we'll
@@ -2580,18 +2598,16 @@ bool DebuggerController::PatchTrace(TraceDestination *trace,
 
         // Note: we have to make sure to bind here. If this function is prejitted, this may be our only chance to get a
         // DebuggerJITInfo and thereby cause a JITComplete callback.
-        AddPatchToStartOfLatestMethod(trace->GetMethodDesc());
-        return true;
+        return AddPatchToStartOfLatestMethod(trace->GetMethodDesc());
 
     case TRACE_FRAME_PUSH:
         LOG((LF_CORDB, LL_INFO10000,
              "Setting frame patch at %p(%p)\n", (void*)trace->GetAddress(), fp.GetSPValue()));
 
-        AddAndActivateNativePatchForAddress((CORDB_ADDRESS_TYPE *)trace->GetAddress(),
-                 fp,
-                 TRUE,
-                 TRACE_FRAME_PUSH);
-        return true;
+        return AddAndActivateNativePatchForAddress((CORDB_ADDRESS_TYPE *)trace->GetAddress(),
+                     fp,
+                     TRUE,
+                     TRACE_FRAME_PUSH) != NULL;
 
     case TRACE_MGR_PUSH:
         LOG((LF_CORDB, LL_INFO10000,
@@ -2601,6 +2617,11 @@ bool DebuggerController::PatchTrace(TraceDestination *trace,
                     LEAF_MOST_FRAME, // But Mgr_push can't have fp affinity!
                     TRUE,
                     DPT_DEFAULT_TRACE_TYPE); // TRACE_OTHER
+        if (dcp == NULL)
+        {
+            return false;
+        }
+
         // Now copy over the trace field since TriggerPatch will expect this
         // to be set for this case.
         if (dcp != NULL)

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -16,9 +16,6 @@
 #include "../inc/common.h"
 #include "eeconfig.h"
 
-#if defined(HOST_IOS)
-#include <TargetConditionals.h>
-#endif
 #include "../../vm/methoditer.h"
 #include "../../vm/tailcallhelp.h"
 
@@ -1861,11 +1858,11 @@ BOOL DebuggerController::CheckGetPatchedOpcode(CORDB_ADDRESS_TYPE *address,
     LOG((LF_CORDB|LF_ENC,LL_INFO1000,"DC::ActivatePatch: patchId:0x%zx\n", patch->patchId));
     patch->LogInstance();
 
-#if defined(HOST_IOS) && !TARGET_OS_SIMULATOR
+#ifndef FEATURE_DYNAMIC_CODE_COMPILED
     if (ExecutionManager::IsReadyToRunCode(dac_cast<PCODE>(patch->address)))
     {
         LOG((LF_CORDB, LL_INFO10000,
-            "DC::ActivatePatch: R2R patch at %p is not supported on physical iOS\n",
+            "DC::ActivatePatch: R2R patch at %p is not supported when dynamic code compilation is disabled\n",
             patch->address));
         return false;
     }
@@ -2035,6 +2032,15 @@ BOOL DebuggerController::AddBindAndActivateILReplicaPatch(DebuggerControllerPatc
     BOOL result = FALSE;
     MethodDesc* pMD = dji->m_nativeCodeVersion.GetMethodDesc();
 
+#ifdef _DEBUG
+#ifndef FEATURE_DYNAMIC_CODE_COMPILED
+    bool isReadyToRunPatchUnsupported =
+        ExecutionManager::IsReadyToRunCode(dac_cast<PCODE>(dji->m_addrOfCode));
+#else
+    constexpr bool isReadyToRunPatchUnsupported = false;
+#endif
+#endif
+
     if (primary->offsetIsIL == 0)
     {
         // Zero is the only native offset that we allow to bind across different jitted
@@ -2056,9 +2062,11 @@ BOOL DebuggerController::AddBindAndActivateILReplicaPatch(DebuggerControllerPatc
         }
 #endif // FEATURE_INTERPRETER
 
-        result = AddBindAndActivatePatchForMethodDesc(pMD, dji,
+        BOOL fOk = AddBindAndActivatePatchForMethodDesc(pMD, dji,
             nativeOffset, PATCH_KIND_IL_REPLICA,
             LEAF_MOST_FRAME, m_pAppDomain);
+        _ASSERTE(fOk || isReadyToRunPatchUnsupported);
+        result = fOk;
     }
     else // bind by IL offset
     {
@@ -2085,9 +2093,11 @@ BOOL DebuggerController::AddBindAndActivateILReplicaPatch(DebuggerControllerPatc
                 continue;
             }
 
-            result = AddBindAndActivatePatchForMethodDesc(pMD, dji,
+            BOOL fOk = AddBindAndActivatePatchForMethodDesc(pMD, dji,
                 offsetNative, PATCH_KIND_IL_REPLICA,
-                LEAF_MOST_FRAME, m_pAppDomain) || result;
+                LEAF_MOST_FRAME, m_pAppDomain);
+            _ASSERTE(fOk || isReadyToRunPatchUnsupported);
+            result = fOk || result;
         }
     }
 
@@ -2557,7 +2567,7 @@ bool DebuggerController::PatchTrace(TraceDestination *trace,
         LOG((LF_CORDB, LL_INFO10000,
              "Setting managed trace patch at 0x%p(%p)\n", (void*)trace->GetAddress(), fp.GetSPValue()));
 
-#if defined(HOST_IOS) && !TARGET_OS_SIMULATOR
+#ifndef FEATURE_DYNAMIC_CODE_COMPILED
         // Resolving debug information can recursively bind pending patches. Reject
         // unpatchable R2R code before entering that path.
         if (ExecutionManager::IsReadyToRunCode(trace->GetAddress()))

--- a/src/coreclr/debug/ee/controller.h
+++ b/src/coreclr/debug/ee/controller.h
@@ -1246,7 +1246,7 @@ private:
     static bool UnapplyPatch(DebuggerControllerPatch *patch);
     static bool IsPatched(CORDB_ADDRESS_TYPE *address, BOOL native);
 
-    static void ActivatePatch(DebuggerControllerPatch *patch);
+    static bool ActivatePatch(DebuggerControllerPatch *patch);
     static void DeactivatePatch(DebuggerControllerPatch *patch);
 
     static void ApplyTraceFlag(Thread *thread);
@@ -1315,7 +1315,7 @@ public:
                   AppDomain *pAppDomain);
 
     // Add a patch at the start of a not-yet-jitted method.
-    void AddPatchToStartOfLatestMethod(MethodDesc * fd);
+    BOOL AddPatchToStartOfLatestMethod(MethodDesc * fd);
 
 
     // This version is particularly useful b/c it doesn't assume that the

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -12,6 +12,10 @@
 #include "../inc/common.h"
 #include "eeconfig.h" // This is here even for retail & free builds...
 
+#if defined(HOST_IOS)
+#include <TargetConditionals.h>
+#endif
+
 #include "vars.hpp"
 #include <limits.h>
 #include "ilformatter.h"
@@ -4820,6 +4824,14 @@ HRESULT Debugger::MapPatchToDJI(DebuggerControllerPatch *dcp, DebuggerJitInfo *d
     // We shouldn't have been asked to map an already bound patch
     _ASSERTE( !dcp->IsBound() );
 
+#if defined(HOST_IOS) && !TARGET_OS_SIMULATOR
+    if (ExecutionManager::IsReadyToRunCode(dac_cast<PCODE>(djiTo->m_addrOfCode)))
+    {
+        // Leave deferred patches unbound because physical iOS cannot patch R2R code.
+        return S_OK;
+    }
+#endif
+
     // If the patch has no DJI then we're doing a UnbindFunctionPatches/RebindFunctionPatches.  Either
     // way, we simply want the most recent version.  In the absence of EnC we should have djiCur == djiTo.
     DebuggerJitInfo *djiCur = dcp->HasDJI() ? dcp->GetDJI() : djiTo;
@@ -4861,7 +4873,12 @@ HRESULT Debugger::MapPatchToDJI(DebuggerControllerPatch *dcp, DebuggerJitInfo *d
             LOG((LF_CORDB, LL_EVERYTHING, "D::MPTDJI trying to bind patch... could be problem\n"));
             if (DebuggerController::BindPatch(dcp, djiTo->m_nativeCodeVersion.GetMethodDesc(), NULL))
             {
-                DebuggerController::ActivatePatch(dcp);
+                if (!DebuggerController::ActivatePatch(dcp))
+                {
+                    DebuggerController::GetPatchTable()->UnbindPatch(dcp);
+                    return CORDBG_E_CODE_NOT_AVAILABLE;
+                }
+
                 LOG((LF_CORDB, LL_INFO1000, "D::MPTDJI Binding went fine!\n" ));
                 return S_OK;
             }
@@ -8904,6 +8921,10 @@ void Debugger::SendCreateThreadAtInterpreterEntry(Thread *pRuntimeThread)
 
     if (pRuntimeThread->HasThreadStateNC(Thread::TSNC_DebuggerThreadStartSent))
         return;
+
+#if defined(HOST_IOS) && !TARGET_OS_SIMULATOR
+    DebuggerController::CancelOutstandingThreadStarter(pRuntimeThread);
+#endif
 
     {
         GCX_PREEMP();

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -12,10 +12,6 @@
 #include "../inc/common.h"
 #include "eeconfig.h" // This is here even for retail & free builds...
 
-#if defined(HOST_IOS)
-#include <TargetConditionals.h>
-#endif
-
 #include "vars.hpp"
 #include <limits.h>
 #include "ilformatter.h"
@@ -4824,10 +4820,10 @@ HRESULT Debugger::MapPatchToDJI(DebuggerControllerPatch *dcp, DebuggerJitInfo *d
     // We shouldn't have been asked to map an already bound patch
     _ASSERTE( !dcp->IsBound() );
 
-#if defined(HOST_IOS) && !TARGET_OS_SIMULATOR
+#ifndef FEATURE_DYNAMIC_CODE_COMPILED
     if (ExecutionManager::IsReadyToRunCode(dac_cast<PCODE>(djiTo->m_addrOfCode)))
     {
-        // Leave deferred patches unbound because physical iOS cannot patch R2R code.
+        // Leave deferred patches unbound because this configuration cannot patch R2R code.
         return S_OK;
     }
 #endif
@@ -8922,7 +8918,7 @@ void Debugger::SendCreateThreadAtInterpreterEntry(Thread *pRuntimeThread)
     if (pRuntimeThread->HasThreadStateNC(Thread::TSNC_DebuggerThreadStartSent))
         return;
 
-#if defined(HOST_IOS) && !TARGET_OS_SIMULATOR
+#ifndef FEATURE_DYNAMIC_CODE_COMPILED
     DebuggerController::CancelOutstandingThreadStarter(pRuntimeThread);
 #endif
 


### PR DESCRIPTION
## Description

When CoreCLR runs an R2R + interpreter application on a physical iOS device, `DebuggerThreadStarter` can try to place a software breakpoint in signed R2R code. Making the page writable removes execute permission, and iOS does not allow the runtime to restore it. The process is then terminated with a code-signing invalid-page failure.

This change prevents debugger patch activation in R2R code when `FEATURE_DYNAMIC_CODE_COMPILED` is disabled. It also:

- propagates patch activation failure instead of reporting success;
- removes or unbinds patches that cannot be activated;
- keeps deferred R2R patches unbound;
- cancels the pending `DebuggerThreadStarter` when interpreter entry sends the thread-start event directly;

Breakpoints cannot be activated in R2R methods in this configuration. A direct breakpoint request fails with `CORDBG_E_UNABLE_TO_SET_BREAKPOINT`.

---

NOTE: This will need to be backported to .NET 11 to fix debugging on iOS physical devices.

> [!NOTE]
> This pull request description was created by GitHub Copilot.