### PR TITLE
Undo float->small integer saturation workaround

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -929,18 +929,10 @@ namespace ILCompiler
                                         context.Target.PointerSize == 8 ? ValueTypeValue.FromInt64((long)(ulong)val) : ValueTypeValue.FromInt32((int)(uint)val));
                                     break;
                                 case ILOpcode.conv_i1:
-                                    // TODO: Once the fix for unchecked float->small integer saturation propagates into
-                                    // the ILC toolchain, the Math.Clamp can be removed and this simplified to:
-                                    // stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((sbyte)val));
-                                    stack.Push(StackValueKind.Int32,
-                                        ValueTypeValue.FromInt32((sbyte)(int)Math.Clamp(double.IsNaN(val) ? 0 : val, sbyte.MinValue, sbyte.MaxValue)));
+                                    stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((sbyte)val));
                                     break;
                                 case ILOpcode.conv_i2:
-                                    // TODO: Once the fix for unchecked float->small integer saturation propagates into
-                                    // the ILC toolchain, the Math.Clamp can be removed and this simplified to:
-                                    // stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((short)val));
-                                    stack.Push(StackValueKind.Int32,
-                                        ValueTypeValue.FromInt32((short)(int)Math.Clamp(double.IsNaN(val) ? 0 : val, short.MinValue, short.MaxValue)));
+                                    stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((short)val));
                                     break;
                                 case ILOpcode.conv_i4:
                                     stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((int)val));
@@ -949,18 +941,10 @@ namespace ILCompiler
                                     stack.Push(StackValueKind.Int64, ValueTypeValue.FromInt64((long)val));
                                     break;
                                 case ILOpcode.conv_u1:
-                                    // TODO: Once the fix for unchecked float->small integer saturation propagates into
-                                    // the ILC toolchain, the Math.Clamp can be removed and this simplified to:
-                                    // stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((byte)val));
-                                    stack.Push(StackValueKind.Int32,
-                                        ValueTypeValue.FromInt32((byte)(int)Math.Clamp(double.IsNaN(val) ? 0 : val, byte.MinValue, byte.MaxValue)));
+                                    stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((byte)val));
                                     break;
                                 case ILOpcode.conv_u2:
-                                    // TODO: Once the fix for unchecked float->small integer saturation propagates into
-                                    // the ILC toolchain, the Math.Clamp can be removed and this simplified to:
-                                    // stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((ushort)val));
-                                    stack.Push(StackValueKind.Int32,
-                                        ValueTypeValue.FromInt32((ushort)(int)Math.Clamp(double.IsNaN(val) ? 0 : val, ushort.MinValue, ushort.MaxValue)));
+                                    stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((ushort)val));
                                     break;
                                 case ILOpcode.conv_u4:
                                     stack.Push(StackValueKind.Int32, ValueTypeValue.FromInt32((int)(uint)val));


### PR DESCRIPTION
The repo builds with .NET 11 RC1.