### PR TITLE
[PERF] Update main performance pipeline triggers

### DIFF
--- a/eng/pipelines/performance/perf-build.yml
+++ b/eng/pipelines/performance/perf-build.yml
@@ -72,8 +72,6 @@ trigger:
   branches:
     include:
     - main
-    - release/9.0
-    - release/8.0
   paths:
     include:
     - '*'

--- a/eng/pipelines/performance/perf-slow.yml
+++ b/eng/pipelines/performance/perf-slow.yml
@@ -14,8 +14,6 @@ trigger:
   branches:
     include:
     - main
-    - release/9.0
-    - release/8.0
   paths:
     include:
     - '*'

--- a/eng/pipelines/performance/perf.yml
+++ b/eng/pipelines/performance/perf.yml
@@ -8,9 +8,7 @@ trigger:
   branches:
     include:
     - main
-    - release/10.0
-    - release/9.0
-    - release/8.0
+    - release/*.0
   paths:
     include:
     - '*'


### PR DESCRIPTION
Use release/*.0 for perf.yml per https://github.com/dotnet/runtime/issues/133428#issuecomment-5600596128, and limit perf-build.yml and perf-slow.yml CI triggers to main. This should make it so we don't need to make release branch specific changes going forward.