### PR TITLE
JIT: Preserve exception order in loop hoisting

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4788,14 +4788,11 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
             //
             if (m_canHoistSideEffects)
             {
-                // Is the value of the whole tree loop invariant?
-                if (!treeIsInvariant)
+                if (!treeIsHoistable)
                 {
-                    // We have a tree that is not loop invariant and we thus cannot hoist
-                    assert(treeIsHoistable == false);
-
                     // Check if we should clear m_canHoistSideEffects.
-                    // If 'tree' can throw an exception then we need to set m_canHoistSideEffects to false.
+                    // If 'tree' cannot be hoisted and can throw an exception then we need to set
+                    // m_canHoistSideEffects to false.
                     // Note that calls are handled below
                     if (tree->OperMayThrow(m_compiler) && !tree->IsCall())
                     {
@@ -4831,11 +4828,8 @@ void Compiler::optHoistLoopBlocks(FlowGraphNaturalLoop* loop,
                         }
 
                         // Additional check for helper calls that throw exceptions
-                        if (!treeIsInvariant)
+                        if (!treeIsHoistable)
                         {
-                            // We have a tree that is not loop invariant and we thus cannot hoist
-                            assert(treeIsHoistable == false);
-
                             // Does this helper call throw?
                             if (!s_helperCallProperties.NoThrow(helpFunc))
                             {

--- a/src/tests/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.cs
@@ -68,6 +68,20 @@ namespace GitHub_7147
             return x == y;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+        static int boundsCheck(int[] array, int index, int dividend, int divisor, int count)
+        {
+            int result = 0;
+
+            for (int i = 0; i < count; i++)
+            {
+                result += array[index];
+                result += dividend / divisor;
+            }
+
+            return result;
+        }
+
         [Fact]
         public static int TestEntryPoint()
         {
@@ -110,6 +124,20 @@ namespace GitHub_7147
             catch (DivideByZeroException)
             {
                 // This is the expected exception
+            }
+
+            try
+            {
+                boundsCheck(new int[1], 5, 1, 0, 5);
+                errors |= 8;
+            }
+            catch (IndexOutOfRangeException)
+            {
+                // This is the expected exception
+            }
+            catch
+            {
+                errors |= 8;
             }
 
             return 100 + errors;


### PR DESCRIPTION
Fixes #133585.

Loop hoisting previously kept its exception-ordering barrier open for an
invariant but non-hoistable throwing expression. This allowed a later throwing
expression to be hoisted ahead of it. Close the barrier whenever a throwing
expression cannot itself be hoisted.

Add coverage to the existing loop-hoisting exception-ordering regression test.

Validation:
- `build.cmd clr.jit -c checked`
- `Regression_o_1`: new case fails with the baseline JIT and passes with the changed JIT
- Windows x64 Checked SuperPMI: 987,559 successful compilations, 0 failures, 42 context diffs across four collections, and effectively neutral aggregate PerfScore geomeans (-0.0000% to +0.0004%)

> [!NOTE]
> This pull request description was generated with GitHub Copilot.