### PR TITLE
Fix runtime diagnostics SOS test configuration

### DIFF
--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -221,6 +221,7 @@ jobs:
           -architecture ${{ parameters.archType }} `
           -privatebuild `
           $(_DacModeArgs) `
+          $(_TestInterpreterArgs) `
           -liveRuntimeDir ${{ parameters.liveRuntimeDir }} `
           $(_InternalInstallArgs) `
           /p:OfficialBuildId=$(BUILD.BUILDNUMBER)

--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -38,6 +38,7 @@ parameters:
   disableComponentGovernance: ''
   liveRuntimeDir: ''
   dacMode: ''
+  useRuntimeCDac: false
   classFilter: ''
   methodFilter: ''
   testInterpreter: false
@@ -91,6 +92,7 @@ jobs:
       - _TestArgs: '-test'
       - _Cross: ''
       - _DacModeArgs: ''
+      - _CDacPackageArgs: ''
       - _ClassFilterArgs: ''
       - _MethodFilterArgs: ''
       - _TestInterpreterArgs: ''
@@ -106,13 +108,13 @@ jobs:
       - ${{ if or(eq(parameters.buildOnly, 'true'), eq(parameters.isCodeQLRun, 'true')) }}:
         - _TestArgs: ''
 
-      # Selects which DAC/cDAC SOS loads (see DacMode in dotnet/diagnostics SOSRunner). The cdac mode
-      # restores the runtime-under-test's cDAC transport package from the local source configured by
-      # sos-test-leg.yml, which installs its matching cDAC and DBI next to sos.dll.
-      - ${{ if eq(parameters.dacMode, 'cdac') }}:
-        - _DacModeArgs: '-dacMode cdac /p:PackageWithCDac=true /p:runtimewinx64MicrosoftDotNetCdacTransportVersion=$(cdacTransportVersion) /p:RestoreAdditionalProjectSources=$(cdacTransportSource)'
-      - ${{ elseif ne(parameters.dacMode, '') }}:
+      # Selects which DAC/cDAC SOS loads (see DacMode in dotnet/diagnostics SOSRunner).
+      - ${{ if ne(parameters.dacMode, '') }}:
         - _DacModeArgs: '-dacMode ${{ parameters.dacMode }}'
+
+      # Installs the cDAC and DBI produced by the runtime build without changing SOS's default policy.
+      - ${{ if eq(parameters.useRuntimeCDac, 'true') }}:
+        - _CDacPackageArgs: '/p:PackageWithCDac=true /p:runtimewinx64MicrosoftDotNetCdacTransportVersion=$(cdacTransportVersion) /p:RestoreAdditionalProjectSources=$(cdacTransportSource)'
 
       - ${{ if ne(parameters.classFilter, '') }}:
         - _ClassFilterArgs: '-classfilter ${{ parameters.classFilter }}'
@@ -221,6 +223,7 @@ jobs:
           -architecture ${{ parameters.archType }} `
           -privatebuild `
           $(_DacModeArgs) `
+          $(_CDacPackageArgs) `
           $(_TestInterpreterArgs) `
           -liveRuntimeDir ${{ parameters.liveRuntimeDir }} `
           $(_InternalInstallArgs) `
@@ -239,6 +242,7 @@ jobs:
           -architecture ${{ parameters.archType }} `
           -privatebuild `
           $(_DacModeArgs) `
+          $(_CDacPackageArgs) `
           $(_TestInterpreterArgs) `
           -liveRuntimeDir ${{ parameters.liveRuntimeDir }} `
           $(_InternalInstallArgs) `

--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -107,10 +107,10 @@ jobs:
         - _TestArgs: ''
 
       # Selects which DAC/cDAC SOS loads (see DacMode in dotnet/diagnostics SOSRunner). The cdac mode
-      # additionally overlays the runtime-under-test's own cDAC next to sos.dll; the freshly built cDAC is
-      # downloaded by sos-test-leg.yml into artifacts/cdac and passed via -cdacPath.
+      # restores the runtime-under-test's cDAC transport package from the local source configured by
+      # sos-test-leg.yml, which installs its matching cDAC and DBI next to sos.dll.
       - ${{ if eq(parameters.dacMode, 'cdac') }}:
-        - _DacModeArgs: '-dacMode cdac -cdacPath $(Build.SourcesDirectory)/artifacts/cdac/mscordaccore_universal.dll'
+        - _DacModeArgs: '-dacMode cdac /p:PackageWithCDac=true /p:runtimewinx64MicrosoftDotNetCdacTransportVersion=$(cdacTransportVersion) /p:RestoreAdditionalProjectSources=$(cdacTransportSource)'
       - ${{ elseif ne(parameters.dacMode, '') }}:
         - _DacModeArgs: '-dacMode ${{ parameters.dacMode }}'
 
@@ -212,27 +212,40 @@ jobs:
         - ${{ else }}:
           - ${{ preBuildStep }}
 
-    # Build
-    - script: $(_buildScript)
-          -ci
-          -configuration ${{ parameters.buildConfig }}
-          -architecture ${{ parameters.archType }}
-          -privatebuild
-          $(_DacModeArgs)
-          $(_TestInterpreterArgs)
-          -liveRuntimeDir ${{ parameters.liveRuntimeDir }}
-          $(_TestArgs)
-          $(_Cross)
-          $(_InternalInstallArgs)
-          $(_ClassFilterArgs)
-          $(_MethodFilterArgs)
+    - powershell: |
+        & "$(Build.SourcesDirectory)\eng\build.ps1" `
+          -restore `
+          -build `
+          -ci `
+          -configuration ${{ parameters.buildConfig }} `
+          -architecture ${{ parameters.archType }} `
+          -privatebuild `
+          $(_DacModeArgs) `
+          -liveRuntimeDir ${{ parameters.liveRuntimeDir }} `
+          $(_InternalInstallArgs) `
           /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-      ${{ if eq(parameters.testOnly, 'true') }}:
-        displayName: Test
-      ${{ elseif eq(parameters.buildOnly, 'true') }}:
-        displayName: Build
-      ${{ else }}:
-        displayName: Build / Test
+        exit $LASTEXITCODE
+      displayName: Build
+      condition: succeeded()
+
+    - powershell: |
+        & "$(Build.SourcesDirectory)\eng\build.ps1" `
+          -test `
+          -skipnative `
+          -skipmanaged `
+          -ci `
+          -configuration ${{ parameters.buildConfig }} `
+          -architecture ${{ parameters.archType }} `
+          -privatebuild `
+          $(_DacModeArgs) `
+          $(_TestInterpreterArgs) `
+          -liveRuntimeDir ${{ parameters.liveRuntimeDir }} `
+          $(_InternalInstallArgs) `
+          $(_ClassFilterArgs) `
+          $(_MethodFilterArgs) `
+          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+        exit $LASTEXITCODE
+      displayName: Test
       condition: succeeded()
 
     - ${{ if in(parameters.osGroup, 'osx', 'ios', 'tvos', 'android') }}:

--- a/eng/pipelines/diagnostics/sos-test-leg.yml
+++ b/eng/pipelines/diagnostics/sos-test-leg.yml
@@ -1,7 +1,6 @@
 # sos-test-leg.yml -- wraps the matrix + job + dep + artifact download +
-# standard postBuildSteps pattern used by the SOS-style test legs (cDAC,
-# cDAC_verify, DAC) that run on windows_x64. Each of those legs
-# only differs in its `name` and `dacMode` value.
+# standard postBuildSteps pattern used by the SOS-style test legs (PreferCDac
+# and DAC) that run on windows_x64.
 #
 # AzDO tasks workaround:
 #   PublishTestResults v2.270.0 garbles parameterized xUnit test names
@@ -14,6 +13,9 @@ parameters:
 - name: dacMode
   type: string
   default: ''
+- name: useRuntimeCDac
+  type: boolean
+  default: false
 
 jobs:
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -28,6 +30,7 @@ jobs:
     jobParameters:
       name: ${{ parameters.name }}
       dacMode: ${{ parameters.dacMode }}
+      useRuntimeCDac: ${{ parameters.useRuntimeCDac }}
       testInterpreter: true
       methodFilter: SOS*
       isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -42,9 +45,7 @@ jobs:
           artifactFileName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr$(archiveExtension)
           unpackFolder: $(Build.SourcesDirectory)/artifacts/runtime
           displayName: 'Runtime Build Artifacts'
-      # The cdac leg exercises the runtime-under-test's matching cDAC and DBI pair. Download the
-      # transport package produced by the runtime build and expose it as a local NuGet source.
-      - ${{ if eq(parameters.dacMode, 'cdac') }}:
+      - ${{ if eq(parameters.useRuntimeCDac, true) }}:
         - template: /eng/pipelines/common/download-artifact-step.yml
           parameters:
             artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_cdac

--- a/eng/pipelines/diagnostics/sos-test-leg.yml
+++ b/eng/pipelines/diagnostics/sos-test-leg.yml
@@ -1,6 +1,6 @@
 # sos-test-leg.yml -- wraps the matrix + job + dep + artifact download +
-# standard postBuildSteps pattern used by the SOS-style test legs (PreferCDac
-# and DAC) that run on windows_x64.
+# standard postBuildSteps pattern used by the SOS-style test legs (cDAC and
+# DAC) that run on windows_x64.
 #
 # AzDO tasks workaround:
 #   PublishTestResults v2.270.0 garbles parameterized xUnit test names

--- a/eng/pipelines/diagnostics/sos-test-leg.yml
+++ b/eng/pipelines/diagnostics/sos-test-leg.yml
@@ -42,17 +42,28 @@ jobs:
           artifactFileName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr$(archiveExtension)
           unpackFolder: $(Build.SourcesDirectory)/artifacts/runtime
           displayName: 'Runtime Build Artifacts'
-      # The cdac leg exercises the runtime-under-test's own cDAC through SOS's standard cDAC hosting.
-      # SOS resolves the cDAC from next to sos.dll, which is the copy restored from a referenced runtime
-      # package -- not the runtime being tested. Download the freshly built cDAC so the build can overlay
-      # it (see -cdacPath in runtime-diag-job.yml / eng/build.* in dotnet/diagnostics).
+      # The cdac leg exercises the runtime-under-test's matching cDAC and DBI pair. Download the
+      # transport package produced by the runtime build and expose it as a local NuGet source.
       - ${{ if eq(parameters.dacMode, 'cdac') }}:
         - template: /eng/pipelines/common/download-artifact-step.yml
           parameters:
             artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_cdac
             artifactFileName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_cdac$(archiveExtension)
             unpackFolder: $(Build.SourcesDirectory)/artifacts/cdac
-            displayName: 'cDAC Build Artifacts'
+            displayName: 'cDAC Transport Package'
+        - powershell: |
+            $packageId = "runtime.win-$(archType).Microsoft.DotNet.Cdac.Transport"
+            $packages = @(Get-ChildItem -File -Path "$(Build.SourcesDirectory)\artifacts\cdac\$packageId.*.nupkg" | Where-Object Name -NotLike '*.symbols.nupkg')
+            if ($packages.Count -ne 1) {
+              throw "Expected one cDAC transport package, but found $($packages.Count)."
+            }
+
+            $packageNamePrefix = "$packageId."
+            $packageVersion = $packages[0].BaseName.Substring($packageNamePrefix.Length)
+
+            Write-Host "##vso[task.setvariable variable=cdacTransportSource]$($packages[0].DirectoryName)"
+            Write-Host "##vso[task.setvariable variable=cdacTransportVersion]$packageVersion"
+          displayName: 'Configure cDAC Transport Package'
       postBuildSteps:
       - task: PublishTestResults@2
         inputs:

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -4,7 +4,7 @@
 #
 #   SOSTests           windows_x64 Release. One shared coreclr+libs build (-c Debug
 #                      -rc release -lc release -clrinterpreter) consumed by 2 SOS
-#                      legs that run on top of it: PreferCDac and DAC.
+#                      legs that run on top of it: cDAC and DAC.
 #                      Each leg sets testInterpreter: true so interpreter coverage
 #                      is exercised inline (no separate Interpreter leg).
 #
@@ -151,7 +151,7 @@ extends:
                 tarCompression: $(tarCompression)
                 artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
                 displayName: Build Assets
-            # Publish the transport package so the PreferCDac leg consumes the same cDAC and DBI
+            # Publish the transport package so the cDAC leg consumes the same cDAC and DBI
             # pair produced by this runtime build.
             - powershell: |
                 $packagePattern = "$(Build.SourcesDirectory)\artifacts\packages\Debug\NonShipping\runtime.win-$(archType).Microsoft.DotNet.Cdac.Transport.*.nupkg"
@@ -178,10 +178,11 @@ extends:
       # SOS test legs: each depends on the shared build above. Differ only in
       # name (artifact namespace) and the cDAC/DAC load mode.
 
-      # Exercise SOS's default behavior, which prefers cDAC and falls back to the DAC.
+      # Exercise SOS's strict standalone cDAC mode with the matching cDAC and DBI.
       - template: /eng/pipelines/diagnostics/sos-test-leg.yml
         parameters:
-          name: PreferCDac
+          name: cDAC
+          dacMode: cdac
           useRuntimeCDac: true
 
       - template: /eng/pipelines/diagnostics/sos-test-leg.yml

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -3,8 +3,8 @@
 # Pipeline overview:
 #
 #   SOSTests           windows_x64 Release. One shared coreclr+libs build (-c Debug
-#                      -rc release -lc release -clrinterpreter) consumed by 3 SOS
-#                      legs that run on top of it: cDAC, cDAC_verify, DAC.
+#                      -rc release -lc release -clrinterpreter) consumed by 2 SOS
+#                      legs that run on top of it: PreferCDac and DAC.
 #                      Each leg sets testInterpreter: true so interpreter coverage
 #                      is exercised inline (no separate Interpreter leg).
 #
@@ -116,7 +116,7 @@ extends:
     stages:
 
     # ----------------------------------------------------------------------
-    # SOS tests: shared windows_x64 build + 3 SOS legs that consume it.
+    # SOS tests: shared windows_x64 build + 2 SOS legs that consume it.
     # ----------------------------------------------------------------------
     - stage: SOSTests
       jobs:
@@ -151,7 +151,7 @@ extends:
                 tarCompression: $(tarCompression)
                 artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
                 displayName: Build Assets
-            # Publish the transport package so the cDAC-only SOS leg consumes the same cDAC and DBI
+            # Publish the transport package so the PreferCDac leg consumes the same cDAC and DBI
             # pair produced by this runtime build.
             - powershell: |
                 $packagePattern = "$(Build.SourcesDirectory)\artifacts\packages\Debug\NonShipping\runtime.win-$(archType).Microsoft.DotNet.Cdac.Transport.*.nupkg"
@@ -178,19 +178,11 @@ extends:
       # SOS test legs: each depends on the shared build above. Differ only in
       # name (artifact namespace) and the cDAC/DAC load mode.
 
-      # cDAC: the runtime-under-test's own standalone cDAC (mscordaccore_universal) loaded through SOS's
-      # standard cDAC hosting path (overlaying the freshly built cDAC next to sos.dll).
+      # Exercise SOS's default behavior, which prefers cDAC and falls back to the DAC.
       - template: /eng/pipelines/diagnostics/sos-test-leg.yml
         parameters:
-          name: cDAC
-          dacMode: cdac
-
-      # cDAC_verify: the in-box DAC hosts the cDAC contract reader without fallback,
-      # while still verifying against the legacy DAC.
-      - template: /eng/pipelines/diagnostics/sos-test-leg.yml
-        parameters:
-          name: cDAC_verify
-          dacMode: cdacverify
+          name: PreferCDac
+          useRuntimeCDac: true
 
       - template: /eng/pipelines/diagnostics/sos-test-leg.yml
         parameters:

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -151,15 +151,23 @@ extends:
                 tarCompression: $(tarCompression)
                 artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
                 displayName: Build Assets
-            # The cDAC (mscordaccore_universal) is built by tools.cdac but is not part of the shared
-            # framework (testhost), so upload it separately for the cDAC-only SOS leg to consume.
+            # Publish the transport package so the cDAC-only SOS leg consumes the same cDAC and DBI
+            # pair produced by this runtime build.
             - powershell: |
-                $cdacDir = Get-ChildItem -Directory -Path "$(Build.SourcesDirectory)\artifacts\bin\mscordaccore_universal\*\win-$(archType)\publish" | Select-Object -ExpandProperty FullName -First 1
-                Write-Host "##vso[task.setvariable variable=cdacDir]$cdacDir"
-              displayName: 'Set Path to cDAC Artifacts'
+                $packagePattern = "$(Build.SourcesDirectory)\artifacts\packages\Debug\NonShipping\runtime.win-$(archType).Microsoft.DotNet.Cdac.Transport.*.nupkg"
+                $packages = @(Get-ChildItem -File -Path $packagePattern | Where-Object Name -NotLike '*.symbols.nupkg')
+                if ($packages.Count -ne 1) {
+                  throw "Expected one cDAC transport package matching '$packagePattern', but found $($packages.Count)."
+                }
+
+                $cdacTransportUploadDir = "$(Build.ArtifactStagingDirectory)\cdac-transport"
+                New-Item -ItemType Directory -Force -Path $cdacTransportUploadDir | Out-Null
+                Copy-Item -Path $packages[0].FullName -Destination $cdacTransportUploadDir
+                Write-Host "##vso[task.setvariable variable=cdacTransportUploadDir]$cdacTransportUploadDir"
+              displayName: 'Stage cDAC Transport Package'
             - template: /eng/pipelines/common/upload-artifact-step.yml
               parameters:
-                rootFolder: $(cdacDir)
+                rootFolder: $(cdacTransportUploadDir)
                 includeRootFolder: false
                 archiveType: $(archiveType)
                 archiveExtension: $(archiveExtension)


### PR DESCRIPTION
Fix the runtime-diagnostics SOS test configuration so it uses a coherent set of runtime, cDAC, and DBI artifacts.

- Build the interpreter debuggee assets when interpreter testing is enabled.
- Publish and restore the cDAC transport package produced by the runtime build, keeping the matching universal cDAC and DBI together.
- Continue exercising strict cDAC-only mode, with a separate forced-DAC comparison leg.

### Strict cDAC-only coverage

The cDAC leg still passes `-dacMode cdac`. Diagnostics maps this to `runtimes --usecdac true`, selecting `OnlyUseCDac`: supported runtimes must use standalone cDAC and SOS may not fall back to a legacy DAC.

`DualRuntimes` also remains covered in this strict mode. dotnet/diagnostics#6026 updates the test for the expected desktop .NET Framework behavior: selecting the desktop runtime succeeds, but its data-access commands must fail because desktop Framework does not support cDAC and fallback is disabled. This preserves the multi-runtime test without weakening the cDAC-only policy.

The separate `DAC` leg passes `-dacMode dac` and provides explicit legacy-DAC comparison coverage.

### Matching cDAC transport package

The cDAC and universal DBI must match the runtime being tested. The pipeline keeps them coherent as follows:

1. The shared runtime job builds CoreCLR, cDAC, and DBI together and produces `runtime.win-x64.Microsoft.DotNet.Cdac.Transport.<version>.nupkg`.
2. That job selects exactly one non-symbol transport package and publishes it as `BuildArtifacts_windows_x64_Release_cdac`.
3. The strict `cDAC` job downloads that artifact into a clean workspace, derives the exact package version from its filename, and exposes the downloaded directory as a local NuGet source.
4. The diagnostics build receives `/p:PackageWithCDac=true`, the filename-derived `runtimewinx64MicrosoftDotNetCdacTransportVersion`, and `/p:RestoreAdditionalProjectSources=<downloaded artifact>`.
5. Diagnostics' `InstallNativePackages.targets` restores that exact transport-package version and copies both `mscordaccore_universal.dll` and `mscordbi_universal.dll` beside SOS. The runtime itself comes from the corresponding same-build CoreCLR artifact through `liveRuntimeDir`.

As an artifact-level check, the SHA-256 of `mscordaccore_universal.dll` inside validation build 1593212's transport package exactly matched the copy in that build's CoreCLR artifact (`63E8DFFB...33B27B8`). The package also contains the matching same-build `mscordbi_universal.dll`.

### Validation

- Parsed all modified YAML files successfully.
- `git diff --check` passes.
- [Runtime-diagnostics build 1593582](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1593582) succeeded using this PR with `diagnosticsBranch=refs/pull/6026/merge`.
- Both `cDAC_windows_x64_release` and `DAC_windows_x64_release` passed.
- The cDAC leg used strict `OnlyUseCDac` together with the transport package produced by the same runtime build.

Addresses #133282. Related to #132073 and dotnet/diagnostics#6026.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.