### PR TITLE
Fix Mono Windows x64 hardware exception continuations

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1777,8 +1777,44 @@ extends:
             extraVariablesTemplates:
               - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
-      # ActiveIssue https://github.com/dotnet/runtime/issues/133702
-      # Re-enable Windows x64 Mono MiniJIT runtime tests once FAST_FAIL_SET_CONTEXT_DENIED is resolved.
+      #
+      # Build the whole product using Mono and run runtime tests
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Release
+          runtimeFlavor: mono
+          platforms:
+            - windows_x64
+          variables:
+            - name: timeoutPerTestInMinutes
+              value: 60
+            - name: timeoutPerTestCollectionInMinutes
+              value: 180
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: AllSubsets_Mono_Minijit_RuntimeTests
+            runtimeVariant: minijit
+            buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release -lc ${{ variables.debugOnPrReleaseOnRolling }}
+            timeoutInMinutes: 180
+            condition: >-
+                  or(
+                    eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                    eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                    eq(variables['isRollingBuild'], true))
+
+            postBuildSteps:
+              - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+                parameters:
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: Mono_Release
+                  useHelixMonitor: ${{ variables.enableHelixJobMonitor }}
+            extraVariablesTemplates:
+              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+                parameters:
+                  liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
 
       #
       # Mono CoreCLR runtime Test executions using live libraries in interpreter mode

--- a/src/mono/mono/mini/exceptions-amd64.c
+++ b/src/mono/mono/mini/exceptions-amd64.c
@@ -56,6 +56,13 @@ void *mono_win_vectored_exception_handle;
 #define W32_SEH_HANDLE_EX(_ex) \
 	if (_ex##_handler) _ex##_handler(er->ExceptionCode, &info, ctx)
 
+static void
+seh_restore_context (void)
+{
+	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
+	mono_restore_context (&jit_tls->ex_ctx);
+}
+
 static LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 {
 #ifndef MONO_CROSS_COMPILE
@@ -156,8 +163,10 @@ static LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 				/* need to restore stack protection once stack is unwound
 				 * restore_stack will restore stack protection and then
 				 * resume control to the saved stack_restore_ctx */
-				mono_sigctx_to_monoctx (ctx, &jit_tls->stack_restore_ctx);
-				ctx->Rip = (guint64)restore_stack;
+				jit_tls->stack_restore_ctx = jit_tls->ex_ctx;
+				MONO_CONTEXT_SET_IP (&jit_tls->ex_ctx, restore_stack);
+				MONO_CONTEXT_SET_SP (&jit_tls->ex_ctx,
+					ALIGN_DOWN_TO ((guint64)MONO_CONTEXT_GET_SP (&jit_tls->ex_ctx), 16) - 8);
 			}
 		} else {
 			info.handled = FALSE;
@@ -825,6 +834,19 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 	mono_sigctx_to_monoctx (sigctx, &mctx);
 
 	mono_handle_exception (&mctx, obj);
+
+#ifdef TARGET_WIN32
+	/*
+	 * Windows validates exception continuation IPs when hardware stack protection is
+	 * enabled. Resume in native runtime code rather than an unregistered JIT handler.
+	 * Keep the handler context in TLS and provide the native entry point with an
+	 * aligned stack, a return-address slot, and the Win64 argument home area.
+	 */
+	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
+	jit_tls->ex_ctx = mctx;
+	MONO_CONTEXT_SET_IP (&mctx, seh_restore_context);
+	MONO_CONTEXT_SET_SP (&mctx, ALIGN_DOWN_TO ((guint64)MONO_CONTEXT_GET_SP (&mctx), 16) - 40);
+#endif
 
 	mono_monoctx_to_sigctx (&mctx, sigctx);
 

--- a/src/tests/baseservices/exceptions/simple/HardwareEh.cs
+++ b/src/tests/baseservices/exceptions/simple/HardwareEh.cs
@@ -23,6 +23,70 @@ public class HardwareEh
 	public const long c_VALUE = 34252;
 	public delegate bool TestDelegate();
 
+    [Theory]
+    [InlineData(0, typeof(DivideByZeroException))]
+    [InlineData(1, typeof(OverflowException))]
+    [InlineData(2, typeof(NullReferenceException))]
+    public static void NestedHardwareExceptions(int operation, Type exceptionType)
+    {
+        int finallyCount = 0;
+
+        for (int i = 0; i < 16; i++)
+        {
+            bool caught = false;
+
+            try
+            {
+                try
+                {
+                    TriggerHardwareException(operation);
+                }
+                finally
+                {
+                    Assert.Throws<NullReferenceException>(() => TriggerHardwareException(2));
+                    finallyCount++;
+                }
+            }
+            catch (Exception ex) when (FilterHardwareException(ex, exceptionType))
+            {
+                caught = true;
+            }
+
+            Assert.True(caught);
+            Assert.Equal(i + 1, finallyCount);
+        }
+    }
+
+    private static bool FilterHardwareException(Exception exception, Type exceptionType)
+    {
+        Assert.Throws<DivideByZeroException>(() => TriggerHardwareException(0));
+        return exception.GetType() == exceptionType;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Divide(int dividend, int divisor)
+    {
+        return dividend / divisor;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TriggerHardwareException(int operation)
+    {
+        switch (operation)
+        {
+            case 0:
+                Divide(1, 0);
+                break;
+            case 1:
+                Divide(int.MinValue, -1);
+                break;
+            case 2:
+                int[] values = null;
+                GC.KeepAlive(values[0]);
+                break;
+        }
+    }
+
 	[Fact]
 	public static int TestEntryPoint()
 	{


### PR DESCRIPTION
## Summary

Fix Windows x64 Mono MiniJIT hardware-exception handling when Windows validates exception-continuation addresses. The vectored exception handler currently resumes directly at a dynamically generated managed handler; affected processes terminate with `FAST_FAIL_SET_CONTEXT_DENIED` instead of entering the catch.

Save the resolved managed handler context in existing thread-local storage and resume first at a native runtime entry point, which restores that context through Mono's existing restore trampoline. Supply the Win64 entry-stack alignment and argument home area, and keep the stack-overflow restoration context separate from the native continuation. This does not change process mitigation settings or add general CET support.

Add a three-case theory covering repeated divide-by-zero, overflow, and null-reference exceptions with nested hardware exceptions in filters and finally blocks. Restore the Windows x64 MiniJIT runtime-test lane disabled by dotnet/runtime#133747 so this PR exercises the full lane.

Fixes dotnet/runtime#133702.

## Validation

- Built Release and Debug Mono on Windows x64.
- `div2_d`, `div2_ro`, `HardwareEh`, `unhandledTester`, and `ExceptionInterop` pass with both native builds in MiniJIT mode.
- The same final `HardwareEh` binary exits with `0xC0000409` on the saved unfixed runtime and passes on the fixed Release and Debug runtimes. Verified that its generated entry point invokes all three new theory cases. It also passes with the Release interpreter.
- Repeated local explicit-throw measurements overlap within measurement uncertainty: baseline 2.070 us versus candidate 2.008 us. The unfixed hardware-throw benchmark terminates, so there is no valid before/after throughput ratio for that path.
- Verified that `eng/pipelines/runtime.yml` exactly matches its pre-quarantine version. Full MiniJIT CI and cross-platform suites have not been run locally.

> [!NOTE]
> This PR was generated with GitHub Copilot.
