### PR TITLE
JIT: validate RBO relop rewrite operands

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1054,6 +1054,19 @@ bool Compiler::optRedundantDominatingBranch(BasicBlock* const block)
 
             if (newRelopFunc != VNF_NONE)
             {
+                // Rewriting just the relop is only valid if the VN relop is over the
+                // actual tree operands. Liberal VN may look through a materialized
+                // predicate and expose a relop over different operands.
+                //
+                const ValueNum treeOp1VN = vnStore->VNNormalValue(tree->AsOp()->gtOp1->GetVN(VNK_Liberal));
+                const ValueNum treeOp2VN = vnStore->VNNormalValue(tree->AsOp()->gtOp2->GetVN(VNK_Liberal));
+
+                if ((pathApp.GetArg(0) != treeOp1VN) || (pathApp.GetArg(1) != treeOp2VN))
+                {
+                    JITDUMP("; relop operands do not match tree operands, cannot simplify\n");
+                    break;
+                }
+
                 newRelop = vnStore->VNRelopToGenTreeOp(newRelopFunc, &isUnsigned);
 
                 if (newRelop != GT_NONE)

--- a/src/tests/JIT/opt/RedundantBranch/RedundantBranchSimplify.cs
+++ b/src/tests/JIT/opt/RedundantBranch/RedundantBranchSimplify.cs
@@ -64,6 +64,56 @@ public class RedundantBranchSimplify
     [InlineData(101, 2)]
     public static void TestGeLeSwapped(int a, int expected) => Assert.Equal(expected, GeLeSwapped(a));
 
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int MaterializedNeLessThan(int a, int b)
+    {
+        bool c = a != b;
+        if (a > b)
+        {
+            goto Shared;
+        }
+
+        if (c)
+        {
+            return 1;
+        }
+
+    Shared:
+        return 0;
+    }
+
+    [Theory]
+    [InlineData(3, 5, 1)]
+    [InlineData(5, 3, 0)]
+    [InlineData(5, 5, 0)]
+    public static void TestMaterializedNeLessThan(int a, int b, int expected) =>
+        Assert.Equal(expected, MaterializedNeLessThan(a, b));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int MaterializedNeGreaterThan(int a, int b)
+    {
+        bool c = a != b;
+        if (a < b)
+        {
+            goto Shared;
+        }
+
+        if (c)
+        {
+            return 1;
+        }
+
+    Shared:
+        return 0;
+    }
+
+    [Theory]
+    [InlineData(3, 5, 0)]
+    [InlineData(5, 3, 1)]
+    [InlineData(5, 5, 0)]
+    public static void TestMaterializedNeGreaterThan(int a, int b, int expected) =>
+        Assert.Equal(expected, MaterializedNeGreaterThan(a, b));
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static int NeLeUnsigned(uint a, uint b)
     {


### PR DESCRIPTION
Ensure dominating RBO only rewrites the remaining predicate when the VN relop operands match the concrete tree operands.

Add coverage for materialized predicates in both relational directions.

Fixes dotnet/runtime#133558.

Validation:
- `JIT.opt` `RedundantBranchSimplify`: 35 passed
- SuperPMI: no asm diffs in 987,559 Windows x64 Checked contexts; 908 identical misses

> [!NOTE]
> This PR description was generated with GitHub Copilot CLI.