### PR TITLE
Make ordinary FCALL contracts nothrow

### DIFF
--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -745,7 +745,13 @@ FCIMPLEND
 
 extern "C" void QCALLTYPE ThreadNative_SpinWait(INT32 iterations)
 {
-    FCALL_CONTRACT;
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
 
     if (iterations <= 0)
     {

--- a/src/coreclr/vm/fcall.h
+++ b/src/coreclr/vm/fcall.h
@@ -562,13 +562,20 @@ typedef INT32 FC_BOOL_ARG;
 
 #define FC_ACCESS_BOOL(x) ((BYTE)x != 0)
 
-// FCALL contracts come in two forms:
+// FCALL contracts come in three forms:
 //
 // Short form that should be used if the FCALL contract does not have any extras like preconditions, failure injection. Example:
 //
 // FCIMPL0(void, foo)
 // {
 //     FCALL_CONTRACT;
+//     ...
+//
+// Short form for FCALLs that set up a frame before throwing or triggering GC:
+//
+// FCIMPL0(void, foo)
+// {
+//     FCALL_CONTRACT_WITH_FRAME;
 //     ...
 //
 // Long form that should be used otherwise. Example:
@@ -584,19 +591,15 @@ typedef INT32 FC_BOOL_ARG;
 // FCALL_CHECK defines the actual contract conditions required for FCALLs
 //
 #define FCALL_CHECK \
-        THROWS; \
-        DISABLED(GC_TRIGGERS); /* FCALLS with HELPER frames have issues with GC_TRIGGERS */ \
+        NOTHROW; \
+        GC_NOTRIGGER; \
         MODE_COOPERATIVE;
 
-//
-// FCALL_CONTRACT should be the following shortcut:
-//
-// #define FCALL_CONTRACT   CONTRACTL { FCALL_CHECK; } CONTRACTL_END;
-//
-#define FCALL_CONTRACT \
+#define FCALL_CONTRACT CONTRACTL { FCALL_CHECK; } CONTRACTL_END
+
+#define FCALL_CONTRACT_WITH_FRAME \
     STATIC_CONTRACT_THROWS; \
-    /* FCALLS are a special case contract wise, they are "NOTRIGGER, unless you setup a frame" */ \
-    STATIC_CONTRACT_GC_NOTRIGGER; \
+    STATIC_CONTRACT_GC_TRIGGERS; \
     STATIC_CONTRACT_MODE_COOPERATIVE
 
 #endif //__FCall_h__

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -794,7 +794,7 @@ void IL_Throw_Impl(Object* obj, TransitionBlock* transitionBlock)
 EXTERN_C HCIMPL2(void, IL_Throw_Impl,  Object* obj, TransitionBlock* transitionBlock)
 #endif
 {
-    FCALL_CONTRACT;
+    FCALL_CONTRACT_WITH_FRAME;
 
     /* Make no assumptions about the current machine state */
     ResetCurrentContext();
@@ -833,7 +833,7 @@ void IL_Rethrow_Impl(TransitionBlock* transitionBlock)
 EXTERN_C HCIMPL1(void, IL_Rethrow_Impl, TransitionBlock* transitionBlock)
 #endif
 {
-    FCALL_CONTRACT;
+    FCALL_CONTRACT_WITH_FRAME;
 
     Thread *pThread = GetThread();
 
@@ -862,7 +862,7 @@ void IL_ThrowExact_Impl(Object* obj, TransitionBlock* transitionBlock)
 EXTERN_C HCIMPL2(void, IL_ThrowExact_Impl,  Object* obj, TransitionBlock* transitionBlock)
 #endif
 {
-    FCALL_CONTRACT;
+    FCALL_CONTRACT_WITH_FRAME;
 
     /* Make no assumptions about the current machine state */
     ResetCurrentContext();
@@ -895,7 +895,7 @@ HCIMPLEND
 // just pass NULL for the transition block, but the check is left in place for future implementation of R2R stack walking on WASM.
 HCIMPL1(void, IL_Throw, Object* obj)
 {
-    FCALL_CONTRACT;
+    FCALL_CONTRACT_WITH_FRAME;
 
     TransitionBlock block;
     block.m_ReturnAddress = 0;
@@ -907,7 +907,7 @@ HCIMPLEND
 
 HCIMPL0(void, IL_Rethrow)
 {
-    FCALL_CONTRACT;
+    FCALL_CONTRACT_WITH_FRAME;
 
     TransitionBlock block;
     block.m_ReturnAddress = 0;
@@ -919,7 +919,7 @@ HCIMPLEND
 
 HCIMPL1(void, IL_ThrowExact, Object* obj)
 {
-    FCALL_CONTRACT;
+    FCALL_CONTRACT_WITH_FRAME;
     TransitionBlock block;
     block.m_ReturnAddress = 0;
     block.m_StackPointer = callersStackPointer;

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -379,7 +379,7 @@ LPCUTF8 MethodDesc::GetName()
 {
     CONTRACTL
     {
-        if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS; // MethodImpl::FindMethodDesc can throw.
+        NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
     }

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -10684,7 +10684,13 @@ void __stdcall ProfilerUnmanagedToManagedTransitionMD(MethodDesc *pMD,
 
 HCIMPL2(EXTERN_C void, ProfileEnter, UINT_PTR clientData, void * platformSpecificHandle)
 {
-    FCALL_CONTRACT;
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
 
     if (GetThreadNULLOk() == NULL)
     {
@@ -10859,7 +10865,13 @@ HCIMPLEND
 
 HCIMPL2(EXTERN_C void, ProfileLeave, UINT_PTR clientData, void * platformSpecificHandle)
 {
-    FCALL_CONTRACT;
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
 
     GCX_COOP();
 


### PR DESCRIPTION
## Summary

- make `FCALL_CHECK` and ordinary `FCALL_CONTRACT` statically and dynamically `NOTHROW`/`GC_NOTRIGGER`
- add `FCALL_CONTRACT_WITH_FRAME` for FCALLs that explicitly establish a frame before exception dispatch
- use the framed contract for `IL_Throw`, `IL_Rethrow`, and `IL_ThrowExact`, including their WASM wrappers
- correct the stale `MethodDesc::GetName()` contract to `NOTHROW`; the parameterless overload only returns stored names or converts metadata lookup failures to `nullptr`

The FCALL audit found only the three IL exception helpers directly enabling GC or dispatching managed exceptions. This draft is intended to validate the stronger dynamic contract across the full CI matrix.

## Validation

- `build.cmd clr -rc checked`
- Checked-runtime smoke covering throw, rethrow, null throw, runtime handles, arrays, strings, GC, threading, marshaling, and math (exit 100)

Broad local testing was intentionally skipped in favor of the CI matrix.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.