### PR TITLE
Fix scalar-typed SIMD operands in Dot and mask inversion lowering

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -33534,11 +33534,11 @@ NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForCmpOp(Compiler*  comp,
 
 #ifdef DEBUG
     // Once in LIR, lowering may feed a size-changing SIMD reinterpret operand directly -- e.g. an
-    // elided GetLower or ToVectorXXXUnsafe. It still occupies a full SIMD register and is consumed
-    // at the node's width, so treat any SIMD-typed operand as a full-vector operand rather than
-    // requiring an exact size match. In HIR the operand size must still be exact.
+    // elided GetLower or ToVectorXXXUnsafe -- or a scalar FP operand from CreateScalarUnsafe.
+    // These occupy SIMD registers and are consumed at the node's width; containment separately
+    // checks the memory-access size. In HIR the operand size must still be exact.
     auto isFullVectorOp = [=](GenTree* op) -> bool {
-        return op->TypeIs(simdType) || ((comp->fgNodeThreading == NodeThreading::LIR) && varTypeIsSIMD(op));
+        return op->TypeIs(simdType) || ((comp->fgNodeThreading == NodeThreading::LIR) && varTypeUsesFloatReg(op));
     };
 #endif // DEBUG
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5583,7 +5583,11 @@ GenTree* Lowering::LowerHWIntrinsicDotInnerMulSum(GenTreeHWIntrinsic* node)
     GenTree* tmp2 = nullptr;
     GenTree* tmp3 = nullptr;
 
-    tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
+    // CreateScalarUnsafe elision can leave scalar-typed operands here, but Dot still needs a
+    // vector multiply. Avoid the scalar-broadcast semantics of gtNewSimdBinOpNode.
+    NamedIntrinsic multiply = GenTreeHWIntrinsic::GetHWIntrinsicIdForBinOp(m_compiler, GT_MUL, op1, op2, simdBaseType,
+                                                                           simdSize, /* isScalar */ false);
+    tmp1 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, op1, op2, multiply, simdBaseType, simdSize);
     BlockRange().InsertBefore(node, tmp1);
     LowerNode(tmp1);
 

--- a/src/tests/JIT/Regression_ro_2/Runtime_133551.cs
+++ b/src/tests/JIT/Regression_ro_2/Runtime_133551.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_133551
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public static void TestDot128(bool reverse)
+    {
+        // Dot consumes undefined upper lanes. Only successful compilation and execution
+        // are required; there is no specified numerical result to assert.
+        Dot128(3.0f, Vector128.Create(2.0f), reverse);
+        Dot128(3.0, Vector128.Create(2.0), reverse);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public static void TestDot256(bool reverse)
+    {
+        Dot256(3.0f, Vector256.Create(2.0f), reverse);
+        Dot256(3.0, Vector256.Create(2.0), reverse);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static T Dot128<T>(T value, Vector128<T> vector, bool reverse)
+    {
+        return reverse ? Vector128.Dot(vector, Vector128.CreateScalarUnsafe(value))
+                       : Vector128.Dot(Vector128.CreateScalarUnsafe(value), vector);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static T Dot256<T>(T value, Vector256<T> vector, bool reverse)
+    {
+        return reverse ? Vector256.Dot(vector, Vector256.CreateScalarUnsafe(value))
+                       : Vector256.Dot(Vector256.CreateScalarUnsafe(value), vector);
+    }
+
+    [Fact]
+    public static void ScalarBroadcast()
+    {
+        Vector128<float> vector = Vector128.Create(2.0f, 4.0f, 6.0f, 8.0f);
+        Assert.Equal(Vector128.Create(6.0f, 12.0f, 18.0f, 24.0f), MultiplyLeft(3.0f, vector));
+        Assert.Equal(Vector128.Create(6.0f, 12.0f, 18.0f, 24.0f), MultiplyRight(vector, 3.0f));
+        Assert.Equal(Vector128.Create(1.0f, 2.0f, 3.0f, 4.0f), Divide(vector, 2.0f));
+
+        Vector128<double> doubles = Vector128.Create(2.0, 4.0);
+        Assert.Equal(Vector128.Create(6.0, 12.0), MultiplyLeft(3.0, doubles));
+        Assert.Equal(Vector128.Create(6.0, 12.0), MultiplyRight(doubles, 3.0));
+        Assert.Equal(Vector128.Create(1.0, 2.0), Divide(doubles, 2.0));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<T> MultiplyLeft<T>(T scalar, Vector128<T> vector) => scalar * vector;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<T> MultiplyRight<T>(Vector128<T> vector, T scalar) => vector * scalar;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<T> Divide<T>(Vector128<T> vector, T scalar) => vector / scalar;
+}

--- a/src/tests/JIT/Regression_ro_2/Runtime_133554.cs
+++ b/src/tests/JIT/Regression_ro_2/Runtime_133554.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_133554
+{
+    [Theory]
+    [InlineData(1.0, 1.0)]
+    [InlineData(1.0, 2.0)]
+    [InlineData(double.NaN, 1.0)]
+    public static void TestSelect(double x, double y)
+    {
+        // Only the low lane is defined by CreateScalarUnsafe.
+        Assert.Equal(x == y ? 0.0 : 7.0, Select(x, y, Vector512.Create(7.0)).ToScalar());
+        Assert.Equal(x == y ? 0.0f : 7.0f, Select((float)x, (float)y, Vector512.Create(7.0f)).ToScalar());
+
+        float singleX = (float)x;
+        float singleY = (float)y;
+        Assert.Equal(x == y ? 0.0 : 7.0, SelectMemory(ref x, ref y, Vector512.Create(7.0)).ToScalar());
+        Assert.Equal(x == y ? 0.0f : 7.0f, SelectMemory(ref singleX, ref singleY, Vector512.Create(7.0f)).ToScalar());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector512<T> Select<T>(T x, T y, Vector512<T> vector)
+    {
+        return Vector512.ConditionalSelect(
+            Vector512.Equals(Vector512.CreateScalarUnsafe(x), Vector512.CreateScalarUnsafe(y)),
+            Vector512<T>.Zero, vector);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector512<T> SelectMemory<T>(ref T x, ref T y, Vector512<T> vector)
+    {
+        return Vector512.ConditionalSelect(
+            Vector512.Equals(Vector512.CreateScalarUnsafe(x), Vector512.CreateScalarUnsafe(y)),
+            Vector512<T>.Zero, vector);
+    }
+}


### PR DESCRIPTION
Fixes dotnet/runtime#133551.
Fixes dotnet/runtime#133554.

Floating-point `CreateScalarUnsafe` elision leaves scalar-typed operands in LIR while hardware-intrinsic consumers still read them as vector registers. Two downstream paths did not account for that representation:

- Dot lowering used `gtNewSimdBinOpNode`, which interprets scalar-typed multiply operands as requesting broadcasts. That could create a child outside the LIR sequence. Select the vector multiply with `GetHWIntrinsicIdForBinOp` and construct the intrinsic directly instead. The shared builder's scalar-broadcast semantics remain unchanged.
- Comparison-ID lookup rejected scalar FP operands when mask inversion attempted to enable embedded zeroing. Accept FP/SIMD register representations in its LIR assertions, retaining exact vector types in HIR. Instruction selection, NaN-aware inversion, scalar spill sizes, and memory-width containment remain unchanged.

Add focused regressions for float/double Dot at 128/256 bits in both operand orders, scalar multiplication/division controls, and 512-bit selects with register/byref inputs covering equal, unequal, and NaN values. Dot tests intentionally do not assert results derived from undefined upper lanes.

### Validation

- Reproduced both assertions with the original Checked JIT.
- Built the final Windows x64 Checked JIT and passed all eight focused cases with native ISA, AVX-512 disabled, AVX disabled, hardware intrinsics disabled, and register stress. Rebuilt and repeated native/AVX runs after formatting.
- All 14 captured leaf disassemblies match the direct-intrinsic-ID implementation in native and AVX configurations. Scalar multiply/divide controls also match the original baseline. Native disassembly confirms packed multiplies, scalar-width byref loads, and masked zeroing.
- JIT formatting passed. Other JIT targets were compile-checked before the final instruction-lookup refactoring; execution was Windows x64 only. No throughput timing or full-suite result is claimed.

> [!NOTE]
> This PR description was generated by GitHub Copilot.
