### PR TITLE
Don't use IgnoreRootRevocationUnknown when processing intermediate CA re-key certificates

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -158,6 +158,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             PublicKey publicKey,
             int? depthLimit = null)
         {
+            return CreateSubordinateCA(
+                new X500DistinguishedName(subject),
+                publicKey,
+                depthLimit);
+        }
+
+        internal X509Certificate2 CreateSubordinateCA(
+            X500DistinguishedName subject,
+            PublicKey publicKey,
+            int? depthLimit = null)
+        {
             return CreateCertificate(
                 subject,
                 publicKey,
@@ -171,7 +182,22 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                     s_caKeyUsage });
         }
 
-        internal X509Certificate2 CreateEndEntity(string subject, PublicKey publicKey, X509ExtensionCollection extensions)
+        internal X509Certificate2 CreateEndEntity(
+            string subject,
+            PublicKey publicKey,
+            X509ExtensionCollection extensions)
+        {
+            return CreateCertificate(
+                new X500DistinguishedName(subject),
+                publicKey,
+                TimeSpan.FromSeconds(2),
+                extensions);
+        }
+
+        internal X509Certificate2 CreateEndEntity(
+            X500DistinguishedName subject,
+            PublicKey publicKey,
+            X509ExtensionCollection extensions)
         {
             return CreateCertificate(
                 subject,
@@ -255,6 +281,18 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             X509ExtensionCollection extensions,
             bool ocspResponder = false)
         {
+            X500DistinguishedName name = new(subject);
+
+            return CreateCertificate(name, publicKey, nestingBuffer, extensions, ocspResponder);
+        }
+
+        private X509Certificate2 CreateCertificate(
+            X500DistinguishedName subject,
+            PublicKey publicKey,
+            TimeSpan nestingBuffer,
+            X509ExtensionCollection extensions,
+            bool ocspResponder = false)
+        {
             if (_cdpExtension == null && CdpUri != null)
             {
                 _cdpExtension = CreateCdpExtension(CdpUri);
@@ -271,7 +309,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
             }
 
             CertificateRequest request = new CertificateRequest(
-                new X500DistinguishedName(subject),
+                subject,
                 publicKey,
                 HashAlgorithmIfNeeded(_cert.GetKeyAlgorithm()),
                 RSASignaturePadding.Pkcs1);
@@ -808,6 +846,74 @@ SingleResponse ::= SEQUENCE {
             bool forTls = false,
             X509ExtensionCollection extensions = null)
         {
+            BuildPrivatePkiCore(
+                pkiOptions,
+                out responder,
+                out rootAuthority,
+                out intermediateAuthorities,
+                out endEntityCert,
+                BuildSubject("A Revocation Test Root", testName, pkiOptions, pkiOptionsInSubject),
+                index => BuildSubject($"A Revocation Test CA {index}", testName, pkiOptions, pkiOptionsInSubject),
+                intermediateAuthorityCount,
+                BuildSubject(subjectName ?? "A Revocation Test Cert", testName, pkiOptions, pkiOptionsInSubject),
+                keyFactoryHashSubjectName: subjectName,
+                testName,
+                registerAuthorities,
+                keyFactory,
+                forTls,
+                extensions);
+        }
+
+        internal static void BuildPrivatePki(
+            PkiOptions pkiOptions,
+            out RevocationResponder responder,
+            X500DistinguishedName rootName,
+            out CertificateAuthority rootAuthority,
+            X500DistinguishedName[] intermediateNames,
+            out CertificateAuthority[] intermediateAuthorities,
+            X500DistinguishedName endEntityName,
+            out X509Certificate2 endEntityCert,
+            string testName = null,
+            bool registerAuthorities = true,
+            KeyFactory keyFactory = null,
+            bool forTls = false,
+            X509ExtensionCollection extensions = null)
+        {
+            BuildPrivatePkiCore(
+                pkiOptions,
+                out responder,
+                out rootAuthority,
+                out intermediateAuthorities,
+                out endEntityCert,
+                rootName,
+                index => intermediateNames[index],
+                intermediateNames.Length,
+                endEntityName: endEntityName,
+                keyFactoryHashSubjectName: null,
+                testName,
+                registerAuthorities,
+                keyFactory,
+                forTls,
+                extensions);
+        }
+
+        private static void BuildPrivatePkiCore(
+            PkiOptions pkiOptions,
+            out RevocationResponder responder,
+            out CertificateAuthority rootAuthority,
+            out CertificateAuthority[] intermediateAuthorities,
+            out X509Certificate2 endEntityCert,
+            X500DistinguishedName rootName,
+            Func<int, X500DistinguishedName> intermediateAuthorityNameFactory,
+            int intermediateAuthorityCount,
+            X500DistinguishedName endEntityName,
+            string keyFactoryHashSubjectName,
+            string testName = null,
+            bool registerAuthorities = true,
+            KeyFactory keyFactory = null,
+            bool forTls = false,
+            X509ExtensionCollection extensions = null)
+        {
             bool rootDistributionViaHttp = !pkiOptions.HasFlag(PkiOptions.NoRootCertDistributionUri);
             bool issuerRevocationViaCrl = pkiOptions.HasFlag(PkiOptions.IssuerRevocationViaCrl);
             bool issuerRevocationViaOcsp = pkiOptions.HasFlag(PkiOptions.IssuerRevocationViaOcsp);
@@ -838,7 +944,7 @@ SingleResponse ::= SEQUENCE {
                     hasher.AppendData(MemoryMarshal.AsBytes(new ReadOnlySpan<PkiOptions>(ref pkiOptions)));
                     hasher.AppendData(MemoryMarshal.AsBytes(new ReadOnlySpan<int>(ref intermediateAuthorityCount)));
                     hasher.AppendData(MemoryMarshal.AsBytes(testName.AsSpan()));
-                    hasher.AppendData(MemoryMarshal.AsBytes(subjectName.AsSpan()));
+                    hasher.AppendData(MemoryMarshal.AsBytes(keyFactoryHashSubjectName.AsSpan()));
 
                     Span<byte> hash = stackalloc byte[256 / 8];
                     int written = hasher.GetCurrentHash(hash);
@@ -854,8 +960,7 @@ SingleResponse ::= SEQUENCE {
             using (KeyHolder rootKey = KeyHolder.CreateKey(keyFactory))
             using (KeyHolder eeKey = KeyHolder.CreateKey(keyFactory))
             {
-                CertificateRequest rootReq = rootKey.CreateRequest(
-                    BuildSubject("A Revocation Test Root", testName, pkiOptions, pkiOptionsInSubject));
+                CertificateRequest rootReq = rootKey.CreateRequest(rootName);
 
                 X509BasicConstraintsExtension caConstraints =
                     new X509BasicConstraintsExtension(true, false, 0, true);
@@ -894,7 +999,7 @@ SingleResponse ::= SEQUENCE {
 
                     {
                         X509Certificate2 intermedPub = issuingAuthority.CreateSubordinateCA(
-                            BuildSubject($"A Revocation Test CA {intermediateIndex}", testName, pkiOptions, pkiOptionsInSubject),
+                            intermediateAuthorityNameFactory(intermediateIndex),
                             intermediateKey.ToPublicKey());
                         intermedCert = intermediateKey.OntoCertificate(intermedPub);
                         intermedPub.Dispose();
@@ -918,7 +1023,7 @@ SingleResponse ::= SEQUENCE {
                 }
 
                 endEntityCert = issuingAuthority.CreateEndEntity(
-                    BuildSubject(subjectName ?? "A Revocation Test Cert", testName, pkiOptions, pkiOptionsInSubject),
+                    endEntityName,
                     eeKey.ToPublicKey(),
                     extensions);
 
@@ -970,7 +1075,7 @@ SingleResponse ::= SEQUENCE {
             intermediateAuthority = intermediateAuthorities.Single();
         }
 
-        private static string BuildSubject(
+        private static X500DistinguishedName BuildSubject(
             string cn,
             string testName,
             PkiOptions pkiOptions,
@@ -979,7 +1084,8 @@ SingleResponse ::= SEQUENCE {
             string testNamePart = !string.IsNullOrWhiteSpace(testName) ? $", O=\"{testName}\"" : "";
             string pkiOptionsPart = includePkiOptions ? $", OU=\"{pkiOptions}\"" : "";
 
-            return $"CN=\"{cn}\"" + testNamePart + pkiOptionsPart;
+            string subject = $"CN=\"{cn}\"" + testNamePart + pkiOptionsPart;
+            return new X500DistinguishedName(subject);
         }
 
         private static HashAlgorithmName HashAlgorithmIfNeeded(string publicKeyOid)
@@ -1114,7 +1220,7 @@ SingleResponse ::= SEQUENCE {
                 return new KeyHolder(factory.CreateKey());
             }
 
-            internal CertificateRequest CreateRequest(string subject)
+            internal CertificateRequest CreateRequest(X500DistinguishedName subject)
             {
                 return _key switch
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixChainVerifier.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixChainVerifier.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using Internal.Cryptography;
 
 namespace System.Security.Cryptography.X509Certificates
 {
@@ -11,22 +10,58 @@ namespace System.Security.Cryptography.X509Certificates
     {
         public static bool Verify(X509ChainElement[] chainElements, X509VerificationFlags flags)
         {
-            bool isEndEntity = true;
+            int rootIndex = HasPartialChain(chainElements) ? -1 : chainElements.Length - 1;
 
-            foreach (X509ChainElement element in chainElements)
+            for (int i = 0; i < chainElements.Length; i++)
             {
-                if (HasUnsuppressedError(flags, element, isEndEntity))
+                // Element 0 is the end-entity.
+                // If the chain is complete, then match the last element under "root".
+                // Otherwise, the element must be part of the middle of a chain.
+                //
+                // Two fuzzy pieces in this logic:
+                // 1. Non-self-issued trust anchors.  We generally don't support them,
+                //    but they're possible on macOS because of system trust rules.
+                //    This logic will treat them as roots, which is more correct than not.
+                //    (As the trust anchor, you're not expecting someone to say it was revoked,
+                //    but instead you remove it from anchor status.)
+                //
+                // 2. Black-box testing suggests Windows has some special considerations for a
+                //    CA cert that was self-issued by the root (but with a different key and not
+                //    self-signed).  This sort of re-keying is exceptionally rare, so it's not a
+                //    high-priority research effort.  Until then, calling the signed re-key an
+                //    intermediate is more accurate than calling it a root, as it will be checked
+                //    for revocation under the ExcludeRoot policy.
+                X509VerificationFlags suppressionFlag =
+                    i == 0 ? X509VerificationFlags.IgnoreEndRevocationUnknown :
+                    i == rootIndex ? X509VerificationFlags.IgnoreRootRevocationUnknown :
+                    X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown;
+
+                if (HasUnsuppressedError(flags, chainElements[i], suppressionFlag))
                 {
                     return false;
                 }
-
-                isEndEntity = false;
             }
 
             return true;
+
+            static bool HasPartialChain(X509ChainElement[] chainElements)
+            {
+                foreach (X509ChainElement element in chainElements)
+                {
+                    foreach (X509ChainStatus status in element.ChainElementStatus)
+                    {
+                        if (status.Status == X509ChainStatusFlags.PartialChain)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
         }
 
-        private static bool HasUnsuppressedError(X509VerificationFlags flags, X509ChainElement element, bool isEndEntity)
+        private static bool HasUnsuppressedError(X509VerificationFlags flags, X509ChainElement element, X509VerificationFlags revocationSuppressionFlag)
         {
             foreach (X509ChainStatus status in element.ChainElementStatus)
             {
@@ -47,18 +82,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 if (status.Status == X509ChainStatusFlags.RevocationStatusUnknown)
                 {
-                    if (isEndEntity)
-                    {
-                        suppressionFlag = X509VerificationFlags.IgnoreEndRevocationUnknown;
-                    }
-                    else if (IsSelfSigned(element.Certificate))
-                    {
-                        suppressionFlag = X509VerificationFlags.IgnoreRootRevocationUnknown;
-                    }
-                    else
-                    {
-                        suppressionFlag = X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown;
-                    }
+                    suppressionFlag = revocationSuppressionFlag;
                 }
                 else if (status.Status == X509ChainStatusFlags.OfflineRevocation)
                 {
@@ -81,11 +105,6 @@ namespace System.Security.Cryptography.X509Certificates
             }
 
             return false;
-        }
-
-        private static bool IsSelfSigned(X509Certificate2 cert)
-        {
-            return cert.SubjectName.RawData.ContentsEqual(cert.IssuerName.RawData);
         }
 
         private static X509VerificationFlags? GetSuppressionFlag(X509ChainStatusFlags status)

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
@@ -1227,6 +1227,166 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 });
         }
 
+        [Theory]
+        [MemberData(nameof(AllViableRevocation))]
+        public static void SelfIssuedButNotSelfSignedRevocationUnknown_IgnoreRootUnknown(PkiOptions pkiOptions)
+        {
+            SelfIssuedButNotSelfSignedRevocationUnknown(
+                pkiOptions,
+                (endEntity, chainHolder) =>
+                {
+                    X509Chain chain = chainHolder.Chain;
+
+                    chain.ChainPolicy.VerificationFlags |=
+                        X509VerificationFlags.IgnoreRootRevocationUnknown;
+
+                    bool success = chain.Build(endEntity);
+
+                    AssertChainStatus(
+                        chain,
+                        rootStatus: X509ChainStatusFlags.NoError,
+                        iss1Status: ThisOsRevocationStatusUnknown,
+                        iss2Status: ThisOsNoErrorWithPreviousRevocationError,
+                        leafStatus: ThisOsNoErrorWithPreviousRevocationError);
+
+                    AssertExtensions.FalseExpression(success, "chain.Build(endEntity)");
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(AllViableRevocation))]
+        public static void SelfIssuedButNotSelfSignedRevocationUnknown_IgnoreIntermediateUnknown(PkiOptions pkiOptions)
+        {
+            SelfIssuedButNotSelfSignedRevocationUnknown(
+                pkiOptions,
+                (endEntity, chainHolder) =>
+                {
+                    X509Chain chain = chainHolder.Chain;
+
+                    chain.ChainPolicy.VerificationFlags |=
+                        X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown;
+
+                    bool success = chain.Build(endEntity);
+
+                    AssertChainStatus(
+                        chain,
+                        rootStatus: X509ChainStatusFlags.NoError,
+                        iss1Status: ThisOsRevocationStatusUnknown,
+                        iss2Status: ThisOsNoErrorWithPreviousRevocationError,
+                        leafStatus: ThisOsNoErrorWithPreviousRevocationError);
+
+                    AssertExtensions.TrueExpression(success, "chain.Build(endEntity)");
+                });
+        }
+
+        private static void SelfIssuedButNotSelfSignedRevocationUnknown(
+            PkiOptions pkiOptions,
+            Action<X509Certificate2, ChainHolder> callback,
+            [CallerMemberName] string callerName = "")
+        {
+            string rootNameStr = BuildSubject(
+                "Some Root CA",
+                callerName,
+                pkiOptions,
+                true);
+
+            string intermediateNameStr = BuildSubject(
+                "Some Self-Issued CA",
+                callerName,
+                pkiOptions,
+                true);
+
+            string endEntityNameStr = BuildSubject(
+                "Some End-Entity Certificate",
+                callerName,
+                pkiOptions,
+                true);
+
+            X500DistinguishedName rootName = new(rootNameStr);
+            X500DistinguishedName intermediateName = new(intermediateNameStr);
+            X500DistinguishedName endEntityName = new(endEntityNameStr);
+
+            BuildPrivatePki(
+                pkiOptions,
+                out RevocationResponder responder,
+                out CertificateAuthority root,
+                out CertificateAuthority[] intermediates,
+                out X509Certificate2 endEntity,
+                rootName: rootName,
+                intermediateNames: [intermediateName, intermediateName],
+                endEntityName: endEntityName,
+                callerName,
+                registerAuthorities: false);
+
+            using (responder)
+            using (root)
+            using (intermediates[0])
+            using (intermediates[1])
+            using (endEntity)
+            using (X509Certificate2 rootCert = root.CloneIssuerCert())
+            using (X509Certificate2 intermediate1Cert = intermediates[0].CloneIssuerCert())
+            using (X509Certificate2 intermediate2Cert = intermediates[1].CloneIssuerCert())
+            {
+                Assert.Equal(intermediate1Cert.SubjectName.RawData, intermediate2Cert.SubjectName.RawData);
+                Assert.Equal(intermediate1Cert.SubjectName.RawData, intermediate2Cert.IssuerName.RawData);
+
+                if (pkiOptions.HasFlag(PkiOptions.RootAuthorityHasDesignatedOcspResponder))
+                {
+                    using (RSA tmpKey = RSA.Create())
+                    using (X509Certificate2 tmp = root.CreateOcspSigner(
+                        BuildSubject("Some Root OCSP Responder", callerName, pkiOptions, true),
+                        tmpKey))
+                    {
+                        root.DesignateOcspResponder(tmp.CopyWithPrivateKey(tmpKey));
+                    }
+                }
+
+                if (pkiOptions.HasFlag(PkiOptions.IssuerAuthorityHasDesignatedOcspResponder))
+                {
+                    using (RSA tmpKey = RSA.Create())
+                    using (X509Certificate2 tmp = intermediates[0].CreateOcspSigner(
+                        BuildSubject("Some Self-Issued CA OCSP Responder", callerName, pkiOptions, true),
+                        tmpKey))
+                    {
+                        intermediates[0].DesignateOcspResponder(tmp.CopyWithPrivateKey(tmpKey));
+                    }
+
+                    using (RSA tmpKey = RSA.Create())
+                    using (X509Certificate2 tmp = intermediates[1].CreateOcspSigner(
+                        BuildSubject("Some Self-Issued CA OCSP Responder", callerName, pkiOptions, true),
+                        tmpKey))
+                    {
+                        intermediates[1].DesignateOcspResponder(tmp.CopyWithPrivateKey(tmpKey));
+                    }
+                }
+
+                // Leave the root unregistered so the original issuing CA has
+                // unknown revocation status. All certificates below it have
+                // conclusive revocation status.
+                responder.AddCertificateAuthority(intermediates[0]);
+                responder.AddCertificateAuthority(intermediates[1]);
+
+                RetryHelper.Execute(
+                    () =>
+                    {
+                        using (ChainHolder holder = new ChainHolder())
+                        {
+                            X509Chain chain = holder.Chain;
+                            chain.ChainPolicy.CustomTrustStore.Add(rootCert);
+                            chain.ChainPolicy.ExtraStore.Add(intermediate1Cert);
+                            chain.ChainPolicy.ExtraStore.Add(intermediate2Cert);
+                            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                            chain.ChainPolicy.VerificationTime = endEntity.NotBefore.AddMinutes(1);
+                            chain.ChainPolicy.UrlRetrievalTimeout = s_urlRetrievalLimit;
+                            chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EntireChain;
+
+                            callback(endEntity, holder);
+                        }
+                    },
+                    maxAttempts: 3);
+            }
+        }
+
         private static void RevokeEndEntityWithInvalidRevocation(
             ChainHolder holder,
             CertificateAuthority intermediate,
@@ -1572,6 +1732,38 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
             }
         }
 
+        private static void AssertChainStatus(
+            X509Chain chain,
+            X509ChainStatusFlags rootStatus,
+            X509ChainStatusFlags iss1Status,
+            X509ChainStatusFlags iss2Status,
+            X509ChainStatusFlags leafStatus)
+        {
+            Assert.Equal(4, chain.ChainElements.Count);
+
+            X509ChainStatusFlags allFlags = rootStatus | iss1Status | iss2Status | leafStatus;
+            X509ChainStatusFlags chainActual = chain.AllStatusFlags();
+
+            X509ChainStatusFlags rootActual = chain.ChainElements[3].AllStatusFlags();
+            X509ChainStatusFlags iss1Actual = chain.ChainElements[2].AllStatusFlags();
+            X509ChainStatusFlags iss2Actual = chain.ChainElements[1].AllStatusFlags();
+            X509ChainStatusFlags leafActual = chain.ChainElements[0].AllStatusFlags();
+
+            // If things don't match, build arrays so the errors pretty print the full chain.
+            if (rootActual != rootStatus ||
+                iss1Actual != iss1Status ||
+                iss2Actual != iss2Status ||
+                leafActual != leafStatus ||
+                chainActual != allFlags)
+            {
+                X509ChainStatusFlags[] expected = { rootStatus, iss1Status, iss2Status, leafStatus };
+                X509ChainStatusFlags[] actual = { rootActual, iss1Actual, iss2Actual, leafActual };
+
+                Assert.Equal(expected, actual);
+                Assert.Equal(allFlags, chainActual);
+            }
+        }
+
         internal static void BuildPrivatePki(
             PkiOptions pkiOptions,
             out RevocationResponder responder,
@@ -1592,7 +1784,50 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                     endEntityRevocationViaCrl || endEntityRevocationViaOcsp,
                 "At least one revocation mode is enabled");
 
-            CertificateAuthority.BuildPrivatePki(pkiOptions, out responder, out rootAuthority, out intermediateAuthority, out endEntityCert, testName, registerAuthorities, pkiOptionsInSubject);
+            CertificateAuthority.BuildPrivatePki(
+                pkiOptions,
+                out responder,
+                out rootAuthority,
+                out intermediateAuthority,
+                out endEntityCert,
+                testName,
+                registerAuthorities,
+                pkiOptionsInSubject);
+        }
+
+        internal static void BuildPrivatePki(
+            PkiOptions pkiOptions,
+            out RevocationResponder responder,
+            out CertificateAuthority rootAuthority,
+            out CertificateAuthority[] intermediateAuthorities,
+            out X509Certificate2 endEntityCert,
+            X500DistinguishedName rootName,
+            X500DistinguishedName[] intermediateNames,
+            X500DistinguishedName endEntityName,
+            [CallerMemberName] string testName = null,
+            bool registerAuthorities = true)
+        {
+            bool issuerRevocationViaCrl = pkiOptions.HasFlag(PkiOptions.IssuerRevocationViaCrl);
+            bool issuerRevocationViaOcsp = pkiOptions.HasFlag(PkiOptions.IssuerRevocationViaOcsp);
+            bool endEntityRevocationViaCrl = pkiOptions.HasFlag(PkiOptions.EndEntityRevocationViaCrl);
+            bool endEntityRevocationViaOcsp = pkiOptions.HasFlag(PkiOptions.EndEntityRevocationViaOcsp);
+
+            Assert.True(
+                issuerRevocationViaCrl || issuerRevocationViaOcsp ||
+                endEntityRevocationViaCrl || endEntityRevocationViaOcsp,
+                "At least one revocation mode is enabled");
+
+            CertificateAuthority.BuildPrivatePki(
+                pkiOptions,
+                out responder,
+                rootName,
+                out rootAuthority,
+                intermediateNames,
+                out intermediateAuthorities,
+                endEntityName,
+                out endEntityCert,
+                testName,
+                registerAuthorities);
         }
 
         private static string BuildSubject(

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
@@ -1228,6 +1228,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Windows)]
         public static void SelfIssuedButNotSelfSignedRevocationUnknown_IgnoreRootUnknown()
         {
             SelfIssuedButNotSelfSignedRevocationUnknown(
@@ -1253,6 +1254,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Windows)]
         public static void SelfIssuedButNotSelfSignedRevocationUnknown_IgnoreIntermediateUnknown()
         {
             SelfIssuedButNotSelfSignedRevocationUnknown(

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
@@ -1227,13 +1227,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 });
         }
 
-        [Theory]
-        [MemberData(nameof(AllViableRevocation))]
-        public static void SelfIssuedButNotSelfSignedRevocationUnknown_IgnoreRootUnknown(PkiOptions pkiOptions)
+        [Fact]
+        public static void SelfIssuedButNotSelfSignedRevocationUnknown_IgnoreRootUnknown()
         {
             SelfIssuedButNotSelfSignedRevocationUnknown(
-                pkiOptions,
-                (endEntity, chainHolder) =>
+                PkiOptions.AllRevocation,
+                static (endEntity, chainHolder) =>
                 {
                     X509Chain chain = chainHolder.Chain;
 
@@ -1245,21 +1244,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                     AssertChainStatus(
                         chain,
                         rootStatus: X509ChainStatusFlags.NoError,
-                        iss1Status: ThisOsRevocationStatusUnknown,
-                        iss2Status: ThisOsNoErrorWithPreviousRevocationError,
+                        iss1Status: X509ChainStatusFlags.NoError,
+                        iss2Status: ThisOsRevocationStatusUnknown,
                         leafStatus: ThisOsNoErrorWithPreviousRevocationError);
 
                     AssertExtensions.FalseExpression(success, "chain.Build(endEntity)");
                 });
         }
 
-        [Theory]
-        [MemberData(nameof(AllViableRevocation))]
-        public static void SelfIssuedButNotSelfSignedRevocationUnknown_IgnoreIntermediateUnknown(PkiOptions pkiOptions)
+        [Fact]
+        public static void SelfIssuedButNotSelfSignedRevocationUnknown_IgnoreIntermediateUnknown()
         {
             SelfIssuedButNotSelfSignedRevocationUnknown(
-                pkiOptions,
-                (endEntity, chainHolder) =>
+                PkiOptions.AllRevocation,
+                static (endEntity, chainHolder) =>
                 {
                     X509Chain chain = chainHolder.Chain;
 
@@ -1271,8 +1269,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                     AssertChainStatus(
                         chain,
                         rootStatus: X509ChainStatusFlags.NoError,
-                        iss1Status: ThisOsRevocationStatusUnknown,
-                        iss2Status: ThisOsNoErrorWithPreviousRevocationError,
+                        iss1Status: X509ChainStatusFlags.NoError,
+                        iss2Status: ThisOsRevocationStatusUnknown,
                         leafStatus: ThisOsNoErrorWithPreviousRevocationError);
 
                     AssertExtensions.TrueExpression(success, "chain.Build(endEntity)");
@@ -1313,7 +1311,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 out CertificateAuthority[] intermediates,
                 out X509Certificate2 endEntity,
                 rootName: rootName,
-                intermediateNames: [intermediateName, intermediateName],
+                intermediateNames: [intermediateName, new X500DistinguishedName(BuildSubject("Some other CA", callerName, pkiOptions, true))],
                 endEntityName: endEntityName,
                 callerName,
                 registerAuthorities: false);
@@ -1327,9 +1325,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
             using (X509Certificate2 intermediate1Cert = intermediates[0].CloneIssuerCert())
             using (X509Certificate2 intermediate2Cert = intermediates[1].CloneIssuerCert())
             {
-                Assert.Equal(intermediate1Cert.SubjectName.RawData, intermediate2Cert.SubjectName.RawData);
-                Assert.Equal(intermediate1Cert.SubjectName.RawData, intermediate2Cert.IssuerName.RawData);
-
                 if (pkiOptions.HasFlag(PkiOptions.RootAuthorityHasDesignatedOcspResponder))
                 {
                     using (RSA tmpKey = RSA.Create())
@@ -1360,10 +1355,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                     }
                 }
 
-                // Leave the root unregistered so the original issuing CA has
-                // unknown revocation status. All certificates below it have
-                // conclusive revocation status.
-                responder.AddCertificateAuthority(intermediates[0]);
+                // Register the root, which covers itself and the original issuing CA.
+                // Do not register intermediates[0], thus leaving intermediates[1] (the re-key cert) as revocation unknown.
+                // Register intermediates[1] to cover the end-entity cer.
+                responder.AddCertificateAuthority(root);
                 responder.AddCertificateAuthority(intermediates[1]);
 
                 RetryHelper.Execute(

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
@@ -1311,7 +1311,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 out CertificateAuthority[] intermediates,
                 out X509Certificate2 endEntity,
                 rootName: rootName,
-                intermediateNames: [intermediateName, new X500DistinguishedName(BuildSubject("Some other CA", callerName, pkiOptions, true))],
+                intermediateNames: [intermediateName, intermediateName],
                 endEntityName: endEntityName,
                 callerName,
                 registerAuthorities: false);
@@ -1357,7 +1357,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                 // Register the root, which covers itself and the original issuing CA.
                 // Do not register intermediates[0], thus leaving intermediates[1] (the re-key cert) as revocation unknown.
-                // Register intermediates[1] to cover the end-entity cer.
+                // Register intermediates[1] to cover the end-entity cert.
                 responder.AddCertificateAuthority(root);
                 responder.AddCertificateAuthority(intermediates[1]);
 


### PR DESCRIPTION
This change ends up with a lot of test infra boilerplate to let DynamicRevocationTests work with a 4-chain instead of a 3-chain, and to specify the names of the certificates to build the re-key state.