### PR TITLE
Fix ILVerify validation of interface MethodImpl bodies

### DIFF
--- a/src/coreclr/tools/ILVerification.Tests/ILTests/InterfaceImplementation.il
+++ b/src/coreclr/tools/ILVerification.Tests/ILTests/InterfaceImplementation.il
@@ -448,3 +448,93 @@
 	{
 	}
 }
+
+.class public auto ansi beforefieldinit ExplicitVirtualMethod_ValidType_Valid
+    extends [System.Runtime]System.Object
+    implements IInterface
+{
+    .method private final hidebysig newslot virtual instance void InterfaceMethod() cil managed
+    {
+        .override method instance void IInterface::InterfaceMethod()
+        .maxstack 0
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit ExplicitNonVirtualMethod_InvalidType_InvalidMethodImpl
+    extends [System.Runtime]System.Object
+    implements IInterface
+{
+    .method private hidebysig instance void InterfaceMethod() cil managed
+    {
+        .override method instance void IInterface::InterfaceMethod()
+        .maxstack 0
+        ret
+    }
+}
+
+.class interface public auto ansi abstract IStaticInterface
+{
+    .method public hidebysig newslot abstract virtual static void StaticMethod() cil managed
+    {
+    }
+}
+
+.class public auto ansi beforefieldinit ExplicitStaticMethod_ValidType_Valid
+    extends [System.Runtime]System.Object
+    implements IStaticInterface
+{
+    .method private hidebysig static void StaticMethod() cil managed
+    {
+        .override method void IStaticInterface::StaticMethod()
+        .maxstack 0
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit MissingStaticMethod_InvalidType_InterfaceMethodNotImplemented
+    extends [System.Runtime]System.Object
+    implements IStaticInterface
+{
+}
+
+.class interface public auto ansi abstract IDefaultStaticInterface
+    implements IStaticInterface
+{
+    .method private hidebysig static void StaticMethod() cil managed
+    {
+        .override method void IStaticInterface::StaticMethod()
+        .maxstack 0
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit DefaultStaticMethod_ValidType_Valid
+    extends [System.Runtime]System.Object
+    implements IDefaultStaticInterface, IStaticInterface
+{
+}
+
+.class public auto ansi beforefieldinit NonVirtualMethodHidesBaseVirtualMethod_InvalidType_InvalidMethodImpl
+    extends BaseClass
+    implements IInterface
+{
+    .method public hidebysig instance void InterfaceMethod() cil managed
+    {
+        .override method instance void IInterface::InterfaceMethod()
+        .maxstack 0
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit InstanceBodyForStaticMethod_InvalidType_InvalidMethodImpl
+    extends [System.Runtime]System.Object
+    implements IStaticInterface
+{
+    .method public hidebysig newslot virtual instance void StaticMethod() cil managed
+    {
+        .override method void IStaticInterface::StaticMethod()
+        .maxstack 0
+        ret
+    }
+}

--- a/src/coreclr/tools/ILVerification/Strings.resx
+++ b/src/coreclr/tools/ILVerification/Strings.resx
@@ -462,4 +462,7 @@
   <data name="BadTypeSpec" xml:space="preserve">
     <value>Invalid TypeSpec metadata.</value>
   </data>
+  <data name="InvalidMethodImpl" xml:space="preserve">
+    <value>Invalid MethodImpl: body '{0}' cannot implement declaration '{1}'. {2}</value>
+  </data>
 </root>

--- a/src/coreclr/tools/ILVerification/TypeVerifier.cs
+++ b/src/coreclr/tools/ILVerification/TypeVerifier.cs
@@ -128,7 +128,31 @@ namespace Internal.TypeVerifier
                             continue;
                         }
 
-                        if (type.ResolveInterfaceMethodTarget(method) is not MethodDesc resolvedMethod)
+                        // Validate the original MethodImpl body before slot resolution can replace it.
+                        bool invalidMethodImpl = false;
+                        MethodImplRecord[] methodImpls = type.FindMethodsImplWithMatchingDeclName(method.Name);
+                        if (methodImpls != null)
+                        {
+                            foreach (MethodImplRecord methodImpl in methodImpls)
+                            {
+                                if (methodImpl.Decl == method && !VerifyMethodImpl(method, methodImpl.Body))
+                                {
+                                    invalidMethodImpl = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (invalidMethodImpl)
+                        {
+                            continue;
+                        }
+
+                        MethodDesc resolvedMethod = method.Signature.IsStatic ?
+                            type.ResolveInterfaceMethodToStaticVirtualMethodOnType(method) :
+                            type.ResolveInterfaceMethodTarget(method);
+
+                        if (resolvedMethod is null)
                         {
                             type.ResolveInterfaceMethodToDefaultImplementationOnType(method, out resolvedMethod);
                         }
@@ -137,9 +161,33 @@ namespace Internal.TypeVerifier
                         {
                             VerificationError(VerifierError.InterfaceMethodNotImplemented, Format(type), Format(implementedInterface.InterfaceType, _module, implementedInterface.InterfaceImplementation), Format(method));
                         }
+                        else
+                        {
+                            VerifyMethodImpl(method, resolvedMethod);
+                        }
                     }
                 }
             }
+        }
+
+        private bool VerifyMethodImpl(MethodDesc declaration, MethodDesc body)
+        {
+            string reason;
+            if (body.Signature.IsStatic != declaration.Signature.IsStatic)
+            {
+                reason = "The body and declaration must both be static or both be instance methods.";
+            }
+            else if (!declaration.Signature.IsStatic && !body.IsVirtual)
+            {
+                reason = "An instance method body must be virtual.";
+            }
+            else
+            {
+                return true;
+            }
+
+            VerificationError(VerifierError.InvalidMethodImpl, Format(body), Format(declaration), reason);
+            return false;
         }
 
         private string Format(TypeDesc type)

--- a/src/coreclr/tools/ILVerification/VerifierError.cs
+++ b/src/coreclr/tools/ILVerification/VerifierError.cs
@@ -193,5 +193,6 @@ namespace ILVerify
         InvalidBaseType, // Type has an invalid base type.
         BadTypeSpec, // Invalid TypeSpec metadata.
         ConstrainedTypeNoInterfaceImpl, // The type operand of the constrained prefix must implement the interface declaring the static virtual method.
+        InvalidMethodImpl, // The MethodImpl body cannot implement its declaration.
     }
 }


### PR DESCRIPTION
Fixes #133500

Reject non-virtual instance `MethodImpl` bodies before interface resolution, which can return a virtual base method and hide the invalid mapping.
Use the static resolver for static interface methods to allow valid non-virtual implementations. 

And add regression tests.