### PR TITLE
Temporarily disable Windows x64 Mono MiniJIT runtime tests

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1777,44 +1777,8 @@ extends:
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
-      #
-      # Build the whole product using Mono and run runtime tests
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-            - windows_x64
-          variables:
-            - name: timeoutPerTestInMinutes
-              value: 60
-            - name: timeoutPerTestCollectionInMinutes
-              value: 180
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_Minijit_RuntimeTests
-            runtimeVariant: minijit
-            buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release -lc ${{ variables.debugOnPrReleaseOnRolling }}
-            timeoutInMinutes: 180
-            condition: >-
-                  or(
-                    eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                    eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                    eq(variables['isRollingBuild'], true))
-
-            postBuildSteps:
-              - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-                parameters:
-                  creator: dotnet-bot
-                  testRunNamePrefixSuffix: Mono_Release
-                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
-            extraVariablesTemplates:
-              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
-                parameters:
-                  liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      # ActiveIssue https://github.com/dotnet/runtime/issues/133702
+      # Re-enable Windows x64 Mono MiniJIT runtime tests once FAST_FAIL_SET_CONTEXT_DENIED is resolved.
 
       #
       # Mono CoreCLR runtime Test executions using live libraries in interpreter mode


### PR DESCRIPTION
## Summary

Remove only the Windows x64 `AllSubsets_Mono_Minijit_RuntimeTests` entry from `eng/pipelines/runtime.yml`, temporarily suspending that leg for PR and rolling builds.

The leg repeatedly fails across 46 process-level work items with `FAST_FAIL_SET_CONTEXT_DENIED`, as documented in #133702. This follows the [discussion about removing the Windows run](https://github.com/dotnet/runtime/issues/133702#issuecomment-5640802858). A lane-level mitigation avoids scattering exclusions across unrelated tests while the systemic exception-continuation failure is investigated.

Linux/macOS MiniJIT runtime tests, Windows Mono library tests, and other Windows coverage remain unchanged. An adjacent `ActiveIssue` comment records the tracking issue and the requirement to re-enable the leg once the failure is resolved.

Related to #133702. **This is a temporary CI mitigation, not a product fix; the issue should remain open.**

## Validation

- Parsed the original and modified YAML and confirmed the only structural difference is removal of the single Windows x64 Mono MiniJIT runtime-test matrix entry; all other pipeline nodes are unchanged.
- `git diff --check` passed.
- No product build or runtime tests run: this changes pipeline scheduling only. Azure Pipelines template expansion was not run locally.

> [!NOTE]
> This PR was generated with GitHub Copilot.