### PR TITLE
Skip LCG Jump-Stub Validation In Rundown Validation Test Under Interpreter Mode

### DIFF
--- a/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
+++ b/src/tests/tracing/eventpipe/rundownvalidation/rundownvalidation.cs
@@ -97,6 +97,7 @@ namespace Tracing.Tests.RundownValidation
 
             if (result != 100 ||
                 !PlatformDetection.IsCoreCLR ||
+                Utilities.IsCoreClrInterpreter ||
                 !RuntimeFeature.IsDynamicCodeCompiled ||
                 !OperatingSystem.IsWindows() ||
                 !PlatformDetection.Is64BitProcess ||


### PR DESCRIPTION
- Skip the JIT-specific LCG jump-stub unload validation when the CoreCLR interpreter is active.
- Continue running the general EventPipe rundown validation in interpreter scenarios.
- Preserve the LCG validation for supported Windows 64-bit Debug and Checked JIT configurations.

The interpreter can create a jump-stub load without releasing the collectible dynamic-method state during the test's collection window. This makes the JIT-specific unload assertion inapplicable rather than indicating missing rundown events.

Fixes #133280

> [!NOTE]
> This pull request description was generated with GitHub Copilot.