### PR TITLE
[PERF] Use standalone Helix monitor for slow performance jobs

### DIFF
--- a/eng/pipelines/performance/perf-slow.yml
+++ b/eng/pipelines/performance/perf-slow.yml
@@ -37,7 +37,7 @@ resources:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: ${{ and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}
+    value: ${{ ne(variables['System.TeamProject'], 'public') }}
 
 schedules:
 - cron: "30 2 * * *"
@@ -54,13 +54,14 @@ extends:
     - stage: Build
       variables:
       # The standalone monitor does not inherit the submitter jobs' variable groups.
-      - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
         - group: DotNet-HelixApi-Access
       jobs:
       - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:
         - template: /eng/common/core-templates/job/helix-job-monitor.yml
           parameters:
-            helixAccessToken: $(HelixApiAccessToken)
+            ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+              helixAccessToken: $(HelixApiAccessToken)
             # Cap monitoring at six hours even though slow jobs can run longer.
             timeoutInMinutes: 360
             allowNoHelixJobs: true

--- a/eng/pipelines/performance/perf-slow.yml
+++ b/eng/pipelines/performance/perf-slow.yml
@@ -37,7 +37,7 @@ resources:
 variables:
   - template: /eng/pipelines/common/variables.yml
   - name: enableHelixJobMonitor
-    value: ${{ ne(variables['System.TeamProject'], 'public') }}
+    value: true
 
 schedules:
 - cron: "30 2 * * *"
@@ -57,14 +57,12 @@ extends:
       - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
         - group: DotNet-HelixApi-Access
       jobs:
-      - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:
-        - template: /eng/common/core-templates/job/helix-job-monitor.yml
-          parameters:
-            ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-              helixAccessToken: $(HelixApiAccessToken)
-            # Cap monitoring at six hours even though slow jobs can run longer.
-            timeoutInMinutes: 360
-            allowNoHelixJobs: true
+      - template: /eng/common/core-templates/job/helix-job-monitor.yml
+        parameters:
+          helixAccessToken: ${{ iif(and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')), '$(HelixApiAccessToken)', '') }}
+          # Cap monitoring at six hours even though slow jobs can run longer.
+          timeoutInMinutes: 360
+          allowNoHelixJobs: true
 
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - template: /eng/pipelines/runtime-slow-perf-jobs.yml@performance

--- a/eng/pipelines/performance/perf-slow.yml
+++ b/eng/pipelines/performance/perf-slow.yml
@@ -36,6 +36,8 @@ resources:
 
 variables:
   - template: /eng/pipelines/common/variables.yml
+  - name: enableHelixJobMonitor
+    value: ${{ and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}
 
 schedules:
 - cron: "30 2 * * *"
@@ -50,7 +52,19 @@ extends:
   parameters:
     stages:
     - stage: Build
+      variables:
+      # The standalone monitor does not inherit the submitter jobs' variable groups.
+      - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:
+        - group: DotNet-HelixApi-Access
       jobs:
+      - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:
+        - template: /eng/common/core-templates/job/helix-job-monitor.yml
+          parameters:
+            helixAccessToken: $(HelixApiAccessToken)
+            # Cap monitoring at six hours even though slow jobs can run longer.
+            timeoutInMinutes: 360
+            allowNoHelixJobs: true
+
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - template: /eng/pipelines/runtime-slow-perf-jobs.yml@performance
           parameters:


### PR DESCRIPTION
## Summary

Adopt the standalone Helix Job Monitor for `perf-slow`, following dotnet/runtime#132807, the stage-scoped credential fix in dotnet/runtime#133633, and the internal-PR credential alignment proposed in dotnet/runtime#133885.

- Always enable asynchronous submission and include the standalone monitor job with an explicit parameter block, including on public and no-selection runs. Existing benchmark selectors are unchanged; no public benchmark workloads are added.
- Import `DotNet-HelixApi-Access` at stage scope for all internal-project runs, including PRs, since the sibling monitor does not inherit submitter job variable groups. Always include `helixAccessToken`, using a compile-time `iif` expression to select `$(HelixApiAccessToken)` only for the internal project and an empty string for anonymous access elsewhere. Public runs, including public PRs, receive no private group or token.
- Keep a six-hour monitor job cap (`360` minutes; the tool's maximum wait is `355` minutes). Existing submitter and workitem timeouts remain unchanged, so this is not a whole-pipeline wall-clock deadline.
- Allow legitimate zero-submission runs and preserve the existing private/scheduled job selection, sanity flag, triggers, and schedules.

Only `eng/pipelines/performance/perf-slow.yml` changes.

## Validation

Internal pipeline **1012**, [sanity run 3072457](https://dev.azure.com/dnceng/internal/_build/results?buildId=3072457), ran with `onlySanityCheck=true`, `runScheduledJobs=true`, and `runPrivateJobs=true`.

- Tested runtime commit: `12fb88f1065a13388d7488fd28e65e18006a08f2`.
- Pinned performance resource: `c735123e8b45db1c8d0e30207bfe24a5fca2621c`.
- All four build jobs and five Azure submitter jobs succeeded. Sends completed in 29-45 seconds, before their Helix workloads finished.
- At 22:23:48 UTC, monitor log **239** recorded nine Azure jobs completed, none running or waiting, while one Helix job/workitem was still running. The monitor was the only remaining Azure job.
- After the final workitem finished at 22:24:06 UTC, the monitor drained all results and exited with code 1. Its final summary was **5 jobs submitted, 0 resubmitted, 5 processed; 5 workitems, 5 failed; 5 results uploaded**. The pipeline correctly finished **failed**, not false-green.

This demonstrates private job discovery, asynchronous agent release, completion gating, and failure propagation. **It is not a fully passing benchmark run.**

### Failure caveats

Four Linux workitems failed with `NETSDK1045`: generated benchmark projects target .NET 12.0 while the SDK reports support through .NET 11.0. The same error was verified in [main's slow-performance run 3072225](https://dev.azure.com/dnceng/internal/_build/results?buildId=3072225), including Linux Helix job `59558d46-2044-4bbe-9b59-cc369574171a`, `arm64.micro.net11.0.Partition0`, console line 848.

The Windows workitem failed differently: `WinError 225` blocked `dotnet --info` for the downloaded SDK as a virus or potentially unwanted software. This is **unclassified**, not a confirmed false positive or confirmed pre-existing failure. Evidence: Helix job `071489c5-3f06-4671-b957-0a25abcd5d65`, `arm64.micro.net11.0.Partition0`, console line 436. Build Analysis supplied no known-issue match.

### Final follow-up coverage

Subsequent revisions decouple private credentials from monitor eligibility. Commit `1b1a9defdfb3d4a1e1e0b47ba5edaeeb0794ce0e` now includes the flag, job, and all three parameters unconditionally. These changes were **not included in the live run** at `12fb88f1065a13388d7488fd28e65e18006a08f2`.

Commit `7b7d4d1bb9319a3f377126a1139e8f60b095db11` also aligns both credential guards with the internal-project-only predicate in dotnet/runtime#133885 (reference head `0250fbf77bfe09a37256a550a2a3de35414444e9`, open when inspected). It enables credentials for internal PRs while leaving public PRs anonymous. This revision has no new live-run coverage.

The final version passed local unique-key YAML parsing and 192 project/reason/private/scheduled/sanity combinations, including 68 public or no-selection cases with a monitor but no benchmark submissions. Checks cover unconditional monitor inclusion, credential import and token selection for internal runs including PRs, an explicit empty token for all other projects, the 360/355-minute limits, preserved workload selection/triggers/schedules, the monitor-template contract, and `git diff --check`.

An Azure preview of the earlier unconditional-monitor revision was attempted but denied because `EditBuild` permission is required. No permissions were changed or bypassed. The local expression checks are not an Azure template compiler or a live internal-PR/public-access test, and no new manual CI run or local product build was performed for this pipeline-only revision.

> [!NOTE]
> This change and PR description were prepared with GitHub Copilot.