### PR TITLE
Populate runtime-async DiagnosticIP for Wasm R2R

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -916,6 +916,7 @@ enum class CorInfoReloc
     WASM_MEMORY_ADDR_REL_LEB,            // Wasm: a relative linear memory index encoded as a 5-byte varuint32. Used as the immediate argument of a load or store instruction,
                                            // e.g. in R2R scenarios as an offset from __image_base
     WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB, // Wasm: an exception tag index encoded as a 5-byte varuint32. Used to refer to the CoreCLR restore context exception tag.
+    WASM_METHOD_RELATIVE_VIRTUAL_IP_I32, // Wasm: the current method's virtual IP relative to the image virtual IP base, stored as a 4-byte uint32.
 };
 
 enum CorInfoGCType

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -37,11 +37,11 @@
 
 #include <minipal/guid.h>
 
-constexpr GUID JITEEVersionIdentifier = { /* 5a3e8dc8-83bf-47e5-b032-531dbd307dbe */
-    0x5a3e8dc8,
-    0x83bf,
-    0x47e5,
-    {0xb0, 0x32, 0x53, 0x1d, 0xbd, 0x30, 0x7d, 0xbe}
+constexpr GUID JITEEVersionIdentifier = { /* d3368fe9-d21b-4c5c-9786-49f591047bf7 */
+    0xd3368fe9,
+    0xd21b,
+    0x4c5c,
+    {0x97, 0x86, 0x49, 0xf5, 0x91, 0x04, 0x7b, 0xf7}
   };
 
 #endif // JIT_EE_VERSIONING_GUID_H

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -19,7 +19,7 @@
 //  src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
 // If you update this, ensure you run `git grep MINIMUM_READYTORUN_MAJOR_VERSION`
 // and handle pending work.
-#define READYTORUN_MAJOR_VERSION 28
+#define READYTORUN_MAJOR_VERSION 29
 #define READYTORUN_MINOR_VERSION 0x0000
 
 #define MINIMUM_READYTORUN_MAJOR_VERSION 26
@@ -69,6 +69,8 @@
 // R2R Version 26.1 adds READYTORUN_FIXUP_StoreMultiCallableAddrOfCode for storing a method's MultiCallableAddrOfCode into a location in the R2R image (used on WebAssembly)
 // R2R Version 27 redefines READYTORUN_FIXUP_DeclaringTypeHandle to be encoded as a method signature instead of a pair of type signatures
 // R2R Version 28 allows entries in the ExternalTypeMaps and ProxyTypeMaps sections to append a sequence of serialized (string, string) type map entries after the per-group NativeHashtable.
+// R2R Version 29 adds the WasmAsyncResumeInfo fixup section and stores method-relative virtual IPs in Wasm async resume information.
+//     R2R 29 is not backward compatible with 28.x or earlier.
 
 struct READYTORUN_CORE_HEADER
 {
@@ -140,6 +142,7 @@ enum class ReadyToRunSectionType : uint32_t
     ExternalTypeMaps            = 124, // Added in V18.3
     ProxyTypeMaps               = 125, // Added in V18.3
     TypeMapAssemblyTargets      = 126, // Added in V18.3
+    WasmAsyncResumeInfo         = 127, // Added in V29
 
     // If you add a new section consider whether it is a breaking or non-breaking change.
     // Usually it is non-breaking, but if it is preferable to have older runtimes fail

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -8534,11 +8534,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
                 // Async call may have been removed very late, after we have introduced suspension/resumption.
                 // In those cases just encode null.
 #ifdef TARGET_WASM
-                BYTE* target = nullptr; // On WASM if we wanted this to have meaning, we would need a reloc to the
-                                        // virtual ip of the location in the method but we both don't have a reloc to
-                                        // represent that, as well as we don't have modeling for virtual ips which is
-                                        // useful for diagnostic purposes at this time. So simply leave it null for now.
-                                        // This is a diagnostic value, so it is not critical to have it be correct.
+                BYTE* target = emitLoc->Valid() && m_compiler->IsReadyToRun() ? emitCodeBlock : nullptr;
 #else
                 BYTE* target = emitLoc->Valid() ? emitOffsetToPtr(emitLoc->CodeOffset(this)) : nullptr;
 #endif
@@ -8550,7 +8546,12 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
                     emitRecordRelocation(&aDstRW[i].Resume, emitAsyncResumeStubEntryPoint, CorInfoReloc::DIRECT);
                     if (target != nullptr)
                     {
+#ifdef TARGET_WASM
+                        emitRecordRelocation(&aDstRW[i].DiagnosticIP, target,
+                                             CorInfoReloc::WASM_METHOD_RELATIVE_VIRTUAL_IP_I32);
+#else
                         emitRecordRelocation(&aDstRW[i].DiagnosticIP, target, CorInfoReloc::DIRECT);
+#endif
                     }
                 }
 

--- a/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
+++ b/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
@@ -11,7 +11,7 @@ struct ReadyToRunHeaderConstants
 {
     static const uint32_t Signature = 0x00525452; // 'RTR'
 
-    static const uint32_t CurrentMajorVersion = 28;
+    static const uint32_t CurrentMajorVersion = 29;
     static const uint32_t CurrentMinorVersion = 0;
 };
 

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -269,6 +269,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 case RelocType.WASM_TABLE_INDEX_I32:
                 case RelocType.WASM_TABLE_INDEX_REL_I32:
+                case RelocType.WASM_METHOD_RELATIVE_VIRTUAL_IP_I32:
                 case RelocType.IMAGE_REL_BASED_REL32:
                 case RelocType.IMAGE_REL_BASED_RELPTR32:
                 case RelocType.IMAGE_REL_BASED_ABSOLUTE:
@@ -280,6 +281,15 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_ADDR32NB:
                 case RelocType.IMAGE_REL_SYMBOL_SIZE:
                     EmitInt(delta);
+                    break;
+                case RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB:
+                    uint value = checked((uint)delta);
+                    for (int i = 0; i < Relocation.GetSize(relocType) - 1; i++)
+                    {
+                        EmitByte((byte)((value & 0x7F) | 0x80));
+                        value >>= 7;
+                    }
+                    EmitByte(checked((byte)value));
                     break;
                 case RelocType.IMAGE_REL_BASED_DIR64:
                     EmitLong(delta);

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -63,6 +63,8 @@ namespace ILCompiler.DependencyAnalysis
                                                        // e.g. in R2R scenarios as an offset from $imageBase
         WASM_TABLE_INDEX_REL_I32   = 0x20A,  // Wasm: a table index encoded as a 4-byte uint32 relative to the tableBase of the R2R image
         WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB = 0x20B, // Wasm: an exception tag index encoded as a 5-byte varuint32. Used to refer to the CoreCLR restore context exception tag.
+        WASM_METHOD_RELATIVE_VIRTUAL_IP_I32 = 0x20C, // Wasm: a method virtual IP relative to the image virtual IP base, stored as a 4-byte uint32.
+        WASM_ASYNC_RESUME_INFO_DELTA_ULEB = 0x20D, // Wasm: an image-relative delta to an async resume info fixup chunk, encoded as ULEB128.
 
         //
         // Relocation operators related to TLS access
@@ -674,6 +676,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.WASM_MEMORY_ADDR_LEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_LEB:
                 case RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB:
+                case RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB:
                     DwarfHelper.WritePaddedULEB128(new Span<byte>((byte*)location, WASM_PADDED_RELOC_SIZE_32), checked((ulong)value));
                     return;
 
@@ -684,6 +687,7 @@ namespace ILCompiler.DependencyAnalysis
                     return;
                 case RelocType.WASM_TABLE_INDEX_I32:
                 case RelocType.WASM_TABLE_INDEX_REL_I32:
+                case RelocType.WASM_METHOD_RELATIVE_VIRTUAL_IP_I32:
                     *(uint*)location = checked((uint)value);
                     return;
                 case RelocType.WASM_TABLE_INDEX_I64:
@@ -707,6 +711,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.WASM_MEMORY_ADDR_LEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_LEB:
                 case RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB:
+                case RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB:
                     DwarfHelper.WriteULEB128(new Span<byte>((byte*)location, WASM_PADDED_RELOC_SIZE_32), checked((ulong)value));
                     return (int)DwarfHelper.SizeOfULEB128((ulong)value);
 
@@ -759,8 +764,10 @@ namespace ILCompiler.DependencyAnalysis
                 RelocType.WASM_MEMORY_ADDR_REL_LEB => WASM_PADDED_RELOC_SIZE_32,
                 RelocType.WASM_MEMORY_ADDR_REL_SLEB => WASM_PADDED_RELOC_SIZE_32,
                 RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB => WASM_PADDED_RELOC_SIZE_32,
+                RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB => WASM_PADDED_RELOC_SIZE_32,
                 RelocType.WASM_TABLE_INDEX_I32 => 4,
                 RelocType.WASM_TABLE_INDEX_REL_I32 => 4,
+                RelocType.WASM_METHOD_RELATIVE_VIRTUAL_IP_I32 => 4,
                 RelocType.WASM_TABLE_INDEX_I64 => 8,
 
                 _ => throw new NotSupportedException(),
@@ -779,7 +786,8 @@ namespace ILCompiler.DependencyAnalysis
                 RelocType.WASM_MEMORY_ADDR_SLEB or
                 RelocType.WASM_MEMORY_ADDR_REL_LEB or
                 RelocType.WASM_MEMORY_ADDR_REL_SLEB or
-                RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB => true,
+                RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB or
+                RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB => true,
                 _ => false,
             };
         }
@@ -795,6 +803,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.WASM_MEMORY_ADDR_LEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_LEB:
                 case RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB:
+                case RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB:
                     return (int)DwarfHelper.SizeOfULEB128((ulong)resolvedValue);
                 case RelocType.WASM_TABLE_INDEX_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_SLEB:
@@ -870,6 +879,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.WASM_MEMORY_ADDR_LEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_LEB:
                 case RelocType.WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB:
+                case RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB:
                     return checked((long)DwarfHelper.ReadULEB128(new ReadOnlySpan<byte>(location, WASM_PADDED_RELOC_SIZE_32)));
                 case RelocType.WASM_TABLE_INDEX_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_SLEB:
@@ -877,6 +887,7 @@ namespace ILCompiler.DependencyAnalysis
                     return DwarfHelper.ReadSLEB128(new ReadOnlySpan<byte>(location, WASM_PADDED_RELOC_SIZE_32));
                 case RelocType.WASM_TABLE_INDEX_I32:
                 case RelocType.WASM_TABLE_INDEX_REL_I32:
+                case RelocType.WASM_METHOD_RELATIVE_VIRTUAL_IP_I32:
                     return *(uint*)location;
 
                 default:

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
@@ -131,6 +131,11 @@ namespace ILCompiler.ObjectWriter
 
                     switch (reloc.Type)
                     {
+                        case RelocType.WASM_METHOD_RELATIVE_VIRTUAL_IP_I32:
+                        {
+                            Relocation.WriteValue(reloc.Type, pData, reloc.Addend + addend);
+                            break;
+                        }
                         case RelocType.WASM_TYPE_INDEX_LEB:
                         case RelocType.WASM_GLOBAL_INDEX_LEB:
                         case RelocType.WASM_TABLE_INDEX_I32:

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
@@ -304,14 +304,128 @@ namespace ILCompiler.ObjectWriter
                 using Stream originalStream = section.ContentReadStream;
                 MemoryStream resolvedStream = new((int)originalStream.Length);
                 originalStream.Position = 0;
-                ResolveRelocations(
-                    section.SectionIndex,
-                    originalStream,
-                    resolvedStream,
-                    relocations,
-                    sectionStart: 0,
-                    shrink: false);
+                if (relocations.Exists(static relocation => relocation.Type == RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB))
+                {
+                    ResolveAsyncResumeInfoRelocations(section.SectionIndex, originalStream, resolvedStream, relocations);
+                }
+                else
+                {
+                    ResolveRelocations(
+                        section.SectionIndex,
+                        originalStream,
+                        resolvedStream,
+                        relocations,
+                        sectionStart: 0,
+                        shrink: false);
+                }
                 section.ContentReadStream = resolvedStream;
+            }
+        }
+
+        private void ResolveAsyncResumeInfoRelocations(
+            int sectionIndex,
+            Stream sourceStream,
+            MemoryStream destinationStream,
+            List<SymbolicRelocation> relocations)
+        {
+            long sourcePosition = 0;
+            uint previousFixupEndRva = 0;
+
+            foreach (SymbolicRelocation relocation in relocations)
+            {
+                if (relocation.Type != RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB)
+                {
+                    throw new InvalidDataException(
+                        $"Unexpected relocation type {relocation.Type} in the Wasm async resume info fixup section.");
+                }
+
+                CopyBytes(sourceStream, destinationStream, sourcePosition, relocation.Offset - sourcePosition);
+
+                SymbolDefinition definedSymbol = _definedSymbols[relocation.SymbolName];
+                if (_sections[definedSymbol.SectionIndex] is not WebcilSection targetSection)
+                {
+                    throw new InvalidDataException(
+                        $"Wasm async resume info target '{relocation.SymbolName}' is not in a WebCIL section.");
+                }
+
+                sourceStream.Position = relocation.Offset;
+                uint locationOffset = ReadULEB128(sourceStream);
+                uint fixupRva = checked(targetSection.Header.VirtualAddress +
+                    (uint)definedSymbol.Value +
+                    (uint)relocation.Addend +
+                    locationOffset);
+                if (fixupRva < previousFixupEndRva)
+                {
+                    throw new InvalidDataException("Wasm async resume info fixups are not ordered by location.");
+                }
+
+                WriteULEB128(destinationStream, fixupRva - previousFixupEndRva);
+
+                sourcePosition = relocation.Offset + Relocation.GetSize(relocation.Type);
+                sourceStream.Position = sourcePosition;
+                uint count = ReadULEB128(sourceStream);
+                uint stride = ReadULEB128(sourceStream);
+                if (count == 0)
+                {
+                    throw new InvalidDataException("Wasm async resume info fixup chunks must not be empty.");
+                }
+                previousFixupEndRva = checked(fixupRva + (count - 1) * stride + sizeof(uint));
+            }
+
+            CopyBytes(sourceStream, destinationStream, sourcePosition, sourceStream.Length - sourcePosition);
+            while (destinationStream.Length < sourceStream.Length)
+            {
+                destinationStream.WriteByte(0);
+            }
+
+            destinationStream.Position = sourceStream.Length;
+
+            static void CopyBytes(Stream source, Stream destination, long sourceOffset, long count)
+            {
+                source.Position = sourceOffset;
+                Span<byte> buffer = stackalloc byte[256];
+                while (count > 0)
+                {
+                    int bytesToRead = (int)Math.Min(count, buffer.Length);
+                    source.ReadExactly(buffer.Slice(0, bytesToRead));
+                    destination.Write(buffer.Slice(0, bytesToRead));
+                    count -= bytesToRead;
+                }
+            }
+
+            static uint ReadULEB128(Stream stream)
+            {
+                uint value = 0;
+                int shift = 0;
+                byte current;
+                do
+                {
+                    int nextByte = stream.ReadByte();
+                    if (nextByte < 0)
+                    {
+                        throw new EndOfStreamException();
+                    }
+
+                    current = (byte)nextByte;
+                    value |= (uint)(current & 0x7F) << shift;
+                    shift += 7;
+                } while ((current & 0x80) != 0);
+
+                return value;
+            }
+
+            static void WriteULEB128(Stream stream, uint value)
+            {
+                do
+                {
+                    byte current = (byte)(value & 0x7F);
+                    value >>= 7;
+                    if (value != 0)
+                    {
+                        current |= 0x80;
+                    }
+                    stream.WriteByte(current);
+                } while (value != 0);
             }
         }
 
@@ -710,6 +824,10 @@ namespace ILCompiler.ObjectWriter
 
                 switch (reloc.Type)
                 {
+                    case RelocType.WASM_METHOD_RELATIVE_VIRTUAL_IP_I32:
+                        Relocation.WriteValue(reloc.Type, pData, reloc.Addend + addend);
+                        break;
+
                     case RelocType.WASM_TYPE_INDEX_LEB:
                     case RelocType.WASM_GLOBAL_INDEX_LEB:
                     case RelocType.WASM_TABLE_INDEX_I32:

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime
     {
         public const uint Signature = 0x00525452; // 'RTR'
 
-        public const ushort CurrentMajorVersion = 28;
+        public const ushort CurrentMajorVersion = 29;
         public const ushort CurrentMinorVersion = 0;
     }
 #if READYTORUN
@@ -84,6 +84,7 @@ namespace Internal.Runtime
         ExternalTypeMaps            = 124, // Added to CoreCLR in V18.3
         ProxyTypeMaps               = 125, // Added to CoreCLR in V18.3
         TypeMapAssemblyTargets      = 126, // Added in V18.3
+        WasmAsyncResumeInfo         = 127, // Added in V29
 
         //
         // NativeAOT ReadyToRun sections

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -455,11 +455,14 @@ namespace Internal.JitInterface
             PublishCode();
             PublishROData();
             PublishRWData();
+            PublishWasmMethodVirtualIPFixups();
 
             return CompilationResult.CompilationComplete;
         }
 
         partial void DetermineIfCompilationShouldBeRetried(ref CompilationResult result);
+        partial void PublishWasmMethodVirtualIPFixups();
+        partial void ClearWasmMethodVirtualIPFixups();
 
         private void PublishCode()
         {
@@ -704,6 +707,7 @@ namespace Internal.JitInterface
             _codeRelocs = default(ArrayBuilder<Relocation>);
             _roDataRelocs = default(ArrayBuilder<Relocation>);
             _rwDataRelocs = default(ArrayBuilder<Relocation>);
+            ClearWasmMethodVirtualIPFixups();
 #if READYTORUN
             _coldCodeRelocs = default(ArrayBuilder<Relocation>);
 #endif
@@ -4553,6 +4557,14 @@ namespace Internal.JitInterface
         partial void findKnownBBCountBlock(ref BlockType blockType, void* location, ref int offset);
 
         partial void TryUseWasmMethodCodeStoreFixup(void* target, CorInfoReloc fRelocType, BlockType locationBlock, int relocOffset, int addlDelta, ref bool handled);
+        partial void TryGetWasmMethodVirtualIPRelocation(
+            void* target,
+            CorInfoReloc fRelocType,
+            BlockType locationBlock,
+            int relocOffset,
+            ref ISymbolNode relocTarget,
+            ref RelocType relocType,
+            ref bool handled);
 
         private ref ArrayBuilder<Relocation> findRelocBlock(BlockType blockType, out int length)
         {
@@ -4639,52 +4651,67 @@ namespace Internal.JitInterface
             int relocDelta;
             BlockType targetBlock = findKnownBlock(target, out relocDelta);
 
-            ISymbolNode relocTarget;
-            switch (targetBlock)
+            ISymbolNode relocTarget = null;
+            RelocType relocType = default;
+            bool handledByMethodVirtualIPRelocation = false;
+            TryGetWasmMethodVirtualIPRelocation(
+                target,
+                fRelocType,
+                locationBlock,
+                relocOffset,
+                ref relocTarget,
+                ref relocType,
+                ref handledByMethodVirtualIPRelocation);
+
+            if (!handledByMethodVirtualIPRelocation)
             {
-                case BlockType.Code:
-                    relocTarget = _methodCodeNode;
-                    break;
+                switch (targetBlock)
+                {
+                    case BlockType.Code:
+                        relocTarget = _methodCodeNode;
+                        break;
 
-                case BlockType.ColdCode:
+                    case BlockType.ColdCode:
 #if READYTORUN
-                    Debug.Assert(_methodColdCodeNode != null);
-                    relocTarget = _methodColdCodeNode;
-                    break;
+                        Debug.Assert(_methodColdCodeNode != null);
+                        relocTarget = _methodColdCodeNode;
+                        break;
 #else
-                    throw new NotImplementedException("ColdCode relocs");
+                        throw new NotImplementedException("ColdCode relocs");
 #endif
 
-                case BlockType.ROData:
-                    relocTarget = _roDataBlob;
-                    break;
+                    case BlockType.ROData:
+                        relocTarget = _roDataBlob;
+                        break;
 
-                case BlockType.RWData:
-                    relocTarget = _rwDataBlob;
-                    break;
+                    case BlockType.RWData:
+                        relocTarget = _rwDataBlob;
+                        break;
 
 #if READYTORUN
-                case BlockType.BBCounts:
-                    relocTarget = null;
-                    break;
+                    case BlockType.BBCounts:
+                        relocTarget = null;
+                        break;
 #endif
 
-                default:
-                    // Reloc points to something outside of the generated blocks
-                    var targetObject = HandleToObject(target);
+                    default:
+                        // Reloc points to something outside of the generated blocks
+                        var targetObject = HandleToObject(target);
 
 #if READYTORUN
-                    if (targetObject is RequiresRuntimeJitIfUsedSymbol requiresRuntimeSymbol)
-                    {
-                        throw new RequiresRuntimeJitException(requiresRuntimeSymbol.Message);
-                    }
+                        if (targetObject is RequiresRuntimeJitIfUsedSymbol requiresRuntimeSymbol)
+                        {
+                            throw new RequiresRuntimeJitException(requiresRuntimeSymbol.Message);
+                        }
 #endif
 
-                    relocTarget = (ISymbolNode)targetObject;
-                    break;
+                        relocTarget = (ISymbolNode)targetObject;
+                        break;
+                }
+
+                relocType = GetRelocType(fRelocType);
             }
 
-            RelocType relocType = GetRelocType(fRelocType);
             relocDelta += addlDelta;
 
             // relocDelta is stored as the value

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -528,6 +528,7 @@ namespace Internal.JitInterface
         WASM_MEMORY_ADDR_REL_LEB,            // Wasm: a relative linear memory index encoded as a 5-byte varuint32. Used as the immediate argument of a load or store instruction,
                                                // e.g. in R2R scenarios, encoding an offset from $imageBase
         WASM_CLR_RESTORE_CONTEXT_EXCEPTION_TAG_LEB, // Wasm: an exception tag index encoded as a 5-byte varuint32. Used to refer to the CoreCLR restore context exception tag.
+        WASM_METHOD_RELATIVE_VIRTUAL_IP_I32, // Wasm: the current method's virtual IP relative to the image virtual IP base, stored as a 4-byte uint32.
     }
 
     public enum CorInfoGCType

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -959,6 +959,39 @@ public class R2RTestSuites
         }
     }
 
+    [ConditionalFact(typeof(TestPaths), nameof(TestPaths.IsWasmTarget))]
+    public void RuntimeAsyncWasmDiagnosticIPFixups()
+    {
+        var asm = new CompiledAssembly
+        {
+            AssemblyName = nameof(RuntimeAsyncWasmDiagnosticIPFixups),
+            SourceResourceNames =
+            [
+                "RuntimeAsync/AsyncMultipleSuspensionPoints.cs",
+                "RuntimeAsync/RuntimeAsyncMethodGenerationAttribute.cs",
+            ],
+            Features = { RuntimeAsyncFeature },
+        };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(RuntimeAsyncWasmDiagnosticIPFixups),
+            [
+                new(nameof(RuntimeAsyncWasmDiagnosticIPFixups), [new CrossgenAssembly(asm)])
+                {
+                    AdditionalArgs = { "--determinism-stress=2" },
+                    OutputFileExtension = ".wasm",
+                    Validate = Validate,
+                },
+            ]));
+
+        static void Validate(ReadyToRunReader reader)
+        {
+            Assert.True(
+                WasmR2RAssert.HasExpectedAsyncResumeInfoFixups(reader, out string diagnostic),
+                diagnostic);
+        }
+    }
+
     /// <summary>
     /// PR #121679: MutableModule async references + cross-module inlining
     /// of runtime-async methods with cross-module dependency.

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
@@ -2,16 +2,88 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using ILCompiler.Reflection.ReadyToRun;
+using Internal.Runtime;
 
 namespace ILCompiler.ReadyToRun.Tests.TestCasesRunner;
 
 internal static class WasmR2RAssert
 {
+    public static bool HasExpectedAsyncResumeInfoFixups(ReadyToRunReader reader, out string diagnostic)
+    {
+        if (!reader.ReadyToRunHeader.Sections.TryGetValue(
+                ReadyToRunSectionType.WasmAsyncResumeInfo, out ReadyToRunSection section))
+        {
+            diagnostic = "The Wasm async resume info fixup section was not found.";
+            return false;
+        }
+
+        ReadOnlySpan<byte> image = reader.CompositeReader.GetEntireImage().AsSpan();
+        int offset = reader.CompositeReader.GetOffset(section.RelativeVirtualAddress);
+        int end = checked(offset + section.Size);
+        uint chunkCount = ReadWasmUleb32(image, ref offset, end);
+        if (chunkCount != 2)
+        {
+            diagnostic = $"Found {chunkCount} async resume info fixup chunks; expected 2.";
+            return false;
+        }
+
+        const uint ExpectedFixupsPerChunk = 3;
+        const uint ExpectedStride = 8;
+        uint currentFixupRva = 0;
+        uint previousMethodVirtualIP = 0;
+
+        for (uint chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++)
+        {
+            currentFixupRva += ReadWasmUleb32(image, ref offset, end);
+            uint fixupCount = ReadWasmUleb32(image, ref offset, end);
+            uint fixupStride = ReadWasmUleb32(image, ref offset, end);
+            if (fixupCount != ExpectedFixupsPerChunk || fixupStride != ExpectedStride)
+            {
+                diagnostic =
+                    $"Chunk {chunkIndex} encoded count {fixupCount}, stride {fixupStride}; " +
+                    $"expected count {ExpectedFixupsPerChunk}, stride {ExpectedStride}.";
+                return false;
+            }
+
+            int firstFixupOffset = reader.CompositeReader.GetOffset(checked((int)currentFixupRva));
+            uint methodVirtualIP = BinaryPrimitives.ReadUInt32LittleEndian(image.Slice(firstFixupOffset, sizeof(uint)));
+            if ((methodVirtualIP & 1) != 0 || (chunkIndex != 0 && methodVirtualIP <= previousMethodVirtualIP))
+            {
+                diagnostic =
+                    $"Chunk {chunkIndex} contains invalid method-relative virtual IP {methodVirtualIP}; " +
+                    $"previous value was {previousMethodVirtualIP}.";
+                return false;
+            }
+
+            for (uint fixupIndex = 1; fixupIndex < fixupCount; fixupIndex++)
+            {
+                int fixupOffset = reader.CompositeReader.GetOffset(
+                    checked((int)(currentFixupRva + fixupIndex * fixupStride)));
+                uint actualVirtualIP =
+                    BinaryPrimitives.ReadUInt32LittleEndian(image.Slice(fixupOffset, sizeof(uint)));
+                if (actualVirtualIP != methodVirtualIP)
+                {
+                    diagnostic =
+                        $"Chunk {chunkIndex}, fixup {fixupIndex} contains virtual IP {actualVirtualIP}; " +
+                        $"expected {methodVirtualIP}.";
+                    return false;
+                }
+            }
+
+            previousMethodVirtualIP = methodVirtualIP;
+            currentFixupRva += (fixupCount - 1) * fixupStride + sizeof(uint);
+        }
+
+        diagnostic = "The Wasm async resume info fixup table has the expected chunks and method-relative virtual IP values.";
+        return true;
+    }
+
     /// <summary>
     /// Returns true if any WASM function body in the image contains a <c>global.get</c> of the
     /// given ABI well-known-global index (the <c>global.get</c> opcode <c>0x23</c> followed

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmAsyncResumeInfoFixupsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmAsyncResumeInfoFixupsNode.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    internal sealed class WasmAsyncResumeInfoFixupsNode : HeaderTableNode
+    {
+        private static readonly ObjectNodeSection FixupSection =
+            new ObjectNodeSection("wasm.asyncresumeinfo", SectionType.ReadOnly);
+
+        private readonly List<Fixup> _fixups = new List<Fixup>();
+
+        public override ObjectNodeSection GetSection(NodeFactory factory) => FixupSection;
+
+        public void AddFixup(ISymbolNode location, int offset)
+        {
+            lock (_fixups)
+            {
+                _fixups.Add(new Fixup(location, offset));
+            }
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("__ReadyToRun_WasmAsyncResumeInfoFixups"u8);
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            Fixup[] fixups;
+            lock (_fixups)
+            {
+                fixups = _fixups.ToArray();
+            }
+
+            Array.Sort(fixups, CompareFixups);
+
+            int stride = factory.Target.PointerSize * 2;
+            List<FixupChunk> chunks = new List<FixupChunk>();
+            for (int i = 0; i < fixups.Length;)
+            {
+                Fixup first = fixups[i];
+                int count = 1;
+                while ((i + count) < fixups.Length &&
+                       fixups[i + count].Location == first.Location &&
+                       fixups[i + count].Offset == first.Offset + count * stride)
+                {
+                    count++;
+                }
+
+                chunks.Add(new FixupChunk(first.Location, first.Offset, count, stride));
+                i += count;
+            }
+
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.AddSymbol(this);
+            EmitULEB128(ref builder, checked((uint)chunks.Count));
+
+            foreach (FixupChunk chunk in chunks)
+            {
+                builder.EmitReloc(chunk.Location, RelocType.WASM_ASYNC_RESUME_INFO_DELTA_ULEB, chunk.Offset);
+                EmitULEB128(ref builder, checked((uint)chunk.Count));
+                EmitULEB128(ref builder, checked((uint)chunk.Stride));
+            }
+
+            return builder.ToObjectData();
+        }
+
+        public override int ClassCode => 1794382631;
+
+        private static int CompareFixups(Fixup left, Fixup right)
+        {
+            int result = CompilerComparer.Instance.Compare((ISortableNode)left.Location, (ISortableNode)right.Location);
+            return result != 0 ? result : left.Offset.CompareTo(right.Offset);
+        }
+
+        private static void EmitULEB128(ref ObjectDataBuilder builder, uint value)
+        {
+            do
+            {
+                byte current = (byte)(value & 0x7F);
+                value >>= 7;
+                if (value != 0)
+                {
+                    current |= 0x80;
+                }
+                builder.EmitByte(current);
+            } while (value != 0);
+        }
+
+        private readonly struct Fixup
+        {
+            public Fixup(ISymbolNode location, int offset)
+            {
+                Location = location;
+                Offset = offset;
+            }
+
+            public ISymbolNode Location { get; }
+            public int Offset { get; }
+        }
+
+        private readonly struct FixupChunk
+        {
+            public FixupChunk(ISymbolNode location, int offset, int count, int stride)
+            {
+                Location = location;
+                Offset = offset;
+                Count = count;
+                Stride = stride;
+            }
+
+            public ISymbolNode Location { get; }
+            public int Offset { get; }
+            public int Count { get; }
+            public int Stride { get; }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmMethodRelativeVirtualIPNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmMethodRelativeVirtualIPNode.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    internal sealed class WasmMethodRelativeVirtualIPNode : SortableDependencyNode, ISortableSymbolNode
+    {
+        private readonly NodeFactory _factory;
+        private readonly MethodWithGCInfo _method;
+
+        public WasmMethodRelativeVirtualIPNode(NodeFactory factory, MethodWithGCInfo method)
+        {
+            _factory = factory;
+            _method = method;
+        }
+
+        public int Offset => unchecked((int)_factory.RuntimeFunctionsTable.GetWasmVirtualIP(_method, 0));
+
+        public bool RepresentsIndirectionCell => false;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            _method.AppendMangledName(nameMangler, sb);
+        }
+
+        protected override string GetName(NodeFactory factory) => $"Wasm relative virtual IP: {_method.Method}";
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            return new DependencyListEntry[] { new DependencyListEntry(_method, "Method for relative virtual IP") };
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
+            List<DependencyNodeCore<NodeFactory>> markedNodes,
+            int firstNode,
+            NodeFactory factory) => null;
+
+        public override int ClassCode => 1987324651;
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            return comparer.Compare(_method.Method, ((WasmMethodRelativeVirtualIPNode)other)._method.Method);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -553,6 +553,11 @@ namespace ILCompiler.DependencyAnalysis
             {
                 return new WasmTypeNode(key);
             });
+
+            _wasmMethodRelativeVirtualIPs = new(method =>
+            {
+                return new WasmMethodRelativeVirtualIPNode(this, method);
+            });
         }
 
         public int CompilationCurrentPhase { get; private set; }
@@ -570,6 +575,8 @@ namespace ILCompiler.DependencyAnalysis
         public GlobalHeaderNode Header;
 
         public RuntimeFunctionsTableNode RuntimeFunctionsTable;
+
+        internal WasmAsyncResumeInfoFixupsNode WasmAsyncResumeInfoFixups;
 
         public HotColdMapNode HotColdMap;
 
@@ -1025,6 +1032,12 @@ namespace ILCompiler.DependencyAnalysis
             RuntimeFunctionsTable = new RuntimeFunctionsTableNode(this);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.RuntimeFunctions, RuntimeFunctionsTable);
 
+            if (Target.IsWasm)
+            {
+                WasmAsyncResumeInfoFixups = new WasmAsyncResumeInfoFixupsNode();
+                Header.Add(Internal.Runtime.ReadyToRunSectionType.WasmAsyncResumeInfo, WasmAsyncResumeInfoFixups);
+            }
+
             RuntimeFunctionsGCInfo = new RuntimeFunctionsGCInfoNode();
             graph.AddRoot(RuntimeFunctionsGCInfo, "GC info is always generated");
 
@@ -1429,6 +1442,7 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         private NodeCache<WasmFuncType, WasmTypeNode> _wasmTypeNodes;
+        private NodeCache<MethodWithGCInfo, WasmMethodRelativeVirtualIPNode> _wasmMethodRelativeVirtualIPs;
 
         private readonly struct WasmUnboxingStubKey : IEquatable<WasmUnboxingStubKey>
         {
@@ -1474,6 +1488,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             WasmFuncType funcType = WasmLowering.GetSignature(method).FuncType;
             return _wasmTypeNodes.GetOrAdd(funcType);
+        }
+
+        internal WasmMethodRelativeVirtualIPNode WasmMethodRelativeVirtualIP(MethodWithGCInfo method)
+        {
+            return _wasmMethodRelativeVirtualIPs.GetOrAdd(method);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -335,9 +335,11 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypeHandle.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypesTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\VirtualResolutionFixupSignature.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\WasmImportThunkPortableEntrypoint.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\WasmAsyncResumeInfoFixupsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\WasmImportThunk.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\WasmImportThunkPortableEntrypoint.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\WasmInterpreterToR2RThunkNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\WasmMethodRelativeVirtualIPNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\WasmR2RToInterpreterThunkNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\WasmUnboxingStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Win32ResourcesNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -486,6 +486,7 @@ namespace Internal.JitInterface
         private List<MethodDesc> _ilBodiesNeeded;
         private Dictionary<TypeDesc, bool> _preInitedTypes = new Dictionary<TypeDesc, bool>();
         private HashSet<MethodDesc> _synthesizedPgoDependencies;
+        private List<(ISymbolNode Location, int Offset)> _wasmMethodVirtualIPFixups;
         public bool HasColdCode { get; private set; }
 
         public CorInfoImpl(ReadyToRunCodegenCompilation compilation)
@@ -3309,6 +3310,52 @@ namespace Internal.JitInterface
             AddPrecodeFixup(fixup);
 
             handled = true;
+        }
+
+        partial void TryGetWasmMethodVirtualIPRelocation(
+            void* target,
+            CorInfoReloc fRelocType,
+            BlockType locationBlock,
+            int relocOffset,
+            ref ISymbolNode relocTarget,
+            ref RelocType relocType,
+            ref bool handled)
+        {
+            if (!_compilation.NodeFactory.Target.IsWasm)
+                return;
+
+            if (fRelocType != CorInfoReloc.WASM_METHOD_RELATIVE_VIRTUAL_IP_I32)
+                return;
+
+            Debug.Assert(locationBlock is BlockType.ROData or BlockType.RWData);
+            Debug.Assert(findKnownBlock(target, out int targetOffset) == BlockType.Code);
+            Debug.Assert(targetOffset == 0);
+
+            ISymbolNode dataBlobNode = locationBlock == BlockType.ROData ? _roDataBlob : _rwDataBlob;
+            Debug.Assert(dataBlobNode is not null);
+
+            relocTarget = _compilation.NodeFactory.WasmMethodRelativeVirtualIP(_methodCodeNode);
+            relocType = RelocType.WASM_METHOD_RELATIVE_VIRTUAL_IP_I32;
+            _wasmMethodVirtualIPFixups ??= new();
+            _wasmMethodVirtualIPFixups.Add((dataBlobNode, relocOffset));
+
+            handled = true;
+        }
+
+        partial void PublishWasmMethodVirtualIPFixups()
+        {
+            if (_wasmMethodVirtualIPFixups is null)
+                return;
+
+            foreach ((ISymbolNode location, int offset) in _wasmMethodVirtualIPFixups)
+            {
+                _compilation.NodeFactory.WasmAsyncResumeInfoFixups.AddFixup(location, offset);
+            }
+        }
+
+        partial void ClearWasmMethodVirtualIPFixups()
+        {
+            _wasmMethodVirtualIPFixups = null;
         }
 
         private unsafe HRESULT allocPgoInstrumentationBySchema(CORINFO_METHOD_STRUCT_* ftnHnd, PgoInstrumentationSchema* pSchema, uint countSchemaItems, byte** pInstrumentationData)

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -2880,6 +2880,95 @@ UINT32 DecodeULEB128AsU32(PTR_BYTE* ppData)
     return result;
 }
 
+static bool TryDecodeULEB128AsU32(PTR_BYTE* ppData, PTR_BYTE pEnd, UINT32* pValue)
+{
+    UINT32 result = 0;
+
+    for (int shift = 0; shift < 32; shift += 7)
+    {
+        if (*ppData >= pEnd)
+            return false;
+
+        BYTE b = *(*ppData)++;
+        if ((shift == 28) && ((b & 0xF0) != 0))
+            return false;
+
+        result |= (UINT32)(b & 0x7F) << shift;
+        if ((b & 0x80) == 0)
+        {
+            *pValue = result;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void ProcessWasmAsyncResumeInfoFixups(
+    TADDR imageBase,
+    SIZE_T imageSize,
+    IMAGE_DATA_DIRECTORY* pFixupSection,
+    DWORD virtualIPBase,
+    bool applyFixups)
+{
+    SIZE_T sectionRva = pFixupSection->VirtualAddress;
+    SIZE_T sectionSize = pFixupSection->Size;
+    if ((sectionRva > imageSize) || (sectionSize > imageSize - sectionRva))
+        COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+
+    PTR_BYTE pFixupData = dac_cast<PTR_BYTE>(imageBase + sectionRva);
+    PTR_BYTE pFixupEnd = pFixupData + sectionSize;
+    UINT32 chunkCount;
+    if (!TryDecodeULEB128AsU32(&pFixupData, pFixupEnd, &chunkCount))
+        COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+
+    SIZE_T currentFixupRva = 0;
+    for (UINT32 chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++)
+    {
+        UINT32 delta;
+        UINT32 fixupCount;
+        UINT32 fixupStride;
+        if (!TryDecodeULEB128AsU32(&pFixupData, pFixupEnd, &delta) ||
+            !TryDecodeULEB128AsU32(&pFixupData, pFixupEnd, &fixupCount) ||
+            !TryDecodeULEB128AsU32(&pFixupData, pFixupEnd, &fixupStride))
+        {
+            COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+        }
+
+        if ((delta > imageSize - currentFixupRva) ||
+            (fixupCount == 0) ||
+            (fixupStride != sizeof(CORINFO_AsyncResumeInfo)))
+        {
+            COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+        }
+
+        currentFixupRva += delta;
+        if ((currentFixupRva > imageSize) ||
+            (sizeof(DWORD) > imageSize - currentFixupRva))
+        {
+            COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+        }
+
+        SIZE_T maximumFixupCount =
+            1 + (imageSize - currentFixupRva - sizeof(DWORD)) / fixupStride;
+        if (fixupCount > maximumFixupCount)
+            COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+
+        for (UINT32 fixupIndex = 0; fixupIndex < fixupCount; fixupIndex++)
+        {
+            SIZE_T diagnosticIPRva = currentFixupRva + (SIZE_T)fixupIndex * fixupStride;
+            PTR_DWORD pDiagnosticIP = dac_cast<PTR_DWORD>(imageBase + diagnosticIPRva);
+            if (*pDiagnosticIP > UINT32_MAX - virtualIPBase)
+                COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+
+            if (applyFixups)
+                *pDiagnosticIP += virtualIPBase;
+        }
+
+        currentFixupRva += (SIZE_T)(fixupCount - 1) * fixupStride + sizeof(DWORD);
+    }
+}
+
 void ReadyToRunInfo::RegisterVirtualIPRange(Module* pModule)
 {
     CONTRACTL {
@@ -2912,6 +3001,18 @@ void ReadyToRunInfo::RegisterVirtualIPRange(Module* pModule)
             totalVirtualIPs,
             ExecutionManager::GetReadyToRunJitManager(),
             pModule));
+
+        IMAGE_DATA_DIRECTORY* pAsyncResumeInfoFixups =
+            m_pComposite->FindSection(ReadyToRunSectionType::WasmAsyncResumeInfo);
+        if (pAsyncResumeInfoFixups != nullptr)
+        {
+            DWORD virtualIPBase = static_cast<DWORD>(m_pComposite->GetMinVirtualIP());
+            SIZE_T imageSize = m_pComposite->GetLayout()->GetVirtualSize();
+            ProcessWasmAsyncResumeInfoFixups(
+                imageBase, imageSize, pAsyncResumeInfoFixups, virtualIPBase, false);
+            ProcessWasmAsyncResumeInfoFixups(
+                imageBase, imageSize, pAsyncResumeInfoFixups, virtualIPBase, true);
+        }
 
         ExecutionManager::AddFunctionTableIndexRange(
             m_minFunctionTableIndex,

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -1805,7 +1805,9 @@ TADDR GetWasmFramePointerFromStackPointer(TADDR sp, PCODE controlPC)
     // frame pointer is found by unwinding to either its containing function, or to a CallFunclet location.
 
     TADDR internalFunctionFramePointer = GetWasmFramePointerFromStackPointer_Internal(sp);
-    _ASSERTE(internalFunctionFramePointer != 0);
+    if (internalFunctionFramePointer == 0)
+        return 0;
+
     uint32_t r2rFunctionTableEntryNumber = *(uint32_t*)(internalFunctionFramePointer + WASM_STACKFRAME_FUNCTION_INDEX_OFFSET);
     _ASSERTE(GetWasmVirtualIPFromStackPointer(sp) == controlPC);
 

--- a/src/tests/async/Directory.Build.targets
+++ b/src/tests/async/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <!-- disable building for configurations that do not yet support runtime async. -->
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono' or '$(TargetArchitecture)' == 'wasm'">true</DisableProjectBuild>
+    <!-- Mono does not support runtime async. Wasm tests must explicitly opt in after avoiding unsupported operations such as Task.Yield. -->
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono' or ('$(TargetArchitecture)' == 'wasm' and '$(EnableRuntimeAsyncOnWasm)' != 'true')">true</DisableProjectBuild>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 </Project>

--- a/src/tests/async/async.csproj
+++ b/src/tests/async/async.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <EnableRuntimeAsyncOnWasm>true</EnableRuntimeAsyncOnWasm>
+  </PropertyGroup>
   <ItemGroup>
-    <MergedWrapperProjectReference Include="*/**/*.??proj" />
+    <MergedWrapperProjectReference Include="*/**/*.??proj" GlobalPropertiesToRemove="EnableRuntimeAsyncOnWasm" />
 
     <!-- Remove manual benchmarks from the test wrapper -->
     <MergedWrapperProjectReference Remove="eh-microbench.csproj" />

--- a/src/tests/async/diagnostic-ip-stacktrace/diagnostic-ip-stacktrace.cs
+++ b/src/tests/async/diagnostic-ip-stacktrace/diagnostic-ip-stacktrace.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class RuntimeAsyncDiagnosticIPStackTrace
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        TaskCompletionSource suspension = new();
+        Task task = Level1(suspension.Task);
+
+        Assert.False(task.IsCompleted);
+        suspension.SetResult();
+        Assert.True(task.IsCompleted);
+
+        InvalidOperationException? exception = null;
+        try
+        {
+            task.GetAwaiter().GetResult();
+        }
+        catch (InvalidOperationException ex)
+        {
+            exception = ex;
+        }
+
+        Assert.NotNull(exception);
+        string stackTrace = exception.StackTrace;
+        Assert.NotNull(stackTrace);
+        Console.WriteLine(stackTrace);
+
+        string[] expectedMethods =
+        [
+            nameof(ThrowAfterResume),
+            nameof(Level4),
+            nameof(Level3),
+            nameof(Level2),
+            nameof(Level1),
+        ];
+
+        int previousFrame = -1;
+        foreach (string method in expectedMethods)
+        {
+            string frame = $"{nameof(RuntimeAsyncDiagnosticIPStackTrace)}.{method}(";
+            int currentFrame = stackTrace.IndexOf(frame, StringComparison.Ordinal);
+            Assert.True(currentFrame > previousFrame, $"Expected '{frame}' after offset {previousFrame} in:{Environment.NewLine}{stackTrace}");
+            previousFrame = currentFrame;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task Level1(Task suspension) => await Level2(suspension);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task Level2(Task suspension) => await Level3(suspension);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task Level3(Task suspension) => await Level4(suspension);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task Level4(Task suspension) => await ThrowAfterResume(suspension);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task ThrowAfterResume(Task suspension)
+    {
+        await suspension;
+        throw new InvalidOperationException();
+    }
+}

--- a/src/tests/async/diagnostic-ip-stacktrace/diagnostic-ip-stacktrace.csproj
+++ b/src/tests/async/diagnostic-ip-stacktrace/diagnostic-ip-stacktrace.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <EnableRuntimeAsyncOnWasm>true</EnableRuntimeAsyncOnWasm>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes dotnet/runtime#133626

## Summary

- populate Wasm ReadyToRun `CORINFO_AsyncResumeInfo.DiagnosticIP` with the virtual IP of the containing method's start
- add a compact ReadyToRun fixup section that records `DiagnosticIP` slots as delta/count/stride ULEB128 chunks
- validate the section and apply the module virtual-IP base after `ExecutionManager::AddVirtualIPRange`
- advance the ReadyToRun format to 29.0 so older runtimes reject images containing method-relative diagnostic IPs
- preserve retry correctness by publishing fixup locations only after successful JIT code/data publication

## Testing

- `dotnet test src\coreclr\tools\aot\ILCompiler.ReadyToRun.Tests\ILCompiler.ReadyToRun.Tests.csproj -c Release --filter RuntimeAsyncWasmDiagnosticIPFixups -p:TargetOS=browser -p:TargetArchitecture=wasm -p:CoreCLRConfiguration=Debug` (1 passed, with `--determinism-stress=2`)
- `src\tests\build.cmd -Test async\async.csproj browser Debug` (build succeeded; exactly one child test project selected)
- rebuilt Wasm native runtime and Core_Root, then ran the generated `async.cmd` wrapper with ReadyToRun enabled (1 passed)
- `python src\coreclr\scripts\jitformat.py -r . -o windows -a x64`
- `git diff --check`

The exception regression test uses a synchronous test entry point to resume a runtime-async chain, prints `Exception.StackTrace`, and verifies these frames in order:

```text
ThrowAfterResume
Level4
Level3
Level2
Level1
TestEntryPoint
```

With the old null `DiagnosticIP` behavior, the same test only reported `ThrowAfterResume` and `TestEntryPoint` and failed the frame assertions.

> [!NOTE]
> This pull request description was generated by GitHub Copilot.