### PR TITLE
JIT: Add legacy small FP conversion compatibility switch

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -137,8 +137,8 @@ CONFIG_INTEGER(JitAwaitHashBreak, "JitAwaitHashBreak", -1)    // Break on jittin
 
 CONFIG_INTEGER(JitLongAddress, "JitLongAddress", 0) // Force using the large pseudo instruction form for long address
 CONFIG_INTEGER(JitMaxUncheckedOffset, "JitMaxUncheckedOffset", 8)
-// Restore the pre-.NET 11 unchecked float/double-to-small-integral conversion behavior for selected methods.
-RELEASE_CONFIG_METHODSET(JitUseLegacySmallFpToIntConversion, "JitUseLegacySmallFpToIntConversion")
+// Restore the pre-.NET 11 unchecked float/double-to-small-integral conversion behavior.
+RELEASE_CONFIG_INTEGER(JitUseLegacySmallFpToIntConversion, "JitUseLegacySmallFpToIntConversion", 0)
 #if defined(TARGET_ARM64)
 RELEASE_CONFIG_INTEGER(JitPacEnabled, "JitPacEnabled", 0)
 #endif

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -137,6 +137,8 @@ CONFIG_INTEGER(JitAwaitHashBreak, "JitAwaitHashBreak", -1)    // Break on jittin
 
 CONFIG_INTEGER(JitLongAddress, "JitLongAddress", 0) // Force using the large pseudo instruction form for long address
 CONFIG_INTEGER(JitMaxUncheckedOffset, "JitMaxUncheckedOffset", 8)
+// Restore the pre-.NET 11 unchecked float/double-to-small-integral conversion behavior for selected methods.
+RELEASE_CONFIG_METHODSET(JitUseLegacySmallFpToIntConversion, "JitUseLegacySmallFpToIntConversion")
 #if defined(TARGET_ARM64)
 RELEASE_CONFIG_INTEGER(JitPacEnabled, "JitPacEnabled", 0)
 #endif

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -293,6 +293,9 @@ GenTree* Compiler::fgMorphExpandCast(GenTreeCast* tree)
         // Do we need to do it in two steps R -> I -> smallType?
         if (varTypeIsSmall(dstType))
         {
+            const bool useLegacySmallFpToIntConversion = JitConfig.JitUseLegacySmallFpToIntConversion().contains(
+                info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args);
+
             // For non-overflow casts of float/double -> smallType, clamp the float
             // source to [smallMin, smallMax] before the R -> int conversion so that
             // the truncating CAST(smallType <- int) produces saturating results,
@@ -315,7 +318,7 @@ GenTree* Compiler::fgMorphExpandCast(GenTreeCast* tree)
             // CAST_OVF(smallType <- int) is responsible for throwing OverflowException
             // when the value is out of range.
 #if defined(FEATURE_HW_INTRINSICS) || defined(TARGET_WASM)
-            if (!tree->gtOverflow())
+            if (!tree->gtOverflow() && !useLegacySmallFpToIntConversion)
             {
                 double smallMin;
                 double smallMax;
@@ -374,7 +377,7 @@ GenTree* Compiler::fgMorphExpandCast(GenTreeCast* tree)
             // clamp the int32 result of the R -> int cast to the small type range.
             // NaN input maps to 0 via the saturating R -> int cast above, which is
             // already in range for any small type.
-            if (!tree->gtOverflow())
+            if (!tree->gtOverflow() && !useLegacySmallFpToIntConversion)
             {
                 NamedIntrinsic satIntrinsic;
                 switch (dstType)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -293,8 +293,7 @@ GenTree* Compiler::fgMorphExpandCast(GenTreeCast* tree)
         // Do we need to do it in two steps R -> I -> smallType?
         if (varTypeIsSmall(dstType))
         {
-            const bool useLegacySmallFpToIntConversion = JitConfig.JitUseLegacySmallFpToIntConversion().contains(
-                info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args);
+            const bool useLegacySmallFpToIntConversion = JitConfig.JitUseLegacySmallFpToIntConversion() != 0;
 
             // For non-overflow casts of float/double -> smallType, clamp the float
             // source to [smallMin, smallMax] before the R -> int conversion so that

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116823/Runtime_116823.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116823/Runtime_116823.cs
@@ -45,6 +45,17 @@ public class Runtime_116823
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static char FloatToChar(float v) => (char)v;
 
+#if LEGACY_SMALL_FP_TO_INT_CONVERSION
+    [Fact]
+    [SkipOnMono("The compatibility switch is specific to the CoreCLR JIT.")]
+    public static void TestEntryPoint()
+    {
+        Assert.Equal((ushort)4714, DoubleToUShort(70250.0));
+        Assert.Equal((ushort)65526, DoubleToUShort(-10.0));
+        Assert.Equal((ushort)4714, FloatToUShort(70250.0f));
+        Assert.Equal((ushort)65526, FloatToUShort(-10.0f));
+    }
+#else
     [Fact]
     [SkipOnMono("https://github.com/dotnet/runtime/issues/100368")]
     public static void TestEntryPoint()
@@ -140,4 +151,5 @@ public class Runtime_116823
         Assert.Equal((char)0, FloatToChar(float.NegativeInfinity));
         Assert.Equal((char)0, FloatToChar(float.NaN));
     }
+#endif
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116823/Runtime_116823.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116823/Runtime_116823.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116823/Runtime_116823_Legacy.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116823/Runtime_116823_Legacy.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <DefineConstants>$(DefineConstants);LEGACY_SMALL_FP_TO_INT_CONVERSION</DefineConstants>
+    <CrossGenTest>false</CrossGenTest>
+    <InterpreterIncompatible>true</InterpreterIncompatible>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Runtime_116823.cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitUseLegacySmallFpToIntConversion"
+                                Value="DoubleToUShort FloatToUShort" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_116823/Runtime_116823_Legacy.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_116823/Runtime_116823_Legacy.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Runtime_116823.cs" />
-    <CLRTestEnvironmentVariable Include="DOTNET_JitUseLegacySmallFpToIntConversion"
-                                Value="DoubleToUShort FloatToUShort" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitUseLegacySmallFpToIntConversion" Value="1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

.NET 11 changed unchecked `float`/`double` conversions to small integral types to saturate at the destination type's bounds in #128604, addressing #116823. This adds a targeted compatibility escape hatch for applications that need the pre-.NET 11 truncating behavior while migrating.

Setting `DOTNET_JitUseLegacySmallFpToIntConversion=1` restores the legacy behavior process-wide for unchecked conversions in the CoreCLR JIT. The switch defaults to `0`, so existing .NET 11 behavior is unchanged unless the switch is explicitly enabled. Checked conversions are unaffected.

The regression test now has two variants: the default saturation behavior and an isolated legacy-switch configuration. An explicit project preserves discovery of the default variant alongside the new legacy project.

## Testing

- `python src\coreclr\scripts\jitformat.py -r . -o windows -a x64`
- `.\build.cmd clr+libs+host`
- `.\build.cmd clr+libs -lc release -rc checked`
- Built both `Runtime_116823` projects and ran the default and legacy variants on Windows x64 Checked

> [!NOTE]
> This pull request description was generated by GitHub Copilot.