### PR TITLE
Reject bare CR in managed HttpListener request parsing

### DIFF
--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/ChunkStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/ChunkStream.cs
@@ -249,8 +249,14 @@ namespace System.Net
                     continue;
                 }
 
-                if (_sawCR && c == '\n')
+                if (_sawCR)
+                {
+                    // The CR must be immediately followed by a LF. Don't drop a bare CR and join the digits around it.
+                    if (c != '\n')
+                        ThrowProtocolViolation("Missing \\n");
+
                     break;
+                }
 
                 _saved.Append(c);
 
@@ -260,9 +266,6 @@ namespace System.Net
 
             if (!_sawCR || c != '\n')
             {
-                if (offset < size)
-                    ThrowProtocolViolation("Missing \\n");
-
                 try
                 {
                     if (_saved.Length > 0)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
@@ -423,6 +423,13 @@ namespace System.Net
             {
                 used++;
                 byte b = buffer[i];
+                if (_lineState == LineState.CR && b != 10)
+                {
+                    // A CR must be immediately followed by a LF. Reject a bare CR, as http.sys does,
+                    // rather than dropping it and joining the text on either side of it.
+                    throw new ProtocolViolationException();
+                }
+
                 if (b == 13)
                 {
                     _lineState = LineState.CR;

--- a/src/libraries/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -736,6 +736,34 @@ namespace System.Net.Tests
             }
         }
 
+        // http.sys rejects this request with a 400 before a context is ever handed out, so there is
+        // no request stream to read from; this asserts the behavior of the managed implementation.
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsManagedImplementation))]
+        public async Task Read_ChunkSizeWithBareCR_ThrowsHttpListenerException()
+        {
+            using (Socket client = _factory.GetConnectedSocket())
+            {
+                Uri listeningUri = new Uri(_factory.ListeningUrl);
+
+                // The CR in "1\r0" isn't followed by a LF, so this must not be read as a 0x10 byte chunk.
+                string request =
+                    $"POST {listeningUri.PathAndQuery} HTTP/1.1\r\n" +
+                    $"Host: {listeningUri.Host}\r\n" +
+                    "Transfer-Encoding: chunked\r\n" +
+                    "\r\n" +
+                    "1\r0\n" +
+                    "0123456789ABCDEF\r\n" +
+                    "0\r\n" +
+                    "\r\n";
+
+                await client.SendAsync(Encoding.ASCII.GetBytes(request));
+                HttpListenerContext context = await _listener.GetContextAsync();
+
+                byte[] buffer = new byte[16];
+                await Assert.ThrowsAsync<HttpListenerException>(() => ReadLengthAsync(context.Request.InputStream, buffer, 0, buffer.Length));
+            }
+        }
+
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsManagedImplementation))]
         [InlineData("80000000")]
         [InlineData("FFFFFFFF")]

--- a/src/libraries/System.Net.HttpListener/tests/InvalidClientRequestTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/InvalidClientRequestTests.cs
@@ -97,6 +97,12 @@ namespace System.Net.Tests
                 yield return new object[] { "GET {path} HTTP/1.1", null, new string[] { "Header\t: value" }, null, "Bad Request" };
             }
 
+            // Bare CR, i.e. a CR that isn't immediately followed by a LF
+            yield return new object[] { "GET {path}a\rb HTTP/1.1", null, null, null, "Bad Request" };
+            yield return new object[] { "GET {path} HTTP/1.1", null, new string[] { "Content-Le\rngth: 0" }, "\r\n", "Bad Request" };
+            yield return new object[] { "GET {path} HTTP/1.1", null, new string[] { "Header: val\rue" }, "\r\n", "Bad Request" };
+            yield return new object[] { "GET {path} HTTP/1.1", null, new string[] { "Header: value\r" }, "\r\n", "Bad Request" };
+
             yield return new object[] { "GET {path} HTTP/1.1", "", null, null, "Bad Request" };
             yield return new object[] { "GET {path} HTTP/1.1", "Host: \r\n", null, null, "Bad Request" };
 


### PR DESCRIPTION
While reading the chunk-size change in #132747 I noticed that the managed HttpListener silently drops a CR that isn't followed by a LF, and glues together the text on either side of it. I replayed a few raw requests against the managed listener (Linux, .NET 8.0.30) and against http.sys (Windows 11, .NET 8.0.29):

| request contains | managed HttpListener | http.sys |
| --- | --- | --- |
| `Content-Le\rngth: 5` + body `Hello` | context with `Content-Length: 5`, body read | 400 |
| `X-Test: ab\rcd` | header value `abcd` | 400 |
| `GET /c\rd HTTP/1.1` | `RawUrl` is `/cd` | 400 |
| `Host: localhost\r\r\n` | accepted | 400 |
| chunk-size line `1\r0\n` | read as a 0x10 byte chunk | 400 |

Both line readers do the same thing. `HttpConnection.ReadLine` moves to `LineState.CR` on a CR but keeps appending the bytes that follow, and the next LF ends the line, so a CR anywhere in the request line or a header just disappears. `ChunkStream.GetChunkSize` behaves the same way. It does have a `Missing \n` check meant for this case, but it sits after the read loop, and the loop only exits without a `break` once `offset == size`, so `offset < size` is never true there.

RFC 9112 section 2.2 says a recipient of a bare CR must treat the element as invalid or replace the CR with SP. Dropping it does neither, and `Content-Le\rngth` becoming `Content-Length` is the same kind of disagreement with an intermediary that #132163 and #132747 closed for whitespace.

The change rejects a CR that isn't immediately followed by a LF in both places: `ReadLine` throws, which `ProcessInput` already turns into a 400, and the `Missing \n` check in `GetChunkSize` moves into the loop where it can fire. A bare LF is still accepted as a line terminator, and a CR and LF split across two reads still work, since the CR state carries over between calls as before.

On the behavior change: the public API is untouched, and the only requests that now fail are ones that are invalid per the RFC and that http.sys already rejects with a 400 behind the same API, so this brings the managed implementation in line with Windows, as #130910 did for Content-Length.

Tests:
- four bare-CR entries in `InvalidClientRequestTests`, not gated on the implementation. I replayed exactly those four requests, built the way `GetContext_InvalidRequest_DoesNotGetContext` builds them, against http.sys on Windows 11 and each got `400 Bad Request`; against the shipped managed listener each one got a context.
- `Read_ChunkSizeWithBareCR_ThrowsHttpListenerException`, managed only, next to the whitespace tests, because http.sys answers 400 before a context is handed out.

I couldn't build the repo on the machines I had (no .NET 11 SDK), so I have not run the xunit tests themselves and am relying on CI for those. What I did run: a net8.0 harness that compiles `ChunkStream.cs` from the tree as-is and `HttpConnection.ReadLine` extracted verbatim. At main, 7 of its bare-CR checks fail; with this change they all pass, and the healthy-path checks (CR/LF split across reads, byte-by-byte input, bare LF endings, chunk extensions, several chunks, whitespace in the chunk size still rejected) pass on both sides.

I also noticed that `ChunkStream.ReadTrailer` never appends the trailer characters themselves to `_saved`, so trailer fields are dropped, and that `0\r\n\r\r\n` leaves the stream waiting for more data. I left that alone here; I can open an issue if it's useful.

AI tools used
