### PR TITLE
[release/11.0] Fix cgroup v2 memory limit traversal at hierarchy root

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs
+++ b/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs
@@ -117,15 +117,23 @@ internal static partial class Interop
         /// <returns>true if the limit was read successfully; otherwise, false.</returns>
         internal static bool TryGetMemoryLimitV2(out ulong limit)
         {
+            return TryGetMemoryLimitV2(s_cgroupMemoryPath, s_cgroupMemoryHierarchyMountPath, out limit);
+        }
+
+        /// <summary>Tries to read the memory limit from a cgroup v2 path hierarchy.</summary>
+        /// <param name="currentCGroupMemoryPath">The current cgroup memory path.</param>
+        /// <param name="cgroupMemoryHierarchyMountPath">The cgroup memory hierarchy mount path.</param>
+        /// <param name="limit">The read limit, or 0 if it couldn't be read.</param>
+        /// <returns>true if the limit was read successfully; otherwise, false.</returns>
+        internal static bool TryGetMemoryLimitV2(string? currentCGroupMemoryPath, string? cgroupMemoryHierarchyMountPath, out ulong limit)
+        {
             bool foundAnyLimit = false;
             ulong minLimit = ulong.MaxValue;
-            string? currentCGroupMemoryPath = s_cgroupMemoryPath;
-            string? cgroupMemoryHierarchyMountPath = s_cgroupMemoryHierarchyMountPath;
             if (currentCGroupMemoryPath != null && cgroupMemoryHierarchyMountPath != null)
             {
                 // Iterate over the directory hierarchy representing the cgroup hierarchy until reaching the
-                // mount directory. The mount directory doesn't contain the memory.max.
-                do
+                // mount directory. The mount directory can contain memory.max when it is not the global root.
+                while (currentCGroupMemoryPath != null && IsPathAtOrBelowMount(currentCGroupMemoryPath, cgroupMemoryHierarchyMountPath))
                 {
                     if (TryReadMemoryValueFromFile(currentCGroupMemoryPath + "/memory.max", out ulong currentLevelLimit))
                     {
@@ -135,14 +143,30 @@ internal static partial class Interop
                             minLimit = currentLevelLimit;
                         }
                     }
+                    if (currentCGroupMemoryPath == cgroupMemoryHierarchyMountPath)
+                    {
+                        break;
+                    }
+
                     currentCGroupMemoryPath = Path.GetDirectoryName(currentCGroupMemoryPath);
                 }
-                while (currentCGroupMemoryPath!.Length != cgroupMemoryHierarchyMountPath.Length);
             }
 
             limit = minLimit;
 
             return foundAnyLimit;
+        }
+
+        private static bool IsPathAtOrBelowMount(string path, string mount)
+        {
+            if (!path.StartsWith(mount, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return path.Length == mount.Length ||
+                mount == "/" ||
+                path[mount.Length] == '/';
         }
 
         /// <summary>Tries to parse a memory limit from the specified file.</summary>

--- a/src/libraries/Common/tests/Tests/Interop/cgroupsTests.cs
+++ b/src/libraries/Common/tests/Tests/Interop/cgroupsTests.cs
@@ -34,9 +34,39 @@ namespace Common.Tests
         [Theory]
         [InlineData("/sys/fs/cgroup/cpu/my_cgroup", "/docker/1234", "/sys/fs/cgroup/cpu", "/docker/1234/my_cgroup")]
         [InlineData("/sys/fs/cgroup/cpu/my_cgroup", "/", "/sys/fs/cgroup/cpu", "/my_cgroup")]
+        [InlineData("/sys/fs/cgroup", "/some/container", "/sys/fs/cgroup", "/some/container")]
         public void ValidateFindCGroupPath(string expectedResult, string hierarchyRoot, string hierarchyMount, string cgroupPathRelativeToMount)
         {
             Assert.Equal(expectedResult, Interop.cgroups.FindCGroupPath(hierarchyRoot, hierarchyMount, cgroupPathRelativeToMount));
+        }
+
+        [Fact]
+        public void ValidateTryGetMemoryLimitV2AtHierarchyMount()
+        {
+            string testRoot = GetTestFilePath();
+            string hierarchyMount = Path.Combine(testRoot, "mount");
+            Directory.CreateDirectory(hierarchyMount);
+            File.WriteAllText(Path.Combine(hierarchyMount, "memory.max"), "1");
+
+            Assert.True(Interop.cgroups.TryGetMemoryLimitV2(hierarchyMount, hierarchyMount, out ulong limit));
+            Assert.Equal(1UL, limit);
+        }
+
+        [Fact]
+        public void ValidateTryGetMemoryLimitV2StopsAtHierarchyMount()
+        {
+            string testRoot = GetTestFilePath();
+            string hierarchyMount = Path.Combine(testRoot, "mount");
+            string parentCGroup = Path.Combine(hierarchyMount, "a");
+            string currentCGroup = Path.Combine(parentCGroup, "b");
+            Directory.CreateDirectory(currentCGroup);
+            File.WriteAllText(Path.Combine(hierarchyMount, "memory.max"), "20");
+            File.WriteAllText(Path.Combine(parentCGroup, "memory.max"), "20");
+            File.WriteAllText(Path.Combine(currentCGroup, "memory.max"), "10");
+            File.WriteAllText(Path.Combine(testRoot, "memory.max"), "2");
+
+            Assert.True(Interop.cgroups.TryGetMemoryLimitV2(currentCGroup, hierarchyMount, out ulong limit));
+            Assert.Equal(10UL, limit);
         }
 
         [Theory]


### PR DESCRIPTION
/cc @janvorli @cuishuang

- [x] Customer reported -  #133470
- [ ] Found internally

This issue affects Linux environments using cgroup v2 where the current process is assigned to the root of the cgroup hierarchy visible through the current cgroup mount.

In this configuration, managed cgroup memory-limit traversal can continue above the hierarchy mount and eventually throw a  `NullReferenceException` . This would happen when user code attempts to access `System.Diagnostics.Process.MaxWorkingSet/MinWorkingSet` properties.

The corresponding native implementation was fixed by  #130377, but I haven't realized there is a managed implementation too; this backport fixes the managed implementation so that .NET 11 handles the configuration consistently.

Regression

- [x] Yes - introduced in .NET 9 in #93611 when support for hierarchical cgroup memory limits was added
- [ ] No

Testing

Regression tests verify that:

• the hierarchy mount's  memory.max  is read when the current cgroup path is the mount itself; • traversal of a nested cgroup stops at the hierarchy mount and does not inspect directories above it; and • cgroup path construction correctly returns the hierarchy mount when the process is assigned to the visible hierarchy root.

Risk

Low. The change is limited to managed cgroup v2 memory-limit traversal. It preserves traversal of the current cgroup and its ancestors, but stops after processing the hierarchy mount and prevents reading paths outside that hierarchy. The behavior is consistent with the native CoreCLR implementation.