### PR TITLE
[PERF] Fix Helix monitor credentials in the runtime performance pipeline

### DIFF
--- a/eng/pipelines/performance/perf.yml
+++ b/eng/pipelines/performance/perf.yml
@@ -54,6 +54,10 @@ extends:
   parameters:
     stages:
     - stage: Build
+      variables:
+      # The standalone monitor does not inherit the submitter jobs' variable groups.
+      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+        - group: DotNet-HelixApi-Access
       jobs:
 
       - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:


### PR DESCRIPTION
## Summary

Fix the regression introduced by **dotnet/runtime#132807 (Enable Helix job monitor for runtime perf)** by making `DotNet-HelixApi-Access` available at the `Build` stage scope in `eng/pipelines/performance/perf.yml` for internal, non-PR runs.

The standalone monitor now inherits the credential needed to discover private Helix jobs. The change is limited to the variable-group import; it leaves the SDK, asynchronous submission, and existing monitor options unchanged.

## Regression

The original PR intentionally made `Send job to Helix` return after submission and delegated completion tracking to `Monitor Helix Jobs`. However, the Helix credential group was imported only inside the individual build/submission jobs. The new sibling monitor did not inherit it, leaving its `$(HelixApiAccessToken)` reference unresolved.

Helix returns an empty successful discovery response without valid authentication. Combined with `allowNoHelixJobs: true`, this allowed the pipeline to succeed while submitted performance work was still queued.

The transition is visible between [20260908.2, before the original PR](https://dev.azure.com/dnceng/internal/_build/results?buildId=3069568&view=logs) and [20260908.3, at its merge commit](https://dev.azure.com/dnceng/internal/_build/results?buildId=3069775&view=logs). Both had the same runtime Arcade SDK pin, so the later SDK update was not the trigger.

## Before / after

**Before:** [Monitor log from 20260909.9](https://dev.azure.com/dnceng/internal/_build/results?buildId=3071091&view=logs&j=078edc60-2a90-5618-e72d-426a045b11f0&t=0ca3371c-1de8-59d8-daef-35ea5811e911) showed an all-zero Helix status throughout the run and finished with:

```text
Jobs:       0 submitted / 0 resubmitted / 0 processed
Work items: 0 submitted / 0 resubmitted / 0 failed
```

**After:** [Internal sanity run 20260910.11 / build 3072330](https://dev.azure.com/dnceng/internal/_build/results?buildId=3072330&view=logs&j=078edc60-2a90-5618-e72d-426a045b11f0&t=0ca3371c-1de8-59d8-daef-35ea5811e911), running this commit with `onlySanityCheck=true`, now shows actual Helix work items and their outcomes in the monitor rather than the all-zero state. For example, the monitor reports `arm64.micro.net11.0.Partition0` from job `40418dd2-e32c-4474-bd8f-e9bf510b7708` and `x86.micro.net11.0.Partition0` from job `4e7b9e80-2a9a-4da8-81a7-731ad8752366`, including their finished state and exit code.

This confirms private-job discovery and outcome reporting. **The run is still in progress at the time of opening this PR; full end-to-end completion is not yet claimed.**

The sampled ARM64/x86 work-item failures are `NETSDK1045` benchmark-generation failures also present in [main build 3072178](https://dev.azure.com/dnceng/internal/_build/results?buildId=3072178). Two iOS setup jobs encountered a `CertHelper` NuGet restore failure also present in [main build 3072012](https://dev.azure.com/dnceng/internal/_build/results?buildId=3072012). These are separate from the credential-scope fix; the repaired monitor is now surfacing real work-item failures that were previously missed.

## Validation

- Parsed the YAML and checked that the only structural difference is the guarded stage-level variable-group import.
- `git diff --check`.
- Queued internal definition 702 on commit `e6f8fbe40248c99b6ae62ebeef27ff40552d5bea` with `onlySanityCheck=true`; monitoring remains in progress as described above.

> [!NOTE]
> This PR description and fix were generated with GitHub Copilot.