### PR TITLE
JIT: Fix hang when a switch targets an empty-block cycle

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6909,6 +6909,8 @@ public:
 
     bool fgOptimizeEmptyBlock(BasicBlock* block);
 
+    bool fgLeadsToEmptyBlockCycle(BasicBlock* block);
+
     bool fgOptimizeBranchToEmptyUnconditional(BasicBlock* block, BasicBlock* bDest);
 
     bool fgOptimizeBranch(BasicBlock* bJump);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1267,6 +1267,36 @@ void Compiler::fgUnreachableBlock(BasicBlock* block)
 }
 
 //-------------------------------------------------------------
+// fgLeadsToEmptyBlockCycle:
+//    Check whether a chain of empty unconditional blocks reaches a cycle.
+//
+// Arguments:
+//    block - start of the chain
+//
+// Returns: true if the chain reaches a cycle of empty unconditional blocks
+//
+// Notes:
+//    Redirecting a branch into such a cycle would indefinitely rotate its target.
+//
+bool Compiler::fgLeadsToEmptyBlockCycle(BasicBlock* block)
+{
+    BitVecTraits traits(fgBBNumMax + 1, this);
+    BitVec       visited = BitVecOps::MakeEmpty(&traits);
+
+    while (block->isEmpty() && block->KindIs(BBJ_ALWAYS))
+    {
+        if (!BitVecOps::TryAddElemD(&traits, visited, block->bbNum))
+        {
+            return true;
+        }
+
+        block = block->GetTarget();
+    }
+
+    return false;
+}
+
+//-------------------------------------------------------------
 // fgOptimizeBranchToEmptyUnconditional:
 //    Optimize a jump to an empty block which ends in an unconditional branch.
 //
@@ -1278,40 +1308,11 @@ void Compiler::fgUnreachableBlock(BasicBlock* block)
 //
 bool Compiler::fgOptimizeBranchToEmptyUnconditional(BasicBlock* block, BasicBlock* bDest)
 {
-    bool optimizeJump = true;
-
     assert(bDest->isEmpty());
     assert(bDest->KindIs(BBJ_ALWAYS));
 
-    BasicBlock* const bDestTarget = bDest->GetTarget();
-
-    // Don't redirect 'block' into a cycle of empty unconditional blocks. The next invocation
-    // would redirect it again, indefinitely rotating its target around the cycle.
-    BasicBlock* slow = bDest;
-    BasicBlock* fast = bDest;
-    while (true)
-    {
-        if (!slow->isEmpty() || !slow->KindIs(BBJ_ALWAYS) || !fast->isEmpty() || !fast->KindIs(BBJ_ALWAYS))
-        {
-            break;
-        }
-
-        slow = slow->GetTarget();
-        fast = fast->GetTarget();
-
-        if (!fast->isEmpty() || !fast->KindIs(BBJ_ALWAYS))
-        {
-            break;
-        }
-
-        fast = fast->GetTarget();
-
-        if (slow == fast)
-        {
-            optimizeJump = false;
-            break;
-        }
-    }
+    BasicBlock* const bDestTarget  = bDest->GetTarget();
+    bool              optimizeJump = !fgLeadsToEmptyBlockCycle(bDest);
 
     // We do not optimize jumps between two different try regions.
     // However jumping to a block that is not in any try region is OK
@@ -1636,7 +1637,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         // Do we have a JUMP to an empty unconditional JUMP block?
         if (bDest->isEmpty() && bDest->KindIs(BBJ_ALWAYS) && !bDest->TargetIs(bDest)) // special case for self jumps
         {
-            bool optimizeJump = true;
+            bool optimizeJump = !fgLeadsToEmptyBlockCycle(bDest);
 
             // We do not optimize jumps between two different try regions.
             // However jumping to a block that is not in any try region is OK
@@ -1711,8 +1712,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
 
     noway_assert(switchTree->TypeIs(TYP_VOID));
 
-    // At this point all of the case jump targets have been updated such
-    // that none of them go to block that is an empty unconditional block
+    // At this point all of the case jump targets have been updated where possible.
     // Now check for two trivial switch jumps.
     //
     if (block->GetSwitchTargets()->GetSuccCount() == 1)

--- a/src/tests/JIT/Regression_ro_2/Runtime_133677.cs
+++ b/src/tests/JIT/Regression_ro_2/Runtime_133677.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection.Emit;
+using TestLibrary;
+using Xunit;
+
+public class Runtime_133677
+{
+    [ConditionalFact(typeof(Utilities), nameof(Utilities.IsReflectionEmitSupported))]
+    public static void TestEntryPoint()
+    {
+        // Emit the cycle directly so the C# compiler cannot collapse it to a self-loop.
+        var method = new DynamicMethod("SwitchCycle", typeof(int), new[] { typeof(int) });
+        ILGenerator il = method.GetILGenerator();
+        Label a = il.DefineLabel();
+        Label b = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Switch, new[] { a, b, a });
+        il.Emit(OpCodes.Ldc_I4_7);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(a);
+        il.Emit(OpCodes.Br, b);
+        il.MarkLabel(b);
+        il.Emit(OpCodes.Br, a);
+
+        Func<int, int> candidate = method.CreateDelegate<Func<int, int>>();
+        Assert.Equal(7, candidate(99));
+    }
+}


### PR DESCRIPTION
Fixes #133677.

`fgOptimizeSwitchBranches` can repeatedly redirect a switch edge around a cycle of empty unconditional blocks without making progress. Share `BitVec`-based cycle detection with `fgOptimizeBranchToEmptyUnconditional` and leave cyclic targets unchanged.

Add `Runtime_133677.cs` to the globbed `Regression_ro_2` runner. The test emits the two-block cycle directly, so it needs neither unoptimized C# compilation nor environment overrides or a separate project.

Validation: the regression hangs with the baseline JIT and passes with the fixed Checked JIT, including default tiering and `JitStress=2`. Cached `benchmarks.run.` replay has no failures, and the asm comparison has no diffs (37 contexts lack recorded data).


The original [repro ](https://github.com/dotnet/runtime/issues/133677)was in C# + debug attribute, converted to IL to avoid the dependency on Roslyn optimizations.