### PR TITLE
Crossgen2: pass the hidden type arg for wasm array Address thunks

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
+++ b/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
@@ -589,7 +589,7 @@ namespace Internal.JitInterface
         public static LoweringFlags GetLoweringFlags(MethodDesc method)
         {
             LoweringFlags flags = 0;
-            if (method.RequiresInstMethodDescArg() || method.RequiresInstMethodTableArg())
+            if (method.RequiresInstMethodDescArg() || method.RequiresInstMethodTableArg() || method.IsArrayAddressMethod())
             {
                 flags |= LoweringFlags.HasGenericContextArg;
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -92,14 +92,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 parameterTypes[parameterIndex] = new TypeHandle(signature[parameterIndex]);
             }
             CallingConventions callingConventions = (hasThis ? CallingConventions.ManagedInstance : CallingConventions.ManagedStatic);
-            bool hasParamType = methodRequiresInstArg && !isUnboxingStub;
-
-            // On X86 the Array address method doesn't use IL stubs, and instead has a custom calling convention
-            if ((context.Target.Architecture == TargetArchitecture.X86) &&
-                methodIsArrayAddressMethod)
-            {
-                hasParamType = true;
-            }
+            bool hasParamType = (methodRequiresInstArg && !isUnboxingStub) || methodIsArrayAddressMethod;
 
             bool hasAsyncContinuation = methodIsAsyncCall;
             // We shouldn't be compiling unboxing stubs for async methods yet.

--- a/src/tests/readytorun/crossgen2/Program.cs
+++ b/src/tests/readytorun/crossgen2/Program.cs
@@ -2272,11 +2272,7 @@ public class Program
         RunTest("ExplicitlySizedClassTest", ExplicitlySizedClassTest());
         RunTest("GenericLdtokenTest", GenericLdtokenTest());
         RunTest("ArrayLdtokenTests", ArrayLdtokenTests());
-        // ActiveIssue https://github.com/dotnet/runtime/issues/133307
-        if (!PlatformDetection.IsWasm || !PlatformDetection.IsReadyToRunCompiled)
-        {
-            RunTest("TestGenericMDArrayBehavior", TestGenericMDArrayBehavior());
-        }
+        RunTest("TestGenericMDArrayBehavior", TestGenericMDArrayBehavior());
         RunTest("TestWithStructureNonBlittableFieldDueToGenerics", TestWithStructureNonBlittableFieldDueToGenerics());
         RunTest("TestSingleElementStructABI", TestSingleElementStructABI());
         RunTest("TestEnumLayoutAlignments", TestEnumLayoutAlignments());


### PR DESCRIPTION
Array address methods need a hidden instantiation argument.

Fixes #133307

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.
