### PR TITLE
Use source generator in JSON trimming tests

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Array.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Array.cs
@@ -1,25 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing Array is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing int[] is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(int[]));
-            if (!(TestHelper.AssertCollectionAndSerialize<int[]>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.Int32Array) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(int[]))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Array.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Array.cs
@@ -6,13 +6,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing int[] is trimming safe.
+    /// Tests that source generated metadata for (de)serializing int[] is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.Int32Array) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(int[]), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentDictionary.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentDictionary.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing ConcurrentDictionary<TKey, TValue> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing ConcurrentDictionary<TKey, TValue> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = """{"Key":1}""";
-            object obj = JsonSerializer.Deserialize(json, typeof(ConcurrentDictionary<string, int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<ConcurrentDictionary<string, int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.ConcurrentDictionaryStringInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(ConcurrentDictionary<string, int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentDictionary.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentDictionary.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing ConcurrentDictionary<TKey, TValue> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing ConcurrentDictionary<TKey, TValue> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.ConcurrentDictionaryStringInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("""{"Key":1}""", typeof(ConcurrentDictionary<string, int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentQueue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentQueue.cs
@@ -1,30 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Concurrent;
-using System.Text.Json;
-using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing ConcurrentQueue<T> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing ConcurrentQueue<T> is trimming safe.
     /// </summary>
     internal class Program
     {
-        // NOTE: ConcurrentQueue is only trimming safe because it's used by runtime thread pool. Except on single-threaded runtimes, where public parameterless constructor is trimmed.
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(ConcurrentQueue<int>))]
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(ConcurrentQueue<int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<ConcurrentQueue<int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.ConcurrentQueueInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(ConcurrentQueue<int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentQueue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentQueue.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing ConcurrentQueue<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing ConcurrentQueue<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.ConcurrentQueueInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(ConcurrentQueue<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentStack.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentStack.cs
@@ -1,24 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
-using System.Text.Json;
+using System.Collections.Concurrent;
 using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IEnumerable is trimming safe.
+    /// Tests that source generated metadata for (de)serializing ConcurrentStack<T> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.IEnumerable) ? 100 : -1;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.ConcurrentStackInt32) ? 100 : -1;
         }
     }
 
-    [JsonSerializable(typeof(IEnumerable))]
-    [JsonSerializable(typeof(JsonElement))]
+    [JsonSerializable(typeof(ConcurrentStack<int>))]
     internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentStack.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ConcurrentStack.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing ConcurrentStack<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing ConcurrentStack<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.ConcurrentStackInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(ConcurrentStack<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/DictionaryOfTKeyTValue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/DictionaryOfTKeyTValue.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing Dictionary<TKey, TValue> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing Dictionary<TKey, TValue> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.DictionaryStringInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("""{"Key":1}""", typeof(Dictionary<string, int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/DictionaryOfTKeyTValue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/DictionaryOfTKeyTValue.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing Dictionary<TKey, TValue> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing Dictionary<TKey, TValue> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = """{"Key":1}""";
-            object obj = JsonSerializer.Deserialize(json, typeof(Dictionary<string, int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<Dictionary<string, int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.DictionaryStringInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(Dictionary<string, int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/HashSetOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/HashSetOfT.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing HashSet<T> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing HashSet<T> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(HashSet<int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<HashSet<int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.HashSetInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(HashSet<int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/HashSetOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/HashSetOfT.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing HashSet<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing HashSet<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.HashSetInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(HashSet<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Hashtable.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Hashtable.cs
@@ -8,13 +8,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing Hashtable is trimming safe.
+    /// Tests that source generated metadata for (de)serializing Hashtable is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.Hashtable) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("""{"Key":1}""", typeof(Hashtable), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Hashtable.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Hashtable.cs
@@ -3,24 +3,22 @@
 
 using System.Collections;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing Hashtable is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing Hashtable is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = """{"Key":1}""";
-            object obj = JsonSerializer.Deserialize(json, typeof(Hashtable));
-            if (!(TestHelper.AssertCollectionAndSerialize<Hashtable>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.Hashtable) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(Hashtable))]
+    [JsonSerializable(typeof(JsonElement))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ICollection.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ICollection.cs
@@ -3,24 +3,22 @@
 
 using System.Collections;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing ICollection is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing ICollection is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(ICollection>));
-            if (!(TestHelper.AssertCollectionAndSerialize<ICollection>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.ICollection) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(ICollection))]
+    [JsonSerializable(typeof(JsonElement))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ICollection.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ICollection.cs
@@ -8,13 +8,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing ICollection is trimming safe.
+    /// Tests that source generated metadata for (de)serializing ICollection is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.ICollection) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(ICollection), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ICollectionOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ICollectionOfT.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing ICollection<T> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing ICollection<T> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(ICollection<int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<ICollection<int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.ICollectionInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(ICollection<int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ICollectionOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ICollectionOfT.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing ICollection<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing ICollection<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.ICollectionInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(ICollection<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IDictionary.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IDictionary.cs
@@ -3,24 +3,22 @@
 
 using System.Collections;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing IDictionary is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing IDictionary is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = """{"Key":1}""";
-            object obj = JsonSerializer.Deserialize(json, typeof(IDictionary));
-            if (!(TestHelper.AssertCollectionAndSerialize<IDictionary>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.IDictionary) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(IDictionary))]
+    [JsonSerializable(typeof(JsonElement))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IDictionary.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IDictionary.cs
@@ -8,13 +8,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IDictionary is trimming safe.
+    /// Tests that source generated metadata for (de)serializing IDictionary is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.IDictionary) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("""{"Key":1}""", typeof(IDictionary), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IDictionaryOfTKeyTValue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IDictionaryOfTKeyTValue.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing IDictionary<TKey, TValue> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing IDictionary<TKey, TValue> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = """{"Key":1}""";
-            object obj = JsonSerializer.Deserialize(json, typeof(IDictionary<string, int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<IDictionary<string, int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.IDictionaryStringInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(IDictionary<string, int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IDictionaryOfTKeyTValue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IDictionaryOfTKeyTValue.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IDictionary<TKey, TValue> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing IDictionary<TKey, TValue> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.IDictionaryStringInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("""{"Key":1}""", typeof(IDictionary<string, int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IEnumerable.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IEnumerable.cs
@@ -8,13 +8,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IEnumerable is trimming safe.
+    /// Tests that source generated metadata for (de)serializing IEnumerable is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.IEnumerable) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(IEnumerable), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IEnumerableOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IEnumerableOfT.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IEnumerable<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing IEnumerable<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.IEnumerableInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(IEnumerable<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IEnumerableOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IEnumerableOfT.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing IEnumerable<T> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing IEnumerable<T> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(IEnumerable<int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<IEnumerable<int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.IEnumerableInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(IEnumerable<int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IList.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IList.cs
@@ -8,13 +8,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IList is trimming safe.
+    /// Tests that source generated metadata for (de)serializing IList is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.IList) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(IList), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IList.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IList.cs
@@ -3,24 +3,22 @@
 
 using System.Collections;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing IList is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing IList is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(IList));
-            if (!(TestHelper.AssertCollectionAndSerialize<IList>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.IList) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(IList))]
+    [JsonSerializable(typeof(JsonElement))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IListOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IListOfT.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IList<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing IList<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.IListInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(IList<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IListOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IListOfT.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing IList<T> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing IList<T> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(IList<int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<IList<int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.IListInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(IList<int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IReadOnlyDictionaryOfTKeyTValue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IReadOnlyDictionaryOfTKeyTValue.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IReadOnlyDictionary<TKey, TValue> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing IReadOnlyDictionary<TKey, TValue> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.IReadOnlyDictionaryStringInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("""{"Key":1}""", typeof(IReadOnlyDictionary<string, int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IReadOnlyDictionaryOfTKeyTValue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/IReadOnlyDictionaryOfTKeyTValue.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing IReadOnlyDictionary<TKey, TValue> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing IReadOnlyDictionary<TKey, TValue> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = """{"Key":1}""";
-            object obj = JsonSerializer.Deserialize(json, typeof(IReadOnlyDictionary<string, int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<IReadOnlyDictionary<string, int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("""{"Key":1}""", Context.Default.IReadOnlyDictionaryStringInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(IReadOnlyDictionary<string, int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ISetOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ISetOfT.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing ISet<T> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing ISet<T> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(ISet<int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<ISet<int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.ISetInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(ISet<int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ISetOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ISetOfT.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing ISet<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing ISet<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.ISetInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(ISet<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ListOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ListOfT.cs
@@ -2,25 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing List<T> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing List<T> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            string json = "[1]";
-            object obj = JsonSerializer.Deserialize(json, typeof(List<int>));
-            if (!(TestHelper.AssertCollectionAndSerialize<List<int>>(obj, json)))
-            {
-                return -1;
-            }
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.ListInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(List<int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ListOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/ListOfT.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing List<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing List<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.ListInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(List<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Queue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Queue.cs
@@ -8,13 +8,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing Queue is trimming safe.
+    /// Tests that source generated metadata for (de)serializing Queue is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.Queue) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(Queue), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Queue.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Queue.cs
@@ -8,17 +8,17 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IEnumerable is trimming safe.
+    /// Tests that source generated metadata for (de)serializing Queue is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.IEnumerable) ? 100 : -1;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.Queue) ? 100 : -1;
         }
     }
 
-    [JsonSerializable(typeof(IEnumerable))]
+    [JsonSerializable(typeof(Queue))]
     [JsonSerializable(typeof(JsonElement))]
     internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/QueueOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/QueueOfT.cs
@@ -1,24 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
-using System.Text.Json;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IEnumerable is trimming safe.
+    /// Tests that source generated metadata for (de)serializing Queue<T> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.IEnumerable) ? 100 : -1;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.QueueInt32) ? 100 : -1;
         }
     }
 
-    [JsonSerializable(typeof(IEnumerable))]
-    [JsonSerializable(typeof(JsonElement))]
+    [JsonSerializable(typeof(Queue<int>))]
     internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/QueueOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/QueueOfT.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing Queue<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing Queue<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.QueueInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(Queue<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Stack.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Stack.cs
@@ -8,13 +8,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing Stack is trimming safe.
+    /// Tests that source generated metadata for (de)serializing Stack is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.Stack) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(Stack), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Stack.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/Stack.cs
@@ -8,17 +8,17 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing IEnumerable is trimming safe.
+    /// Tests that source generated metadata for (de)serializing Stack is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.IEnumerable) ? 100 : -1;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.Stack) ? 100 : -1;
         }
     }
 
-    [JsonSerializable(typeof(IEnumerable))]
+    [JsonSerializable(typeof(Stack))]
     [JsonSerializable(typeof(JsonElement))]
     internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/StackOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/StackOfT.cs
@@ -7,13 +7,18 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that source generated metadata for (de)serializing Stack<T> is trimming safe.
+    /// Tests that source generated metadata for (de)serializing Stack<T> is trimming-safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            return TestHelper.RoundtripCollection("[1]", Context.Default.StackInt32) ? 100 : -1;
+            if (!TestHelper.RoundtripCollection("[1]", typeof(Stack<int>), Context.Default))
+            {
+                return -1;
+            }
+
+            return 100;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/StackOfT.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Collections/StackOfT.cs
@@ -2,27 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the serializer's warm up routine for (de)serializing Stack<T> is trimming-safe.
+    /// Tests that source generated metadata for (de)serializing Stack<T> is trimming safe.
     /// </summary>
     internal class Program
     {
         static int Main(string[] args)
         {
-            // Test is currently disabled until issue #53393 is addressed.
-
-            //string json = "[1]";
-            //object obj = JsonSerializer.Deserialize(json, typeof(Stack<int>));
-            //if (!(TestHelper.AssertCollectionAndSerialize<Stack<int>>(obj, json)))
-            //{
-            //    return -1;
-            //}
-
-            return 100;
+            return TestHelper.RoundtripCollection("[1]", Context.Default.StackInt32) ? 100 : -1;
         }
     }
+
+    [JsonSerializable(typeof(Stack<int>))]
+    internal partial class Context : JsonSerializerContext;
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Helper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Helper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace SerializerTrimmingTest
 {
@@ -84,9 +85,14 @@ namespace SerializerTrimmingTest
             }
         }
 
-        public static bool AssertCollectionAndSerialize<T>(object obj, string json)
+        /// <summary>
+        /// Deserializes and re-serializes a collection payload using source generated
+        /// metadata, asserting that it round trips unchanged.
+        /// </summary>
+        public static bool RoundtripCollection<T>(string json, JsonTypeInfo<T> typeInfo)
         {
-            return obj is T && JsonSerializer.Serialize(obj) == json;
+            T obj = JsonSerializer.Deserialize(json, typeInfo);
+            return obj != null && JsonSerializer.Serialize(obj, typeInfo) == json;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Helper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/Helper.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
 
 namespace SerializerTrimmingTest
 {
@@ -89,10 +88,10 @@ namespace SerializerTrimmingTest
         /// Deserializes and re-serializes a collection payload using source generated
         /// metadata, asserting that it round trips unchanged.
         /// </summary>
-        public static bool RoundtripCollection<T>(string json, JsonTypeInfo<T> typeInfo)
+        public static bool RoundtripCollection(string json, Type type, JsonSerializerContext context)
         {
-            T obj = JsonSerializer.Deserialize(json, typeInfo);
-            return obj != null && JsonSerializer.Serialize(obj, typeInfo) == json;
+            object obj = JsonSerializer.Deserialize(json, type, context);
+            return obj != null && JsonSerializer.Serialize(obj, type, context) == json;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/ObjectConvertersTest.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/ObjectConvertersTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -8,7 +9,7 @@ using System.Text.Json.Serialization;
 namespace SerializerTrimmingTest
 {
     /// <summary>
-    /// Tests that the object converters are trimming safe when used with source generated metadata.
+    /// Tests that the object converters are trimming-safe when used with source generated metadata.
     /// </summary>
     internal class Program
     {
@@ -19,27 +20,31 @@ namespace SerializerTrimmingTest
             MyClass @class = JsonSerializer.Deserialize(json, Context.Default.MyClass); // ObjectDefaultConverter
             if (!TestHelper.JsonEqual(json, JsonSerializer.Serialize(@class, Context.Default.MyClass)))
             {
+                Console.Error.WriteLine("MyClass did not round trip (ObjectDefaultConverter).");
                 return -1;
             }
 
             MyStruct @struct = JsonSerializer.Deserialize(json, Context.Default.MyStruct); // SmallObjectWithParameterizedConstructorConverter
             if (!TestHelper.JsonEqual(json, JsonSerializer.Serialize(@struct, Context.Default.MyStruct)))
             {
-                return -2;
+                Console.Error.WriteLine("MyStruct did not round trip (SmallObjectWithParameterizedConstructorConverter).");
+                return -1;
             }
 
             json = """{"A":"A","B":"B","C":"C","One":1,"Two":2,"Three":3}""";
             MyBigClass bigClass = JsonSerializer.Deserialize(json, Context.Default.MyBigClass); // LargeObjectWithParameterizedConstructorConverter
             if (!TestHelper.JsonEqual(json, JsonSerializer.Serialize(bigClass, Context.Default.MyBigClass)))
             {
-                return -3;
+                Console.Error.WriteLine("MyBigClass did not round trip (LargeObjectWithParameterizedConstructorConverter).");
+                return -1;
             }
 
             json = """{"Key":1,"Value":2}""";
             KeyValuePair<int, int> kvp = JsonSerializer.Deserialize(json, Context.Default.KeyValuePairInt32Int32); // KeyValuePairConverter
             if (!TestHelper.JsonEqual(json, JsonSerializer.Serialize(kvp, Context.Default.KeyValuePairInt32Int32)))
             {
-                return -4;
+                Console.Error.WriteLine("KeyValuePair<int, int> did not round trip (KeyValuePairConverter).");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/ObjectConvertersTest.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/ObjectConvertersTest.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the object converters are trimming safe when used with source generated metadata.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            string json = """{"X":1,"Y":2}""";
+
+            MyClass @class = JsonSerializer.Deserialize(json, Context.Default.MyClass); // ObjectDefaultConverter
+            if (!TestHelper.JsonEqual(json, JsonSerializer.Serialize(@class, Context.Default.MyClass)))
+            {
+                return -1;
+            }
+
+            MyStruct @struct = JsonSerializer.Deserialize(json, Context.Default.MyStruct); // SmallObjectWithParameterizedConstructorConverter
+            if (!TestHelper.JsonEqual(json, JsonSerializer.Serialize(@struct, Context.Default.MyStruct)))
+            {
+                return -2;
+            }
+
+            json = """{"A":"A","B":"B","C":"C","One":1,"Two":2,"Three":3}""";
+            MyBigClass bigClass = JsonSerializer.Deserialize(json, Context.Default.MyBigClass); // LargeObjectWithParameterizedConstructorConverter
+            if (!TestHelper.JsonEqual(json, JsonSerializer.Serialize(bigClass, Context.Default.MyBigClass)))
+            {
+                return -3;
+            }
+
+            json = """{"Key":1,"Value":2}""";
+            KeyValuePair<int, int> kvp = JsonSerializer.Deserialize(json, Context.Default.KeyValuePairInt32Int32); // KeyValuePairConverter
+            if (!TestHelper.JsonEqual(json, JsonSerializer.Serialize(kvp, Context.Default.KeyValuePairInt32Int32)))
+            {
+                return -4;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(MyClass))]
+    [JsonSerializable(typeof(MyStruct))]
+    [JsonSerializable(typeof(MyBigClass))]
+    [JsonSerializable(typeof(KeyValuePair<int, int>))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromReader.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromReader.BoxedObject.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Deserialize(ref Utf8JsonReader reader, Type returnType,
+    /// JsonSerializerContext context) overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            string json = "[1]";
+            Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(json));
+            int[] arr = (int[])JsonSerializer.Deserialize(ref reader, typeof(int[]), Context.Default);
+            if (arr is not [1])
+            {
+                return -1;
+            }
+
+            json = """{"X":1,"Y":2}""";
+            reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+            var obj = (MyClassWithParameterizedCtor)JsonSerializer.Deserialize(ref reader, typeof(MyClassWithParameterizedCtor), Context.Default);
+            if (obj is not { X: 1, Y: 2 })
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyClassWithParameterizedCtor))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromReader.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromReader.BoxedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -9,7 +10,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Deserialize(ref Utf8JsonReader reader, Type returnType,
-    /// JsonSerializerContext context) overload is trimming safe. A collection and a POCO are used.
+    /// JsonSerializerContext context) overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -20,6 +21,7 @@ namespace SerializerTrimmingTest
             int[] arr = (int[])JsonSerializer.Deserialize(ref reader, typeof(int[]), Context.Default);
             if (arr is not [1])
             {
+                Console.Error.WriteLine("Deserializing int[] returned an unexpected value.");
                 return -1;
             }
 
@@ -28,7 +30,8 @@ namespace SerializerTrimmingTest
             var obj = (MyClassWithParameterizedCtor)JsonSerializer.Deserialize(ref reader, typeof(MyClassWithParameterizedCtor), Context.Default);
             if (obj is not { X: 1, Y: 2 })
             {
-                return -2;
+                Console.Error.WriteLine("Deserializing MyClassWithParameterizedCtor returned an unexpected value.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromReader.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromReader.TypedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -9,7 +10,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Deserialize<T>(ref Utf8JsonReader reader, JsonTypeInfo<T> jsonTypeInfo)
-    /// overload is trimming safe. A collection and a POCO are used.
+    /// overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -20,6 +21,7 @@ namespace SerializerTrimmingTest
             int[] arr = JsonSerializer.Deserialize(ref reader, Context.Default.Int32Array);
             if (arr is not [1])
             {
+                Console.Error.WriteLine("Deserializing int[] returned an unexpected value.");
                 return -1;
             }
 
@@ -28,7 +30,8 @@ namespace SerializerTrimmingTest
             MyClassWithParameterizedCtor obj = JsonSerializer.Deserialize(ref reader, Context.Default.MyClassWithParameterizedCtor);
             if (obj is not { X: 1, Y: 2 })
             {
-                return -2;
+                Console.Error.WriteLine("Deserializing MyClassWithParameterizedCtor returned an unexpected value.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromReader.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromReader.TypedObject.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Deserialize<T>(ref Utf8JsonReader reader, JsonTypeInfo<T> jsonTypeInfo)
+    /// overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            string json = "[1]";
+            Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(json));
+            int[] arr = JsonSerializer.Deserialize(ref reader, Context.Default.Int32Array);
+            if (arr is not [1])
+            {
+                return -1;
+            }
+
+            json = """{"X":1,"Y":2}""";
+            reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+            MyClassWithParameterizedCtor obj = JsonSerializer.Deserialize(ref reader, Context.Default.MyClassWithParameterizedCtor);
+            if (obj is not { X: 1, Y: 2 })
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyClassWithParameterizedCtor))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromSpan.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromSpan.BoxedObject.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType,
+    /// JsonSerializerContext context) overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            string json = "[1]";
+            int[] arr = (int[])JsonSerializer.Deserialize(Encoding.UTF8.GetBytes(json), typeof(int[]), Context.Default);
+            if (arr is not [1])
+            {
+                return -1;
+            }
+
+            json = """{"X":1,"Y":2}""";
+            var obj = (MyClassWithParameterizedCtor)JsonSerializer.Deserialize(Encoding.UTF8.GetBytes(json), typeof(MyClassWithParameterizedCtor), Context.Default);
+            if (obj is not { X: 1, Y: 2 })
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyClassWithParameterizedCtor))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromSpan.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromSpan.BoxedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -9,7 +10,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType,
-    /// JsonSerializerContext context) overload is trimming safe. A collection and a POCO are used.
+    /// JsonSerializerContext context) overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -19,6 +20,7 @@ namespace SerializerTrimmingTest
             int[] arr = (int[])JsonSerializer.Deserialize(Encoding.UTF8.GetBytes(json), typeof(int[]), Context.Default);
             if (arr is not [1])
             {
+                Console.Error.WriteLine("Deserializing int[] returned an unexpected value.");
                 return -1;
             }
 
@@ -26,7 +28,8 @@ namespace SerializerTrimmingTest
             var obj = (MyClassWithParameterizedCtor)JsonSerializer.Deserialize(Encoding.UTF8.GetBytes(json), typeof(MyClassWithParameterizedCtor), Context.Default);
             if (obj is not { X: 1, Y: 2 })
             {
-                return -2;
+                Console.Error.WriteLine("Deserializing MyClassWithParameterizedCtor returned an unexpected value.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromSpan.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromSpan.TypedObject.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Deserialize<T>(ReadOnlySpan<byte> utf8Json, JsonTypeInfo<T> jsonTypeInfo)
+    /// overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            string json = "[1]";
+            int[] arr = JsonSerializer.Deserialize(Encoding.UTF8.GetBytes(json), Context.Default.Int32Array);
+            if (arr is not [1])
+            {
+                return -1;
+            }
+
+            json = """{"X":1,"Y":2}""";
+            MyClassWithParameterizedCtor obj = JsonSerializer.Deserialize(Encoding.UTF8.GetBytes(json), Context.Default.MyClassWithParameterizedCtor);
+            if (obj is not { X: 1, Y: 2 })
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyClassWithParameterizedCtor))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromSpan.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromSpan.TypedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -9,7 +10,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Deserialize<T>(ReadOnlySpan<byte> utf8Json, JsonTypeInfo<T> jsonTypeInfo)
-    /// overload is trimming safe. A collection and a POCO are used.
+    /// overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -19,6 +20,7 @@ namespace SerializerTrimmingTest
             int[] arr = JsonSerializer.Deserialize(Encoding.UTF8.GetBytes(json), Context.Default.Int32Array);
             if (arr is not [1])
             {
+                Console.Error.WriteLine("Deserializing int[] returned an unexpected value.");
                 return -1;
             }
 
@@ -26,7 +28,8 @@ namespace SerializerTrimmingTest
             MyClassWithParameterizedCtor obj = JsonSerializer.Deserialize(Encoding.UTF8.GetBytes(json), Context.Default.MyClassWithParameterizedCtor);
             if (obj is not { X: 1, Y: 2 })
             {
-                return -2;
+                Console.Error.WriteLine("Deserializing MyClassWithParameterizedCtor returned an unexpected value.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromString.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromString.BoxedObject.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Deserialize(string json, Type returnType, JsonSerializerContext context)
+    /// overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            string json = "[1]";
+            int[] arr = (int[])JsonSerializer.Deserialize(json, typeof(int[]), Context.Default);
+            if (arr is not [1])
+            {
+                return -1;
+            }
+
+            json = """{"X":1,"Y":2}""";
+            var obj = (MyClassWithParameterizedCtor)JsonSerializer.Deserialize(json, typeof(MyClassWithParameterizedCtor), Context.Default);
+            if (obj is not { X: 1, Y: 2 })
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyClassWithParameterizedCtor))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromString.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromString.BoxedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -8,7 +9,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Deserialize(string json, Type returnType, JsonSerializerContext context)
-    /// overload is trimming safe. A collection and a POCO are used.
+    /// overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -18,6 +19,7 @@ namespace SerializerTrimmingTest
             int[] arr = (int[])JsonSerializer.Deserialize(json, typeof(int[]), Context.Default);
             if (arr is not [1])
             {
+                Console.Error.WriteLine("Deserializing int[] returned an unexpected value.");
                 return -1;
             }
 
@@ -25,7 +27,8 @@ namespace SerializerTrimmingTest
             var obj = (MyClassWithParameterizedCtor)JsonSerializer.Deserialize(json, typeof(MyClassWithParameterizedCtor), Context.Default);
             if (obj is not { X: 1, Y: 2 })
             {
-                return -2;
+                Console.Error.WriteLine("Deserializing MyClassWithParameterizedCtor returned an unexpected value.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromString.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromString.TypedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -8,7 +9,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Deserialize<T>(string json, JsonTypeInfo<T> jsonTypeInfo)
-    /// overload is trimming safe. A collection and a POCO are used.
+    /// overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -18,6 +19,7 @@ namespace SerializerTrimmingTest
             int[] arr = JsonSerializer.Deserialize(json, Context.Default.Int32Array);
             if (arr is not [1])
             {
+                Console.Error.WriteLine("Deserializing int[] returned an unexpected value.");
                 return -1;
             }
 
@@ -25,7 +27,8 @@ namespace SerializerTrimmingTest
             MyClassWithParameterizedCtor obj = JsonSerializer.Deserialize(json, Context.Default.MyClassWithParameterizedCtor);
             if (obj is not { X: 1, Y: 2 })
             {
-                return -2;
+                Console.Error.WriteLine("Deserializing MyClassWithParameterizedCtor returned an unexpected value.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromString.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Deserialize.FromString.TypedObject.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Deserialize<T>(string json, JsonTypeInfo<T> jsonTypeInfo)
+    /// overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            string json = "[1]";
+            int[] arr = JsonSerializer.Deserialize(json, Context.Default.Int32Array);
+            if (arr is not [1])
+            {
+                return -1;
+            }
+
+            json = """{"X":1,"Y":2}""";
+            MyClassWithParameterizedCtor obj = JsonSerializer.Deserialize(json, Context.Default.MyClassWithParameterizedCtor);
+            if (obj is not { X: 1, Y: 2 })
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyClassWithParameterizedCtor))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/DeserializeAsync.FromStream.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/DeserializeAsync.FromStream.BoxedObject.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.DeserializeAsync(Stream utf8Json, Type returnType,
+    /// JsonSerializerContext context, CancellationToken cancellationToken) overload is trimming safe.
+    /// A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static async Task<int> Main(string[] args)
+        {
+            string json = "[1]";
+            using (MemoryStream stream = new(Encoding.UTF8.GetBytes(json)))
+            {
+                int[] arr = (int[])await JsonSerializer.DeserializeAsync(stream, typeof(int[]), Context.Default);
+                if (arr is not [1])
+                {
+                    return -1;
+                }
+            }
+
+            json = """{"X":1,"Y":2}""";
+            using (MemoryStream stream = new(Encoding.UTF8.GetBytes(json)))
+            {
+                var obj = (MyClassWithParameterizedCtor)await JsonSerializer.DeserializeAsync(stream, typeof(MyClassWithParameterizedCtor), Context.Default);
+                if (obj is not { X: 1, Y: 2 })
+                {
+                    return -2;
+                }
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyClassWithParameterizedCtor))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/DeserializeAsync.FromStream.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/DeserializeAsync.FromStream.BoxedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -11,7 +12,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.DeserializeAsync(Stream utf8Json, Type returnType,
-    /// JsonSerializerContext context, CancellationToken cancellationToken) overload is trimming safe.
+    /// JsonSerializerContext context, CancellationToken cancellationToken) overload is trimming-safe.
     /// A collection and a POCO are used.
     /// </summary>
     internal class Program
@@ -24,6 +25,7 @@ namespace SerializerTrimmingTest
                 int[] arr = (int[])await JsonSerializer.DeserializeAsync(stream, typeof(int[]), Context.Default);
                 if (arr is not [1])
                 {
+                    Console.Error.WriteLine("Deserializing int[] returned an unexpected value.");
                     return -1;
                 }
             }
@@ -34,7 +36,8 @@ namespace SerializerTrimmingTest
                 var obj = (MyClassWithParameterizedCtor)await JsonSerializer.DeserializeAsync(stream, typeof(MyClassWithParameterizedCtor), Context.Default);
                 if (obj is not { X: 1, Y: 2 })
                 {
-                    return -2;
+                    Console.Error.WriteLine("Deserializing MyClassWithParameterizedCtor returned an unexpected value.");
+                    return -1;
                 }
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/DeserializeAsync.FromStream.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/DeserializeAsync.FromStream.TypedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -11,7 +12,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.DeserializeAsync<T>(Stream utf8Json, JsonTypeInfo<T> jsonTypeInfo,
-    /// CancellationToken cancellationToken) overload is trimming safe. A collection and a POCO are used.
+    /// CancellationToken cancellationToken) overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -23,6 +24,7 @@ namespace SerializerTrimmingTest
                 int[] arr = await JsonSerializer.DeserializeAsync(stream, Context.Default.Int32Array);
                 if (arr is not [1])
                 {
+                    Console.Error.WriteLine("Deserializing int[] returned an unexpected value.");
                     return -1;
                 }
             }
@@ -33,7 +35,8 @@ namespace SerializerTrimmingTest
                 MyClassWithParameterizedCtor obj = await JsonSerializer.DeserializeAsync(stream, Context.Default.MyClassWithParameterizedCtor);
                 if (obj is not { X: 1, Y: 2 })
                 {
-                    return -2;
+                    Console.Error.WriteLine("Deserializing MyClassWithParameterizedCtor returned an unexpected value.");
+                    return -1;
                 }
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/DeserializeAsync.FromStream.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/DeserializeAsync.FromStream.TypedObject.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.DeserializeAsync<T>(Stream utf8Json, JsonTypeInfo<T> jsonTypeInfo,
+    /// CancellationToken cancellationToken) overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static async Task<int> Main(string[] args)
+        {
+            string json = "[1]";
+            using (MemoryStream stream = new(Encoding.UTF8.GetBytes(json)))
+            {
+                int[] arr = await JsonSerializer.DeserializeAsync(stream, Context.Default.Int32Array);
+                if (arr is not [1])
+                {
+                    return -1;
+                }
+            }
+
+            json = """{"X":1,"Y":2}""";
+            using (MemoryStream stream = new(Encoding.UTF8.GetBytes(json)))
+            {
+                MyClassWithParameterizedCtor obj = await JsonSerializer.DeserializeAsync(stream, Context.Default.MyClassWithParameterizedCtor);
+                if (obj is not { X: 1, Y: 2 })
+                {
+                    return -2;
+                }
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyClassWithParameterizedCtor))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToByteArray.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToByteArray.BoxedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -9,7 +10,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.SerializeToUtf8Bytes(object value, Type inputType,
-    /// JsonSerializerContext context) overload is trimming safe. A collection and a POCO are used.
+    /// JsonSerializerContext context) overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -19,6 +20,7 @@ namespace SerializerTrimmingTest
             string actual = Encoding.UTF8.GetString(JsonSerializer.SerializeToUtf8Bytes(arr, typeof(int[]), Context.Default));
             if (actual != "[1]")
             {
+                Console.Error.WriteLine("Serializing int[] produced unexpected JSON.");
                 return -1;
             }
 
@@ -26,7 +28,8 @@ namespace SerializerTrimmingTest
             actual = Encoding.UTF8.GetString(JsonSerializer.SerializeToUtf8Bytes(obj, typeof(MyStruct), Context.Default));
             if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
             {
-                return -2;
+                Console.Error.WriteLine("Serializing MyStruct produced unexpected JSON.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToByteArray.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToByteArray.BoxedObject.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.SerializeToUtf8Bytes(object value, Type inputType,
+    /// JsonSerializerContext context) overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            int[] arr = [1];
+            string actual = Encoding.UTF8.GetString(JsonSerializer.SerializeToUtf8Bytes(arr, typeof(int[]), Context.Default));
+            if (actual != "[1]")
+            {
+                return -1;
+            }
+
+            MyStruct obj = default;
+            actual = Encoding.UTF8.GetString(JsonSerializer.SerializeToUtf8Bytes(obj, typeof(MyStruct), Context.Default));
+            if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyStruct))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToByteArray.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToByteArray.TypedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -9,7 +10,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.SerializeToUtf8Bytes<T>(T value, JsonTypeInfo<T> jsonTypeInfo)
-    /// overload is trimming safe. A collection and a POCO are used.
+    /// overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -19,6 +20,7 @@ namespace SerializerTrimmingTest
             string actual = Encoding.UTF8.GetString(JsonSerializer.SerializeToUtf8Bytes(arr, Context.Default.Int32Array));
             if (actual != "[1]")
             {
+                Console.Error.WriteLine("Serializing int[] produced unexpected JSON.");
                 return -1;
             }
 
@@ -26,7 +28,8 @@ namespace SerializerTrimmingTest
             actual = Encoding.UTF8.GetString(JsonSerializer.SerializeToUtf8Bytes(obj, Context.Default.MyStruct));
             if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
             {
-                return -2;
+                Console.Error.WriteLine("Serializing MyStruct produced unexpected JSON.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToByteArray.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToByteArray.TypedObject.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.SerializeToUtf8Bytes<T>(T value, JsonTypeInfo<T> jsonTypeInfo)
+    /// overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            int[] arr = [1];
+            string actual = Encoding.UTF8.GetString(JsonSerializer.SerializeToUtf8Bytes(arr, Context.Default.Int32Array));
+            if (actual != "[1]")
+            {
+                return -1;
+            }
+
+            MyStruct obj = default;
+            actual = Encoding.UTF8.GetString(JsonSerializer.SerializeToUtf8Bytes(obj, Context.Default.MyStruct));
+            if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyStruct))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.BoxedObject.WithWriter.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.BoxedObject.WithWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -10,7 +11,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Serialize(Utf8JsonWriter writer, object value, Type inputType,
-    /// JsonSerializerContext context) overload is trimming safe. A collection and a POCO are used.
+    /// JsonSerializerContext context) overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -24,6 +25,7 @@ namespace SerializerTrimmingTest
                 string actual = Encoding.UTF8.GetString(stream.ToArray());
                 if (actual != "[1]")
                 {
+                    Console.Error.WriteLine("Serializing int[] produced unexpected JSON.");
                     return -1;
                 }
             }
@@ -36,7 +38,8 @@ namespace SerializerTrimmingTest
                 string actual = Encoding.UTF8.GetString(stream.ToArray());
                 if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
                 {
-                    return -2;
+                    Console.Error.WriteLine("Serializing MyStruct produced unexpected JSON.");
+                    return -1;
                 }
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.BoxedObject.WithWriter.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.BoxedObject.WithWriter.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Serialize(Utf8JsonWriter writer, object value, Type inputType,
+    /// JsonSerializerContext context) overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            {
+                using MemoryStream stream = new();
+                using Utf8JsonWriter writer = new(stream);
+                int[] arr = [1];
+                JsonSerializer.Serialize(writer, arr, typeof(int[]), Context.Default);
+                string actual = Encoding.UTF8.GetString(stream.ToArray());
+                if (actual != "[1]")
+                {
+                    return -1;
+                }
+            }
+
+            {
+                using MemoryStream stream = new();
+                using Utf8JsonWriter writer = new(stream);
+                MyStruct obj = default;
+                JsonSerializer.Serialize(writer, obj, typeof(MyStruct), Context.Default);
+                string actual = Encoding.UTF8.GetString(stream.ToArray());
+                if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
+                {
+                    return -2;
+                }
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyStruct))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.BoxedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -8,7 +9,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Serialize(object value, Type inputType, JsonSerializerContext context)
-    /// overload is trimming safe. A collection and a POCO are used.
+    /// overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -17,13 +18,15 @@ namespace SerializerTrimmingTest
             int[] arr = [1];
             if (JsonSerializer.Serialize(arr, typeof(int[]), Context.Default) != "[1]")
             {
+                Console.Error.WriteLine("Serializing int[] produced unexpected JSON.");
                 return -1;
             }
 
             MyStruct obj = default;
             if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", JsonSerializer.Serialize(obj, typeof(MyStruct), Context.Default)))
             {
-                return -2;
+                Console.Error.WriteLine("Serializing MyStruct produced unexpected JSON.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.BoxedObject.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Serialize(object value, Type inputType, JsonSerializerContext context)
+    /// overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            int[] arr = [1];
+            if (JsonSerializer.Serialize(arr, typeof(int[]), Context.Default) != "[1]")
+            {
+                return -1;
+            }
+
+            MyStruct obj = default;
+            if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", JsonSerializer.Serialize(obj, typeof(MyStruct), Context.Default)))
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyStruct))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.TypedObject.WithWriter.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.TypedObject.WithWriter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -10,7 +11,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Serialize<T>(Utf8JsonWriter writer, T value,
-    /// JsonTypeInfo<T> jsonTypeInfo) overload is trimming safe. A collection and a POCO are used.
+    /// JsonTypeInfo<T> jsonTypeInfo) overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -24,6 +25,7 @@ namespace SerializerTrimmingTest
                 string actual = Encoding.UTF8.GetString(stream.ToArray());
                 if (actual != "[1]")
                 {
+                    Console.Error.WriteLine("Serializing int[] produced unexpected JSON.");
                     return -1;
                 }
             }
@@ -36,7 +38,8 @@ namespace SerializerTrimmingTest
                 string actual = Encoding.UTF8.GetString(stream.ToArray());
                 if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
                 {
-                    return -2;
+                    Console.Error.WriteLine("Serializing MyStruct produced unexpected JSON.");
+                    return -1;
                 }
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.TypedObject.WithWriter.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.TypedObject.WithWriter.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Serialize<T>(Utf8JsonWriter writer, T value,
+    /// JsonTypeInfo<T> jsonTypeInfo) overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            {
+                using MemoryStream stream = new();
+                using Utf8JsonWriter writer = new(stream);
+                int[] arr = [1];
+                JsonSerializer.Serialize(writer, arr, Context.Default.Int32Array);
+                string actual = Encoding.UTF8.GetString(stream.ToArray());
+                if (actual != "[1]")
+                {
+                    return -1;
+                }
+            }
+
+            {
+                using MemoryStream stream = new();
+                using Utf8JsonWriter writer = new(stream);
+                MyStruct obj = default;
+                JsonSerializer.Serialize(writer, obj, Context.Default.MyStruct);
+                string actual = Encoding.UTF8.GetString(stream.ToArray());
+                if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
+                {
+                    return -2;
+                }
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyStruct))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.TypedObject.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.Serialize<T>(T value, JsonTypeInfo<T> jsonTypeInfo)
+    /// overload is trimming safe. A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static int Main(string[] args)
+        {
+            int[] arr = [1];
+            if (JsonSerializer.Serialize(arr, Context.Default.Int32Array) != "[1]")
+            {
+                return -1;
+            }
+
+            MyStruct obj = default;
+            if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", JsonSerializer.Serialize(obj, Context.Default.MyStruct)))
+            {
+                return -2;
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyStruct))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/Serialize.ToString.TypedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -8,7 +9,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.Serialize<T>(T value, JsonTypeInfo<T> jsonTypeInfo)
-    /// overload is trimming safe. A collection and a POCO are used.
+    /// overload is trimming-safe. A collection and a POCO are used.
     /// </summary>
     internal class Program
     {
@@ -17,13 +18,15 @@ namespace SerializerTrimmingTest
             int[] arr = [1];
             if (JsonSerializer.Serialize(arr, Context.Default.Int32Array) != "[1]")
             {
+                Console.Error.WriteLine("Serializing int[] produced unexpected JSON.");
                 return -1;
             }
 
             MyStruct obj = default;
             if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", JsonSerializer.Serialize(obj, Context.Default.MyStruct)))
             {
-                return -2;
+                Console.Error.WriteLine("Serializing MyStruct produced unexpected JSON.");
+                return -1;
             }
 
             return 100;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/SerializeAsync.ToStream.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/SerializeAsync.ToStream.BoxedObject.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.SerializeAsync(Stream utf8Json, object value, Type inputType,
+    /// JsonSerializerContext context, CancellationToken cancellationToken) overload is trimming safe.
+    /// A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static async Task<int> Main(string[] args)
+        {
+            using (MemoryStream stream = new())
+            {
+                int[] arr = [1];
+                await JsonSerializer.SerializeAsync(stream, arr, typeof(int[]), Context.Default);
+                string actual = Encoding.UTF8.GetString(stream.ToArray());
+                if (actual != "[1]")
+                {
+                    return -1;
+                }
+            }
+
+            using (MemoryStream stream = new())
+            {
+                MyStruct obj = default;
+                await JsonSerializer.SerializeAsync(stream, obj, typeof(MyStruct), Context.Default);
+                string actual = Encoding.UTF8.GetString(stream.ToArray());
+                if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
+                {
+                    return -2;
+                }
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyStruct))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/SerializeAsync.ToStream.BoxedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/SerializeAsync.ToStream.BoxedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -11,7 +12,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.SerializeAsync(Stream utf8Json, object value, Type inputType,
-    /// JsonSerializerContext context, CancellationToken cancellationToken) overload is trimming safe.
+    /// JsonSerializerContext context, CancellationToken cancellationToken) overload is trimming-safe.
     /// A collection and a POCO are used.
     /// </summary>
     internal class Program
@@ -25,6 +26,7 @@ namespace SerializerTrimmingTest
                 string actual = Encoding.UTF8.GetString(stream.ToArray());
                 if (actual != "[1]")
                 {
+                    Console.Error.WriteLine("Serializing int[] produced unexpected JSON.");
                     return -1;
                 }
             }
@@ -36,7 +38,8 @@ namespace SerializerTrimmingTest
                 string actual = Encoding.UTF8.GetString(stream.ToArray());
                 if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
                 {
-                    return -2;
+                    Console.Error.WriteLine("Serializing MyStruct produced unexpected JSON.");
+                    return -1;
                 }
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/SerializeAsync.ToStream.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/SerializeAsync.ToStream.TypedObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -11,7 +12,7 @@ namespace SerializerTrimmingTest
 {
     /// <summary>
     /// Tests that the serializer's JsonSerializer.SerializeAsync<T>(Stream utf8Json, T value,
-    /// JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken) overload is trimming safe.
+    /// JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken) overload is trimming-safe.
     /// A collection and a POCO are used.
     /// </summary>
     internal class Program
@@ -25,6 +26,7 @@ namespace SerializerTrimmingTest
                 string actual = Encoding.UTF8.GetString(stream.ToArray());
                 if (actual != "[1]")
                 {
+                    Console.Error.WriteLine("Serializing int[] produced unexpected JSON.");
                     return -1;
                 }
             }
@@ -36,7 +38,8 @@ namespace SerializerTrimmingTest
                 string actual = Encoding.UTF8.GetString(stream.ToArray());
                 if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
                 {
-                    return -2;
+                    Console.Error.WriteLine("Serializing MyStruct produced unexpected JSON.");
+                    return -1;
                 }
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/SerializeAsync.ToStream.TypedObject.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/SerializerEntryPoint/SerializeAsync.ToStream.TypedObject.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace SerializerTrimmingTest
+{
+    /// <summary>
+    /// Tests that the serializer's JsonSerializer.SerializeAsync<T>(Stream utf8Json, T value,
+    /// JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken) overload is trimming safe.
+    /// A collection and a POCO are used.
+    /// </summary>
+    internal class Program
+    {
+        static async Task<int> Main(string[] args)
+        {
+            using (MemoryStream stream = new())
+            {
+                int[] arr = [1];
+                await JsonSerializer.SerializeAsync(stream, arr, Context.Default.Int32Array);
+                string actual = Encoding.UTF8.GetString(stream.ToArray());
+                if (actual != "[1]")
+                {
+                    return -1;
+                }
+            }
+
+            using (MemoryStream stream = new())
+            {
+                MyStruct obj = default;
+                await JsonSerializer.SerializeAsync(stream, obj, Context.Default.MyStruct);
+                string actual = Encoding.UTF8.GetString(stream.ToArray());
+                if (!TestHelper.JsonEqual("""{"X":0,"Y":0}""", actual))
+                {
+                    return -2;
+                }
+            }
+
+            return 100;
+        }
+    }
+
+    [JsonSerializable(typeof(int[]))]
+    [JsonSerializable(typeof(MyStruct))]
+    internal partial class Context : JsonSerializerContext;
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
@@ -1,9 +1,7 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
-  <!-- These tests need to be rewritten to use source generator: https://github.com/dotnet/runtime/issues/53437,
-       so conditioning on RunNativeAotTestApps -->
-  <ItemGroup Condition="'$(RunNativeAotTestApps)' != 'true'">
+  <ItemGroup>
     <TestConsoleAppSourceFiles Include="Collections\Array.cs">
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
@@ -11,6 +9,9 @@
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="Collections\ConcurrentQueue.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="Collections\ConcurrentStack.cs">
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="Collections\DictionaryOfTKeyTValue.cs">
@@ -21,10 +22,9 @@
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="Collections\Hashtable.cs">
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
-      <!-- Hashtable's ctor is getting trimmed on browser-wasm causing this test to fail.
-      These tests should be converted to use the source generator.
-      See https://github.com/dotnet/runtime/issues/53437 -->    
-      <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="Collections\ICollection.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="Collections\ICollectionOfT.cs">
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
@@ -56,17 +56,30 @@
     <TestConsoleAppSourceFiles Include="Collections\ListOfT.cs">
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="Collections\Queue.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="Collections\QueueOfT.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="Collections\Stack.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="Collections\StackOfT.cs">
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
-    <TestConsoleAppSourceFiles Include="EnumConverterTest.cs" />
-    <TestConsoleAppSourceFiles Include="JsonConverterAttributeTest.cs" />
-    <TestConsoleAppSourceFiles Include="StackOrQueueNotRootedTest.cs" />
   </ItemGroup>
 
-  <!-- All tests declared above rely on JsonSerializerIsReflectionEnabledByDefault behavior.-->
   <ItemGroup>
-    <TestConsoleAppSourceFiles Update="@(TestConsoleAppSourceFiles)" EnabledProperties="JsonSerializerIsReflectionEnabledByDefault" />
+    <TestConsoleAppSourceFiles Update="Collections\*.cs" DisabledProperties="JsonSerializerIsReflectionEnabledByDefault" />
+  </ItemGroup>
+
+  <!-- These tests exercise the reflection-based serializer, which is annotated
+       `RequiresDynamicCode` and therefore not Native AOT compatible. -->
+  <ItemGroup Condition="'$(RunNativeAotTestApps)' != 'true'">
+    <TestConsoleAppSourceFiles Include="EnumConverterTest.cs" EnabledProperties="JsonSerializerIsReflectionEnabledByDefault" />
+    <TestConsoleAppSourceFiles Include="JsonConverterAttributeTest.cs" EnabledProperties="JsonSerializerIsReflectionEnabledByDefault" />
+    <TestConsoleAppSourceFiles Include="StackOrQueueNotRootedTest.cs" EnabledProperties="JsonSerializerIsReflectionEnabledByDefault" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
@@ -68,10 +68,62 @@
     <TestConsoleAppSourceFiles Include="Collections\StackOfT.cs">
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Deserialize.FromReader.BoxedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Deserialize.FromReader.TypedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Deserialize.FromSpan.BoxedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Deserialize.FromSpan.TypedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Deserialize.FromString.BoxedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Deserialize.FromString.TypedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\DeserializeAsync.FromStream.BoxedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\DeserializeAsync.FromStream.TypedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Serialize.ToByteArray.BoxedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Serialize.ToByteArray.TypedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Serialize.ToString.BoxedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Serialize.ToString.BoxedObject.WithWriter.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Serialize.ToString.TypedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\Serialize.ToString.TypedObject.WithWriter.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\SerializeAsync.ToStream.BoxedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="SerializerEntryPoint\SerializeAsync.ToStream.TypedObject.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="ObjectConvertersTest.cs">
+      <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
+    </TestConsoleAppSourceFiles>
   </ItemGroup>
 
   <ItemGroup>
-    <TestConsoleAppSourceFiles Update="Collections\*.cs" DisabledProperties="JsonSerializerIsReflectionEnabledByDefault" />
+    <TestConsoleAppSourceFiles Update="Collections\*.cs;SerializerEntryPoint\*.cs;ObjectConvertersTest.cs"
+                               DisabledProperties="JsonSerializerIsReflectionEnabledByDefault" />
   </ItemGroup>
 
   <!-- These tests exercise the reflection-based serializer, which is annotated


### PR DESCRIPTION
Fixes #53437.

The existing collection trimming tests now use the source generator, and I rewrote the remaining 16 `SerializerEntryPoint` apps  (one per `JsonSerializer` overload) along with `ObjectConvertersTest`. Like the collection tests, they run with reflection disabled and on the Native AOT test leg.

These were removed in #53235, the same PR that deleted the `DynamicallyAccessedMembers` annotations they validated (#52268), so the source generated versions verify the overloads themselves instead. The same goes for `Stack`, `Queue`, `Queue<T>` and `ConcurrentStack`, restored here and supported by the source generator since #53393.

A nice consequence is that `Hashtable` no longer needs its `browser-wasm` skip. The generated `ObjectCreator` roots the constructor statically, and that is what was getting trimmed.
