### PR TITLE
Report failed interface devirtualization lookup

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DevirtualizationManager.cs
+++ b/src/coreclr/tools/Common/Compiler/DevirtualizationManager.cs
@@ -167,6 +167,11 @@ namespace ILCompiler
                                 break;
                         }
                     }
+
+                    if (impl == null)
+                    {
+                        devirtualizationDetail = CORINFO_DEVIRTUALIZATION_DETAIL.CORINFO_DEVIRTUALIZATION_FAILED_LOOKUP;
+                    }
                 }
             }
             else


### PR DESCRIPTION
Fixes #133270

When managed devirtualization cannot resolve an interface method to either a class implementation or a default interface implementation, report `CORINFO_DEVIRTUALIZATION_FAILED_LOOKUP` instead of leaving the detail as `CORINFO_DEVIRTUALIZATION_UNKNOWN`. This matches the CoreCLR VM JIT interface behavior.

The assignment remains inside the no-class-target path so that an unexpected failure after finding an interface slot continues to report `UNKNOWN` and trigger the diagnostic assertion.

Validation:
- `./build.sh clr+libs.pretest -rc checked -lc release`
- `ComImportUnimplementedMethod` under composite Crossgen2 with a large version bubble (`CompositeBuildMode=1`, `LargeVersionBubble=1`)

> [!NOTE]
> This pull request description was drafted with GitHub Copilot.