### PR TITLE
Do not hold a file lock on the PDB read for stack trace symbols

### DIFF
--- a/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
@@ -229,13 +229,22 @@ namespace System.Diagnostics
 
             try
             {
-                // Open with the most permissive sharing. On Unix, any FileShare other than ReadWrite
-                // takes an advisory flock, and the provider built on this stream is cached for the
-                // lifetime of the assembly, so the lock would be held for the life of the process.
-                // iOS terminates a suspended app that holds a file lock outside its data container,
-                // and the PDB lives in the app bundle (see #133697). The lock buys nothing here: the
-                // file is read-only, and FileShare.Delete already allows it to be removed underneath us.
-                return new FileStream(path!, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                // The provider built on this stream reads lazily and is cached for the lifetime of
+                // the assembly, so whatever this handle holds, it holds for the life of the process.
+                //
+                // On Unix that is an advisory flock, and iOS terminates a suspended app that holds a
+                // file lock outside its data container — the PDB lives in the app bundle, so a Debug
+                // app is killed shortly after being backgrounded (see #133697). Ask for no lock there:
+                // the flock only ever coordinated with other .NET readers of a read-only symbol file.
+                //
+                // On Windows the share mode is enforced by the OS and is doing real work: it stops
+                // another process from rewriting the PDB underneath a reader that reads lazily. Keep
+                // denying writes there.
+                FileShare share = OperatingSystem.IsWindows()
+                    ? FileShare.Read | FileShare.Delete
+                    : FileShare.ReadWrite | FileShare.Delete;
+
+                return new FileStream(path!, FileMode.Open, FileAccess.Read, share);
             }
             catch
             {

--- a/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.cs
@@ -229,8 +229,13 @@ namespace System.Diagnostics
 
             try
             {
-                // Open the file with read and delete FileShare flags. This matches what dll loading does
-                return new FileStream(path!, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
+                // Open with the most permissive sharing. On Unix, any FileShare other than ReadWrite
+                // takes an advisory flock, and the provider built on this stream is cached for the
+                // lifetime of the assembly, so the lock would be held for the life of the process.
+                // iOS terminates a suspended app that holds a file lock outside its data container,
+                // and the PDB lives in the app bundle (see #133697). The lock buys nothing here: the
+                // file is read-only, and FileShare.Delete already allows it to be removed underneath us.
+                return new FileStream(path!, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             }
             catch
             {


### PR DESCRIPTION
Fixes #133697.

`StackTraceSymbols.TryOpenFile` opens the PDB with `FileShare.Read | FileShare.Delete`. The
`MetadataReaderProvider` built on that stream uses `MetadataStreamOptions.Default` — sections are
read lazily and the stream is kept — and the provider is cached in a
`ConditionalWeakTable<Assembly, MetadataReaderProvider?>` keyed by the assembly. So the handle, and
whatever it holds, lives for the whole process.

On Unix that is an advisory `flock(LOCK_SH)` (`SafeFileHandle.Unix.cs`: any `FileShare` other than
`ReadWrite` takes one). iOS terminates a suspended app that holds a file lock outside its data
container, and the PDB sits in the app bundle, so a Debug app is killed a few seconds after being
backgrounded with `RUNNINGBOARD 0xdead10cc`. The RunningBoard log names the PDB; device evidence is
in the issue.

This asks for no lock **only where locking is advisory**. On Windows the share mode is enforced by
the OS and is doing real work — it stops another process from rewriting the PDB underneath a reader
that reads lazily — so Windows keeps `FileShare.Read | FileShare.Delete`. On Unix the `flock` only
ever coordinated with other .NET readers of a read-only symbol file, which is not worth an app
being killed.

### Alternative, if you prefer a platform-neutral fix

Opening with `MetadataStreamOptions.PrefetchMetadata` and letting the stream close would remove the
retained handle everywhere, not just the lock — arguably the better shape, since nothing here wants
a file handle held for the life of the process. It trades that for holding the PDB metadata in
memory per assembly, which is why I did not assume it. Happy to switch if that is the direction you
want.
