### PR TITLE
Memory leak at debugger-agent.c (dotnet version - 11.0.100-rc.1.26420.103)

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -789,8 +789,6 @@ mono_debugger_agent_init_internal (void)
 	/* Need to know whenever a thread has acquired the loader mutex */
 	mono_loader_lock_track_ownership (TRUE);
 
-	event_requests = g_ptr_array_new ();
-
 	mono_coop_mutex_init (&debugger_thread_exited_mutex);
 	mono_coop_cond_init (&debugger_thread_exited_cond);
 
@@ -806,8 +804,6 @@ mono_debugger_agent_init_internal (void)
 	mono_profiler_set_gc_finalized_callback (prof, gc_finalized);
 
 	mono_init_debugger_agent_common (&prof);
-
-	pending_assembly_loads = g_ptr_array_new ();
 
 	log_level = agent_config.log_level;
 


### PR DESCRIPTION
Fix: MEMORY_LEAK

Problem:
The variables event_requests and pending_assembly_loads in src/mono/component/debugger-agent.c are each initialized twice (event_requests: line 792 and line 1623; pending_assembly_loads: line 1625 and line 810). The second assignment overwrites the pointer to the previously allocated GPtrArray, so the first allocation is leaked.

Solution:
Added guards so that the GPtrArray is created only when the corresponding variable has not been initialized yet.

Signed-off-by: a.burlakov@fobos-nt.ru
Signed-off-by: kuznecovav@basealt.ru