### PR TITLE
JIT: Preserve constrained boxing order

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -639,6 +639,12 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                     }
                 }
 
+                if (callInfo->thisTransform != CORINFO_NO_THIS_TRANSFORM)
+                {
+                    impSpillSideEffects(false, CHECK_SPILL_ALL DEBUGARG(
+                                                   "LDVIRTFTN constrained call requires transforming 'this'"));
+                }
+
                 impPopCallArgs(sig, call->AsCall());
 
                 if (call->AsCall()->IsAsync())

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1034,17 +1034,17 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     // The main group of arguments, and the this pointer.
 
     // 'this' is pushed on the IL stack before all call args, but if this is a
-    // constrained call 'this' is a byref that may need to be dereferenced.
-    // That dereference should happen _after_ all args, so we need to spill
-    // them if they can interfere.
+    // constrained call 'this' is a byref that may need to be dereferenced or
+    // boxed. That transformation should happen _after_ all args, so we need
+    // to spill them if they can interfere.
     bool hasThis;
     hasThis = ((mflags & CORINFO_FLG_STATIC) == 0) && ((sig->callConv & CORINFO_CALLCONV_EXPLICITTHIS) == 0) &&
               ((opcode != CEE_NEWOBJ) || (newobjThis != nullptr));
 
-    if (hasThis && (constraintCallThisTransform == CORINFO_DEREF_THIS))
+    if (hasThis && (constraintCallThisTransform != CORINFO_NO_THIS_TRANSFORM))
     {
         impSpillSideEffects(false, CHECK_SPILL_ALL DEBUGARG(
-                                       "constrained call requires dereference for 'this' right before call"));
+                                       "constrained call requires transforming 'this' right before call"));
     }
 
     impPopCallArgs(sig, call->AsCall());

--- a/src/tests/JIT/Regression_2/Runtime_133716/Runtime_133716.cs
+++ b/src/tests/JIT/Regression_2/Runtime_133716/Runtime_133716.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_133716
+{
+    private static S s_value;
+
+    [Fact]
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static int Main()
+    {
+        s_value.X = 1;
+
+        Assert.True(s_value.Equals(Mutate()));
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static object Mutate()
+    {
+        s_value.X = 7;
+        return new S { X = 7 };
+    }
+
+    private struct S
+    {
+        public int X;
+    }
+}

--- a/src/tests/JIT/Regression_2/Runtime_133716/Runtime_133716.cs
+++ b/src/tests/JIT/Regression_2/Runtime_133716/Runtime_133716.cs
@@ -10,13 +10,28 @@ public class Runtime_133716
     private static S s_value;
 
     [Fact]
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
     public static int Main()
     {
         s_value.X = 1;
+        Assert.True(TestBoxThis(), nameof(TestBoxThis));
 
-        Assert.True(s_value.Equals(Mutate()));
+        s_value.X = 1;
+        Assert.True(TestLdvirtftn(ref s_value), nameof(TestLdvirtftn));
+
         return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool TestBoxThis()
+    {
+        return s_value.Equals(Mutate());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool TestLdvirtftn<T>(ref T value)
+        where T : I
+    {
+        return value.Equals<int>(Mutate());
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -26,7 +41,15 @@ public class Runtime_133716
         return new S { X = 7 };
     }
 
-    private struct S
+    private interface I
+    {
+        bool Equals<T>(object other)
+        {
+            return Equals(other);
+        }
+    }
+
+    private struct S : I
     {
         public int X;
     }

--- a/src/tests/JIT/Regression_2/Runtime_133716/Runtime_133716.csproj
+++ b/src/tests/JIT/Regression_2/Runtime_133716/Runtime_133716.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <Optimize>true</Optimize>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Spill interfering argument side effects before transforming constrained
receivers so boxing observes mutations performed while evaluating arguments.

Fixes #133716

> [!NOTE]
> This PR description was generated with GitHub Copilot.