### PR TITLE
[wasm] Fix caller identification across R2R prestub transitions

### DIFF
--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -196,19 +196,6 @@ static StackWalkAction GetStackFramesCallback(CrawlFrame* pCf, VOID* data)
     MethodDesc* pFunc = pCf->GetFunction();
     DebugStackTrace::GetStackFramesData* pData = (DebugStackTrace::GetStackFramesData*)data;
 
-#ifdef TARGET_WASM
-    // The portable-entrypoint slow path keeps its prestub frame active while it invokes a newly
-    // discovered R2R body. The body is already reported as a frameless method.
-    if (!pCf->IsFrameless() &&
-        pCf->GetFrame()->GetFrameIdentifier() == FrameIdentifier::PrestubMethodFrame &&
-        pData->cElements > 0 &&
-        pData->pElements[pData->cElements - 1].pFunc == pFunc &&
-        pData->pElements[pData->cElements - 1].ip != (PCODE)NULL)
-    {
-        return SWA_CONTINUE;
-    }
-#endif // TARGET_WASM
-
     if (pFunc != nullptr && pFunc == g_pEnvironmentCallEntryPointMethodDesc)
     {
         return SWA_CONTINUE;

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -300,6 +300,7 @@ public:
         FRAME_ATTR_EXCEPTION = 1,           // This frame caused an exception
         FRAME_ATTR_FAULTED = 4,             // Exception caused by Win32 fault
         FRAME_ATTR_RESUMABLE = 8,           // We may resume from this frame
+        FRAME_ATTR_NO_MANAGED_ACTIVATION = 16, // Retained for rooting and unwinding, not an additional managed call
     };
     unsigned GetFrameAttribs_Impl()
     {
@@ -1397,8 +1398,33 @@ typedef DPTR(class PrestubMethodFrame) PTR_PrestubMethodFrame;
 
 class PrestubMethodFrame : public FramedMethodFrame
 {
+#ifdef TARGET_WASM
+    bool m_isPrestubComplete = false;
+#endif // TARGET_WASM
+
 public:
     PrestubMethodFrame(TransitionBlock * pTransitionBlock, MethodDesc * pMD);
+
+#ifdef TARGET_WASM
+    void MarkPrestubComplete()
+    {
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_NOTRIGGER;
+            MODE_COOPERATIVE;
+        }
+        CONTRACTL_END;
+
+        m_isPrestubComplete = true;
+    }
+
+    unsigned GetFrameAttribs_Impl()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return m_isPrestubComplete ? FRAME_ATTR_NO_MANAGED_ACTIVATION : FRAME_ATTR_NONE;
+    }
+#endif // TARGET_WASM
 
     void GcScanRoots_Impl(promote_func *fn, ScanContext* sc)
     {

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2207,6 +2207,15 @@ void ExecuteInterpretedMethodWithArgs_PortableEntryPoint_Complex(PCODE portableE
             if (targetIp == NULL)
             {
                 _ASSERTE(!PortableEntryPoint::PrefersInterpreterEntryPoint(portableEntrypoint));
+#ifdef TARGET_WASM
+                // Keep the transition and argument roots while invoking R2R code, but report
+                // the managed activation through its R2R body rather than this prestub.
+                // An FCall can still need the prestub to represent its native implementation.
+                if (!pMethod->IsFCall())
+                {
+                    pPFrame->MarkPrestubComplete();
+                }
+#endif // TARGET_WASM
                 Object* continuationRet = nullptr;
                 Object** pContinuationRet = nullptr;
 #ifdef TARGET_WASM

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2039,6 +2039,13 @@ ProcessFuncletsForGCReporting:
             case SFITER_SKIPPED_FRAME_FUNCTION:
                 if (!fSkippingFunclet)
                 {
+#ifdef TARGET_WASM
+                    if ((m_flags & FUNCTIONSONLY) &&
+                        (m_crawl.pFrame->GetFrameAttribs() & Frame::FRAME_ATTR_NO_MANAGED_ACTIVATION))
+                    {
+                        break;
+                    }
+#endif // TARGET_WASM
                     if (m_flags & GC_FUNCLET_REFERENCE_REPORTING)
                     {
                         // If we are enumerating frames for GC reporting and we determined that

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xunit;
 using TestLibrary;
@@ -117,8 +118,64 @@ public class Program : ProgramBase<InputData>, TestItf2<InputData>
     [Fact]
     public static void TestEntryPoint()
     {
+        ValidateCurrentMethod();
         new Program().Start();
         ValidateExceptionStackTrace();
+    }
+
+    private static void ValidateCurrentMethod()
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            Assert.Equal(nameof(ValidateCurrentMethod), MethodBase.GetCurrentMethod().Name);
+            Assert.Equal(nameof(GetCurrentMethodInlineable), GetCurrentMethodInlineable().Name);
+            MethodBase genericMethod = GetCurrentMethodGeneric<string>();
+            Assert.Equal(nameof(GetCurrentMethodGeneric), genericMethod.Name);
+            Assert.True(genericMethod.IsGenericMethodDefinition);
+            Assert.Equal(typeof(Program).Assembly, Assembly.GetExecutingAssembly());
+            Assert.Equal(typeof(Program).Assembly, Assembly.GetCallingAssembly());
+            ValidateRecursiveCurrentMethod(3);
+            InputData byref = new InputData { i = 2 };
+            ValidateTransitionRoots(new InputData { i = 1 }, ref byref,
+                (new InputData { i = 3 }, new InputData { i = 4 }));
+        }
+    }
+
+    private static MethodBase GetCurrentMethodInlineable() => MethodBase.GetCurrentMethod();
+
+    private static MethodBase GetCurrentMethodGeneric<T>() => MethodBase.GetCurrentMethod();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateTransitionRoots(InputData value, ref InputData byref, (InputData, InputData) pair)
+    {
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+        Assert.Equal(1, value.i);
+        Assert.Equal(2, byref.i);
+        Assert.Equal(3, pair.Item1.i);
+        Assert.Equal(4, pair.Item2.i);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ValidateRecursiveCurrentMethod(int depth)
+    {
+        Assert.Equal(nameof(ValidateRecursiveCurrentMethod), MethodBase.GetCurrentMethod().Name);
+        if (depth > 0)
+        {
+            ValidateRecursiveCurrentMethod(depth - 1);
+        }
+        else
+        {
+            int frameCount = 0;
+            foreach (System.Diagnostics.StackFrame frame in new System.Diagnostics.StackTrace().GetFrames())
+            {
+                if (frame.GetMethod().Name == nameof(ValidateRecursiveCurrentMethod))
+                {
+                    frameCount++;
+                }
+            }
+
+            Assert.Equal(4, frameCount);
+        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Fixes #133617.

## Problem

The Wasm portable-entrypoint slow path retains a `PrestubMethodFrame` while invoking a resolved R2R body. Function-only stack walks can report both the real managed activation and that transition frame. `MethodBase.GetCurrentMethod` can therefore accept its own prestub frame as the caller.

A Checked-runtime capture confirmed this: the stack marker was `0x4fe71c`; the real `GetCurrentMethod` body at SP `0x4fe710` did not pass the caller-marker comparison, but its explicit `PrestubMethodFrame` at SP `0x4fe720` did. The result was `GetCurrentMethod` instead of the calling method. This also reproduces without trimming.

#133610 addressed the duplicate in `GetStackFramesCallback`, but caller-sensitive reflection uses a different callback and did not benefit from that filter.

## Change

- Mark completed non-FCall Wasm prestub transitions as not representing an additional managed activation.
- Filter those frames centrally for `FUNCTIONSONLY` walks, covering both ordinary and skipped explicit frames.
- Retain the frame, MethodDesc, argument-root reporting, and physical unwind/exception lifetime. Popping early or clearing the MethodDesc would lose GC protection and the unwind bridge across interpreter-to-R2R transitions.
- Replace #133610's StackTrace-specific adjacency filter. Filtering by lifecycle rather than matching method identities preserves genuine recursion.
- Extend the existing `github60486` regression with direct/inlineable/generic caller identity, assembly lookup, recursive frame counts, and compacting-GC object/byref/struct argument coverage. Its original DIM frame-sequence and exception-stack checks remain intact.

Native FCalls retain their existing representation. Non-Wasm filtering behavior is unchanged.

## Validation

### CoreCLR runtime regression

Built browser-Wasm and macOS arm64 Checked runtimes with Release libraries. The expanded `Loader/classloader/DefaultInterfaceMethods/regressions/github60486` passes with fixed Wasm R2R, the interpreter, and native arm64. The identical final regression assembly fails against the saved original Wasm runtime: expected `ValidateCurrentMethod`, actual `GetCurrentMethod`.

These fixed runs include the original regression checks from #133610, with its `debugdebugger.cpp` filter removed.

### Original browser library lane

Validated the exact patch in an isolated checkout of #133656 at `282d12dfe220a1f34d0bb81a85239cab60c779ce`, which supplies the browser R2R publishing/test prerequisites. Built matched original/fixed CoreCLR Release products locally and ran Chromium 153. Temporarily enabled only the nine #133617-quarantined methods, preserving every original assertion and unrelated exclusion; all annotations were restored afterward. This PR contains no library-test quarantine changes.

| Coverage | Original | Fixed |
|---|---:|---:|
| Cold trimmed direct GetCurrentMethod | 1 failed | 1 passed |
| Cold trimmed inlineable GetCurrentMethod | 1 failed | 1 passed |
| Trimmed targeted batch | 7 passed, 1 failed | 8 passed |
| Untrimmed R2R targeted batch | 8 passed, 1 failed | 9 passed |
| Full trimmed System.Runtime | 77,396 passed, 1 failed, 175 skipped | 77,397 passed, 0 failed, 175 skipped |

The affected-class fixed run also passed: 23 passed, 3 existing skips. `CrossAssembly2` remains excluded when trimmed by dotnet/linker#2078 and passes untrimmed; it is not counted as a trimmed pass.

Main test IL and main R2R images are byte-identical across each original/fixed pair; skip sets are identical. Served assets were verified against their respective rebuilt packs. This is a matched-product A/B, not a native-module-only swap: CoreLib R2R image bytes also differ.

### Existing reflection compatibility controls

`System.Reflection.Tests` caller-assembly theory, real cross-assembly delegate invocation, static-constructor caller lookup, executing-assembly lookup, and reflected first/second invocation all pass: six cases on each original/fixed, trimmed/untrimmed browser R2R configuration. Fresh-process delegate and reflective-invocation probes also pass in all four configurations. All existing annotations remained intact. These are compatibility controls, not failing-before reproductions.

Full browser reflection suites have identical original/fixed results:

- Untrimmed: 1,750 passed, 1 failed, 23 skipped.
- Trimmed: 1,747 passed, 2 failed, 23 skipped.

Existing failures are `GetEntryAssembly` (browser host expectation versus R2R expectation) and, trimmed only, `AssemblyGetForwardedTypesLoadFailure` (underlying trimming cause not isolated). Failure signatures and skip sets match before/after; neither was suppressed.

Native arm64 Checked reflection control: six focused cases passed; full suite 1,776 passed, 2 platform skips, zero failures.

## Remaining scope

Draft for review of the frame-lifecycle distinction and FCall exception. Dedicated FCall cold/warm stack-identity coverage, a broader CoreCLR GC-stress campaign, and other browsers have not been run. No performance claim is made.

> [!NOTE]
> This change and pull request description were developed with GitHub Copilot assistance.