### PR TITLE
Enable Roslyn compiler output caching in non-official builds

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -141,6 +141,9 @@ jobs:
       - name: MSBUILDDEBUGPATH
         value: $(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/MsbuildDebugLogs
 
+      - name: _compilerCacheBuildArgs
+        value: ''
+
       - ${{ each variableTemplate in parameters.extraVariablesTemplates }}:
         - template: ${{ variableTemplate.template }}
           parameters:
@@ -224,7 +227,7 @@ jobs:
     # Build
     - template: /eng/pipelines/common/templates/global-build-step.yml
       parameters:
-        buildArgs: ${{ parameters.buildArgs }}
+        buildArgs: ${{ parameters.buildArgs }} $(_compilerCacheBuildArgs)
         useContinueOnErrorDuringBuild: ${{ parameters.useContinueOnErrorDuringBuild }}
         shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
 

--- a/eng/pipelines/coreclr/templates/roslyn-cache-stats.yml
+++ b/eng/pipelines/coreclr/templates/roslyn-cache-stats.yml
@@ -1,0 +1,24 @@
+steps:
+  - script: |
+      set -euo pipefail
+
+      dotnet="$(Build.SourcesDirectory)/.dotnet/dotnet"
+      if [[ -z "${ROSLYN_CACHE_PATH:-}" ||
+            -z "${ROSLYN_CACHE_BUILD_START:-}" ||
+            ! -x "$dotnet" ]]; then
+          echo "Roslyn compiler cache statistics are unavailable."
+          exit 0
+      fi
+
+      sdkVersion="$("$dotnet" --version)"
+      compilerServer="$(Build.SourcesDirectory)/.dotnet/sdk/$sdkVersion/Roslyn/bincore/VBCSCompiler.dll"
+      if [[ ! -f "$compilerServer" ]]; then
+          echo "Roslyn compiler server not found at $compilerServer."
+          exit 0
+      fi
+
+      "$dotnet" "$compilerServer" \
+        "-cachestats:${ROSLYN_CACHE_BUILD_START}" \
+        "-cachepath:${ROSLYN_CACHE_PATH}" || true
+    displayName: Roslyn compiler cache stats
+    condition: always()

--- a/eng/pipelines/coreclr/templates/sccache-stats.yml
+++ b/eng/pipelines/coreclr/templates/sccache-stats.yml
@@ -13,6 +13,8 @@ parameters:
 
 steps:
   - ${{ if and(or(eq(parameters.osGroup, 'linux'), eq(parameters.osGroup, 'freebsd'), eq(parameters.osGroup, 'openbsd'), eq(parameters.osGroup, 'osx')), or(eq(parameters.archType, 'x64'), eq(parameters.archType, 'arm64'))) }}:
+    - template: /eng/pipelines/coreclr/templates/roslyn-cache-stats.yml
+
     - script: sccache --show-stats || true
       displayName: Sccache stats
       condition: always()

--- a/eng/pipelines/coreclr/templates/setup-roslyn-cache.yml
+++ b/eng/pipelines/coreclr/templates/setup-roslyn-cache.yml
@@ -1,0 +1,30 @@
+parameters:
+  archType: 'x64'
+  osGroup: 'linux'
+  nameSuffix: ''
+  osSubgroup: ''
+
+steps:
+  # Cache entries restored by pull request builds come only from the pull
+  # request itself or its target branch. This lets rolling builds seed the
+  # cache without allowing pull requests to modify caches used by main.
+  #
+  # The managed configuration is intentionally excluded. Roslyn's
+  # deterministic key includes the compilation options, and some pipeline
+  # legs override the matrix configuration in their build arguments.
+  - task: Cache@2
+    displayName: Roslyn compiler cache
+    continueOnError: true
+    inputs:
+      key: roslyn | v1 | ${{ parameters.osGroup }}${{ parameters.osSubgroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }} | "$(Build.BuildId)"
+      path: $(Pipeline.Workspace)/.roslyn-cache
+      restoreKeys: |
+        roslyn | v1 | ${{ parameters.osGroup }}${{ parameters.osSubgroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }}
+
+  - script: |
+      set -euo pipefail
+      echo "##vso[task.setvariable variable=ROSLYN_CACHE_PATH]$(Pipeline.Workspace)/.roslyn-cache"
+      echo "##vso[task.setvariable variable=ROSLYN_CACHE_BUILD_START]$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+      echo "##vso[task.setvariable variable=EnableSourceLink]false"
+      echo "##vso[task.setvariable variable=_compilerCacheBuildArgs]/p:EnableSourceLink=false"
+    displayName: Configure Roslyn compiler cache

--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -17,6 +17,13 @@ parameters:
 
 steps:
   - ${{ if and(or(eq(parameters.osGroup, 'linux'), eq(parameters.osGroup, 'freebsd'), eq(parameters.osGroup, 'openbsd'), eq(parameters.osGroup, 'osx')), or(eq(parameters.archType, 'x64'), eq(parameters.archType, 'arm64'))) }}:
+    - template: /eng/pipelines/coreclr/templates/setup-roslyn-cache.yml
+      parameters:
+        osGroup: ${{ parameters.osGroup }}
+        osSubgroup: ${{ parameters.osSubgroup }}
+        archType: ${{ parameters.archType }}
+        nameSuffix: ${{ parameters.nameSuffix }}
+
     # Set up the Azure Pipeline Cache for sccache's local cache directory.
     # Use a rolling key so each build can update the cache; restoreKeys
     # falls back to the most recent saved entry.


### PR DESCRIPTION
Enable Roslyn's experimental compiler output cache in the Unix x64/arm64 non-official build legs that already use sccache.

The setup:

- persists the compiler cache with Azure Pipelines `Cache@2`
- allows rolling builds to seed caches that PR builds can restore
- preserves Azure's cache security boundary so PR writes cannot affect caches consumed by main
- disables SourceLink for these non-official builds because commit-specific SourceLink inputs invalidate compiler cache entries
- uses the deterministic `PathMap` already produced by `ContinuousIntegrationBuild`
- reports per-build hit/store statistics alongside sccache statistics

Official builds are unaffected and continue to produce SourceLink-enabled outputs without using this cache.

In a two-commit `libs.tests` experiment using a Roslyn build containing dotnet/roslyn#84916, globally disabling SourceLink produced 358 hits and one store across 359 compiler invocations. The cached build took 4m53s versus 6m32s with the cache disabled, a 25.25% reduction (1.338x speedup). With SourceLink enabled, only 13 invocations hit.

A local integration probe using `ROSLYN_CACHE_PATH` produced 41 stores on the first rebuild and 41 hits on the second rebuild.

The Roslyn compiler output cache remains experimental. Cache read or write failures fall back to normal compilation, and the outer cache key is versioned so its provisional format can be invalidated independently.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
