### PR TITLE
[NativeAOT] Emit managed thread-static storage layouts in Unix DWARF

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -584,6 +584,8 @@ namespace ILCompiler
             List<DataFieldDescriptor> nonGcStaticFields = new List<DataFieldDescriptor>();
             List<DataFieldDescriptor> gcStaticFields = new List<DataFieldDescriptor>();
             List<DataFieldDescriptor> threadStaticFields = new List<DataFieldDescriptor>();
+            // Unix static declarations discard the field offset, so preserve it for the thread-static storage layout.
+            List<DataFieldDescriptor> threadStaticStorageFields = new List<DataFieldDescriptor>();
             List<StaticDataFieldDescriptor> staticsDescs = new List<StaticDataFieldDescriptor>();
 
             Utf8String nonGcStaticDataName = NodeFactory.NameMangler.NodeMangler.NonGCStatics(type);
@@ -676,6 +678,9 @@ namespace ILCompiler
                 {
                     if (NodeFactory.Target.OperatingSystem != TargetOS.Windows)
                     {
+                        if (fieldDesc.IsThreadStatic)
+                            threadStaticStorageFields.Add(field);
+
                         StaticDataFieldDescriptor staticDesc = new StaticDataFieldDescriptor
                         {
                             StaticOffset = (ulong)fieldOffsetEmit
@@ -695,6 +700,8 @@ namespace ILCompiler
                             staticDesc.IsStaticDataInObject = 0;
                         }
 
+                        // The DWARF writer pairs static declarations and locations by index.
+                        fieldsDescs.Add(field);
                         staticsDescs.Add(staticDesc);
                     }
 
@@ -719,9 +726,7 @@ namespace ILCompiler
             }
             else
             {
-                fieldsDescs.AddRange(nonGcStaticFields);
-                fieldsDescs.AddRange(gcStaticFields);
-                fieldsDescs.AddRange(threadStaticFields);
+                EmitThreadStaticFieldRegionType(defType, threadStaticStorageFields);
             }
 
             DataFieldDescriptor[] fields = new DataFieldDescriptor[fieldsDescs.Count];
@@ -842,6 +847,39 @@ namespace ILCompiler
 
                 fieldDescs.Add(staticRegionField);
             }
+        }
+
+        private void EmitThreadStaticFieldRegionType(
+            DefType defType,
+            List<DataFieldDescriptor> staticFields)
+        {
+            if (staticFields.Count == 0)
+                return;
+
+            LayoutInt regionSize = defType.ThreadGcStaticFieldSize;
+            ulong emittedRegionSize = regionSize.IsIndeterminate ? 0 : (ulong)regionSize.AsInt;
+
+            ClassFieldsTypeDescriptor fieldsDescriptor = new ClassFieldsTypeDescriptor
+            {
+                Size = emittedRegionSize,
+                FieldsCount = staticFields.Count
+            };
+
+            ClassTypeDescriptor classTypeDescriptor = new ClassTypeDescriptor
+            {
+                IsStruct = 0,
+                Name = Utf8String.Concat(
+                    "__type"u8,
+                    NodeFactory.NameMangler.NodeMangler.ThreadStatics(defType).AsSpan()),
+                BaseClassId = GetTypeIndex(defType.Context.GetWellKnownType(WellKnownType.Object), true),
+                InstanceSize = emittedRegionSize
+            };
+
+            _objectWriter.GetCompleteClassTypeIndex(
+                classTypeDescriptor,
+                fieldsDescriptor,
+                staticFields.ToArray(),
+                null);
         }
 
         private uint GetPrimitiveTypeIndex(TypeDesc type)


### PR DESCRIPTION
## Description

Emit a synthetic DWARF type describing the storage layout of NativeAOT
managed thread-static fields on Unix.

The synthetic type is named from the existing thread-static storage naming
convention:

```text
__type<ThreadStatics(type)>
```

Each managed thread-static field is emitted as an instance field with its
storage-relative offset. This is analogous to the thread-static storage type
already emitted into NativeAOT PDBs on Windows.

A diagnostic reader can:

1. Resolve the existing `__TypeThreadStaticIndex<type>` symbol.
2. Traverse NativeAOT's managed storage for the requested thread.
3. Read the field offset from the synthetic DWARF type.

## Before / after example

The following Linux x64 excerpts show `AsyncDispatcherInfo.t_current` from
locally inspected ELF/DWARF images. The names and layout offsets are shown
as emitted; build-specific addresses, numeric DIE references, and unrelated
members are omitted.

### Before

The ELF symbol table already contains the per-type thread-static index:

```text
__TypeThreadStaticIndexS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo
```

The managed type's DWARF contains the static field declaration, but no
storage-relative `DW_AT_data_member_location` for that field:

```text
DW_TAG_class_type
  DW_AT_name ("S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo")
  DW_AT_byte_size (0x00000048)

  DW_TAG_member
    DW_AT_name ("t_current")
    DW_AT_type ("S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo *")
    DW_AT_external (true)
    DW_AT_declaration (true)
```

There is no
`__type__THREADSTATICSS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo`
storage-layout type.

### After

The same ELF index-symbol name and original field declaration are retained.
The following **additional DWARF type** describes the thread-static storage
layout:

```text
DW_TAG_class_type
  DW_AT_name ("__type__THREADSTATICSS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo")
  DW_AT_byte_size (0x00000010)

  DW_TAG_inheritance
    DW_AT_type ("Object")
    DW_AT_data_member_location (0x00)

  DW_TAG_member
    DW_AT_name ("t_current")
    DW_AT_type ("S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo *")
    DW_AT_data_member_location (0x00000008)
```

The new type describes a 16-byte storage layout, with `t_current` at offset
8 after the object header. It is not the layout of an `AsyncDispatcherInfo`
instance. Once a diagnostic reader locates the type's storage for a selected
thread, the field slot is at `threadStaticStorage + 0x8`.

This adds a debug type, **not a new ELF data symbol or runtime allocation**.
In this inspected example, the per-type `__THREADSTATICS...` data symbol is
absent, so there is no separate variable-location definition for `t_current`.
Where the existing pipeline does emit `DW_TAG_variable` / `DW_AT_location`
records, those are retained as well.

## Windows comparison

Windows already provides the same two mappings: the per-type index identifies
how to find storage for a selected thread, and a synthetic PDB type describes
the field offsets within that storage.

For the same `AsyncDispatcherInfo` type, the Windows index symbol's linker
name is:

```text
?__THREADSTATICINDEX@S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo@@
```

The debugger presents it as a synthetic static member:

```text
S_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo::__THREADSTATICINDEX
```

The existing Windows emitter gives this index record the following helper
type. These are schematic x64 PDB layouts from the emitter, not literal
debugger output; unrelated details and addresses are omitted:

```text
__ThreadStaticHelper<__type__THREADSTATICSS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo>
  +0x000 TypeManagerSlot : TypeManagerSlot*
  +0x008 ClassIndex      : signed 64-bit integer
```

The helper's type argument is the existing storage-layout type:

```text
__type__THREADSTATICSS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo
  base: Object
  +0x008 t_current : AsyncDispatcherInfo*
```

`NativeAOT.natvis` recognizes `__ThreadStaticHelper<...>`. It uses the index
record and the selected thread's runtime storage, then interprets the storage
using the helper's type argument. The helper is a debug view of the existing
index record, not an additional runtime allocation.

The equivalent Unix index symbol is
`__TypeThreadStaticIndexS_P_CoreLib_System_Runtime_CompilerServices_AsyncDispatcherInfo`.
This PR adds the DWARF counterpart of the **storage-layout type**, but does
not copy the Windows NatVis helper or synthetic static-member convention.
On Unix, a runtime-aware diagnostic reader performs the storage lookup.

## Compatibility and scope

The existing field declarations and static-variable location metadata are
retained for compatibility. This adds storage-layout metadata; it does not
make the legacy `DW_AT_location` expressions thread-aware or change runtime
TLS storage.

Unix static field declarations are also collected alongside their location
descriptors rather than regrouped by storage kind. The DWARF writer associates
these records by index, so both must retain the same order to avoid associating
fields with incorrect storage locations. The existing Windows grouping and
NatVis helper emission remain unchanged.

This builds on the thread-static field-availability correction in #133109,
which is already in `main` and is not part of this diff.

Related to #132237. This supplies independent layout information while
preserving the existing location metadata.

## Validation

- Built the managed compiler with the changed descriptor source.
- Local-only descriptor checks passed 48 cases and 1,437 assertions targeting
  Linux x64, Linux ARM64, and Windows x64.
- Published a Linux x64 NativeAOT smoke application with the reviewed emitter
  source and checked the emitted DWARF for the synthetic storage type, field
  offsets, declaration/location pairing, and retained legacy metadata.
- No new automated tests are included in this PR; the existing `DwarfDump`
  smoke test is unchanged.
- These checks do not establish successful end-to-end SOS `dumpasync`
  rendering.
