### PR TITLE
Fix internal Helix queue alias expansion

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -30,6 +30,9 @@ jobs:
     pool: ${{ parameters.pool }}
     platform: ${{ parameters.platform }}
     shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+
+    # IMPORTANT: Select public/internal queue aliases explicitly. Runtime macros expand too late
+    # for helix.yml to strip the .Open suffix at template expansion time for internal runs.
     helixQueues:
 
     # iOS Simulator/Mac Catalyst arm64

--- a/eng/pipelines/installer/helix-queues-setup.yml
+++ b/eng/pipelines/installer/helix-queues-setup.yml
@@ -18,6 +18,9 @@ steps:
     osGroup: ${{ parameters.osGroup }}
     osSubgroup: ${{ parameters.osSubgroup }}
     useHelixMonitor: ${{ parameters.useHelixMonitor }}
+
+    # IMPORTANT: Use ${{ variables.* }} for queue aliases, not $(...), so helix.yml can strip the .Open suffix
+    # at template expansion time for internal runs. Runtime macros expand too late.
     helixQueues:
 
     # Linux arm
@@ -42,11 +45,11 @@ steps:
 
     # OSX arm64
     - ${{ if eq(parameters.platform, 'osx_arm64') }}:
-      - $(helix_macos_arm64)
+      - ${{ variables.helix_macos_arm64 }}
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
-      - $(helix_macos_x64)
+      - ${{ variables.helix_macos_x64 }}
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:

--- a/eng/pipelines/installer/helix-queues-setup.yml
+++ b/eng/pipelines/installer/helix-queues-setup.yml
@@ -19,8 +19,8 @@ steps:
     osSubgroup: ${{ parameters.osSubgroup }}
     useHelixMonitor: ${{ parameters.useHelixMonitor }}
 
-    # IMPORTANT: Use ${{ variables.* }} for queue aliases, not $(...), so helix.yml can strip the .Open suffix
-    # at template expansion time for internal runs. Runtime macros expand too late.
+    # IMPORTANT: Select public/internal queue aliases explicitly. Runtime macros expand too late
+    # for helix.yml to strip the .Open suffix at template expansion time for internal runs.
     helixQueues:
 
     # Linux arm
@@ -45,11 +45,17 @@ steps:
 
     # OSX arm64
     - ${{ if eq(parameters.platform, 'osx_arm64') }}:
-      - ${{ variables.helix_macos_arm64 }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - $(helix_macos_arm64)
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - $(helix_macos_arm64_latest_internal)
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
-      - ${{ variables.helix_macos_x64 }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - $(helix_macos_x64)
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - $(helix_macos_x64_latest_internal)
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -21,6 +21,9 @@ jobs:
     pool: ${{ parameters.pool }}
     platform: ${{ parameters.platform }}
     shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+
+    # IMPORTANT: Use ${{ variables.* }} for queue aliases, not $(...), so helix.yml can strip the .Open suffix
+    # at template expansion time for internal runs. Runtime macros expand too late.
     helixQueues:
 
     # Linux arm
@@ -81,11 +84,11 @@ jobs:
 
     # OSX arm64
     - ${{ if eq(parameters.platform, 'osx_arm64') }}:
-      - $(helix_macos_arm64)
+      - ${{ variables.helix_macos_arm64 }}
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
-      - $(helix_macos_x64)
+      - ${{ variables.helix_macos_x64 }}
 
     # Android
     # Use the Ubuntu-based Android queue for x86/x64/bionic_x64 on all projects,
@@ -101,19 +104,19 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'iossimulator_arm64', 'tvossimulator_arm64', 'maccatalyst_arm64') }}:
-      - $(helix_macos_ios_simulator_arm64)
+      - ${{ variables.helix_macos_ios_simulator_arm64 }}
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iossimulator_x64', 'tvossimulator_x64', 'maccatalyst_x64') }}:
-      - $(helix_macos_ios_simulator_x64)
+      - ${{ variables.helix_macos_ios_simulator_x64 }}
 
     # iOS devices
     - ${{ if in(parameters.platform, 'ios_arm64') }}:
-      - $(helix_macos_ios_device)
+      - ${{ variables.helix_macos_ios_device }}
 
     # tvOS devices
     - ${{ if in(parameters.platform, 'tvos_arm64') }}:
-      - $(helix_macos_tvos_device)
+      - ${{ variables.helix_macos_tvos_device }}
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:
@@ -132,7 +135,7 @@ jobs:
               - (Windows.10.Amd64.ServerRS5.Open)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2019-helix-amd64@sha256:377831a7ccbdcbb1d71b5fd7dcf1a5e79314bd4d5e12f818cdc41815a3b3b2a6
           - ${{ if or(ne(parameters.jobParameters.isExtraPlatformsBuild, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
             # Primary Windows queues for all builds: latest + Nano (distinct environment)
-            - $(helix_windows_x64_latest)
+            - ${{ variables.helix_windows_x64_latest }}
             - ${{ if ne(parameters.jobParameters.runtimeFlavor, 'mono') }}:
               - (Windows.Nano.1809.Amd64.Open)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1809-helix-amd64@sha256:d2d8804d22eb173947282a2aa24f73fbfe06e35ccbf26dcde3199368218158b8
             # Additional Windows versions on non-PR builds for broader coverage
@@ -190,6 +193,6 @@ jobs:
 
     # Browser WebAssembly macOS
     - ${{ if eq(parameters.platform, 'browser_wasm_mac') }}:
-      - $(helix_macos_arm64)
+      - ${{ variables.helix_macos_arm64 }}
 
     ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -22,8 +22,8 @@ jobs:
     platform: ${{ parameters.platform }}
     shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
 
-    # IMPORTANT: Use ${{ variables.* }} for queue aliases, not $(...), so helix.yml can strip the .Open suffix
-    # at template expansion time for internal runs. Runtime macros expand too late.
+    # IMPORTANT: Select public/internal queue aliases explicitly. Runtime macros expand too late
+    # for helix.yml to strip the .Open suffix at template expansion time for internal runs.
     helixQueues:
 
     # Linux arm
@@ -84,11 +84,17 @@ jobs:
 
     # OSX arm64
     - ${{ if eq(parameters.platform, 'osx_arm64') }}:
-      - ${{ variables.helix_macos_arm64 }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - $(helix_macos_arm64)
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - $(helix_macos_arm64_latest_internal)
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
-      - ${{ variables.helix_macos_x64 }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - $(helix_macos_x64)
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - $(helix_macos_x64_latest_internal)
 
     # Android
     # Use the Ubuntu-based Android queue for x86/x64/bionic_x64 on all projects,
@@ -104,19 +110,31 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'iossimulator_arm64', 'tvossimulator_arm64', 'maccatalyst_arm64') }}:
-      - ${{ variables.helix_macos_ios_simulator_arm64 }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - $(helix_macos_ios_simulator_arm64)
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - $(helix_macos_ios_simulator_arm64_internal)
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iossimulator_x64', 'tvossimulator_x64', 'maccatalyst_x64') }}:
-      - ${{ variables.helix_macos_ios_simulator_x64 }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - $(helix_macos_ios_simulator_x64)
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - $(helix_macos_ios_simulator_x64_internal)
 
     # iOS devices
     - ${{ if in(parameters.platform, 'ios_arm64') }}:
-      - ${{ variables.helix_macos_ios_device }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - $(helix_macos_ios_device)
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - $(helix_macos_ios_device_internal)
 
     # tvOS devices
     - ${{ if in(parameters.platform, 'tvos_arm64') }}:
-      - ${{ variables.helix_macos_tvos_device }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - $(helix_macos_tvos_device)
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - $(helix_macos_tvos_device_internal)
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:
@@ -135,7 +153,10 @@ jobs:
               - (Windows.10.Amd64.ServerRS5.Open)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:windowsservercore-ltsc2019-helix-amd64@sha256:377831a7ccbdcbb1d71b5fd7dcf1a5e79314bd4d5e12f818cdc41815a3b3b2a6
           - ${{ if or(ne(parameters.jobParameters.isExtraPlatformsBuild, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
             # Primary Windows queues for all builds: latest + Nano (distinct environment)
-            - ${{ variables.helix_windows_x64_latest }}
+            - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+              - $(helix_windows_x64_latest)
+            - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+              - $(helix_windows_x64_latest_internal)
             - ${{ if ne(parameters.jobParameters.runtimeFlavor, 'mono') }}:
               - (Windows.Nano.1809.Amd64.Open)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1809-helix-amd64@sha256:d2d8804d22eb173947282a2aa24f73fbfe06e35ccbf26dcde3199368218158b8
             # Additional Windows versions on non-PR builds for broader coverage
@@ -193,6 +214,9 @@ jobs:
 
     # Browser WebAssembly macOS
     - ${{ if eq(parameters.platform, 'browser_wasm_mac') }}:
-      - ${{ variables.helix_macos_arm64 }}
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - $(helix_macos_arm64)
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - $(helix_macos_arm64_latest_internal)
 
     ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
## Summary

Fix internal Helix submissions using public `.Open` queues, including the macOS Mono MiniJIT libraries and iOS/MacCatalyst smoke jobs.

The libraries and installer submission templates strip `.open` with a compile-time `${{ replace(...) }}` expression. Queue aliases passed as `$(helix_...)` do not expand until runtime, so the replacement sees only the macro name and leaves the eventual public queue unchanged. Helix then rejects the submission:

> Helix '.open' queues should only be used from public AzDO projects.

Explicitly select public or `_internal` queue aliases based on `System.TeamProject`, matching the existing CoreCLR queue-selector pattern. Keep runtime macro expansion so the aliases remain available through the nested pipeline templates, without relying on compile-time `.open` removal for alias values. This also covers the Windows x64 libraries alias and macOS-hosted browser tests. Public queue selection remains unchanged.

> [!NOTE]
> This PR description was generated with GitHub Copilot.
