### PR TITLE
JIT: stop inferring through bitwise complement

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -408,10 +408,9 @@ static const RelopImplicationRule s_implicationRules[] =
 // First looks for exact or similar relations.
 //
 // If that fails, then looks for cases where the user or optOptimizeBools
-// has combined two distinct predicates with a boolean AND, OR, or has wrapped
-// a predicate in NOT.
+// has combined two distinct predicates with a boolean AND or OR.
 //
-// This will be expressed as  {NE/EQ}({AND/OR/NOT}(...), 0).
+// This will be expressed as  {NE/EQ}({AND/OR}(...), 0).
 // If the operator is EQ then a true {AND/OR} result implies
 // a false taken branch, so we need to invert the sense of our
 // inferences.
@@ -515,7 +514,7 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
     // See if dominating compare is a compound comparison that might
     // tell us the value of the tree compare.
     //
-    // Look for {EQ,NE}({AND,OR,NOT}, 0)
+    // Look for {EQ,NE}({AND,OR}, 0)
     //
     genTreeOps const oper = genTreeOps(domFunc);
     if (!GenTree::StaticOperIs(oper, GT_EQ, GT_NE))
@@ -537,14 +536,14 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
 
     genTreeOps const predOper = genTreeOps(predFuncApp.GetFunc());
 
-    if (!GenTree::StaticOperIs(predOper, GT_AND, GT_OR, GT_NOT))
+    if (!GenTree::StaticOperIs(predOper, GT_AND, GT_OR))
     {
         return;
     }
 
-    // Dominating compare is {EQ,NE}({AND,OR,NOT}, 0).
+    // Dominating compare is {EQ,NE}({AND,OR}, 0).
     //
-    // See if one of {AND,OR,NOT} operands is related.
+    // See if one of {AND,OR} operands is related.
     //
     for (unsigned int i = 0; (i < predFuncApp.GetArity()) && !rii->canInfer; i++)
     {
@@ -580,22 +579,14 @@ void Compiler::optRelopImpliesRelop(RelopImplicationInfo* rii)
                     rii->canInferFromTrue = (oper == GT_NE);
                     rii->reverseSense ^= (oper == GT_EQ);
                 }
-                else if (predOper == GT_OR)
+                else
                 {
+                    assert(predOper == GT_OR);
                     // NE(OR, 0) false ==> OR false ==> OR operands false
                     rii->canInferFromFalse = (oper == GT_NE);
                     // EQ(OR, 0) true ==> OR false ==> OR operands false
                     rii->canInferFromTrue = (oper == GT_EQ);
                     rii->reverseSense ^= (oper == GT_EQ);
-                }
-                else
-                {
-                    assert(predOper == GT_NOT);
-                    // NE(NOT(x), 0) ==> NOT(X)
-                    // EQ(NOT(x), 0) ==> X
-                    rii->canInferFromTrue  = true;
-                    rii->canInferFromFalse = true;
-                    rii->reverseSense ^= (oper == GT_NE);
                 }
 
                 JITDUMP("Inferring predicate value from %s\n", GenTree::OpName(predOper));

--- a/src/tests/JIT/opt/RedundantBranch/RedundantBranchSimplify.cs
+++ b/src/tests/JIT/opt/RedundantBranch/RedundantBranchSimplify.cs
@@ -11,6 +11,28 @@ using Xunit;
 // (or the dominated relop can be reversed/rewritten).
 public class RedundantBranchSimplify
 {
+    // The bitwise complement of a 0/1 comparison is always nonzero and provides no information about the comparison.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int ComplementedRelop(int a, int b)
+    {
+        int value = (a != b) ? 1 : 0;
+        if (~value != 0)
+        {
+            if (a != b)
+            {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    [Theory]
+    [InlineData(3, 3, 0)]
+    [InlineData(3, 5, 1)]
+    public static void TestComplementedRelop(int a, int b, int expected) =>
+        Assert.Equal(expected, ComplementedRelop(a, b));
+
     // if (a >= 100) { if (a <= 100) return 1; } => inner becomes (a == 100)
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static int GeLe(int a)


### PR DESCRIPTION
## Summary

- stop redundant branch inference from treating bitwise `GT_NOT` as logical negation
- add coverage for complemented comparison results with equal and unequal operands

Fixes #133557.

## Validation

- `python src\coreclr\scripts\jitformat.py -r . -o windows -a x64`
- `build.cmd clr.jit -rc Checked`
- `RedundantBranchSimplify.TestComplementedRelop`: failed before the fix and passed afterward
- all 31 `RedundantBranchSimplify` tests passed
- SuperPMI asmdiffs: no diffs across 987,555 successfully compiled Windows x64 contexts in 9 collections; 0 failing and 912 missing contexts

## Regression history

The underlying issue was introduced by #69291 and first shipped in .NET 7. Optimized IL reproduces on .NET 7 through .NET 11; the exact unoptimized IL shape from #133557 is newly exposed on current main.

> [!NOTE]
> This PR description was generated with GitHub Copilot CLI.