### PR TITLE
JIT: Refine promotion costing for cold small parameter fields

### DIFF
--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -778,7 +778,18 @@ public:
         else if (lcl->lvIsParam)
         {
             // For parameters, the backend may be able to map it directly from a register.
-            if (Promotion::MapsToParameterRegister(comp, lclNum, access.Offset, access.AccessType))
+            // Small fields can pack many values into each parameter register, so eagerly
+            // extracting rarely used fields can add substantial work and register pressure.
+            // Wider fields naturally limit the number of extractions per register.
+            // Restrict the credit for small fields with few accesses to target these cases.
+            // This is an imprecise heuristic: it does not model extraction cost, register
+            // pressure, or shared parameter spill costs.
+            const weight_t MIN_RELATIVE_ACCESS_WEIGHT = 0.10;
+            bool           allowBitwiseExtraction =
+                !varTypeIsSmall(access.AccessType) ||
+                (access.CountWtd + inducedCountWtd) >= MIN_RELATIVE_ACCESS_WEIGHT * comp->fgFirstBB->getBBWeight(comp);
+            if (Promotion::MapsToParameterRegister(comp, lclNum, access.Offset, access.AccessType,
+                                                   allowBitwiseExtraction))
             {
                 // No promotion will result in a store to stack in the prolog.
                 costWithout += COST_STRUCT_ACCESS_CYCLES * comp->fgFirstBB->getBBWeight(comp);
@@ -3063,15 +3074,17 @@ GenTree* Promotion::EffectiveUser(Compiler::GenTreeStack& ancestors)
 //   expected to map to a register.
 //
 // Parameters:
-//   comp       - Compiler instance
-//   lclNum     - Local being accessed into
-//   offset     - Offset being accessed at
-//   accessType - Type of access
+//   comp                   - Compiler instance
+//   lclNum                 - Local being accessed into
+//   offset                 - Offset being accessed at
+//   accessType             - Type of access
+//   allowBitwiseExtraction - Whether to allow mappings requiring extraction or a register-class change
 //
 // Returns:
 //   True if the access can be efficiently done via a parameter register.
 //
-bool Promotion::MapsToParameterRegister(Compiler* comp, unsigned lclNum, unsigned offset, var_types accessType)
+bool Promotion::MapsToParameterRegister(
+    Compiler* comp, unsigned lclNum, unsigned offset, var_types accessType, bool allowBitwiseExtraction)
 {
     assert(lclNum < comp->info.compArgsCount);
 
@@ -3100,6 +3113,12 @@ bool Promotion::MapsToParameterRegister(Compiler* comp, unsigned lclNum, unsigne
         }
 
         if (genIsValidFloatReg(seg.GetRegister()) && (offset != seg.Offset))
+        {
+            continue;
+        }
+
+        if (!allowBitwiseExtraction && ((offset != seg.Offset) || (genTypeSize(accessType) != seg.Size) ||
+                                        (varTypeUsesIntReg(accessType) != genIsValidIntReg(seg.GetRegister()))))
         {
             continue;
         }

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -782,8 +782,6 @@ public:
             // extracting rarely used fields can add substantial work and register pressure.
             // Wider fields naturally limit the number of extractions per register.
             // Restrict the credit for small fields with few accesses to target these cases.
-            // This is an imprecise heuristic: it does not model extraction cost, register
-            // pressure, or shared parameter spill costs.
             const weight_t MIN_RELATIVE_ACCESS_WEIGHT = 0.10;
             bool           allowBitwiseExtraction =
                 !varTypeIsSmall(access.AccessType) ||

--- a/src/coreclr/jit/promotion.h
+++ b/src/coreclr/jit/promotion.h
@@ -154,7 +154,8 @@ class Promotion
 
     static bool     IsCandidateForPhysicalPromotion(LclVarDsc* dsc);
     static GenTree* EffectiveUser(Compiler::GenTreeStack& ancestors);
-    static bool     MapsToParameterRegister(Compiler* comp, unsigned lclNum, unsigned offs, var_types accessType);
+    static bool     MapsToParameterRegister(
+            Compiler* comp, unsigned lclNum, unsigned offs, var_types accessType, bool allowBitwiseExtraction = true);
 public:
     explicit Promotion(Compiler* compiler)
         : m_compiler(compiler)


### PR DESCRIPTION
Withhold bitwise parameter-register extraction credit for byte/short fields whose weighted access count is less than 10% of the entry-block weight. Preserve direct register mappings and wider-field costing.

Many byte/short fields can fit into each parameter register, so eagerly extracting them can introduce substantial work and register pressure even when most fields are rarely accessed. Larger fields naturally limit the number of values that fit in a register and therefore the number of eager extractions. Restrict the heuristic to small fields to target this pattern.

This intentionally imprecise heuristic targets cases where eager field extraction is not profitable, such as Guid.CompareTo returning before its later fields are accessed. It does not precisely model extraction costs, register pressure, or shared spill/copy costs, and is not a general profitability model. Initialization of promoted fields remains unchanged.

Fix #119770

### PriorityQueue<Guid, Guid> — fix-119770 vs baseline

**Environment:** Linux/x64, AMD Ryzen 9 5950X, Release JITs, tiered PGO enabled, ReadyToRun disabled. BenchmarkDotNet: two launches, eight warmups, fifteen measured iterations.

| Benchmark | Size | Baseline | fix-119770 | Ratio | BDN classification |
|---|---:|---:|---:|---:|---|
| HeapSort | 10 | 186.2 ns | 142.1 ns | 0.76 | Faster |
| Dequeue_And_Enqueue | 10 | 559.2 ns | 496.0 ns | 0.89 | Faster |
| K_Max_Elements | 10 | 182.9 ns | 158.3 ns | 0.87 | Faster |
| HeapSort | 100 | 4.191 µs | 2.785 µs | 0.66 | Faster |
| Dequeue_And_Enqueue | 100 | 11.279 µs | 9.234 µs | 0.82 | Faster |
| K_Max_Elements | 100 | 846.0 ns | 867.7 ns | 1.03 | Same |
| HeapSort | 1000 | 83.540 µs | 66.290 µs | 0.79 | Faster |
| Dequeue_And_Enqueue | 1000 | 237.735 µs | 212.093 µs | 0.89 | Faster |
| K_Max_Elements | 1000 | 5.577 µs | 4.592 µs | 0.82 | Faster |