### PR TITLE
[browser][coreclr] Add LibraryTestsCoreCLR_EAT library test leg

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1281,6 +1281,18 @@ extends:
             - WasmTestOnFirefox
             - WasmTestOnV8
 
+      # WebAssembly CoreCLR - EAT (EnableAggressiveTrimming) library tests - only run on linux
+      - template: /eng/pipelines/common/templates/wasm-coreclr-library-tests.yml
+        parameters:
+          platforms:
+            - browser_wasm
+          nameSuffix: _EAT
+          alwaysRun: ${{ variables.isRollingBuild }}
+          extraBuildArgs: /p:EnableAggressiveTrimming=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+          useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+          scenarios:
+            - WasmTestOnChrome
+
       # EAT Library tests - only run on linux
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
         parameters:


### PR DESCRIPTION
Adds a browser-wasm CoreCLR counterpart to the Mono `LibraryTests_EAT` leg, so the CoreCLR library tests also get exercised in the aggressive-trimming configuration once trimming is re-enabled for browser tests.

The new leg reuses the existing `wasm-coreclr-library-tests.yml` template with `nameSuffix: _EAT` and `/p:EnableAggressiveTrimming=true`, producing `LibraryTestsCoreCLR_EAT` on `browser_wasm` / Chrome, full suite, rolling `alwaysRun`, same 240 min timeout. I did not add a CoreCLR variant of `wasm-library-aot-tests.yml`, since the wrapper only exists to pass the Mono AOT knobs (`RunAOTCompilation`, `BuildAOTTestsOnHelix`) and browser-CoreCLR has no AOT path.

Two deliberate deltas from the Mono leg:

- No `/p:NeedsToBuildWasmAppsOnHelix=true` Helix argument. It only provisions EMSDK and bumps the work item timeout to 1h, and nothing is built on Helix here.
- Keeps the CoreCLR template's `/maxcpucount:1` instead of Mono's `/maxcpucount:2` override, matching the sibling `LibraryTestsCoreCLR` legs.

Worth flagging for review: `eng/testing/tests.browser.targets` currently forces `PublishTrimmed=false` for browser tests and only re-enables it for `RunAOTCompilation` / `PublishReadyToRun` / `TestTrimming` (WASM-TODO, #133193), and the `EnableAggressiveTrimming` `ProjectExclusions` group in `src/libraries/tests.proj` is empty. So until #133193 lands this leg does not actually run ILLink and largely duplicates `LibraryTestsCoreCLR`. That is exactly the state Mono's `LibraryTests_EAT` is in today, so this is faithful parity, but it does cost another CoreCLR wasm job. Opening as draft for that reason - happy to hold it until #133193, or to add `/p:PublishTrimmed=true` if we want the leg to trim now and surface CoreCLR trim failures early.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.