### PR TITLE
Fix TensorPrimitives MinNumber/MaxNumber span reductions propagating NaN (#133346)

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IAggregationOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IAggregationOperator.cs
@@ -19,6 +19,15 @@ namespace System.Numerics.Tensors
             static abstract T Invoke(Vector256<T> x);
             static abstract T Invoke(Vector512<T> x);
 
+            /// <summary>
+            /// Whether the operator propagates NaN inputs to its output, as the IEEE 754:2019
+            /// <c>minimum</c>/<c>maximum</c> (and magnitude) functions do. Operators implementing the
+            /// <c>minimumNumber</c>/<c>maximumNumber</c> family return <see langword="false"/>, so the
+            /// reduction does not early-exit on a NaN and the lane-wise operator gets to ignore it
+            /// when a numeric operand is available.
+            /// </summary>
+            static virtual bool PropagatesNaNs => true;
+
             static virtual T IdentityValue => throw new NotSupportedException();
         }
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Max.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Max.cs
@@ -147,7 +147,7 @@ namespace System.Numerics.Tensors
                 Vector512<T> current;
 
                 Vector512<T> nanMask;
-                if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                if (TMinMaxOperator.PropagatesNaNs && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
                 {
                     // Check for NaNs
                     nanMask = Vector512.IsNaN(result);
@@ -166,7 +166,7 @@ namespace System.Numerics.Tensors
                     // Load the next vector, and early exit on NaN.
                     current = Vector512.LoadUnsafe(ref xRef, (uint)i);
 
-                    if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                    if (TMinMaxOperator.PropagatesNaNs && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
                     {
                         // Check for NaNs
                         nanMask = ~Vector512.Equals(current, current);
@@ -185,7 +185,7 @@ namespace System.Numerics.Tensors
                 {
                     current = Vector512.LoadUnsafe(ref xRef, (uint)(x.Length - Vector512<T>.Count));
 
-                    if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                    if (TMinMaxOperator.PropagatesNaNs && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
                     {
                         // Check for NaNs
                         nanMask = ~Vector512.Equals(current, current);
@@ -212,7 +212,7 @@ namespace System.Numerics.Tensors
                 Vector256<T> current;
 
                 Vector256<T> nanMask;
-                if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                if (TMinMaxOperator.PropagatesNaNs && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
                 {
                     // Check for NaNs
                     nanMask = ~Vector256.Equals(result, result);
@@ -231,7 +231,7 @@ namespace System.Numerics.Tensors
                     // Load the next vector, and early exit on NaN.
                     current = Vector256.LoadUnsafe(ref xRef, (uint)i);
 
-                    if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                    if (TMinMaxOperator.PropagatesNaNs && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
                     {
                         // Check for NaNs
                         nanMask = ~Vector256.Equals(current, current);
@@ -251,7 +251,7 @@ namespace System.Numerics.Tensors
                     current = Vector256.LoadUnsafe(ref xRef, (uint)(x.Length - Vector256<T>.Count));
 
 
-                    if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                    if (TMinMaxOperator.PropagatesNaNs && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
                     {
                         // Check for NaNs
                         nanMask = ~Vector256.Equals(current, current);
@@ -278,7 +278,7 @@ namespace System.Numerics.Tensors
                 Vector128<T> current;
 
                 Vector128<T> nanMask;
-                if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                if (TMinMaxOperator.PropagatesNaNs && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
                 {
                     // Check for NaNs
                     nanMask = Vector128.IsNaN(result);
@@ -297,7 +297,7 @@ namespace System.Numerics.Tensors
                     // Load the next vector, and early exit on NaN.
                     current = Vector128.LoadUnsafe(ref xRef, (uint)i);
 
-                    if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                    if (TMinMaxOperator.PropagatesNaNs && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
                     {
                         // Check for NaNs
                         nanMask = Vector128.IsNaN(current);
@@ -316,7 +316,7 @@ namespace System.Numerics.Tensors
                 {
                     current = Vector128.LoadUnsafe(ref xRef, (uint)(x.Length - Vector128<T>.Count));
 
-                    if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                    if (TMinMaxOperator.PropagatesNaNs && (typeof(T) == typeof(float) || typeof(T) == typeof(double)))
                     {
                         // Check for NaNs
                         nanMask = Vector128.IsNaN(current);
@@ -335,7 +335,7 @@ namespace System.Numerics.Tensors
 
             // Scalar path used when either vectorization is not supported or the input is too small to vectorize.
             T curResult = x[0];
-            if (T.IsNaN(curResult))
+            if (TMinMaxOperator.PropagatesNaNs && T.IsNaN(curResult))
             {
                 return curResult;
             }
@@ -343,7 +343,7 @@ namespace System.Numerics.Tensors
             for (int i = 1; i < x.Length; i++)
             {
                 T current = x[i];
-                if (T.IsNaN(current))
+                if (TMinMaxOperator.PropagatesNaNs && T.IsNaN(current))
                 {
                     return current;
                 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitudeNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxMagnitudeNumber.cs
@@ -105,6 +105,8 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
+            public static bool PropagatesNaNs => false;
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static T Invoke(T x, T y) => T.MaxMagnitudeNumber(x, y);
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MaxNumber.cs
@@ -99,6 +99,8 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
+            public static bool PropagatesNaNs => false;
+
             public static T Invoke(T x, T y) => T.MaxNumber(x, y);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitudeNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinMagnitudeNumber.cs
@@ -105,6 +105,8 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
+            public static bool PropagatesNaNs => false;
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static T Invoke(T x, T y) => T.MinMagnitudeNumber(x, y);
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinNumber.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.MinNumber.cs
@@ -99,6 +99,8 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
 
+            public static bool PropagatesNaNs => false;
+
             public static T Invoke(T x, T y) => T.MinNumber(x, y);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -1772,6 +1772,77 @@ namespace System.Numerics.Tensors.Tests
             });
         }
         #endregion
+
+        #region Number aggregates ignore NaN
+        [Theory]
+        [InlineData(1)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(16)]
+        [InlineData(33)]
+        public void NumberAggregates_IgnoreNaN(int length)
+        {
+            // IEEE 754:2019 minimumNumber/maximumNumber ignore a NaN operand when a numeric one is
+            // available, while minimum/maximum propagate it. The span reductions must match.
+            T nan = T.CreateTruncating(float.NaN);
+            T one = T.One;
+            T two = one + one;
+
+            if (length == 1)
+            {
+                AssertEqualAggregate(nan, TensorPrimitives.MinNumber<T>([nan]));
+                AssertEqualAggregate(nan, TensorPrimitives.MaxNumber<T>([nan]));
+                AssertEqualAggregate(nan, TensorPrimitives.MinMagnitudeNumber<T>([nan]));
+                AssertEqualAggregate(nan, TensorPrimitives.MaxMagnitudeNumber<T>([nan]));
+                AssertEqualAggregate(nan, TensorPrimitives.Min<T>([nan]));
+                AssertEqualAggregate(nan, TensorPrimitives.Max<T>([nan]));
+                return;
+            }
+
+            T[] values = new T[length];
+
+            // NaN at the start, in the middle, and at the end of the span, so both the vectorized
+            // and the scalar tails of the reduction see it.
+            foreach (int nanIndex in new[] { 0, length / 2, length - 1 })
+            {
+                Array.Fill(values, two);
+                values[nanIndex] = nan;
+
+                // A distinct minimum so the reduction is not trivially the fill value.
+                values[(nanIndex + 1) % length] = one;
+
+                // Number variants ignore the NaN and pick the numeric extreme.
+                AssertEqualAggregate(one, TensorPrimitives.MinNumber<T>(values));
+                AssertEqualAggregate(two, TensorPrimitives.MaxNumber<T>(values));
+                AssertEqualAggregate(one, TensorPrimitives.MinMagnitudeNumber<T>(values));
+                AssertEqualAggregate(two, TensorPrimitives.MaxMagnitudeNumber<T>(values));
+
+                // Plain Min/Max still propagate NaN.
+                AssertEqualAggregate(nan, TensorPrimitives.Min<T>(values));
+                AssertEqualAggregate(nan, TensorPrimitives.Max<T>(values));
+                AssertEqualAggregate(nan, TensorPrimitives.MinMagnitude<T>(values));
+                AssertEqualAggregate(nan, TensorPrimitives.MaxMagnitude<T>(values));
+            }
+
+            // Signed zeros follow minimumNumber/maximumNumber: +0 is greater than -0.
+            T[] signedZeros = { -T.Zero, T.Zero };
+            Assert.True(T.IsNegative(TensorPrimitives.MinNumber<T>(signedZeros)));
+            Assert.False(T.IsNegative(TensorPrimitives.MaxNumber<T>(signedZeros)));
+
+            static void AssertEqualAggregate(T expected, T actual)
+            {
+                if (T.IsNaN(expected))
+                {
+                    Assert.True(T.IsNaN(actual), $"expected NaN, got {actual}");
+                }
+                else
+                {
+                    Assert.Equal(expected, actual);
+                }
+            }
+        }
+        #endregion
     }
 
     public unsafe abstract class GenericSignedIntegerTensorPrimitivesTests<T> : GenericIntegerTensorPrimitivesTests<T>

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -1773,74 +1773,84 @@ namespace System.Numerics.Tensors.Tests
         }
         #endregion
 
-        #region Number aggregates ignore NaN
-        [Theory]
-        [InlineData(1)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        [InlineData(16)]
-        [InlineData(33)]
-        public void NumberAggregates_IgnoreNaN(int length)
+        #region Number aggregates
+        [Fact]
+        public void NumberAggregates_AllLengths()
+        {
+            Assert.All(Helpers.TensorLengths, length =>
+            {
+                T[] values = new T[length];
+                for (int i = 0; i < length; i++)
+                {
+                    T value = T.CreateChecked(i + 1);
+                    values[i] = (i & 1) == 0 ? value : -value;
+                }
+
+                T expectedMinNumber = values[0];
+                T expectedMaxNumber = values[0];
+                T expectedMinMagnitudeNumber = values[0];
+                T expectedMaxMagnitudeNumber = values[0];
+
+                for (int i = 1; i < values.Length; i++)
+                {
+                    expectedMinNumber = T.MinNumber(expectedMinNumber, values[i]);
+                    expectedMaxNumber = T.MaxNumber(expectedMaxNumber, values[i]);
+                    expectedMinMagnitudeNumber = T.MinMagnitudeNumber(expectedMinMagnitudeNumber, values[i]);
+                    expectedMaxMagnitudeNumber = T.MaxMagnitudeNumber(expectedMaxMagnitudeNumber, values[i]);
+                }
+
+                Assert.Equal(expectedMinNumber, TensorPrimitives.MinNumber<T>(values));
+                Assert.Equal(expectedMaxNumber, TensorPrimitives.MaxNumber<T>(values));
+                Assert.Equal(expectedMinMagnitudeNumber, TensorPrimitives.MinMagnitudeNumber<T>(values));
+                Assert.Equal(expectedMaxMagnitudeNumber, TensorPrimitives.MaxMagnitudeNumber<T>(values));
+            });
+        }
+
+        [Fact]
+        public void NumberAggregates_IgnoreNaN_AllLengths()
         {
             // IEEE 754:2019 minimumNumber/maximumNumber ignore a NaN operand when a numeric one is
-            // available, while minimum/maximum propagate it. The span reductions must match.
+            // available. Exercise every reduction length so scalar, Vector128, Vector256, Vector512,
+            // and scalar-tail paths are covered where supported.
             T nan = T.CreateTruncating(float.NaN);
             T one = T.One;
             T two = one + one;
 
-            if (length == 1)
+            Assert.All(Helpers.TensorLengths, length =>
             {
-                AssertEqualAggregate(nan, TensorPrimitives.MinNumber<T>([nan]));
-                AssertEqualAggregate(nan, TensorPrimitives.MaxNumber<T>([nan]));
-                AssertEqualAggregate(nan, TensorPrimitives.MinMagnitudeNumber<T>([nan]));
-                AssertEqualAggregate(nan, TensorPrimitives.MaxMagnitudeNumber<T>([nan]));
-                AssertEqualAggregate(nan, TensorPrimitives.Min<T>([nan]));
-                AssertEqualAggregate(nan, TensorPrimitives.Max<T>([nan]));
-                return;
-            }
+                T[] allNaNs = new T[length];
+                Array.Fill(allNaNs, nan);
 
-            T[] values = new T[length];
+                Assert.Equal(nan, TensorPrimitives.MinNumber<T>(allNaNs));
+                Assert.Equal(nan, TensorPrimitives.MaxNumber<T>(allNaNs));
+                Assert.Equal(nan, TensorPrimitives.MinMagnitudeNumber<T>(allNaNs));
+                Assert.Equal(nan, TensorPrimitives.MaxMagnitudeNumber<T>(allNaNs));
 
-            // NaN at the start, in the middle, and at the end of the span, so both the vectorized
-            // and the scalar tails of the reduction see it.
-            foreach (int nanIndex in new[] { 0, length / 2, length - 1 })
-            {
-                Array.Fill(values, two);
-                values[nanIndex] = nan;
+                if (length == 1)
+                {
+                    return;
+                }
 
-                // A distinct minimum so the reduction is not trivially the fill value.
-                values[(nanIndex + 1) % length] = one;
+                T[] values = new T[length];
+                T expectedMaximum = length > 2 ? two : one;
 
-                // Number variants ignore the NaN and pick the numeric extreme.
-                AssertEqualAggregate(one, TensorPrimitives.MinNumber<T>(values));
-                AssertEqualAggregate(two, TensorPrimitives.MaxNumber<T>(values));
-                AssertEqualAggregate(one, TensorPrimitives.MinMagnitudeNumber<T>(values));
-                AssertEqualAggregate(two, TensorPrimitives.MaxMagnitudeNumber<T>(values));
+                foreach (int nanIndex in new[] { 0, length / 2, length - 1 })
+                {
+                    Array.Fill(values, two);
+                    values[nanIndex] = nan;
+                    values[(nanIndex + 1) % length] = one;
 
-                // Plain Min/Max still propagate NaN.
-                AssertEqualAggregate(nan, TensorPrimitives.Min<T>(values));
-                AssertEqualAggregate(nan, TensorPrimitives.Max<T>(values));
-                AssertEqualAggregate(nan, TensorPrimitives.MinMagnitude<T>(values));
-                AssertEqualAggregate(nan, TensorPrimitives.MaxMagnitude<T>(values));
-            }
+                    Assert.Equal(one, TensorPrimitives.MinNumber<T>(values));
+                    Assert.Equal(expectedMaximum, TensorPrimitives.MaxNumber<T>(values));
+                    Assert.Equal(one, TensorPrimitives.MinMagnitudeNumber<T>(values));
+                    Assert.Equal(expectedMaximum, TensorPrimitives.MaxMagnitudeNumber<T>(values));
+                }
+            });
 
             // Signed zeros follow minimumNumber/maximumNumber: +0 is greater than -0.
             T[] signedZeros = { -T.Zero, T.Zero };
             Assert.True(T.IsNegative(TensorPrimitives.MinNumber<T>(signedZeros)));
             Assert.False(T.IsNegative(TensorPrimitives.MaxNumber<T>(signedZeros)));
-
-            static void AssertEqualAggregate(T expected, T actual)
-            {
-                if (T.IsNaN(expected))
-                {
-                    Assert.True(T.IsNaN(actual), $"expected NaN, got {actual}");
-                }
-                else
-                {
-                    Assert.Equal(expected, actual);
-                }
-            }
         }
         #endregion
     }


### PR DESCRIPTION
### Summary

Fixes #133346

`TensorPrimitives.MinNumber(ReadOnlySpan<T>)` (and `MaxNumber`, `MinMagnitudeNumber`, `MaxMagnitudeNumber`) returned `NaN` as soon as the reduction encountered a `NaN`, while the scalar `T.MinNumber`/`T.MaxNumber` semantics ignore a NaN operand when a numeric one is available (IEEE 754:2019 `minimumNumber`/`maximumNumber`).

The span reductions share `MinMaxCore<T, TMinMaxOperator>` with the plain Min/Max/Magnitude reductions, and that core early-exits on the first NaN at every vector width and in its scalar tail. The early exit is correct for `minimum`/`maximum` (which propagate NaN), but wrong for the `*Number` family.

### Changes

- `IAggregationOperator<T>` gains `static virtual bool PropagatesNaNs => true`.
- The four `*NumberOperator<T>` structs override it with `false`.
- `MinMaxCore` gates its NaN early-exits on `TMinMaxOperator.PropagatesNaNs` (Vector512/256/128 paths plus the scalar tail), so `*Number` reductions proceed and the lane-wise `*Number` operator ignores the NaN, while plain Min/Max/Magnitude behavior is unchanged.
- Regression tests `NumberAggregates_AllLengths` and `NumberAggregates_IgnoreNaN_AllLengths` in `TensorPrimitives.Generic.cs`: all four `*Number` reductions run across every configured `Helpers.TensorLengths` value; the NaN suite covers all-NaN spans plus NaN at the start/middle/end, and retains signed-zero checks.

### Validation

Reproduced on the released .NET 10 SDK (10.0.401): `TensorPrimitives.MinNumber<float>([1f, NaN, 2f])` returned `NaN`, and the same for `MaxNumber`, `MinMagnitudeNumber`, `MaxMagnitudeNumber`.

The fixed sources were compiled with the SDK (all `src/System.Numerics.Tensors` netcore sources) and verified against a 25-case matrix:

- Before the fix (same harness against the unmodified sources): `MinNumber(float) [1, NaN, 2]` FAILED with `got NaN, expected 1`.
- After the fix: all 25 cases pass - `MinNumber`/`MaxNumber`/`MinMagnitudeNumber`/`MaxMagnitudeNumber` ignore NaN (float, double, Half; NaN first/middle/last; vector-sized and scalar inputs), all-NaN inputs still return NaN, `-0` vs `+0` ordering preserved, and plain `Min`/`Max`/`MinMagnitude`/`MaxMagnitude` still propagate NaN.

The full upstream runtime matrix ran on the current head. Its remaining red statuses are unrelated to this change: one macOS job exceeded the 120-minute limit and Helix reported three `System.Net.Sockets.Tests` work-item failures; the other displayed runtime matrix jobs passed. The regression tests follow existing conventions in `TensorPrimitives.Generic.cs` and run on all four floating-point instantiations.

The .NET Foundation CLA check passes for `jabrailkhalil`.
