### PR TITLE
Fix JIT this pointer null check elision

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -14171,6 +14171,10 @@ void Compiler::impInlineInitVars(InlineInfo* pInlineInfo)
 
     /* init the argument struct */
     memset(inlArgInfo, 0, (MAX_INL_ARGS + 1) * sizeof(inlArgInfo[0]));
+    for (unsigned i = 0; i <= MAX_INL_ARGS; i++)
+    {
+        inlArgInfo[i].argTmpNum = BAD_VAR_NUM;
+    }
 
     pInlineInfo->argCnt = pInlineInfo->inlineCandidateInfo->methInfo.args.totalILArgs();
     unsigned ilArgCnt   = 0;

--- a/src/tests/JIT/Regression_o_3/Runtime_133713.cs
+++ b/src/tests/JIT/Regression_o_3/Runtime_133713.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Runtime_133713;
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_133713
+{
+    private sealed class Data
+    {
+        public int V;
+    }
+
+    private sealed class Node
+    {
+        public int Get(Data data) => data.V;
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        try
+        {
+            Data data = new() { V = 123 };
+            _ = Foo(data, null);
+        }
+        catch (NullReferenceException)
+        {
+            return 100;
+        }
+
+        return -1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static int Foo(Data data, Node node) => node.Get(data);
+}


### PR DESCRIPTION
## Summary

- Initialize inline argument temp mappings with `BAD_VAR_NUM` before analyzing this pointer dereferences.
- Prevent an unfetched this pointer from being confused with caller local `V00`, preserving the required null check.
- Add a regression test under `Regression_o_3`.

Fixes #133713

> [!NOTE]
> This pull request description was generated with GitHub Copilot.