### PR TITLE
JIT: keep the null check when a method table load folds to a constant

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -13556,6 +13556,17 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                                 assert(embedClsHnd != nullptr);
                                 ValueNum handleVN = vnStore->VNForHandle((ssize_t)embedClsHnd, GTF_ICON_CLASS_HDL);
                                 tree->gtVNPair    = vnStore->VNPWithExc(ValueNumPair(handleVN, handleVN), addrXvnp);
+
+                                if (tree->IndirMayFault(this))
+                                {
+                                    // The value is known, but the load still dereferences "addr" and can
+                                    // raise NullReferenceException. It has to be recorded here because
+                                    // fgValueNumberAddExceptionSetForIndirection skips indirections whose
+                                    // value numbers are constants.
+                                    tree->gtVNPair = vnStore->VNPWithExc(tree->gtVNPair,
+                                                                         fgValueNumberIndirNullCheckExceptions(addr));
+                                }
+
                                 returnsTypeHandle = true;
                             }
                         }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_133559/Runtime_133559.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_133559/Runtime_133559.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_133559
+{
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int CompareTypes(string a, string b)
+    {
+        if (a.GetType() != b.GetType())
+        {
+            return 2;
+        }
+
+        return 3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool SameType(string a, string b)
+    {
+        return a.GetType() == b.GetType();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int TypeHandleOnly(string a)
+    {
+        // The comparison result is unused, but the load still dereferences "a".
+        return a.GetType() == typeof(string) ? 1 : 1;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        // string is sealed, so value numbering folds both GetType() loads to a constant
+        // type handle. The loads still dereference their operand, so they must raise
+        // NullReferenceException rather than being optimized away.
+        Assert.Throws<NullReferenceException>(() => CompareTypes(null, "text"));
+        Assert.Throws<NullReferenceException>(() => CompareTypes("text", null));
+        Assert.Throws<NullReferenceException>(() => SameType(null, "text"));
+        Assert.Throws<NullReferenceException>(() => SameType("text", null));
+        Assert.Throws<NullReferenceException>(() => TypeHandleOnly(null));
+
+        Assert.Equal(3, CompareTypes("text", "other"));
+        Assert.True(SameType("text", "other"));
+        Assert.Equal(1, TypeHandleOnly("text"));
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -57,6 +57,7 @@
     <Compile Include="JitBlue\Runtime_58972\Runtime_58972.cs" />
     <Compile Include="JitBlue\Runtime_59298\Runtime_59298.cs" />
     <Compile Include="JitBlue\Runtime_59444\Runtime_59444.cs" />
+    <Compile Include="JitBlue\Runtime_133559\Runtime_133559.cs" />
     <Compile Include="JitBlue\Runtime_59871\Runtime_59871.cs" />
     <Compile Include="JitBlue\Runtime_60035\Runtime_60035.cs" />
     <Compile Include="JitBlue\Runtime_60297\Runtime_60297.cs" />


### PR DESCRIPTION
Fixes #133559