### PR TITLE
Preserve profiling for managed intrinsic implementations

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5547,6 +5547,7 @@ public:
     static const unsigned CHECK_SPILL_NONE = static_cast<unsigned>(-2);
 
     NamedIntrinsic lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method);
+    NamedIntrinsic resolveNamedIntrinsic(CORINFO_METHOD_HANDLE method, NamedIntrinsic intrinsic);
     void impBeginTreeList();
     void impEndTreeList(BasicBlock* block, Statement* firstStmt, Statement* lastStmt);
     void impEndTreeList(BasicBlock* block);

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1109,6 +1109,12 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                 {
                     ni = resolveNamedIntrinsic(methodHnd, lookupNamedIntrinsic(methodHnd));
 
+                    if (((ni == NI_System_Numerics_Intrinsic) || (ni == NI_System_Runtime_Intrinsics_Intrinsic)) &&
+                        gtIsRecursiveCall(methodHnd, false))
+                    {
+                        ni = NI_Throw_PlatformNotSupportedException;
+                    }
+
                     bool foldableIntrinsic = false;
 
                     if (IsMathIntrinsic(ni))

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1107,7 +1107,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
 
                 if (isIntrinsic)
                 {
-                    ni = lookupNamedIntrinsic(methodHnd);
+                    ni = resolveNamedIntrinsic(methodHnd, lookupNamedIntrinsic(methodHnd));
 
                     bool foldableIntrinsic = false;
 
@@ -1498,7 +1498,11 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                         }
                     }
 
-                    if (foldableIntrinsic)
+                    if (ni == NI_Throw_PlatformNotSupportedException)
+                    {
+                        compInlineResult->Note(InlineObservation::CALLEE_THROW_BLOCK);
+                    }
+                    else if (foldableIntrinsic)
                     {
                         compInlineResult->Note(InlineObservation::CALLSITE_FOLDABLE_INTRINSIC);
                         handled = true;
@@ -1514,7 +1518,8 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                     }
                 }
 
-                if ((codeAddr < codeEndp - sz) && (OPCODE)getU1LittleEndian(codeAddr + sz) == CEE_RET)
+                if ((ni != NI_Throw_PlatformNotSupportedException) && (codeAddr < codeEndp - sz) &&
+                    (OPCODE)getU1LittleEndian(codeAddr + sz) == CEE_RET)
                 {
                     // If the method has a call followed by a ret, assume that
                     // it is a wrapper method.

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2561,42 +2561,71 @@ PhaseStatus Compiler::fgPrepareToInstrumentMethod()
     const bool minimalProfiling =
         prejit ? (JitConfig.JitMinimalPrejitProfiling() > 0) : (JitConfig.JitMinimalJitProfiling() > 0);
 
-    // In majority of cases, methods marked with [Intrinsic] are imported directly
-    // in Tier1 so the profile will never be consumed. Thus, let's avoid unnecessary probes...
+    // Intrinsic recognition must not prevent ordinary managed implementations from
+    // benefiting from profiles. Exclude compiler primitives and explicit SIMD APIs,
+    // rather than requiring every managed fallback to be recognized here.
     if (minimalProfiling && (info.compFlags & CORINFO_FLG_INTRINSIC) != 0)
     {
-        //... except a few intrinsics that might still need it:
-        bool           shouldBeInstrumented = false;
+        bool           shouldBeInstrumented = true;
         NamedIntrinsic ni                   = lookupNamedIntrinsic(info.compMethodHnd);
         switch (ni)
         {
-            // These are marked as [Intrinsic] only to be handled (unrolled) for constant inputs.
-            // In other cases they have large managed implementations we want to profile.
-            case NI_System_String_Equals:
-            case NI_System_SpanHelpers_Memmove:
-            case NI_System_MemoryExtensions_Equals:
-            case NI_System_MemoryExtensions_SequenceEqual:
-            case NI_System_MemoryExtensions_StartsWith:
-            case NI_System_SpanHelpers_Fill:
-            case NI_System_SpanHelpers_SequenceEqual:
-            case NI_System_SpanHelpers_ClearWithoutReferences:
-
-            // Same here, these are only folded when JIT knows the exact types
-            case NI_System_Type_IsAssignableFrom:
-            case NI_System_Type_IsAssignableTo:
-            case NI_System_Type_op_Equality:
-            case NI_System_Type_op_Inequality:
-                shouldBeInstrumented = true;
+            case NI_System_Runtime_Intrinsics_Intrinsic:
+            case NI_System_Runtime_Intrinsics_PlatformIntrinsic:
+            case NI_IsSupported:
+            case NI_IsHardwareAccelerated:
+            case NI_IsSupported_Type:
+            case NI_Vector_GetCount:
+            case NI_System_GC_KeepAlive:
+            case NI_System_Threading_Thread_FastPollGC:
+            case NI_System_Threading_Interlocked_MemoryBarrier:
+            case NI_System_Threading_Volatile_ReadBarrier:
+            case NI_System_Threading_Volatile_WriteBarrier:
+            case NI_System_StubHelpers_GetStubContext:
+            case NI_System_StubHelpers_NextCallReturnAddress:
+            case NI_System_Activator_AllocatorOf:
+            case NI_System_Activator_DefaultConstructorOf:
+            case NI_Internal_Runtime_MethodTable_Of:
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsKnownConstant:
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsRuntimeAsync:
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences:
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_GetMethodTable:
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_WriteBarrier:
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_SetNextCallGenericContext:
+            case NI_System_Runtime_CompilerServices_RuntimeHelpers_SetNextCallAsyncContinuation:
+            case NI_System_Runtime_CompilerServices_AsyncHelpers_AsyncSuspend:
+            case NI_System_Runtime_CompilerServices_AsyncHelpers_AsyncCallContinuation:
+            case NI_System_Runtime_CompilerServices_AsyncHelpers_TailAwait:
+            case NI_System_Runtime_CompilerServices_StaticsHelpers_VolatileReadAsByref:
+                shouldBeInstrumented = false;
                 break;
 
+            case NI_System_Numerics_Intrinsic:
+            {
+                // Fixed-size numerics are ordinary managed APIs. Only Vector and Vector<T>
+                // belong to the explicit SIMD policy.
+                const char* namespaceName = nullptr;
+                const char* className     = getClassNameFromMetadata(info.compClassHnd, &namespaceName);
+                shouldBeInstrumented      = (strcmp(className, "Vector") != 0) && (strcmp(className, "Vector`1") != 0);
+                break;
+            }
+
             default:
-                // Some Math intrinsics have large managed implementations we want to profile.
-                shouldBeInstrumented = ni >= NI_SYSTEM_MATH_START && ni <= NI_SYSTEM_MATH_END;
+                assert(ni != NI_Throw_PlatformNotSupportedException);
+#ifdef FEATURE_HW_INTRINSICS
+                if ((ni > NI_HW_INTRINSIC_START) && (ni < NI_HW_INTRINSIC_END))
+                {
+                    shouldBeInstrumented = false;
+                    break;
+                }
+#endif
+                shouldBeInstrumented = !((ni > NI_SRCS_UNSAFE_START) && (ni < NI_SRCS_UNSAFE_END));
                 break;
         }
 
         if (!shouldBeInstrumented)
         {
+            JITDUMP("Not instrumenting intrinsic excluded by minimal profiling\n");
             fgCountInstrumentor     = new (this, CMK_Pgo) NonInstrumentor(this);
             fgHistogramInstrumentor = new (this, CMK_Pgo) NonInstrumentor(this);
             fgValueInstrumentor     = new (this, CMK_Pgo) NonInstrumentor(this);

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -1198,15 +1198,12 @@ static NamedIntrinsic binarySearchId(CORINFO_InstructionSet isa, CORINFO_SIG_INF
 }
 
 //------------------------------------------------------------------------
-// lookupId: Gets the NamedIntrinsic for a given method name and InstructionSet
+// resolveId: Resolve a hardware intrinsic against the compilation's ISA support
 //
 // Arguments:
 //    comp                    -- The compiler
-//    sig                     -- The signature of the intrinsic
-//    className               -- The name of the class associated with the HWIntrinsic to lookup
-//    methodName              -- The name of the method associated with the HWIntrinsic to lookup
-//    innerEnclosingClassName -- The name of the inner enclosing class of nested 64-bit classes
-//    outerEnclosingClassName -- The name of the outer enclosing class of nested 64-bit classes
+//    id                      -- The identity returned by lookup, independent of support
+//    isa                     -- The declaring ISA, before aliasing
 //    isXplatIntrinsic        -- True if the intrinsic lives directly under the cross-platform
 //                               System.Runtime.Intrinsics (or System.Numerics) namespace and
 //                               therefore has a managed fallback when the underlying ISA isn't
@@ -1215,55 +1212,24 @@ static NamedIntrinsic binarySearchId(CORINFO_InstructionSet isa, CORINFO_SIG_INF
 //                               PlatformNotSupportedException when the ISA isn't available.
 //
 // Return Value:
-//    The NamedIntrinsic associated with methodName and isa
-NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
-                                         CORINFO_SIG_INFO* sig,
-                                         const char*       className,
-                                         const char*       methodName,
-                                         const char*       innerEnclosingClassName,
-                                         const char*       outerEnclosingClassName,
-                                         bool              isXplatIntrinsic)
+//    The operation ID, a support-query result, NI_Illegal for a managed fallback,
+//    or NI_Throw_PlatformNotSupportedException for an unavailable platform API.
+//
+// Notes:
+//    Reports dependencies on the declaring ISA, not the operation's aliased ISA
+//    (for example, AVX10v1 operations use AVX512 IDs).
+NamedIntrinsic HWIntrinsicInfo::resolveId(Compiler*              comp,
+                                          NamedIntrinsic         id,
+                                          CORINFO_InstructionSet isa,
+                                          bool                   isXplatIntrinsic)
 {
-#if defined(DEBUG)
-    static bool validationCompleted = false;
-
-    if (!validationCompleted)
-    {
-        ValidateHWIntrinsicIsaRangeArray();
-        validationCompleted = true;
-    }
-#endif // DEBUG
-
-    // Signatures that have a 'this' parameter are illegal intrinsics.
-    if (sig->hasThis())
-    {
-        return NI_Illegal;
-    }
-
-    CORINFO_InstructionSet isa = comp->lookupIsa(className, innerEnclosingClassName, outerEnclosingClassName);
-
-    if (isa == InstructionSet_ILLEGAL)
-    {
-        return NI_Illegal;
-    }
+    assert(isa != InstructionSet_ILLEGAL);
 
     bool     isHWIntrinsicEnabled      = (JitConfig.EnableHWIntrinsic() != 0);
     bool     isIsaSupported            = isHWIntrinsicEnabled && comp->compSupportsHWIntrinsic(isa);
-    bool     isHardwareAcceleratedProp = false;
-    bool     isSupportedProp           = false;
+    bool     isHardwareAcceleratedProp = (id == NI_IsHardwareAccelerated);
+    bool     isSupportedProp           = (id == NI_IsSupported);
     uint32_t vectorByteLength          = 0;
-
-    if (strncmp(methodName, "get_Is", 6) == 0)
-    {
-        if (strcmp(methodName + 6, "HardwareAccelerated") == 0)
-        {
-            isHardwareAcceleratedProp = true;
-        }
-        else if (strcmp(methodName + 6, "Supported") == 0)
-        {
-            isSupportedProp = true;
-        }
-    }
 
 #ifdef TARGET_XARCH
     if (isHardwareAcceleratedProp)
@@ -1288,19 +1254,8 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
             isa              = InstructionSet_AVX512;
             vectorByteLength = 64;
         }
-        else
-        {
-            assert((strcmp(className, "Vector128") != 0) && (strcmp(className, "Vector256") != 0) &&
-                   (strcmp(className, "Vector512") != 0));
-        }
     }
 #endif
-
-    if (isSupportedProp && (strncmp(className, "Vector", 6) == 0))
-    {
-        // The Vector*<T>.IsSupported props report if T is supported & is specially handled in lookupNamedIntrinsic
-        return NI_Illegal;
-    }
 
     if (isSupportedProp || isHardwareAcceleratedProp)
     {
@@ -1397,14 +1352,48 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
     }
     else if (isa == InstructionSet_VectorT)
     {
-        // This instruction set should only be set when SVE is enabled.
-        // Baseline Vector<T> will use InstructionSet_VectorT128.
-        if (!comp->compOpportunisticallyDependsOn(InstructionSet_Sve))
-        {
-            return NI_Illegal;
-        }
+        // Scalable Vector<T> has no intrinsic table implementation yet.
+        return NI_Illegal;
     }
 #endif
+
+    return id;
+}
+
+//------------------------------------------------------------------------
+// lookupId: identify an operation within an ISA without querying target support
+//
+// Arguments:
+//    sig -- method signature
+//    isa -- declaring ISA, before mapping aliases such as AVX10v1
+//    methodName -- name of the operation
+//
+// Returns:
+//    The operation's intrinsic ID, or NI_Illegal if it is not recognized.
+//
+NamedIntrinsic HWIntrinsicInfo::lookupId(CORINFO_SIG_INFO* sig, CORINFO_InstructionSet isa, const char* methodName)
+{
+#if defined(DEBUG)
+    static bool validationCompleted = false;
+
+    if (!validationCompleted)
+    {
+        ValidateHWIntrinsicIsaRangeArray();
+        validationCompleted = true;
+    }
+#endif // DEBUG
+
+    if (sig->hasThis())
+    {
+        return NI_Illegal;
+    }
+
+    if (isa == InstructionSet_Vector)
+    {
+        // Portable vector widths share operation IDs. Vector<T> recognition need
+        // not select a width or report the associated ISA dependency.
+        return binarySearchId(InstructionSet_Vector128, sig, methodName);
+    }
 
 #if defined(TARGET_XARCH)
     // AVX10v1 is a strict superset of all AVX512 ISAs
@@ -1437,6 +1426,29 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
 #endif // TARGET_XARCH
 
     return binarySearchId(isa, sig, methodName);
+}
+
+//------------------------------------------------------------------------
+// lookupVectorIsa: identify the portable vector ISA for a Vector<T> width
+//
+CORINFO_InstructionSet HWIntrinsicInfo::lookupVectorIsa(uint32_t size)
+{
+    switch (size)
+    {
+        case 16:
+            return InstructionSet_Vector128;
+#ifdef TARGET_XARCH
+        case 32:
+            return InstructionSet_Vector256;
+        case 64:
+            return InstructionSet_Vector512;
+#elif defined(TARGET_ARM64)
+        case SIZE_UNKNOWN:
+            return InstructionSet_VectorT;
+#endif
+        default:
+            unreached();
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -561,13 +561,14 @@ struct HWIntrinsicInfo
 
     static const HWIntrinsicInfo& lookup(NamedIntrinsic id);
 
-    static NamedIntrinsic lookupId(Compiler*         comp,
-                                   CORINFO_SIG_INFO* sig,
-                                   const char*       className,
-                                   const char*       methodName,
-                                   const char*       innerEnclosingClassName,
-                                   const char*       outerEnclosingClassName,
-                                   bool              isXplatIntrinsic);
+    static NamedIntrinsic lookupId(CORINFO_SIG_INFO* sig, CORINFO_InstructionSet isa, const char* methodName);
+
+    static CORINFO_InstructionSet lookupVectorIsa(uint32_t size);
+
+    static NamedIntrinsic resolveId(Compiler*              comp,
+                                    NamedIntrinsic         id,
+                                    CORINFO_InstructionSet isa,
+                                    bool                   isXplatIntrinsic);
 
     static unsigned lookupSimdSize(Compiler* comp, NamedIntrinsic id, CORINFO_SIG_INFO* sig);
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3325,7 +3325,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
     const bool isIntrinsic = (methodFlags & CORINFO_FLG_INTRINSIC) != 0;
     int        memberRef   = pResolvedToken->token;
 
-    NamedIntrinsic ni = lookupNamedIntrinsic(method);
+    NamedIntrinsic ni = resolveNamedIntrinsic(method, lookupNamedIntrinsic(method));
 
     if (isIntrinsic)
     {
@@ -3337,6 +3337,16 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
         // For mismatched VM (AltJit) we want to check all methods as intrinsic to ensure
         // we get more accurate codegen. This particularly applies to HWIntrinsic usage
         assert(!info.compMatchedVM);
+    }
+
+    if ((ni == NI_System_Numerics_Intrinsic) || (ni == NI_System_Runtime_Intrinsics_Intrinsic))
+    {
+        // Only an actual recursive intrinsic call requires replacement. Looking up
+        // the method being compiled (for example, for profiling) does not.
+        if (gtIsRecursiveCall(method, false))
+        {
+            ni = NI_Throw_PlatformNotSupportedException;
+        }
     }
 
     // We specially support the following on all platforms to allow for dead
@@ -11466,6 +11476,92 @@ GenTree* Compiler::impMathIntrinsic(CORINFO_METHOD_HANDLE method,
 }
 
 //------------------------------------------------------------------------
+// resolveNamedIntrinsic: resolve an intrinsic identity for import or inline screening
+//
+// Arguments:
+//    method -- target method, retaining the declaring ISA when IDs are shared
+//    intrinsic -- identity returned by lookupNamedIntrinsic
+//
+// Returns:
+//    The resolved operation, support-query result, managed fallback, or PNSE marker.
+//
+// Notes:
+//    Unlike lookup, this may report ISA dependencies. Recursive-call handling
+//    belongs to impIntrinsic, not to method identity or support resolution.
+//
+NamedIntrinsic Compiler::resolveNamedIntrinsic(CORINFO_METHOD_HANDLE method, NamedIntrinsic intrinsic)
+{
+    bool isSupportQuery      = (intrinsic == NI_IsSupported) || (intrinsic == NI_IsHardwareAccelerated);
+    bool isPlatformIntrinsic = (intrinsic == NI_System_Runtime_Intrinsics_PlatformIntrinsic);
+    bool isHWIntrinsic       = false;
+#ifdef FEATURE_HW_INTRINSICS
+    isHWIntrinsic = (intrinsic > NI_HW_INTRINSIC_START) && (intrinsic < NI_HW_INTRINSIC_END);
+#endif
+
+    if (!isSupportQuery && !isPlatformIntrinsic && !isHWIntrinsic)
+    {
+        return intrinsic;
+    }
+
+    NamedIntrinsic result   = NI_Illegal;
+    NamedIntrinsic fallback = NI_System_Runtime_Intrinsics_Intrinsic;
+
+#ifdef FEATURE_HW_INTRINSICS
+    const char* className              = nullptr;
+    const char* namespaceName          = nullptr;
+    const char* enclosingClassNames[2] = {nullptr};
+    info.compCompHnd->getMethodNameFromMetadata(method, &className, &namespaceName, enclosingClassNames,
+                                                ArrLen(enclosingClassNames));
+
+    CORINFO_InstructionSet isa              = InstructionSet_ILLEGAL;
+    bool                   isNumerics       = (strcmp(namespaceName, "System.Numerics") == 0);
+    bool                   isXplatIntrinsic = isNumerics || (strcmp(namespaceName, "System.Runtime.Intrinsics") == 0);
+
+    if (isNumerics)
+    {
+        fallback      = NI_System_Numerics_Intrinsic;
+        uint32_t size = getCompileTimeVectorTByteLength();
+        isa           = HWIntrinsicInfo::lookupVectorIsa(size);
+    }
+    else
+    {
+#if defined(TARGET_XARCH)
+        const char* platformNamespaceName = "System.Runtime.Intrinsics.X86";
+#elif defined(TARGET_ARM64)
+        const char* platformNamespaceName = "System.Runtime.Intrinsics.Arm";
+#elif defined(TARGET_WASM)
+        const char* platformNamespaceName = "System.Runtime.Intrinsics.Wasm";
+#else
+#error Unsupported platform
+#endif
+        if (!isXplatIntrinsic && (strcmp(namespaceName, platformNamespaceName) != 0))
+        {
+            return isSupportQuery ? NI_IsSupported_False : NI_Throw_PlatformNotSupportedException;
+        }
+
+        isa = lookupIsa(className, enclosingClassNames[0], enclosingClassNames[1]);
+    }
+
+    if (isa != InstructionSet_ILLEGAL)
+    {
+        result = HWIntrinsicInfo::resolveId(this, intrinsic, isa, isXplatIntrinsic);
+    }
+#endif // FEATURE_HW_INTRINSICS
+
+    if (isSupportQuery)
+    {
+        return (result == NI_Illegal) ? NI_IsSupported_False : result;
+    }
+
+    if ((result == NI_Illegal) || (result == NI_System_Runtime_Intrinsics_PlatformIntrinsic))
+    {
+        return fallback;
+    }
+
+    return result;
+}
+
+//------------------------------------------------------------------------
 // lookupNamedIntrinsic: map method to jit named intrinsic value
 //
 // Arguments:
@@ -11477,6 +11573,8 @@ GenTree* Compiler::impMathIntrinsic(CORINFO_METHOD_HANDLE method,
 // Notes:
 //    method should have CORINFO_FLG_INTRINSIC set in its attributes,
 //    otherwise it is not a named jit intrinsic.
+//    Hardware IDs identify operations independently of target support.
+//    This lookup does not interpret recursion or report instruction set dependencies.
 //
 NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
 {
@@ -12016,47 +12114,6 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                                 }
                             }
 
-                            uint32_t size = getCompileTimeVectorTByteLength();
-#ifdef TARGET_ARM64
-                            assert((size == 16) || (size == SIZE_UNKNOWN));
-#else
-                            assert((size == 16) || (size == 32) || (size == 64));
-#endif
-
-                            const char* lookupClassName = className;
-
-                            switch (size)
-                            {
-                                case 16:
-                                {
-                                    lookupClassName = isVectorT ? "Vector128`1" : "Vector128";
-                                    break;
-                                }
-
-                                case 32:
-                                {
-                                    lookupClassName = isVectorT ? "Vector256`1" : "Vector256";
-                                    break;
-                                }
-
-                                case 64:
-                                {
-                                    lookupClassName = isVectorT ? "Vector512`1" : "Vector512";
-                                    break;
-                                }
-#ifdef TARGET_ARM64
-                                case SIZE_UNKNOWN:
-                                {
-                                    // NTD, Vector<T> is implemented directly with SVE in this case.
-                                    break;
-                                }
-#endif
-                                default:
-                                {
-                                    unreached();
-                                }
-                            }
-
                             const char* lookupMethodName = methodName;
 
                             if ((strncmp(methodName, "As", 2) == 0) && (methodName[2] != '\0'))
@@ -12131,12 +12188,7 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                                 CORINFO_SIG_INFO sig;
                                 info.compCompHnd->getMethodSig(method, &sig);
 
-                                // System.Numerics.Vector<T> and System.Numerics.Vector are cross-platform
-                                // APIs with managed fallbacks; they must not throw PNSE when the ISA isn't
-                                // available.
-                                result = HWIntrinsicInfo::lookupId(this, &sig, lookupClassName, lookupMethodName,
-                                                                   enclosingClassNames[0], enclosingClassNames[1],
-                                                                   /* isXplatIntrinsic */ true);
+                                result = HWIntrinsicInfo::lookupId(&sig, InstructionSet_Vector, lookupMethodName);
                             }
                         }
 #endif // FEATURE_HW_INTRINSICS
@@ -12153,20 +12205,12 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                             }
                             else if (strcmp(methodName, "get_IsHardwareAccelerated") == 0)
                             {
-                                result = NI_IsSupported_False;
+                                result = NI_IsHardwareAccelerated;
                             }
                             else if (strcmp(methodName, "get_Count") == 0)
                             {
                                 assert(strcmp(className, "Vector`1") == 0);
                                 result = NI_Vector_GetCount;
-                            }
-                            else if (gtIsRecursiveCall(method, false))
-                            {
-                                // For the framework itself, any recursive intrinsics will either be
-                                // only supported on a single platform or will be guarded by a relevant
-                                // IsSupported check so the throw PNSE will be valid or dropped.
-
-                                result = NI_Throw_PlatformNotSupportedException;
                             }
                             else
                             {
@@ -12393,26 +12437,10 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                     }
                     else if (strncmp(namespaceName, "Intrinsics", 10) == 0)
                     {
-                        // We go down this path even when FEATURE_HW_INTRINSICS isn't enabled
-                        // so we can specially handle IsSupported and recursive calls.
-
-                        // This is required to appropriately handle the intrinsics on platforms
-                        // which don't support them. On such a platform methods like Vector64.Create
-                        // will be seen as `Intrinsic` and `mustExpand` due to having a code path
-                        // which is recursive. When such a path is hit we expect it to be handled by
-                        // the importer and we fire an assert if it wasn't and in previous versions
-                        // of the JIT would fail fast. This was changed to throw a PNSE instead but
-                        // we still assert as most intrinsics should have been recognized/handled.
-
-                        // In order to avoid the assert, we specially handle the IsSupported checks
-                        // (to better allow dead-code optimizations) and we explicitly throw a PNSE
-                        // as we know that is the desired behavior for the HWIntrinsics when not
-                        // supported. For cases like Vector64.Create, this is fine because it will
-                        // be behind a relevant IsSupported check and will never be hit and the
-                        // software fallback will be executed instead.
+                        namespaceName += 10;
+                        bool isXplatIntrinsic = (namespaceName[0] == '\0');
 
 #ifdef FEATURE_HW_INTRINSICS
-                        namespaceName += 10;
                         const char* platformNamespaceName;
 
 #if defined(TARGET_XARCH)
@@ -12444,18 +12472,19 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                             }
                         }
 
-                        bool isXplatIntrinsic              = (namespaceName[0] == '\0');
-                        bool isPlatformMatchedIntrinsic    = (strcmp(namespaceName, platformNamespaceName) == 0);
-                        bool isPlatformMismatchedIntrinsic = !isXplatIntrinsic && !isPlatformMatchedIntrinsic;
+                        bool isPlatformMatchedIntrinsic = (strcmp(namespaceName, platformNamespaceName) == 0);
 
                         if (isXplatIntrinsic || isPlatformMatchedIntrinsic)
                         {
                             CORINFO_SIG_INFO sig;
                             info.compCompHnd->getMethodSig(method, &sig);
 
-                            result =
-                                HWIntrinsicInfo::lookupId(this, &sig, className, methodName, enclosingClassNames[0],
-                                                          enclosingClassNames[1], isXplatIntrinsic);
+                            CORINFO_InstructionSet isa =
+                                lookupIsa(className, enclosingClassNames[0], enclosingClassNames[1]);
+                            if (isa != InstructionSet_ILLEGAL)
+                            {
+                                result = HWIntrinsicInfo::lookupId(&sig, isa, methodName);
+                            }
                         }
 #endif // FEATURE_HW_INTRINSICS
 
@@ -12477,12 +12506,12 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                                 }
                                 else
                                 {
-                                    result = NI_IsSupported_False;
+                                    result = NI_IsSupported;
                                 }
                             }
                             else if (strcmp(methodName, "get_IsHardwareAccelerated") == 0)
                             {
-                                result = NI_IsSupported_False;
+                                result = NI_IsHardwareAccelerated;
                             }
                             else if (strcmp(methodName, "get_Count") == 0)
                             {
@@ -12492,24 +12521,10 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
 
                                 result = NI_Vector_GetCount;
                             }
-                            else if (gtIsRecursiveCall(method, false))
+                            else if (!isXplatIntrinsic)
                             {
-                                // For the framework itself, any recursive intrinsics will either be
-                                // only supported on a single platform or will be guarded by a relevant
-                                // IsSupported check so the throw PNSE will be valid or dropped.
-
-                                result = NI_Throw_PlatformNotSupportedException;
+                                result = NI_System_Runtime_Intrinsics_PlatformIntrinsic;
                             }
-#ifdef FEATURE_HW_INTRINSICS
-                            else if (isPlatformMismatchedIntrinsic)
-                            {
-                                // The API lives in a platform-specific sub-namespace under
-                                // System.Runtime.Intrinsics (e.g., .X86 on ARM64, .Wasm on xarch) that
-                                // does not match the target architecture. Such APIs are platform-specific
-                                // with no managed fallback, so they must throw PlatformNotSupportedException.
-                                result = NI_Throw_PlatformNotSupportedException;
-                            }
-#endif // FEATURE_HW_INTRINSICS
                             else
                             {
                                 // Otherwise mark this as a general intrinsic in the namespace
@@ -12673,24 +12688,24 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
         }
     }
 
+    assert((result != NI_IsSupported_True) && (result != NI_IsSupported_False) && (result != NI_IsSupported_Dynamic) &&
+           (result != NI_Throw_PlatformNotSupportedException));
+
     if (result == NI_Illegal)
     {
         JITDUMP("Not recognized\n");
     }
-    else if ((result == NI_System_Numerics_Intrinsic) || (result == NI_System_Runtime_Intrinsics_Intrinsic))
+    else if ((result == NI_System_Numerics_Intrinsic) || (result == NI_System_Runtime_Intrinsics_Intrinsic) ||
+             (result == NI_System_Runtime_Intrinsics_PlatformIntrinsic))
     {
-        // These are special markers used just to ensure we still get the inlining profitability
-        // boost. We actually have the implementation in managed, however, to keep the JIT simpler.
         JITDUMP("Not recognized - inlining boost\n");
     }
-    else if (result == NI_IsSupported_False)
+#ifdef FEATURE_HW_INTRINSICS
+    else if ((result > NI_HW_INTRINSIC_START) && (result < NI_HW_INTRINSIC_END))
     {
-        JITDUMP("Unsupported - return false");
+        JITDUMP("Recognized hardware intrinsic: %s (%u)\n", HWIntrinsicInfo::lookupName(result), result);
     }
-    else if (result == NI_Throw_PlatformNotSupportedException)
-    {
-        JITDUMP("Unsupported - throw PlatformNotSupportedException");
-    }
+#endif // FEATURE_HW_INTRINSICS
     else
     {
         JITDUMP("Recognized\n");

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -215,9 +215,14 @@ enum NamedIntrinsic : unsigned short
     NI_System_Threading_Tasks_ValueTask_1__ctor,
     NI_System_Threading_Tasks_ValueTask_1_AsTask,
 
-    // These two are special marker IDs so that we still get the inlining profitability boost
+    // These are special marker IDs so that we still get the inlining profitability boost.
     NI_System_Numerics_Intrinsic,
     NI_System_Runtime_Intrinsics_Intrinsic,
+    NI_System_Runtime_Intrinsics_PlatformIntrinsic,
+
+    // Support-query identities; resolution determines their value for the target.
+    NI_IsSupported,
+    NI_IsHardwareAccelerated,
 
 #if defined(FEATURE_HW_INTRINSICS)
     NI_HW_INTRINSIC_START,


### PR DESCRIPTION
Fixes dotnet/runtime#132145.

## Regression

Adding `[Intrinsic]` to the `Half` conversions in dotnet/runtime#130512 unintentionally disabled dynamic profiling of their managed implementations under minimal profiling. On hardware without the direct AVX10.1 conversion, `double`-to-`Half` still executes managed code. Losing its profile prevented profitable inlining of `RoundPackToHalf`, regressing `BinaryWriter.WriteHalf`; the writer itself was unchanged. F16C does not provide a direct double-to-half conversion, and going through `float` is not equivalent because of double rounding.

## Changes

Make ordinary managed intrinsic methods eligible for profiling by default, with explicit exclusions for SIMD APIs and compiler/runtime primitives. This removes the need to keep adding managed fallbacks to an allowlist whenever another API receives `[Intrinsic]`.

### Instrumentation policy

The table applies to `[Intrinsic]` methods under minimal profiling. Methods without `[Intrinsic]` retain their existing behavior.

| Category | Profiling eligibility |
| --- | --- |
| Ordinary managed intrinsics, including numeric conversions such as `Half`, string/span operations, and other managed helpers | Eligible |
| `Vector2`, `Vector3`, `Vector4`, `Quaternion`, and `Plane` | Eligible |
| Unrecognized `[Intrinsic]` methods outside the explicitly excluded families | Eligible |
| Explicit SIMD intrinsics: `Vector`/`Vector<T>`, portable `Vector64/128/256/512`, platform intrinsics, and unrecognized intrinsic methods in the `System.Runtime.Intrinsics` namespace family | Excluded, including managed fallbacks |
| Support/acceleration queries, vector count, and `Unsafe` intrinsics | Excluded |
| Explicitly listed compiler/runtime primitives: barriers, `GC.KeepAlive`, GC polling, stub/context helpers, allocator/method-table helpers, and runtime async plumbing | Excluded |

Eligibility does not guarantee probes: existing instrumentation settings and probe-selection rules still apply, including skipping block-count instrumentation for single-block methods. Operations replaced by intrinsic IR or native calls have no managed implementation at that call site to instrument. This changes profile collection, not ordinary R2R/NativeAOT image generation or profile consumption.

Separate intrinsic recognition from support resolution so profiling can inspect identity without changing compilation state:

- `lookupNamedIntrinsic` and hardware `lookupId` return exact operation IDs where recognized, independent of ISA availability. Unresolved support-query IDs and family markers cover queries and unrecognized methods.
- Import and inline screening explicitly resolve target support. Resolution retains the declaring ISA for dependencies, including AVX10 aliases, and selects `Vector<T>` width only when needed.
- Actual recursive intrinsic-call handling stays in import. Looking up the method being compiled for profiling is not evidence of recursion and must not produce PNSE.
- Inline screening records a resolved PNSE call as a throw observation instead of granting intrinsic or wrapper profitability credit. The throw counter itself adds no penalty. The scan still counts instructions in dead branches; reachability-aware profitability is deferred.

## Performance evidence

Local BenchmarkDotNet measurements of enabling the managed profiling path, using matching locally built runtimes on Windows x64 / Ryzen 9 7950X, without AVX10.1:

| Benchmark | Baseline | Profiling enabled | Ratio |
| --- | ---: | ---: | ---: |
| `WriteHalf` | 10.754 ns | 8.636 ns | 0.80 |
| `ConvertDouble` | 6.049 ns | 4.711 ns | 0.78 |
| `WriteHalfPrecomputed` (control) | 4.191 ns | 4.292 ns | 1.03 |

The precomputed control was within run variability. These measurements were collected for the profiling correction during the investigation, not rerun after every lookup/observation refactoring. Separate codegen comparisons checked the subsequent refactorings; these are targeted measurements, not a claim of universal performance improvement.

## Validation

- Windows x64 Checked and Release JIT builds; JIT formatting validation.
- All 37 existing runners passed: 36 intrinsic runners and the original `InstrumentedTiers` test. No additional test-source churn.
- Focused supported/unsupported intrinsic probes, including hardware-disabled execution, support queries, and argument side effects.
- Baseline-versus-changed inline-policy assertions confirmed removal of incorrect PNSE intrinsic/wrapper credit. Guarded ISA dispatch and explicit-throw controls still inlined, with identical normalized instructions in all 12 compared root-method disassemblies across normal and hardware-disabled configurations.
- Focused JIT comparisons with normal, AVX2-disabled, and hardware-disabled configurations. Fifteen focused R2R image comparisons were byte-identical across no-AVX, x86-64-v3, and AVX10.1 targets.

No ARM64 or AVX10.1 hardware execution, or NativeAOT executable validation, was performed locally.

> [!NOTE]
> This PR description was drafted with GitHub Copilot.
