### PR TITLE
Don't fold reads that partially overlap a GC slot of a static readonly field

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12825,8 +12825,10 @@ bool CEEInfo::getStaticFieldContent(CORINFO_FIELD_HANDLE fieldHnd, uint8_t* buff
     {
         if (field->IsObjRef())
         {
-            // there is no point in returning a chunk of a gc handle
-            if ((valueOffset == 0) && (sizeof(CORINFO_OBJECT_HANDLE) <= (UINT)bufferSize) && !field->IsRVA())
+            // There is no point in returning a chunk of a gc handle, and we can only fill
+            // exactly sizeof(CORINFO_OBJECT_HANDLE) bytes - reject any other buffer size,
+            // otherwise the caller would end up reading uninitialized data.
+            if ((valueOffset == 0) && ((UINT)bufferSize == sizeof(CORINFO_OBJECT_HANDLE)) && !field->IsRVA())
             {
                 GCX_COOP();
 
@@ -12863,6 +12865,9 @@ bool CEEInfo::getStaticFieldContent(CORINFO_FIELD_HANDLE fieldHnd, uint8_t* buff
 
                         _ASSERT(numSlots > 0);
 
+                        const unsigned requestBegin = (unsigned)valueOffset;
+                        const unsigned requestEnd = (unsigned)(valueOffset + bufferSize);
+
                         useMemcpy = true;
                         for (unsigned i = 0; i < numSlots; i++)
                         {
@@ -12875,13 +12880,13 @@ bool CEEInfo::getStaticFieldContent(CORINFO_FIELD_HANDLE fieldHnd, uint8_t* buff
                             const unsigned gcSlotBegin = i * TARGET_POINTER_SIZE;
                             const unsigned gcSlotEnd = gcSlotBegin + TARGET_POINTER_SIZE;
 
-                            if (gcSlotBegin >= (unsigned)valueOffset && gcSlotEnd <= (unsigned)(valueOffset + bufferSize))
+                            if (gcSlotBegin < requestEnd && gcSlotEnd > requestBegin)
                             {
                                 // GC slot intersects with our valueOffset + bufferSize - we can't use memcpy...
                                 useMemcpy = false;
 
                                 // ...unless we're interested in that GC slot's value itself
-                                if (gcSlotBegin == (unsigned)valueOffset && gcSlotEnd == (unsigned)(valueOffset + bufferSize) && ptr[i] == TYPE_GC_REF)
+                                if (gcSlotBegin == requestBegin && gcSlotEnd == requestEnd && ptr[i] == TYPE_GC_REF)
                                 {
                                     GCX_COOP();
 

--- a/src/tests/JIT/opt/ValueNumbering/StaticReadonlyStructWithGC.cs
+++ b/src/tests/JIT/opt/ValueNumbering/StaticReadonlyStructWithGC.cs
@@ -23,6 +23,26 @@ public class StaticReadonlyStructWithGC
         if (!Test7()) throw new Exception("Test7 failed");
         if (!Test8()) throw new Exception("Test8 failed");
         if (!Test9()) throw new Exception("Test9 failed");
+
+        RuntimeHelpers.RunClassConstructor(typeof(MovableRefHolder).TypeHandle);
+
+        // Bake the values in (if the JIT incorrectly folds them, this is where it happens),
+        // then relocate the referenced object with a compacting gen2 GC and read again.
+        ReadLowHalfOptimized();
+        ReadAcrossSlotOptimized();
+
+        for (int i = 0; i < 4; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
+
+        if (ReadLowHalfOptimized() != ReadLowHalfUnoptimized())
+            throw new Exception("Test10 failed");
+        if (ReadAcrossSlotOptimized() != ReadAcrossSlotUnoptimized())
+            throw new Exception("Test11 failed");
+
+        GC.KeepAlive(MovableRefHolder.Value.Obj);
     }
 
     static readonly MyStruct MyStructFld = new()
@@ -46,6 +66,57 @@ public class StaticReadonlyStructWithGC
     [MethodImpl(MethodImplOptions.NoInlining)] static bool Test7() => MyStructFld.F.B == typeof(string);
     [MethodImpl(MethodImplOptions.NoInlining)] static bool Test8() => MyStructFld.G.Length == 0;
     [MethodImpl(MethodImplOptions.NoInlining)] static bool Test9() => MyStructFld.H == null;
+
+    // The JIT is allowed to fold a whole object reference slot of a static readonly struct into
+    // a constant (the referenced object then has to be non-movable), but it must never fold a
+    // read that only partially overlaps such a slot - the GC is free to relocate the object and
+    // rewrite the pointer, which makes the baked bytes stale.
+
+    struct Holder
+    {
+        public object Obj;
+        public int Tag;
+        public int Tag2;
+    }
+
+    static class MovableRefHolder
+    {
+        internal static readonly Holder Value;
+
+        static MovableRefHolder()
+        {
+            // Allocate garbage in front of the target object so that a compacting gen2 GC
+            // actually has a reason to move it.
+            object[] filler = new object[100000];
+            for (int i = 0; i < filler.Length; i++)
+            {
+                filler[i] = new object();
+            }
+            Value = new Holder { Obj = new object(), Tag = 0x12345678, Tag2 = unchecked((int)0x9ABCDEF0) };
+            GC.KeepAlive(filler);
+        }
+    }
+
+    // Reads the low half of Holder.Obj.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static int ReadLowHalfOptimized() =>
+        Unsafe.As<Holder, int>(ref Unsafe.AsRef(in MovableRefHolder.Value));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    static int ReadLowHalfUnoptimized() =>
+        Unsafe.As<Holder, int>(ref Unsafe.AsRef(in MovableRefHolder.Value));
+
+    // Reads the high half of Holder.Obj together with Holder.Tag (on 32-bit targets this read
+    // does not overlap the object reference slot, it just covers Tag and Tag2).
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static long ReadAcrossSlotOptimized() =>
+        Unsafe.ReadUnaligned<long>(
+            ref Unsafe.Add(ref Unsafe.As<Holder, byte>(ref Unsafe.AsRef(in MovableRefHolder.Value)), 4));
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    static long ReadAcrossSlotUnoptimized() =>
+        Unsafe.ReadUnaligned<long>(
+            ref Unsafe.Add(ref Unsafe.As<Holder, byte>(ref Unsafe.AsRef(in MovableRefHolder.Value)), 4));
 
     struct MyStruct
     {


### PR DESCRIPTION
Fixes #133680.

`CEEInfo::getStaticFieldContent` used a containment test instead of an intersection test when checking whether the requested range overlaps a GC slot, so a partial read of a reference slot (e.g. 4 bytes at offset 0 of an 8-byte ref) fell through to the raw `memcpy` path and baked half of a movable pointer into codegen.

Also tightened the `IsObjRef` branch: it accepted any `bufferSize >= sizeof(CORINFO_OBJECT_HANDLE)` but only ever fills exactly that many bytes, so the JIT folded uninitialized buffer bytes into a constant.
