### PR TITLE
Track the actual item count in BlockingCollection

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -45,6 +45,7 @@ namespace System.Collections.Concurrent
     public class BlockingCollection<T> : IEnumerable<T>, ICollection, IDisposable, IReadOnlyCollection<T>
     {
         private IProducerConsumerCollection<T> _collection;
+        private int _actualCount;
         private int _boundedCapacity;
         private const int NON_BOUNDED = -1;
         private SemaphoreSlim? _freeNodes;
@@ -92,7 +93,7 @@ namespace System.Collections.Concurrent
             get
             {
                 CheckDisposed();
-                return (IsAddingCompleted && (_occupiedNodes.CurrentCount == 0));
+                return (IsAddingCompleted && (Volatile.Read(ref _actualCount) == 0));
             }
         }
 
@@ -105,7 +106,7 @@ namespace System.Collections.Concurrent
             get
             {
                 CheckDisposed();
-                return _occupiedNodes.CurrentCount;
+                return Volatile.Read(ref _actualCount);
             }
         }
 
@@ -212,6 +213,7 @@ namespace System.Collections.Concurrent
             Debug.Assert(boundedCapacity > 0 || boundedCapacity == NON_BOUNDED);
 
             _collection = collection;
+            _actualCount = collectionCount;
             _boundedCapacity = boundedCapacity;
             _isDisposed = false;
             _consumersCancellationTokenSource = new CancellationTokenSource();
@@ -480,9 +482,12 @@ namespace System.Collections.Concurrent
                 finally
                 {
                     if (addingSucceeded)
+                    {
+                        Interlocked.Increment(ref _actualCount);
                         //After adding an element to the underlying storage, signal to the consumers
                         //waiting on _occupiedNodes that there is a new item added ready to be consumed.
                         _occupiedNodes.Release();
+                    }
                     else
                         //TryAdd did not result in increasing the size of the underlying store and hence we need
                         //to increment back the count of the _freeNodes semaphore.
@@ -706,6 +711,7 @@ namespace System.Collections.Concurrent
                     // removeFaulted implies !removeSucceeded, but the reverse is not true.
                     if (removeSucceeded)
                     {
+                        Interlocked.Decrement(ref _actualCount);
                         if (_freeNodes != null)
                         {
                             Debug.Assert(_boundedCapacity != NON_BOUNDED);

--- a/src/libraries/System.Collections.Concurrent/tests/BlockingCollectionTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/BlockingCollectionTests.cs
@@ -704,6 +704,38 @@ namespace System.Collections.Concurrent.Tests
                 "Test13_IsSynchronized_SyncRoot: > test failed - IsSynchronized should be false");
         }
 
+        /// <summary>
+        /// Validates that BlockingCollection.IsCompleted remains false after cancellation when items are still available.
+        /// </summary>
+        /// <returns>True if test succeeded, false otherwise.</returns>
+        [Fact]
+        public static void Test14_IsCompleted_RemainsFalse_AfterCancellation()
+        {
+            BlockingCollection<int> blockingCollection = ConstructBlockingCollection<int>();
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            blockingCollection.Add(10);
+            blockingCollection.CompleteAdding();
+
+            Assert.False(blockingCollection.IsCompleted);
+
+            Task consumer = Task.Run(() =>
+            {
+                Assert.Throws<OperationCanceledException>(() => blockingCollection.Take(cts.Token));
+            });
+
+            cts.Cancel();
+            consumer.Wait();
+
+            Assert.False(blockingCollection.IsCompleted);
+
+            int item;
+            Assert.True(blockingCollection.TryTake(out item));
+            Assert.Equal(10, item);
+
+            Assert.True(blockingCollection.IsCompleted);
+        }
+
         /// <summary>Initializes an array of blocking collections such that all are full except one in case of Adds and
         /// all are empty except one (the same blocking collection) in case of Takes.
         /// Adds "numOfAdds" elements to the BlockingCollection and then takes "numOfTakes" elements and checks


### PR DESCRIPTION
## Description

`BlockingCollection.IsCompleted` currently uses `_occupiedNodes.CurrentCount` to determine whether the collection is empty.

However, `_occupiedNodes` is also used to synchronize consumer operations. This can cause `IsCompleted` to temporarily report `true` even though the collection still contains an item.

For example:

1. A `BlockingCollection` contains a single item.
2. `CompleteAdding()` is called, so `IsCompleted` is initially `false`.
3. A consumer starts a `Take` operation and successfully waits on `_occupiedNodes`.
4. `_occupiedNodes.CurrentCount` becomes `0`, causing `IsCompleted` to return `true` even though the item has not yet been removed from the collection.
5. The consumer operation is canceled before the item is removed.
6. `_occupiedNodes.CurrentCount` is restored to `1`.
7. `IsCompleted` then returns to `false`.

As a result, `IsCompleted` can transition from `false` to `true` and back to `false` even though the item was never removed from the collection.

## Fix

Introduce a separate `_actualCount` field to track the number of items successfully added to and removed from the collection.

`_actualCount` is initialized from the existing collection count and updated atomically after each successful add or remove operation, specifically in `TryAddWithNoTimeValidation` and `TryTakeWithNoTimeValidation`.

`Count` and `IsCompleted` now use `_actualCount` instead of `_occupiedNodes.CurrentCount`.

This separates the synchronization state of `_occupiedNodes` from the actual item count and prevents consumer cancellation from changing the state reported by `IsCompleted`.

## Tests

Added a regression test that verifies that `IsCompleted` remains `false` when:

* the collection contains a single item,
* `CompleteAdding()` has been called,
* a consumer waits to take the item using a cancellation token,
* the operation is canceled before the item is removed.

The test then removes the remaining item and verifies that `IsCompleted` becomes `true`.

Closes #109217
