### PR TITLE
[wasm] Fix duplicate R2R stack trace frames

### DIFF
--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -194,13 +194,25 @@ static StackWalkAction GetStackFramesCallback(CrawlFrame* pCf, VOID* data)
     //        NOT AT ALL!!!, but we can assume it's a function
     //                       because we asked the stackwalker for it!
     MethodDesc* pFunc = pCf->GetFunction();
+    DebugStackTrace::GetStackFramesData* pData = (DebugStackTrace::GetStackFramesData*)data;
+
+#ifdef TARGET_WASM
+    // The portable-entrypoint slow path keeps its prestub frame active while it invokes a newly
+    // discovered R2R body. The body is already reported as a frameless method.
+    if (!pCf->IsFrameless() &&
+        pCf->GetFrame()->GetFrameIdentifier() == FrameIdentifier::PrestubMethodFrame &&
+        pData->cElements > 0 &&
+        pData->pElements[pData->cElements - 1].pFunc == pFunc)
+    {
+        return SWA_CONTINUE;
+    }
+#endif // TARGET_WASM
 
     if (pFunc != nullptr && pFunc == g_pEnvironmentCallEntryPointMethodDesc)
     {
         return SWA_CONTINUE;
     }
 
-    DebugStackTrace::GetStackFramesData* pData = (DebugStackTrace::GetStackFramesData*)data;
     if (pData->cElements >= pData->cElementsAllocated)
     {
         DebugStackTrace::Element* pTemp = new (nothrow) DebugStackTrace::Element[2*pData->cElementsAllocated];

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -202,7 +202,8 @@ static StackWalkAction GetStackFramesCallback(CrawlFrame* pCf, VOID* data)
     if (!pCf->IsFrameless() &&
         pCf->GetFrame()->GetFrameIdentifier() == FrameIdentifier::PrestubMethodFrame &&
         pData->cElements > 0 &&
-        pData->pElements[pData->cElements - 1].pFunc == pFunc)
+        pData->pElements[pData->cElements - 1].pFunc == pFunc &&
+        pData->pElements[pData->cElements - 1].ip != (PCODE)NULL)
     {
         return SWA_CONTINUE;
     }

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.cs
@@ -114,11 +114,35 @@ public class ProgramBase<TT> : TestItf4<TT>
 public class Program : ProgramBase<InputData>, TestItf2<InputData>
 {
     [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsSimulator))]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/133505", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmReadyToRun))]
     [Fact]
     public static void TestEntryPoint()
     {
         new Program().Start();
+        ValidateExceptionStackTrace();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowForStackTrace() => throw new Exception();
+
+    private static void ValidateExceptionStackTrace()
+    {
+        try
+        {
+            ThrowForStackTrace();
+        }
+        catch (Exception ex)
+        {
+            int frameCount = 0;
+            foreach (string line in ex.StackTrace.Split(Environment.NewLine))
+            {
+                if (line.Contains($"{nameof(Program)}.{nameof(ThrowForStackTrace)}(", StringComparison.Ordinal))
+                {
+                    frameCount++;
+                }
+            }
+
+            Assert.Equal(1, frameCount);
+        }
     }
 
     public void Start()

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.cs
@@ -132,8 +132,12 @@ public class Program : ProgramBase<InputData>, TestItf2<InputData>
         }
         catch (Exception ex)
         {
+            Assert.NotNull(ex.StackTrace);
+
             int frameCount = 0;
-            foreach (string line in ex.StackTrace.Split(Environment.NewLine))
+            foreach (string line in ex.StackTrace.Split(
+                new string[] { Environment.NewLine },
+                StringSplitOptions.None))
             {
                 if (line.Contains($"{nameof(Program)}.{nameof(ThrowForStackTrace)}(", StringComparison.Ordinal))
                 {


### PR DESCRIPTION
Fixes #133505.

When the portable-entrypoint slow path discovers a ReadyToRun body, it invokes that body while its `PrestubMethodFrame` remains on the explicit frame chain. Wasm stack capture consequently reported the same `MethodDesc` twice: first as the real frameless R2R method and then as the prestub frame.

This change suppresses only that precise duplicate in `GetStackFramesCallback`: a Wasm `PrestubMethodFrame` is omitted when its method matches the immediately preceding collected frame. Genuine prestub-only frames remain visible. It also removes the Wasm R2R exclusion from `github60486` and verifies that exception stack traces retain a single method frame.

Validation:

- Browser-wasm CoreCLR Release libraries / Checked runtime build
- `Loader/classloader/DefaultInterfaceMethods/regressions/github60486` under browser-wasm Checked ReadyToRun: passed
- macOS arm64 Checked CoreCLR build and `github60486`: passed
- Negative control before the fix reproduced adjacent duplicate frames and exited 1

> [!NOTE]
> This pull request was created with GitHub Copilot assistance.

Fixes: #133561