### PR TITLE
Add incremental chunked reading to CborReader

### DIFF
--- a/src/libraries/System.Formats.Cbor/ref/System.Formats.Cbor.cs
+++ b/src/libraries/System.Formats.Cbor/ref/System.Formats.Cbor.cs
@@ -27,6 +27,7 @@ namespace System.Formats.Cbor
     {
         public CborReader(System.ReadOnlyMemory<byte> data, System.Formats.Cbor.CborConformanceMode conformanceMode = System.Formats.Cbor.CborConformanceMode.Strict, bool allowMultipleRootLevelValues = false) { }
         public CborReader(System.ReadOnlyMemory<byte> data, System.Formats.Cbor.CborReaderOptions? options) { }
+        public CborReader(System.ReadOnlyMemory<byte> data, System.Formats.Cbor.CborReaderOptions? options, bool isFinalBlock) { }
         public bool AllowMultipleRootLevelValues { get { throw null; } }
         public int BytesRemaining { get { throw null; } }
         public System.Formats.Cbor.CborConformanceMode ConformanceMode { get { throw null; } }
@@ -68,10 +69,14 @@ namespace System.Formats.Cbor
         public ulong ReadUInt64() { throw null; }
         public System.DateTimeOffset ReadUnixTimeSeconds() { throw null; }
         public void Reset(System.ReadOnlyMemory<byte> data) { }
+        public void Reset(System.ReadOnlyMemory<byte> data, bool isFinalBlock) { }
         public void SkipToParent(bool disableConformanceModeChecks = false) { }
         public void SkipValue(bool disableConformanceModeChecks = false) { }
+        public void SlideData(System.ReadOnlyMemory<byte> data, bool isFinalBlock) { }
         public bool TryReadByteString(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryReadTextString(System.Span<char> destination, out int charsWritten) { throw null; }
+        public bool TrySkipToParent(bool disableConformanceModeChecks = false) { throw null; }
+        public bool TrySkipValue(bool disableConformanceModeChecks = false) { throw null; }
     }
     public sealed partial class CborReaderOptions
     {
@@ -103,6 +108,7 @@ namespace System.Formats.Cbor
         Null = 18,
         Boolean = 19,
         Finished = 20,
+        NeedsMoreData = 21,
     }
     public enum CborSimpleValue : byte
     {

--- a/src/libraries/System.Formats.Cbor/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Cbor/src/Resources/Strings.resx
@@ -153,6 +153,15 @@
   <data name="Cbor_Reader_DefiniteLengthExceedsBufferSize" xml:space="preserve">
     <value>Declared definite length of CBOR data item exceeds available buffer size.</value>
   </data>
+  <data name="Cbor_Reader_NotFinalBlockRequiresLaxConformance" xml:space="preserve">
+    <value>Reading CBOR data incrementally is only supported in the 'Lax' conformance mode.</value>
+  </data>
+  <data name="Cbor_Reader_CannotSlideDataOnFinalBlock" xml:space="preserve">
+    <value>Cannot slide new data after the reader's data has been supplied as the final block. Call Reset to read a new payload.</value>
+  </data>
+  <data name="Cbor_Reader_SlideDataBufferTooSmall" xml:space="preserve">
+    <value>The new buffer cannot be smaller than the unconsumed bytes of the current buffer.</value>
+  </data>
   <data name="Cbor_Reader_NoMoreDataItemsToRead" xml:space="preserve">
     <value>No more CBOR data items to read in the current context.</value>
   </data>

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Array.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Array.cs
@@ -32,7 +32,7 @@ namespace System.Formats.Cbor
             else
             {
                 ReadOnlySpan<byte> buffer = GetRemainingBytes();
-                int arrayLength = DecodeDefiniteLength(header, buffer, out int bytesRead);
+                int arrayLength = DecodeCollectionLength(header, buffer, out int bytesRead);
 
                 AdvanceBuffer(bytesRead);
                 PushDataItem(CborMajorType.Array, arrayLength);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Integer.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Integer.cs
@@ -153,6 +153,27 @@ namespace System.Formats.Cbor
             return (int)length;
         }
 
+        // Peek definite length for an array or map data item. Unlike strings, the contents of
+        // collections are separate data items, so when the current data is not the final block
+        // the declared length may exceed the buffer: the contents can be supplied by later
+        // SlideData calls. The length must still be representable in a single buffer.
+        private int DecodeCollectionLength(CborInitialByte header, ReadOnlySpan<byte> data, out int bytesRead)
+        {
+            if (_isFinalBlock)
+            {
+                return DecodeDefiniteLength(header, data, out bytesRead);
+            }
+
+            ulong length = DecodeUnsignedInteger(header, data, out bytesRead);
+
+            if (length > int.MaxValue)
+            {
+                throw new CborContentException(SR.Cbor_Reader_DefiniteLengthExceedsBufferSize);
+            }
+
+            return (int)length;
+        }
+
         // Unsigned integer decoding https://tools.ietf.org/html/rfc7049#section-2.1
         private ulong DecodeUnsignedInteger(CborInitialByte header, ReadOnlySpan<byte> data, out int bytesRead)
         {

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Map.cs
@@ -48,9 +48,13 @@ namespace System.Formats.Cbor
             {
                 ReadOnlySpan<byte> buffer = GetRemainingBytes();
 
-                int mapSize = DecodeDefiniteLength(header, buffer, out int bytesRead);
+                int mapSize = DecodeCollectionLength(header, buffer, out int bytesRead);
 
-                if (2 * (ulong)mapSize > (ulong)(buffer.Length - bytesRead))
+                // conservative check: each key-value pair is encoded in at least two bytes.
+                // When the current data is not the final block the contents may be supplied later,
+                // but the item count 2 * mapSize must remain representable.
+                if (mapSize > int.MaxValue / 2 ||
+                    (_isFinalBlock && 2 * (ulong)mapSize > (ulong)(buffer.Length - bytesRead)))
                 {
                     throw new CborContentException(SR.Cbor_Reader_DefiniteLengthExceedsBufferSize);
                 }

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.PeekState.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.PeekState.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Diagnostics;
 
 namespace System.Formats.Cbor
@@ -10,6 +11,15 @@ namespace System.Formats.Cbor
         /// <summary>Reads the next CBOR token, without advancing the reader.</summary>
         /// <returns>An object that represents the current CBOR reader state.</returns>
         /// <exception cref="CborContentException">The underlying data is not a well-formed CBOR encoding.</exception>
+        /// <remarks>
+        /// <para>If the reader's current data is not the final block, <see cref="CborReaderState.NeedsMoreData" /> is returned
+        /// when the next token is incomplete in the current buffer, instead of throwing <see cref="CborContentException" />.
+        /// Any other returned token state guarantees that the method reading that single token will not fail
+        /// due to an unexpected end of the data, unless the token declares a definite length that can never fit
+        /// a single buffer, in which case the reading method throws <see cref="CborContentException" />.</para>
+        /// <para>Methods consuming multiple tokens at once, such as <see cref="ReadByteString" /> on indefinite-length strings
+        /// or <see cref="ReadEncodedValue" />, can still throw <see cref="CborContentException" /> on truncated data.</para>
+        /// </remarks>
         public CborReaderState PeekState()
         {
             if (_cachedState == CborReaderState.Undefined)
@@ -43,6 +53,12 @@ namespace System.Formats.Cbor
             if (_offset == _data.Length)
             {
                 // is at the end of the read buffer
+                if (!_isFinalBlock)
+                {
+                    // more data may follow, even at the end of a sequence of root-level values
+                    return CborReaderState.NeedsMoreData;
+                }
+
                 if (_currentMajorType is null && _definiteLength is null)
                 {
                     // is at the end of a well-defined sequence of root-level values
@@ -107,6 +123,12 @@ namespace System.Formats.Cbor
                 }
             }
 
+            if (!_isFinalBlock && !IsNextTokenFullyAvailable(GetRemainingBytes()))
+            {
+                // the next token is truncated, but more data may follow
+                return CborReaderState.NeedsMoreData;
+            }
+
             switch (initialByte.MajorType)
             {
                 case CborMajorType.UnsignedInteger: return CborReaderState.UnsignedInteger;
@@ -150,6 +172,75 @@ namespace System.Formats.Cbor
                     default:
                         return CborReaderState.SimpleValue;
                 }
+            }
+        }
+
+        // Checks that the token starting at remaining[0] is fully available in the buffer:
+        // its header, the header's argument, and, for definite-length strings, their contents.
+        // Checks availability only; malformed encodings are reported as available,
+        // deferring to the corresponding Read method to throw.
+        private static bool IsNextTokenFullyAvailable(ReadOnlySpan<byte> remaining)
+        {
+            Debug.Assert(!remaining.IsEmpty);
+
+            var initialByte = new CborInitialByte(remaining[0]);
+            int argumentWidth;
+
+            switch (initialByte.AdditionalInfo)
+            {
+                case CborAdditionalInfo x when (x < CborAdditionalInfo.Additional8BitData):
+                    argumentWidth = 0;
+                    break;
+                case CborAdditionalInfo.Additional8BitData:
+                    argumentWidth = sizeof(byte);
+                    break;
+                case CborAdditionalInfo.Additional16BitData:
+                    argumentWidth = sizeof(ushort);
+                    break;
+                case CborAdditionalInfo.Additional32BitData:
+                    argumentWidth = sizeof(uint);
+                    break;
+                case CborAdditionalInfo.Additional64BitData:
+                    argumentWidth = sizeof(ulong);
+                    break;
+                default:
+                    // Indefinite-length tokens are the initial byte only; the reserved values 28-30
+                    // are malformed regardless of any additional data.
+                    return true;
+            }
+
+            if (remaining.Length < 1 + argumentWidth)
+            {
+                return false;
+            }
+
+            switch (initialByte.MajorType)
+            {
+                case CborMajorType.ByteString:
+                case CborMajorType.TextString:
+                    // definite-length string tokens include their contents
+                    ulong length = argumentWidth switch
+                    {
+                        0 => (ulong)initialByte.AdditionalInfo,
+                        sizeof(byte) => remaining[1],
+                        sizeof(ushort) => BinaryPrimitives.ReadUInt16BigEndian(remaining.Slice(1)),
+                        sizeof(uint) => BinaryPrimitives.ReadUInt32BigEndian(remaining.Slice(1)),
+                        _ => BinaryPrimitives.ReadUInt64BigEndian(remaining.Slice(1)),
+                    };
+
+                    if (length > (ulong)(int.MaxValue - (1 + argumentWidth)))
+                    {
+                        // can never fit a single buffer, so this is not a truncation condition
+                        return true;
+                    }
+
+                    return (ulong)(remaining.Length - (1 + argumentWidth)) >= length;
+
+                default:
+                    // For all other tokens the argument concludes the token: integers and float or
+                    // simple-value payloads are encoded in the argument itself, and the contents of
+                    // tags, arrays and maps are separate tokens.
+                    return true;
             }
         }
     }

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.SkipValue.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.SkipValue.cs
@@ -9,7 +9,7 @@ namespace System.Formats.Cbor
     {
         /// <summary>Reads the contents of the next value, discarding the result and advancing the reader.</summary>
         /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the skipped values, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
-        /// <exception cref="InvalidOperationException">The reader is not at the start of new value.</exception>
+        /// <exception cref="InvalidOperationException">The reader is not at the start of a new value.</exception>
         /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
         /// <para>-or-</para>
         /// <para>There was an unexpected end of CBOR encoding data.</para>
@@ -17,12 +17,31 @@ namespace System.Formats.Cbor
         /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
         public void SkipValue(bool disableConformanceModeChecks = false)
         {
-            SkipToAncestor(0, disableConformanceModeChecks);
+            if (!TrySkipToAncestor(0, disableConformanceModeChecks))
+            {
+                // only reachable when the current data is not the final block
+                throw new CborContentException(SR.Cbor_Reader_InvalidCbor_UnexpectedEndOfBuffer);
+            }
+        }
+
+        /// <summary>Attempts to read the contents of the next value, discarding the result and advancing the reader.</summary>
+        /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the skipped values, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
+        /// <returns><see langword="true" /> if the value was skipped; <see langword="false" /> if the value is incomplete
+        /// in the current buffer and the reader's current data is not the final block, in which case the reader state is unchanged.</returns>
+        /// <exception cref="InvalidOperationException">The reader is not at the start of a new value.</exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data and the reader's current data is the final block.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
+        public bool TrySkipValue(bool disableConformanceModeChecks = false)
+        {
+            return TrySkipToAncestor(0, disableConformanceModeChecks);
         }
 
         /// <summary>Reads the remaining contents of the current value context, discarding results and advancing the reader to the next value in the parent context.</summary>
         /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the skipped values, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
-        /// <exception cref="InvalidOperationException">The reader is at the root context</exception>
+        /// <exception cref="InvalidOperationException">The reader is at the root context.</exception>
         /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
         /// <para>-or-</para>
         /// <para>There was an unexpected end of CBOR encoding data.</para>
@@ -35,10 +54,34 @@ namespace System.Formats.Cbor
                 throw new InvalidOperationException(SR.Cbor_Reader_IsAtRootContext);
             }
 
-            SkipToAncestor(1, disableConformanceModeChecks);
+            if (!TrySkipToAncestor(1, disableConformanceModeChecks))
+            {
+                // only reachable when the current data is not the final block
+                throw new CborContentException(SR.Cbor_Reader_InvalidCbor_UnexpectedEndOfBuffer);
+            }
         }
 
-        private void SkipToAncestor(int depth, bool disableConformanceModeChecks)
+        /// <summary>Attempts to read the remaining contents of the current value context, discarding results and advancing the reader to the next value in the parent context.</summary>
+        /// <param name="disableConformanceModeChecks"><see langword="true" /> to disable conformance mode validation for the skipped values, equivalent to using <see cref="CborConformanceMode.Lax" />; otherwise, <see langword="false" />.</param>
+        /// <returns><see langword="true" /> if the current value context was skipped; <see langword="false" /> if its contents are incomplete
+        /// in the current buffer and the reader's current data is not the final block, in which case the reader state is unchanged.</returns>
+        /// <exception cref="InvalidOperationException">The reader is at the root context.</exception>
+        /// <exception cref="CborContentException"><para>The next value has an invalid CBOR encoding.</para>
+        /// <para>-or-</para>
+        /// <para>There was an unexpected end of CBOR encoding data and the reader's current data is the final block.</para>
+        /// <para>-or-</para>
+        /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
+        public bool TrySkipToParent(bool disableConformanceModeChecks = false)
+        {
+            if (_currentMajorType is null)
+            {
+                throw new InvalidOperationException(SR.Cbor_Reader_IsAtRootContext);
+            }
+
+            return TrySkipToAncestor(1, disableConformanceModeChecks);
+        }
+
+        private bool TrySkipToAncestor(int depth, bool disableConformanceModeChecks)
         {
             Debug.Assert(0 <= depth && depth <= CurrentDepth);
             Checkpoint checkpoint = CreateCheckpoint();
@@ -48,8 +91,15 @@ namespace System.Formats.Cbor
             {
                 do
                 {
-                    SkipNextNode(ref depth);
+                    if (!TrySkipNextNode(ref depth))
+                    {
+                        // the value is truncated, but more data may follow
+                        RestoreCheckpoint(in checkpoint);
+                        return false;
+                    }
                 } while (depth > 0);
+
+                return true;
             }
             catch
             {
@@ -62,7 +112,7 @@ namespace System.Formats.Cbor
             }
         }
 
-        private void SkipNextNode(ref int depth)
+        private bool TrySkipNextNode(ref int depth)
         {
             CborReaderState state;
 
@@ -70,6 +120,12 @@ namespace System.Formats.Cbor
             while ((state = PeekStateCore()) == CborReaderState.Tag)
             {
                 ReadTag();
+            }
+
+            if (state == CborReaderState.NeedsMoreData)
+            {
+                // only reachable when the current data is not the final block
+                return false;
             }
 
             switch (state)
@@ -149,6 +205,8 @@ namespace System.Formats.Cbor
                 default:
                     throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_Skip_InvalidState, state));
             }
+
+            return true;
 
             // guards against cases where the caller attempts to skip when reader is not positioned at the start of a value
             static void ValidatePop(CborReaderState state, int depth)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.String.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.String.cs
@@ -101,6 +101,8 @@ namespace System.Formats.Cbor
         /// <para>There was an unexpected end of CBOR encoding data.</para>
         /// <para>-or-</para>
         /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
+        /// <remarks>The returned memory is a view over the buffer supplied to the reader. If the caller reuses that buffer,
+        /// for example when supplying new data with <see cref="SlideData" />, the contents of the returned memory may be overwritten.</remarks>
         public ReadOnlyMemory<byte> ReadDefiniteLengthByteString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
@@ -262,6 +264,8 @@ namespace System.Formats.Cbor
         /// <para>There was an unexpected end of CBOR encoding data.</para>
         /// <para>-or-</para>
         /// <para>The next value uses a CBOR encoding that is not valid under the current conformance mode.</para></exception>
+        /// <remarks>The returned memory is a view over the buffer supplied to the reader. If the caller reuses that buffer,
+        /// for example when supplying new data with <see cref="SlideData" />, the contents of the returned memory may be overwritten.</remarks>
         public ReadOnlyMemory<byte> ReadDefiniteLengthTextStringBytes()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Tag.cs
@@ -60,7 +60,7 @@ namespace System.Formats.Cbor
             {
                 ReadExpectedTag(expectedTag: CborTag.DateTimeString);
 
-                switch (PeekState())
+                switch (PeekStateEnsuringDataAvailable())
                 {
                     case CborReaderState.TextString:
                     case CborReaderState.StartIndefiniteLengthTextString:
@@ -108,7 +108,7 @@ namespace System.Formats.Cbor
             {
                 ReadExpectedTag(expectedTag: CborTag.UnixTimeSeconds);
 
-                switch (PeekState())
+                switch (PeekStateEnsuringDataAvailable())
                 {
                     case CborReaderState.UnsignedInteger:
                     case CborReaderState.NegativeInteger:
@@ -165,7 +165,7 @@ namespace System.Formats.Cbor
                     _ => throw new InvalidOperationException(SR.Cbor_Reader_InvalidBigNumEncoding),
                 };
 
-                switch (PeekState())
+                switch (PeekStateEnsuringDataAvailable())
                 {
                     case CborReaderState.ByteString:
                     case CborReaderState.StartIndefiniteLengthByteString:
@@ -208,7 +208,7 @@ namespace System.Formats.Cbor
             {
                 ReadExpectedTag(expectedTag: CborTag.DecimalFraction);
 
-                if (PeekState() != CborReaderState.StartArray || ReadStartArray() != 2)
+                if (PeekStateEnsuringDataAvailable() != CborReaderState.StartArray || ReadStartArray() != 2)
                 {
                     throw new CborContentException(SR.Cbor_Reader_InvalidDecimalEncoding);
                 }
@@ -216,7 +216,7 @@ namespace System.Formats.Cbor
                 decimal mantissa; // signed integral component of the decimal value
                 long exponent;    // base-10 exponent
 
-                switch (PeekState())
+                switch (PeekStateEnsuringDataAvailable())
                 {
                     case CborReaderState.UnsignedInteger:
                     case CborReaderState.NegativeInteger:
@@ -227,7 +227,7 @@ namespace System.Formats.Cbor
                         throw new CborContentException(SR.Cbor_Reader_InvalidDecimalEncoding);
                 }
 
-                switch (PeekState())
+                switch (PeekStateEnsuringDataAvailable())
                 {
                     case CborReaderState.UnsignedInteger:
                         mantissa = ReadUInt64();
@@ -264,6 +264,22 @@ namespace System.Formats.Cbor
                 RestoreCheckpoint(in checkpoint);
                 throw;
             }
+        }
+
+        // Semantic tag readers consume multiple tokens atomically, so a truncated non-final
+        // buffer surfaces as an unexpected end of buffer rather than as NeedsMoreData;
+        // the reader state is rolled back via checkpoint so the caller can retry
+        // after supplying more data.
+        private CborReaderState PeekStateEnsuringDataAvailable()
+        {
+            CborReaderState state = PeekState();
+
+            if (state == CborReaderState.NeedsMoreData)
+            {
+                throw new CborContentException(SR.Cbor_Reader_InvalidCbor_UnexpectedEndOfBuffer);
+            }
+
+            return state;
         }
 
         private void ReadExpectedTag(CborTag expectedTag)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.cs
@@ -13,6 +13,7 @@ namespace System.Formats.Cbor
 
         private ReadOnlyMemory<byte> _data;
         private int _offset;
+        private bool _isFinalBlock = true; // false iff the caller has declared that more data may follow via SlideData
 
         private Stack<StackFrame>? _nestedDataItems;
         private CborMajorType? _currentMajorType; // major type of the currently written data item. Null iff at the root context
@@ -57,6 +58,17 @@ namespace System.Formats.Cbor
         /// <param name="data">The CBOR-encoded data to read.</param>
         /// <param name="options">The options that control reading behavior.</param>
         public CborReader(ReadOnlyMemory<byte> data, CborReaderOptions? options)
+            : this(data, options, isFinalBlock: true)
+        {
+        }
+
+        /// <summary>Initializes a <see cref="CborReader" /> instance over the specified <paramref name="data" /> with the given options.</summary>
+        /// <param name="data">The CBOR-encoded data to read.</param>
+        /// <param name="options">The options that control reading behavior.</param>
+        /// <param name="isFinalBlock"><see langword="true" /> to indicate that <paramref name="data" /> contains the complete remainder of the document(s) to read;
+        /// <see langword="false" /> if more data may be supplied using <see cref="SlideData" />.</param>
+        /// <exception cref="ArgumentException"><paramref name="isFinalBlock" /> is <see langword="false" /> and the conformance mode is not <see cref="CborConformanceMode.Lax" />.</exception>
+        public CborReader(ReadOnlyMemory<byte> data, CborReaderOptions? options, bool isFinalBlock)
         {
             CborConformanceMode conformanceMode = CborConformanceMode.Strict;
             bool allowMultipleRootLevelValues = false;
@@ -71,7 +83,10 @@ namespace System.Formats.Cbor
                 Debug.Assert(maxDepth >= -1);
             }
 
+            ValidateIsFinalBlock(isFinalBlock, conformanceMode);
+
             _data = data;
+            _isFinalBlock = isFinalBlock;
             ConformanceMode = conformanceMode;
             AllowMultipleRootLevelValues = allowMultipleRootLevelValues;
             MaxDepth = maxDepth < 0 ? DefaultMaxDepth : maxDepth;
@@ -101,6 +116,8 @@ namespace System.Formats.Cbor
         /// <exception cref="CborContentException"><para>The data item is not a valid CBOR data item encoding.</para>
         /// <para>-or-</para>
         /// <para>The CBOR encoding is not valid under the current conformance mode.</para></exception>
+        /// <remarks>The returned memory is a view over the buffer supplied to the reader. If the caller reuses that buffer,
+        /// for example when supplying new data with <see cref="SlideData" />, the contents of the returned memory may be overwritten.</remarks>
         public ReadOnlyMemory<byte> ReadEncodedValue(bool disableConformanceModeChecks = false)
         {
             // keep a snapshot of the current offset
@@ -118,12 +135,30 @@ namespace System.Formats.Cbor
         /// <see cref="ConformanceMode"/> and <see cref="AllowMultipleRootLevelValues"/> are unchanged.
         /// </summary>
         /// <param name="data">The CBOR-encoded data to read.</param>
+        /// <remarks><paramref name="data" /> is treated as the final block: subsequent calls to <see cref="SlideData" /> throw.
+        /// Use <see cref="Reset(ReadOnlyMemory{byte}, bool)" /> to start reading a new document incrementally.</remarks>
         public void Reset(ReadOnlyMemory<byte> data)
+        {
+            Reset(data, isFinalBlock: true);
+        }
+
+        /// <summary>
+        /// Resets the <see cref="CborReader"/> instance over the specified <paramref name="data"/> with unchanged configuration.
+        /// <see cref="ConformanceMode"/> and <see cref="AllowMultipleRootLevelValues"/> are unchanged.
+        /// </summary>
+        /// <param name="data">The CBOR-encoded data to read.</param>
+        /// <param name="isFinalBlock"><see langword="true" /> to indicate that <paramref name="data" /> contains the complete remainder of the document(s) to read;
+        /// <see langword="false" /> if more data may be supplied using <see cref="SlideData" />.</param>
+        /// <exception cref="ArgumentException"><paramref name="isFinalBlock" /> is <see langword="false" /> and the conformance mode is not <see cref="CborConformanceMode.Lax" />.</exception>
+        public void Reset(ReadOnlyMemory<byte> data, bool isFinalBlock)
         {
             // ConformanceMode and AllowMultipleRootLevelValues are set in ctor, they remain unchanged.
 
+            ValidateIsFinalBlock(isFinalBlock, ConformanceMode);
+
             _data = data;
             _offset = 0;
+            _isFinalBlock = isFinalBlock;
 
             _nestedDataItems?.Clear();
             _currentMajorType = default;
@@ -141,6 +176,49 @@ namespace System.Formats.Cbor
             // or _indefiniteLengthStringRangeAllocation.
         }
 
+        /// <summary>
+        /// Replaces the buffer with data that continues from the reader's current position, preserving the nesting context.
+        /// </summary>
+        /// <param name="data">The CBOR-encoded data to continue reading from. It must start with the unconsumed bytes
+        /// of the previous buffer (see <see cref="BytesRemaining" />), followed by any newly available data.</param>
+        /// <param name="isFinalBlock"><see langword="true" /> to indicate that <paramref name="data" /> contains the complete remainder of the document(s) to read;
+        /// <see langword="false" /> if more data may be supplied by a subsequent call to this method.</param>
+        /// <exception cref="InvalidOperationException">The reader's current data was supplied as the final block.</exception>
+        /// <exception cref="ArgumentException"><paramref name="data" /> is shorter than the unconsumed bytes of the current buffer (see <see cref="BytesRemaining" />).</exception>
+        /// <remarks>
+        /// <para>The caller is responsible for preserving all unread bytes, in order, at the beginning of <paramref name="data" />.
+        /// Only the length of the new buffer is validated, not its contents.</para>
+        /// <para><see cref="ReadOnlyMemory{T}" /> values previously returned by methods such as <see cref="ReadEncodedValue" /> are views
+        /// over the reader's previous buffer; if the caller reuses that buffer, their contents may be overwritten.</para>
+        /// <para>Calling this method after a complete document has been read does not resume reading; the reader continues to report
+        /// <see cref="CborReaderState.Finished" />. Use <see cref="Reset(ReadOnlyMemory{byte}, bool)" /> to begin reading a new document.</para>
+        /// </remarks>
+        public void SlideData(ReadOnlyMemory<byte> data, bool isFinalBlock)
+        {
+            if (_isFinalBlock)
+            {
+                throw new InvalidOperationException(SR.Cbor_Reader_CannotSlideDataOnFinalBlock);
+            }
+
+            if (data.Length < BytesRemaining)
+            {
+                throw new ArgumentException(SR.Cbor_Reader_SlideDataBufferTooSmall, nameof(data));
+            }
+
+            // Conformance bookkeeping (frame offsets, key encoding ranges) is buffer-relative
+            // and becomes stale after a slide. This is safe because non-final mode requires
+            // Lax conformance, which never dereferences it; enforced in the constructor
+            // and Reset, asserted below. A conformance mode that reads this bookkeeping
+            // must rebase it here before supporting non-final blocks.
+            Debug.Assert(ConformanceMode == CborConformanceMode.Lax);
+            Debug.Assert(_keyEncodingRanges is null);
+
+            _data = data;
+            _offset = 0;
+            _isFinalBlock = isFinalBlock;
+            _cachedState = CborReaderState.Undefined;
+        }
+
         private CborInitialByte PeekInitialByte()
         {
             if (_definiteLength - _itemsRead == 0)
@@ -150,7 +228,14 @@ namespace System.Formats.Cbor
 
             if (_offset == _data.Length)
             {
-                if (_currentMajorType is null && _definiteLength is null && _offset > 0)
+                if (!_isFinalBlock)
+                {
+                    // more data may follow; PeekState reports this position as NeedsMoreData
+                    throw new CborContentException(SR.Cbor_Reader_InvalidCbor_UnexpectedEndOfBuffer);
+                }
+
+                // check _itemsRead in addition to _offset since SlideData resets the offset to 0
+                if (_currentMajorType is null && _definiteLength is null && (_offset > 0 || _itemsRead > 0))
                 {
                     // we are at the end of a well-formed sequence of root-level CBOR values
                     throw new InvalidOperationException(SR.Cbor_Reader_NoMoreDataItemsToRead);
@@ -328,6 +413,17 @@ namespace System.Formats.Cbor
             }
         }
 
+        private static void ValidateIsFinalBlock(bool isFinalBlock, CborConformanceMode conformanceMode)
+        {
+            // Non-Lax modes currently track map key encodings as offsets into the buffer, which
+            // become stale when SlideData discards consumed bytes. Supporting them requires reader-owned
+            // key copies; so we are currently restricting incremental reading to Lax.
+            if (!isFinalBlock && conformanceMode != CborConformanceMode.Lax)
+            {
+                throw new ArgumentException(SR.Cbor_Reader_NotFinalBlockRequiresLaxConformance, nameof(isFinalBlock));
+            }
+        }
+
         private readonly struct StackFrame
         {
             public StackFrame(
@@ -385,6 +481,7 @@ namespace System.Formats.Cbor
                 int offset,
                 int frameOffset,
                 int itemsRead,
+                bool isTagContext,
                 int? currentKeyOffset,
                 (int Offset, int Length)? previousKeyEncodingRange)
 
@@ -393,6 +490,7 @@ namespace System.Formats.Cbor
                 Offset = offset;
                 FrameOffset = frameOffset;
                 ItemsRead = itemsRead;
+                IsTagContext = isTagContext;
                 CurrentKeyOffset = currentKeyOffset;
                 PreviousKeyEncodingRange = previousKeyEncodingRange;
             }
@@ -401,6 +499,7 @@ namespace System.Formats.Cbor
             public int Offset { get; }
             public int FrameOffset { get; }
             public int ItemsRead { get; }
+            public bool IsTagContext { get; }
 
             public int? CurrentKeyOffset { get; }
             public (int Offset, int Length)? PreviousKeyEncodingRange { get; }
@@ -413,6 +512,7 @@ namespace System.Formats.Cbor
                 offset: _offset,
                 frameOffset: _frameOffset,
                 itemsRead: _itemsRead,
+                isTagContext: _isTagContext,
                 currentKeyOffset: _currentKeyOffset,
                 previousKeyEncodingRange: _previousKeyEncodingRange);
         }
@@ -455,6 +555,7 @@ namespace System.Formats.Cbor
 
             _offset = checkpoint.Offset;
             _itemsRead = checkpoint.ItemsRead;
+            _isTagContext = checkpoint.IsTagContext;
             _previousKeyEncodingRange = checkpoint.PreviousKeyEncodingRange;
             _currentKeyOffset = checkpoint.CurrentKeyOffset;
             _cachedState = CborReaderState.Undefined;

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReaderState.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReaderState.cs
@@ -72,5 +72,12 @@ namespace System.Formats.Cbor
         /// the reader will report this value even if the buffer contains trailing bytes.</para>
         /// </summary>
         Finished,
+
+        /// <summary>
+        /// <para>Indicates that the next CBOR data item is incomplete in the current buffer.</para>
+        /// <para>This value is only reported by readers whose current data is not the final block.
+        /// Supply more data using <see cref="CborReader.SlideData" />.</para>
+        /// </summary>
+        NeedsMoreData,
     }
 }

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Helpers.cs
@@ -227,7 +227,9 @@ namespace System.Formats.Cbor.Tests
                 "60",
                 "6161",
                 "6449455446",
+                "63e6b0b4",
                 "7f62616260ff",
+                "7f63e6b0b46161ff",
                 // Arrays
                 "80",
                 "840120604107",
@@ -244,11 +246,16 @@ namespace System.Formats.Cbor.Tests
                 // simple values
                 "f4",
                 "f6",
+                "f8ff",
                 // floating point encodings
+                "f93c00",
                 "fa47c35000",
+                "fb3ff199999999999a",
             };
 
-        public static string[] InvalidCborValues =>
+        // Truncations of well-formed encodings: appending the right bytes to any of these
+        // produces a valid value, so non-final-block readers can complete them with more data.
+        public static string[] TruncatedCborValues =>
             new[]
             {
                 "",
@@ -275,10 +282,9 @@ namespace System.Formats.Cbor.Tests
                 // definite-length maps with missing fields
                 "a1",
                 "a20102",
-                // maps with odd number of elements
+                // maps with missing values
                 "a101",
                 "a2010203",
-                "bf01ff",
                 // indefinite-length collections with missing break byte
                 "9f",
                 "9f01",
@@ -288,7 +294,6 @@ namespace System.Formats.Cbor.Tests
                 "d8",
                 "d9ff",
                 "daffffff",
-                "daffffffffff",
                 // valid tag not followed by value
                 "c2",
                 // floats missing data
@@ -298,5 +303,15 @@ namespace System.Formats.Cbor.Tests
                 // two-byte simple value missing data
                 "f8",
             };
+
+        // Encodings that are invalid regardless of any data that could follow.
+        public static string[] MalformedCborValues =>
+            new[]
+            {
+                "bf01ff", // indefinite-length map key missing a value
+                "daffffffffff", // tag followed by break byte
+            };
+
+        public static string[] InvalidCborValues => TruncatedCborValues.Concat(MalformedCborValues).ToArray();
     }
 }

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.SkipValue.cs
@@ -276,7 +276,247 @@ namespace System.Formats.Cbor.Tests
             Assert.Equal(CborReaderState.Finished, reader.PeekState());
         }
 
+        [Theory]
+        [MemberData(nameof(TruncatedCborInputs))]
+        public static void TrySkipValue_NotFinalBlock_TruncatedValue_ReturnsFalseAndPreservesState(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+
+            Assert.False(reader.TrySkipValue());
+            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.CurrentDepth);
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodedValueInputs))]
+        public static void TrySkipValue_NotFinalBlock_AllSplitPoints_SucceedsAfterSlideData(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+
+            for (int split = 0; split < encoding.Length; split++)
+            {
+                var reader = new CborReader(encoding.AsMemory(0, split), LaxOptions, isFinalBlock: false);
+
+                Assert.False(reader.TrySkipValue());
+                Assert.Equal(split, reader.BytesRemaining); // reader state was restored
+
+                reader.SlideData(encoding, isFinalBlock: true);
+                Assert.True(reader.TrySkipValue());
+                Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodedValueInputs))]
+        public static void TrySkipToParent_NotFinalBlock_AllSplitPoints_SucceedsAfterSlideData(string hexEncoding)
+        {
+            byte[] encoding = ("8301" + hexEncoding + "03").HexToByteArray(); // [1, <value>, 3]
+
+            for (int split = 2; split < encoding.Length; split++)
+            {
+                var reader = new CborReader(encoding.AsMemory(0, split), LaxOptions, isFinalBlock: false);
+                reader.ReadStartArray();
+                Helpers.VerifyValue(reader, 1);
+
+                int bytesRemaining = reader.BytesRemaining;
+                Assert.False(reader.TrySkipToParent());
+                Assert.Equal(bytesRemaining, reader.BytesRemaining); // reader state was restored
+                Assert.Equal(1, reader.CurrentDepth);
+
+                reader.SlideData(encoding.AsMemory(split - reader.BytesRemaining), isFinalBlock: true);
+                Assert.True(reader.TrySkipToParent());
+                Assert.Equal(0, reader.CurrentDepth);
+                Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(SkipTestInputs))]
+        public static void TrySkipValue_FinalBlock_HappyPath(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding);
+
+            Assert.True(reader.TrySkipValue());
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        [MemberData(nameof(SkipTestInvalidCborInputs))]
+        public static void TrySkipValue_FinalBlock_InvalidValue_ShouldThrowCborContentException(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding);
+
+            Assert.Throws<CborContentException>(() => reader.TrySkipValue());
+            Assert.Equal(encoding.Length, reader.BytesRemaining);
+        }
+
+        [Theory]
+        [InlineData("bf01ff")] // indefinite-length map key missing a value
+        [InlineData("daffffffffff")] // tag followed by break byte
+        [InlineData("1c")] // reserved additional information value
+        [InlineData("ff")] // break byte at the root context
+        public static void TrySkipValue_NotFinalBlock_MalformedData_ShouldThrowCborContentException(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+
+            Assert.Throws<CborContentException>(() => reader.TrySkipValue());
+            Assert.Equal(encoding.Length, reader.BytesRemaining);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonConformingSkipValueEncodings))]
+        public static void TrySkipValue_ValidationDisabled_NonConformingValues_ShouldSucceed(CborConformanceMode mode, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, mode);
+
+            Assert.True(reader.TrySkipValue(disableConformanceModeChecks: true));
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Fact]
+        public static void TrySkipToParent_RootContext_ShouldThrowInvalidOperationException()
+        {
+            var reader = new CborReader("01".HexToByteArray(), LaxOptions, isFinalBlock: false);
+            Assert.Throws<InvalidOperationException>(() => reader.TrySkipToParent());
+        }
+
+        [Fact]
+        public static void TrySkipValue_NotAtStartOfValue_ShouldThrowInvalidOperationException()
+        {
+            // at the end of a definite-length collection
+            var reader = new CborReader("8101".HexToByteArray(), LaxOptions, isFinalBlock: false); // [1]
+            reader.ReadStartArray();
+            Helpers.VerifyValue(reader, 1);
+            Assert.Equal(CborReaderState.EndArray, reader.PeekState());
+            Assert.Throws<InvalidOperationException>(() => reader.TrySkipValue());
+
+            // at the end of the document
+            reader = new CborReader("01".HexToByteArray(), LaxOptions, isFinalBlock: false);
+            Helpers.VerifyValue(reader, 1);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            Assert.Throws<InvalidOperationException>(() => reader.TrySkipValue());
+        }
+
+        [Fact]
+        public static void TrySkipValue_NotFinalBlock_AfterReadTag_ShouldRestoreTagContext()
+        {
+            byte[] encoding = "c1820102".HexToByteArray(); // 1([1, 2])
+            var reader = new CborReader(encoding.AsMemory(0, 3), LaxOptions, isFinalBlock: false);
+
+            Assert.Equal((CborTag)1, reader.ReadTag());
+
+            // the failed skip enters the truncated array before restoring,
+            // which exercises checkpoint restoration of the pending tag context
+            Assert.False(reader.TrySkipValue());
+            Assert.Equal(2, reader.BytesRemaining);
+            Assert.Equal(CborReaderState.StartArray, reader.PeekState());
+
+            reader.SlideData(encoding.AsMemory(1), isFinalBlock: true);
+            Assert.True(reader.TrySkipValue());
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Fact]
+        public static void TrySkipValue_NotFinalBlock_TruncatedNestedTags_ShouldRestoreTagContext()
+        {
+            byte[] encoding = "c1c201".HexToByteArray(); // 1(2(1))
+            var reader = new CborReader(encoding.AsMemory(0, 2), LaxOptions, isFinalBlock: false);
+
+            // the failed skip consumes both tags before restoring,
+            // which exercises checkpoint restoration of the pending tag context
+            Assert.False(reader.TrySkipValue());
+            Assert.Equal(2, reader.BytesRemaining);
+            Assert.Equal(CborReaderState.Tag, reader.PeekState());
+
+            reader.SlideData(encoding, isFinalBlock: true);
+            Assert.True(reader.TrySkipValue());
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Fact]
+        public static void TrySkipValue_NotFinalBlock_TruncatedMapValue_ReturnsFalseAndResumesAfterSlideData()
+        {
+            byte[] encoding = "a26161820102616203".HexToByteArray(); // {"a": [1, 2], "b": 3}
+            var reader = new CborReader(encoding.AsMemory(0, 5), LaxOptions, isFinalBlock: false);
+
+            reader.ReadStartMap();
+            Assert.Equal("a", reader.ReadTextString());
+
+            // the failed skip at a value position enters the truncated array before restoring,
+            // which exercises checkpoint restoration of the map frame's key/value bookkeeping
+            Assert.False(reader.TrySkipValue());
+            Assert.Equal(2, reader.BytesRemaining);
+            Assert.Equal(1, reader.CurrentDepth);
+            Assert.Equal(CborReaderState.StartArray, reader.PeekState());
+
+            reader.SlideData(encoding.AsMemory(3), isFinalBlock: true);
+            Assert.True(reader.TrySkipValue());
+            Assert.Equal("b", reader.ReadTextString());
+            Helpers.VerifyValue(reader, 3);
+            reader.ReadEndMap();
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        [MemberData(nameof(TruncatedCborInputs))]
+        public static void SkipValue_NotFinalBlock_TruncatedValue_ShouldThrowCborContentException(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+
+            Assert.Throws<CborContentException>(() => reader.SkipValue());
+            Assert.Equal(encoding.Length, reader.BytesRemaining);
+        }
+
+        [Theory]
+        [MemberData(nameof(SampleValuesAndChunkSizes))]
+        public static void TrySkipValue_NotFinalBlock_ChunkedReading_HappyPath(string hexEncoding, int chunkSize)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var feeder = new ChunkedFeeder(encoding, chunkSize);
+            var reader = new CborReader(ReadOnlyMemory<byte>.Empty, LaxOptions, isFinalBlock: false);
+
+            while (!reader.TrySkipValue())
+            {
+                feeder.Slide(reader);
+            }
+
+            Assert.Equal(0, reader.BytesRemaining);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Fact]
+        public static void TrySkipToParent_NotFinalBlock_NestedContexts_SucceedsAfterSlideData()
+        {
+            byte[] encoding = "a16161820102".HexToByteArray(); // {"a": [1, 2]}
+
+            for (int split = 4; split < encoding.Length; split++)
+            {
+                var reader = new CborReader(encoding.AsMemory(0, split), LaxOptions, isFinalBlock: false);
+                reader.ReadStartMap();
+                reader.ReadTextString();
+                reader.ReadStartArray();
+                Assert.Equal(2, reader.CurrentDepth);
+
+                Assert.False(reader.TrySkipToParent());
+                Assert.Equal(2, reader.CurrentDepth);
+
+                reader.SlideData(encoding.AsMemory(split - reader.BytesRemaining), isFinalBlock: true);
+                Assert.True(reader.TrySkipToParent()); // exits the array
+                Assert.Equal(1, reader.CurrentDepth);
+                Assert.True(reader.TrySkipToParent()); // exits the map
+                Assert.Equal(0, reader.CurrentDepth);
+                Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            }
+        }
+
         public static IEnumerable<object[]> SkipTestInputs => SampleCborValues.Select(x => new [] { x });
         public static IEnumerable<object[]> SkipTestInvalidCborInputs => InvalidCborValues.Select(x => new[] { x });
+        public static IEnumerable<object[]> TruncatedCborInputs => TruncatedCborValues.Select(x => new object[] { x });
     }
 }

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.SlideData.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.SlideData.cs
@@ -1,0 +1,685 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Formats.Cbor.Tests
+{
+    public partial class CborReaderTests
+    {
+        private static CborReaderOptions LaxOptions => new CborReaderOptions { ConformanceMode = CborConformanceMode.Lax };
+
+        public static IEnumerable<object[]> SampleValuesAndChunkSizes =>
+            from hexEncoding in SampleCborValues
+            from chunkSize in new[] { 1, 2, 3, 10 }
+            select new object[] { hexEncoding, chunkSize };
+
+        [Theory]
+        [MemberData(nameof(SampleValuesAndChunkSizes))]
+        public static void SlideData_ChunkedReading_HappyPath(string hexEncoding, int chunkSize)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            List<string> expectedTokens = ReadAllTokens(new CborReader(encoding, LaxOptions));
+
+            var feeder = new ChunkedFeeder(encoding, chunkSize);
+            var reader = new CborReader(ReadOnlyMemory<byte>.Empty, LaxOptions, isFinalBlock: false);
+            List<string> actualTokens = ReadAllTokens(reader, () => feeder.Slide(reader));
+
+            Assert.Equal(expectedTokens, actualTokens);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        [MemberData(nameof(EncodedValueInputs))]
+        public static void SlideData_AllSplitPoints_HappyPath(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            List<string> expectedTokens = ReadAllTokens(new CborReader(encoding, LaxOptions));
+
+            for (int split = 0; split < encoding.Length; split++)
+            {
+                int currentSplit = split;
+                var reader = new CborReader(encoding.AsMemory(0, split), LaxOptions, isFinalBlock: false);
+                List<string> actualTokens = ReadAllTokens(reader, () =>
+                {
+                    // slide in the remainder of the document, starting at the reader's current position
+                    reader.SlideData(encoding.AsMemory(currentSplit - reader.BytesRemaining), isFinalBlock: true);
+                    return true;
+                });
+
+                Assert.Equal(expectedTokens, actualTokens);
+                Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            }
+        }
+
+        [Fact]
+        public static void SlideData_PreservesNestingContext()
+        {
+            byte[] encoding = "8301820203820405".HexToByteArray(); // [1, [2, 3], [4, 5]]
+
+            var reader = new CborReader(encoding.AsMemory(0, 4), LaxOptions, isFinalBlock: false);
+            reader.ReadStartArray();
+            Helpers.VerifyValue(reader, 1);
+            reader.ReadStartArray();
+            Helpers.VerifyValue(reader, 2);
+
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+            Assert.Equal(2, reader.CurrentDepth);
+
+            reader.SlideData(encoding.AsMemory(4), isFinalBlock: true);
+
+            Assert.Equal(2, reader.CurrentDepth);
+            Helpers.VerifyValue(reader, 3);
+            reader.ReadEndArray();
+            Helpers.VerifyValue(reader, new object[] { 4, 5 });
+            reader.ReadEndArray();
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Fact]
+        public static void Reset_NotFinalBlock_ResetsNestingContext()
+        {
+            byte[] encoding = "8301820203820405".HexToByteArray(); // [1, [2, 3], [4, 5]]
+
+            var reader = new CborReader(encoding.AsMemory(0, 4), LaxOptions, isFinalBlock: false);
+            reader.ReadStartArray();
+            Helpers.VerifyValue(reader, 1);
+            reader.ReadStartArray();
+
+            reader.Reset(encoding, isFinalBlock: false);
+
+            Assert.Equal(0, reader.CurrentDepth);
+            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Helpers.VerifyValue(reader, new object[] { 1, new object[] { 2, 3 }, new object[] { 4, 5 } });
+
+            // the single root-level value has been consumed, so the document is complete
+            // even though the reader has not been handed a final block
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        // truncated tokens
+        [InlineData("", CborReaderState.NeedsMoreData)]
+        [InlineData("18", CborReaderState.NeedsMoreData)] // uint, missing 8-bit argument
+        [InlineData("1b00000000", CborReaderState.NeedsMoreData)] // uint, truncated 64-bit argument
+        [InlineData("3affff", CborReaderState.NeedsMoreData)] // nint, truncated 32-bit argument
+        [InlineData("44", CborReaderState.NeedsMoreData)] // byte string, contents missing
+        [InlineData("44010203", CborReaderState.NeedsMoreData)] // byte string, truncated contents
+        [InlineData("62c3", CborReaderState.NeedsMoreData)] // text string, truncated contents
+        [InlineData("5901", CborReaderState.NeedsMoreData)] // byte string, truncated 16-bit length argument
+        [InlineData("9905", CborReaderState.NeedsMoreData)] // array, truncated 16-bit length argument
+        [InlineData("d9", CborReaderState.NeedsMoreData)] // tag, missing 16-bit argument
+        [InlineData("f8", CborReaderState.NeedsMoreData)] // simple value, missing 8-bit argument
+        [InlineData("f9ff", CborReaderState.NeedsMoreData)] // half-precision float, truncated argument
+        [InlineData("fa000000", CborReaderState.NeedsMoreData)] // single-precision float, truncated argument
+        // complete tokens whose contents are separate tokens
+        [InlineData("82", CborReaderState.StartArray)]
+        [InlineData("a2", CborReaderState.StartMap)]
+        [InlineData("c2", CborReaderState.Tag)]
+        [InlineData("5f", CborReaderState.StartIndefiniteLengthByteString)]
+        [InlineData("7f", CborReaderState.StartIndefiniteLengthTextString)]
+        // malformed initial byte is not a truncation condition
+        [InlineData("1c", CborReaderState.UnsignedInteger)] // reserved additional information value
+        public static void PeekState_NotFinalBlock_ReturnsExpectedState(string hexEncoding, CborReaderState expectedState)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+            Assert.Equal(expectedState, reader.PeekState());
+            Assert.Equal(encoding.Length, reader.BytesRemaining);
+        }
+
+        [Theory]
+        [InlineData("18", CborReaderState.UnsignedInteger)]
+        [InlineData("44010203", CborReaderState.ByteString)]
+        public static void PeekState_FinalBlock_TruncatedToken_DoesNotGateReads(string hexEncoding, CborReaderState expectedState)
+        {
+            // final-block readers preserve the historical behavior: PeekState validates
+            // the initial byte only, and truncation surfaces when the token is read
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: true);
+            Assert.Equal(expectedState, reader.PeekState());
+            Assert.Throws<CborContentException>(() => reader.SkipValue());
+        }
+
+        [Theory]
+        [InlineData("ff")] // break byte at the root context
+        [InlineData("c2ff")] // tag followed by break byte
+        [InlineData("bf01ff")] // indefinite-length map key missing a value
+        [InlineData("5f01ff")] // indefinite-length byte string containing an invalid data item
+        public static void PeekState_NotFinalBlock_MalformedData_ShouldThrowCborContentException(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+            Assert.Throws<CborContentException>(() => ReadAllTokens(reader));
+        }
+
+        [Fact]
+        public static void PeekState_NotFinalBlock_StateIsRefreshedAfterSlideData()
+        {
+            var reader = new CborReader(ReadOnlyMemory<byte>.Empty, LaxOptions, isFinalBlock: false);
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+
+            reader.SlideData("01".HexToByteArray(), isFinalBlock: true);
+            Assert.Equal(CborReaderState.UnsignedInteger, reader.PeekState());
+        }
+
+        [Fact]
+        public static void PeekState_NotFinalBlock_MultipleRootLevelValues_ReturnsNeedsMoreDataBetweenValues()
+        {
+            var options = new CborReaderOptions { ConformanceMode = CborConformanceMode.Lax, AllowMultipleRootLevelValues = true };
+            var reader = new CborReader(ReadOnlyMemory<byte>.Empty, options, isFinalBlock: false);
+            byte[] encoding = "010203".HexToByteArray();
+
+            for (int i = 0; i < encoding.Length; i++)
+            {
+                Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+                reader.SlideData(encoding.AsMemory(i, 1), isFinalBlock: false);
+                Helpers.VerifyValue(reader, i + 1);
+            }
+
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+            reader.SlideData(ReadOnlyMemory<byte>.Empty, isFinalBlock: true);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Fact]
+        public static void SlideData_AfterDocumentCompleted_ReaderRemainsFinished()
+        {
+            var reader = new CborReader("01".HexToByteArray(), LaxOptions, isFinalBlock: false);
+            Helpers.VerifyValue(reader, 1);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+
+            // sliding in more data does not resume reading a completed single-root document
+            reader.SlideData("02".HexToByteArray(), isFinalBlock: false);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            Assert.Throws<InvalidOperationException>(() => reader.ReadInt32());
+        }
+
+        [Fact]
+        public static void ReadEncodedValue_NotFinalBlock_TruncatedValue_ShouldThrowCborContentException()
+        {
+            byte[] encoding = "820102".HexToByteArray(); // [1, 2]
+            var reader = new CborReader(encoding.AsMemory(0, 2), LaxOptions, isFinalBlock: false);
+
+            Assert.Throws<CborContentException>(() => reader.ReadEncodedValue());
+            Assert.Equal(2, reader.BytesRemaining);
+
+            reader.SlideData(encoding, isFinalBlock: true);
+            Assert.Equal(encoding, reader.ReadEncodedValue().ToArray());
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Fact]
+        public static void TryReadString_NotFinalBlock_FalseMeansDestinationTooSmallOnly()
+        {
+            // fully buffered values: false signals an undersized destination, not missing data
+            var reader = new CborReader("4401020304".HexToByteArray(), LaxOptions, isFinalBlock: false);
+            Assert.Equal(CborReaderState.ByteString, reader.PeekState());
+            Assert.False(reader.TryReadByteString(new byte[2], out int bytesWritten));
+            Assert.Equal(0, bytesWritten);
+            Assert.True(reader.TryReadByteString(new byte[4], out bytesWritten));
+            Assert.Equal(4, bytesWritten);
+
+            reader = new CborReader("6461626364".HexToByteArray(), LaxOptions, isFinalBlock: false); // "abcd"
+            Assert.Equal(CborReaderState.TextString, reader.PeekState());
+            Assert.False(reader.TryReadTextString(new char[2], out int charsWritten));
+            Assert.Equal(0, charsWritten);
+            Assert.True(reader.TryReadTextString(new char[4], out charsWritten));
+            Assert.Equal(4, charsWritten);
+
+            // truncated values are not reported via the boolean; they throw as in final blocks
+            reader = new CborReader("440102".HexToByteArray(), LaxOptions, isFinalBlock: false);
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+            Assert.Throws<CborContentException>(() => reader.TryReadByteString(new byte[4], out _));
+
+            reader = new CborReader("646162".HexToByteArray(), LaxOptions, isFinalBlock: false);
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+            Assert.Throws<CborContentException>(() => reader.TryReadTextString(new char[4], out _));
+        }
+
+        [Theory]
+        [InlineData(CborConformanceMode.Strict)]
+        [InlineData(CborConformanceMode.Canonical)]
+        [InlineData(CborConformanceMode.Ctap2Canonical)]
+        public static void Constructor_NotFinalBlock_NonLaxConformance_ShouldThrowArgumentException(CborConformanceMode mode)
+        {
+            var options = new CborReaderOptions { ConformanceMode = mode };
+            AssertExtensions.Throws<ArgumentException>("isFinalBlock", () => new CborReader(ReadOnlyMemory<byte>.Empty, options, isFinalBlock: false));
+        }
+
+        [Fact]
+        public static void Constructor_NotFinalBlock_NullOptions_ShouldThrowArgumentException()
+        {
+            // null options default to the Strict conformance mode
+            AssertExtensions.Throws<ArgumentException>("isFinalBlock", () => new CborReader(ReadOnlyMemory<byte>.Empty, null, isFinalBlock: false));
+        }
+
+        [Theory]
+        [InlineData(CborConformanceMode.Strict)]
+        [InlineData(CborConformanceMode.Canonical)]
+        [InlineData(CborConformanceMode.Ctap2Canonical)]
+        public static void Reset_NotFinalBlock_NonLaxConformance_ShouldThrowArgumentException(CborConformanceMode mode)
+        {
+            var reader = new CborReader(ReadOnlyMemory<byte>.Empty, new CborReaderOptions { ConformanceMode = mode });
+            AssertExtensions.Throws<ArgumentException>("isFinalBlock", () => reader.Reset(ReadOnlyMemory<byte>.Empty, isFinalBlock: false));
+        }
+
+        [Fact]
+        public static void SlideData_FinalBlock_ShouldThrowInvalidOperationException()
+        {
+            byte[] encoding = "01".HexToByteArray();
+
+            // default constructors produce final-block readers
+            var reader = new CborReader(encoding);
+            Assert.Throws<InvalidOperationException>(() => reader.SlideData(encoding, isFinalBlock: false));
+
+            reader = new CborReader(encoding, LaxOptions, isFinalBlock: true);
+            Assert.Throws<InvalidOperationException>(() => reader.SlideData(encoding, isFinalBlock: false));
+
+            // sliding in a final block prevents further slides
+            reader = new CborReader(ReadOnlyMemory<byte>.Empty, LaxOptions, isFinalBlock: false);
+            reader.SlideData(encoding, isFinalBlock: true);
+            Assert.Throws<InvalidOperationException>(() => reader.SlideData(encoding, isFinalBlock: false));
+        }
+
+        [Fact]
+        public static void Reset_SingleArgument_MakesReaderFinalBlock()
+        {
+            byte[] encoding = "01".HexToByteArray();
+            var reader = new CborReader(ReadOnlyMemory<byte>.Empty, LaxOptions, isFinalBlock: false);
+
+            reader.Reset(encoding);
+            Assert.Throws<InvalidOperationException>(() => reader.SlideData(encoding, isFinalBlock: false));
+
+            reader.Reset(encoding, isFinalBlock: false);
+            reader.SlideData(encoding, isFinalBlock: true); // does not throw
+        }
+
+        [Fact]
+        public static void ReadStartArray_NotFinalBlock_TruncatedContents_ShouldSucceed()
+        {
+            byte[] encoding = "990100".HexToByteArray(); // array of declared length 256, contents missing
+
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+            Assert.Equal(256, reader.ReadStartArray());
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+
+            // the conservative declared-length check still applies to final blocks
+            reader = new CborReader(encoding, LaxOptions, isFinalBlock: true);
+            Assert.Throws<CborContentException>(() => reader.ReadStartArray());
+        }
+
+        [Fact]
+        public static void ReadStartMap_NotFinalBlock_TruncatedContents_ShouldSucceed()
+        {
+            byte[] encoding = "b90100".HexToByteArray(); // map of declared length 256, contents missing
+
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+            Assert.Equal(256, reader.ReadStartMap());
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+
+            // the conservative declared-length check still applies to final blocks
+            reader = new CborReader(encoding, LaxOptions, isFinalBlock: true);
+            Assert.Throws<CborContentException>(() => reader.ReadStartMap());
+        }
+
+        [Theory]
+        [InlineData("5b7fffffffffffffff")] // byte string declaring a length that cannot fit any buffer
+        [InlineData("9b7fffffffffffffff")] // array declaring a length that cannot fit any buffer
+        [InlineData("bb7fffffffffffffff")] // map declaring a length that cannot fit any buffer
+        public static void Read_NotFinalBlock_UnrepresentableDefiniteLength_ShouldThrowCborContentException(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+
+            // an unrepresentable length is not a truncation condition: the token is reported as available
+            Assert.NotEqual(CborReaderState.NeedsMoreData, reader.PeekState());
+
+            Assert.Throws<CborContentException>(() =>
+            {
+                switch (encoding[0])
+                {
+                    case 0x5b: reader.ReadByteString(); break;
+                    case 0x9b: reader.ReadStartArray(); break;
+                    default: reader.ReadStartMap(); break;
+                }
+            });
+            Assert.Equal(encoding.Length, reader.BytesRemaining);
+
+            Assert.Throws<CborContentException>(() => reader.SkipValue());
+            Assert.Equal(encoding.Length, reader.BytesRemaining);
+        }
+
+        [Theory]
+        [InlineData("5f41ab")] // indefinite-length byte string missing chunks and break byte
+        [InlineData("5f4401")] // indefinite-length byte string with a truncated chunk
+        public static void ReadByteString_NotFinalBlock_TruncatedIndefiniteLengthString_ShouldThrowCborContentException(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+
+            // the concatenating read consumes multiple tokens and can fail beyond the peeked token
+            Assert.Equal(CborReaderState.StartIndefiniteLengthByteString, reader.PeekState());
+            Assert.Throws<CborContentException>(() => reader.ReadByteString());
+            Assert.Equal(encoding.Length, reader.BytesRemaining);
+
+            // the non-throwing alternatives report the truncation
+            Assert.False(reader.TrySkipValue());
+        }
+
+        [Fact]
+        public static void PeekState_DanglingTagAtEndOfRootSequence_MatchesFinalBlockBehavior()
+        {
+            var options = new CborReaderOptions { ConformanceMode = CborConformanceMode.Lax, AllowMultipleRootLevelValues = true };
+
+            // while more data may follow, the truncated tagged value is reported as NeedsMoreData
+            var reader = new CborReader("01c1".HexToByteArray(), options, isFinalBlock: false);
+            Helpers.VerifyValue(reader, 1);
+            reader.ReadTag();
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+
+            // once the final block arrives, incremental readers match the shipped final-block behavior:
+            // the dangling tag is reported as the end of the sequence rather than as malformed data
+            reader.SlideData(ReadOnlyMemory<byte>.Empty, isFinalBlock: true);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            Assert.Throws<InvalidOperationException>(() => reader.ReadInt32());
+
+            // final mode behaves identically
+            reader = new CborReader("01c1".HexToByteArray(), options, isFinalBlock: true);
+            Helpers.VerifyValue(reader, 1);
+            reader.ReadTag();
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            Assert.Throws<InvalidOperationException>(() => reader.ReadInt32());
+        }
+
+        [Fact]
+        public static void SlideData_CompletesTaggedValueAtEndOfRootSequence()
+        {
+            var options = new CborReaderOptions { ConformanceMode = CborConformanceMode.Lax, AllowMultipleRootLevelValues = true };
+            var reader = new CborReader("01c1".HexToByteArray(), options, isFinalBlock: false);
+            Helpers.VerifyValue(reader, 1);
+            Assert.Equal((CborTag)1, reader.ReadTag());
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+
+            reader.SlideData("187b".HexToByteArray(), isFinalBlock: true);
+            Helpers.VerifyValue(reader, 123);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        [InlineData("c07818323032302d30342d31305431303a30353a33372e3939395a")] // 0("2020-04-10T10:05:37.999Z")
+        [InlineData("c11a514b67b0")] // 1(1363896240)
+        [InlineData("c249010000000000000000")] // 2(h'010000000000000000')
+        [InlineData("c48221196ab3")] // 4([-2, 27315])
+        public static void ReadTaggedValue_NotFinalBlock_AllSplitPoints_SucceedsAfterSlideData(string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            object expected = ReadTaggedValue(new CborReader(encoding, LaxOptions));
+
+            for (int split = 1; split < encoding.Length; split++)
+            {
+                var reader = new CborReader(encoding.AsMemory(0, split), LaxOptions, isFinalBlock: false);
+
+                // semantic tag readers consume multiple tokens, so they throw on truncation
+                // even though the tag token itself passes the PeekState gate
+                Assert.Throws<CborContentException>(() => ReadTaggedValue(reader));
+                Assert.Equal(split, reader.BytesRemaining); // reader state was restored
+
+                reader.SlideData(encoding, isFinalBlock: true);
+                Assert.Equal(expected, ReadTaggedValue(reader));
+                Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            }
+        }
+
+        [Fact]
+        public static void SlideData_BufferSmallerThanBytesRemaining_ShouldThrowArgumentException()
+        {
+            byte[] encoding = "820102".HexToByteArray(); // [1, 2]
+            var reader = new CborReader(encoding, LaxOptions, isFinalBlock: false);
+            reader.ReadStartArray();
+            Assert.Equal(2, reader.BytesRemaining);
+
+            AssertExtensions.Throws<ArgumentException>("data", () => reader.SlideData("01".HexToByteArray(), isFinalBlock: false));
+
+            // the failed call leaves the reader unchanged; an equally-sized buffer is accepted
+            Assert.Equal(2, reader.BytesRemaining);
+            reader.SlideData("0102".HexToByteArray(), isFinalBlock: true);
+            Helpers.VerifyValue(reader, 1);
+            Helpers.VerifyValue(reader, 2);
+            reader.ReadEndArray();
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Fact]
+        public static void ReadStartMap_NotFinalBlock_PairCountOverflow_ShouldThrowCborContentException()
+        {
+            // the key-value item count 2 * mapSize must remain representable even though
+            // the contents can be supplied by later SlideData calls
+            var reader = new CborReader("ba7fffffff".HexToByteArray(), LaxOptions, isFinalBlock: false); // int.MaxValue pairs
+            Assert.Throws<CborContentException>(() => reader.ReadStartMap());
+
+            reader = new CborReader("ba40000000".HexToByteArray(), LaxOptions, isFinalBlock: false); // int.MaxValue / 2 + 1 pairs
+            Assert.Throws<CborContentException>(() => reader.ReadStartMap());
+
+            reader = new CborReader("ba3fffffff".HexToByteArray(), LaxOptions, isFinalBlock: false); // int.MaxValue / 2 pairs
+            Assert.Equal(int.MaxValue / 2, reader.ReadStartMap());
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+        }
+
+        [Fact]
+        public static void SlideData_MaxDepthLimit_EnforcedAcrossSlides()
+        {
+            var options = new CborReaderOptions { ConformanceMode = CborConformanceMode.Lax, MaxDepth = 2 };
+            var reader = new CborReader("81".HexToByteArray(), options, isFinalBlock: false);
+            reader.ReadStartArray();
+
+            reader.SlideData("81".HexToByteArray(), isFinalBlock: false);
+            reader.ReadStartArray();
+
+            reader.SlideData("81".HexToByteArray(), isFinalBlock: false);
+            Assert.Equal(CborReaderState.StartArray, reader.PeekState());
+            Assert.Throws<CborContentException>(() => reader.ReadStartArray());
+        }
+
+        [Fact]
+        public static void ReadInt32_NotFinalBlock_TruncatedArgument_ThrowsAndRecoversAfterSlideData()
+        {
+            var reader = new CborReader("1a000f".HexToByteArray(), LaxOptions, isFinalBlock: false);
+
+            // reading past NeedsMoreData throws, but leaves the reader state unchanged
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+            Assert.Throws<CborContentException>(() => reader.ReadInt32());
+            Assert.Equal(3, reader.BytesRemaining);
+
+            reader.SlideData("1a000f4240".HexToByteArray(), isFinalBlock: true);
+            Assert.Equal(1_000_000, reader.ReadInt32());
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceMode.Lax)]
+        [InlineData(CborConformanceMode.Strict)]
+        [InlineData(CborConformanceMode.Canonical)]
+        [InlineData(CborConformanceMode.Ctap2Canonical)]
+        public static void Constructor_FinalBlock_AnyConformanceMode_Succeeds(CborConformanceMode mode)
+        {
+            var options = new CborReaderOptions { ConformanceMode = mode };
+            var reader = new CborReader("01".HexToByteArray(), options, isFinalBlock: true);
+            Helpers.VerifyValue(reader, 1);
+
+            reader.Reset("01".HexToByteArray(), isFinalBlock: true);
+            Helpers.VerifyValue(reader, 1);
+        }
+
+        [Fact]
+        public static void Read_NotFinalBlock_AtRootValueBoundary_ShouldThrowCborContentException()
+        {
+            var options = new CborReaderOptions { ConformanceMode = CborConformanceMode.Lax, AllowMultipleRootLevelValues = true };
+            var reader = new CborReader("01".HexToByteArray(), options, isFinalBlock: false);
+            Helpers.VerifyValue(reader, 1);
+            Assert.Equal(CborReaderState.NeedsMoreData, reader.PeekState());
+
+            // reading past NeedsMoreData reports the truncation, mirroring mid-token truncation,
+            // rather than declaring the end of the sequence
+            Assert.Throws<CborContentException>(() => reader.ReadInt32());
+
+            reader.SlideData("02".HexToByteArray(), isFinalBlock: false);
+            Helpers.VerifyValue(reader, 2);
+        }
+
+        [Fact]
+        public static void Read_FinishedRootSequenceAfterEmptyFinalSlide_ShouldThrowInvalidOperationException()
+        {
+            var options = new CborReaderOptions { ConformanceMode = CborConformanceMode.Lax, AllowMultipleRootLevelValues = true };
+            var reader = new CborReader("01".HexToByteArray(), options, isFinalBlock: false);
+            Helpers.VerifyValue(reader, 1);
+
+            reader.SlideData(ReadOnlyMemory<byte>.Empty, isFinalBlock: true);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+
+            // over-reading a well-formed, fully consumed sequence is a usage error, not a content error
+            Assert.Throws<InvalidOperationException>(() => reader.ReadInt32());
+        }
+
+        // Dispatches to the strongly-typed semantic tag reader for the next value's tag.
+        private static object ReadTaggedValue(CborReader reader)
+        {
+            return reader.PeekTag() switch
+            {
+                CborTag.DateTimeString => reader.ReadDateTimeOffset(),
+                CborTag.UnixTimeSeconds => reader.ReadUnixTimeSeconds(),
+                CborTag.UnsignedBigNum or CborTag.NegativeBigNum => (object)reader.ReadBigInteger(),
+                CborTag.DecimalFraction => reader.ReadDecimal(),
+                _ => throw new InvalidOperationException($"Unexpected tag {reader.PeekTag()}."),
+            };
+        }
+
+        // Walks an entire document token by token, gated on PeekState(),
+        // invoking the supplied callback whenever the reader needs more data.
+        // Returns a trace of the tokens read for comparison across buffering strategies.
+        private static List<string> ReadAllTokens(CborReader reader, Func<bool>? slide = null)
+        {
+            var tokens = new List<string>();
+
+            while (true)
+            {
+                CborReaderState state = reader.PeekState();
+                switch (state)
+                {
+                    case CborReaderState.Finished:
+                        return tokens;
+                    case CborReaderState.NeedsMoreData:
+                        Assert.NotNull(slide);
+                        Assert.True(slide!(), "Reader needs more data, but the full document has already been supplied.");
+                        continue;
+                    case CborReaderState.UnsignedInteger:
+                        tokens.Add($"{state}:{reader.ReadUInt64()}");
+                        break;
+                    case CborReaderState.NegativeInteger:
+                        tokens.Add($"{state}:{reader.ReadCborNegativeIntegerRepresentation()}");
+                        break;
+                    case CborReaderState.ByteString:
+                        tokens.Add($"{state}:{reader.ReadByteString().ByteArrayToHex()}");
+                        break;
+                    case CborReaderState.TextString:
+                        tokens.Add($"{state}:{reader.ReadTextString()}");
+                        break;
+                    case CborReaderState.StartIndefiniteLengthByteString:
+                        reader.ReadStartIndefiniteLengthByteString();
+                        tokens.Add(state.ToString());
+                        break;
+                    case CborReaderState.EndIndefiniteLengthByteString:
+                        reader.ReadEndIndefiniteLengthByteString();
+                        tokens.Add(state.ToString());
+                        break;
+                    case CborReaderState.StartIndefiniteLengthTextString:
+                        reader.ReadStartIndefiniteLengthTextString();
+                        tokens.Add(state.ToString());
+                        break;
+                    case CborReaderState.EndIndefiniteLengthTextString:
+                        reader.ReadEndIndefiniteLengthTextString();
+                        tokens.Add(state.ToString());
+                        break;
+                    case CborReaderState.StartArray:
+                        tokens.Add($"{state}:{reader.ReadStartArray()}");
+                        break;
+                    case CborReaderState.EndArray:
+                        reader.ReadEndArray();
+                        tokens.Add(state.ToString());
+                        break;
+                    case CborReaderState.StartMap:
+                        tokens.Add($"{state}:{reader.ReadStartMap()}");
+                        break;
+                    case CborReaderState.EndMap:
+                        reader.ReadEndMap();
+                        tokens.Add(state.ToString());
+                        break;
+                    case CborReaderState.Tag:
+                        tokens.Add($"{state}:{reader.ReadTag()}");
+                        break;
+                    case CborReaderState.HalfPrecisionFloat:
+                    case CborReaderState.SinglePrecisionFloat:
+                    case CborReaderState.DoublePrecisionFloat:
+                        tokens.Add($"{state}:{reader.ReadDouble()}");
+                        break;
+                    case CborReaderState.Null:
+                        reader.ReadNull();
+                        tokens.Add(state.ToString());
+                        break;
+                    case CborReaderState.Boolean:
+                        tokens.Add($"{state}:{reader.ReadBoolean()}");
+                        break;
+                    case CborReaderState.SimpleValue:
+                        tokens.Add($"{state}:{reader.ReadSimpleValue()}");
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unexpected reader state {state}.");
+                }
+            }
+        }
+
+        // Supplies a document to a non-final-block reader in fixed-size chunks,
+        // copying the unconsumed tail to the front of the buffer on every slide.
+        private sealed class ChunkedFeeder
+        {
+            private readonly byte[] _encoding;
+            private readonly int _chunkSize;
+            private int _position;
+            private byte[] _buffer;
+            private int _dataLength;
+
+            public ChunkedFeeder(byte[] encoding, int chunkSize)
+            {
+                _encoding = encoding;
+                _chunkSize = chunkSize;
+                _buffer = new byte[chunkSize];
+            }
+
+            public bool Slide(CborReader reader)
+            {
+                Assert.True(_position < _encoding.Length, "Reader needs more data, but the full document has already been supplied.");
+
+                int keep = reader.BytesRemaining;
+                int start = _dataLength - keep;
+                int read = Math.Min(_chunkSize, _encoding.Length - _position);
+
+                if (_buffer.Length < keep + read)
+                {
+                    Array.Resize(ref _buffer, Math.Max(2 * _buffer.Length, keep + read));
+                }
+
+                Buffer.BlockCopy(_buffer, start, _buffer, 0, keep);
+                Buffer.BlockCopy(_encoding, _position, _buffer, keep, read);
+                _position += read;
+                _dataLength = keep + read;
+
+                reader.SlideData(_buffer.AsMemory(0, _dataLength), isFinalBlock: _position == _encoding.Length);
+                return true;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj
+++ b/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="Reader\CborReaderTests.Helpers.cs" />
     <Compile Include="Reader\CborReaderTests.Map.cs" />
     <Compile Include="Reader\CborReaderTests.SkipValue.cs" />
+    <Compile Include="Reader\CborReaderTests.SlideData.cs" />
     <Compile Include="Reader\CborReaderTests.Simple.cs" />
     <Compile Include="Reader\CborReaderTests.Tag.cs" />
     <Compile Include="Reader\CborReaderTests.Array.cs" />


### PR DESCRIPTION
Implements the API approved in #129718, adding incremental reading mode where the caller owns I/O and supplies data in chunks:
```csharp
public partial class CborReader
{
    public CborReader(ReadOnlyMemory<byte> data, CborReaderOptions? options, bool isFinalBlock);
    public void SlideData(ReadOnlyMemory<byte> data, bool isFinalBlock);
    public void Reset(ReadOnlyMemory<byte> data, bool isFinalBlock);
    public bool TrySkipValue(bool disableConformanceModeChecks = false);
    public bool TrySkipToParent(bool disableConformanceModeChecks = false);
}

public partial enum CborReaderState
{
    NeedsMoreData,
}
```

- In non-final mode, `PeekState()` returns `NeedsMoreData` when the next token is incomplete in the buffer; any other state guarantees the single-token read won't fail on end of data. Multi-token reads (indefinite-length strings, `ReadEncodedValue`, semantic tag readers) still throw on truncation and restore the reader state, so the caller can slide in more data and retry.
- `SlideData` replaces the buffer and preserves nesting state; the caller must keep the unread bytes (`BytesRemaining`) at the start of the new buffer. Only the length is validated.
- Non-final mode is Lax-only in this version (per the proposal): other conformance modes track map keys by buffer offset, which cannot survive a slide. The validation is centralized so a future all-modes implementation has one place to rebase that bookkeeping.
- Final-block readers (all existing constructors and `Reset(data)`) are behaviorally unchanged.

Notes for reviewers:
- In non-final mode, reading at a root-value boundary throws `CborContentException` rather than `InvalidOperationException`, since the reader can't know the sequence ended until the final block arrives.
- Found but not fixed here: a root sequence ending in a dangling tag reports `Finished`, though it isn't well-formed. This predates this change; incremental readers deliberately match it for consistency. I think we should track it separately and will create an issue for it.
