### PR TITLE
Fix github60486 AOT caller identity and frame enumeration

### DIFF
--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -2078,6 +2078,9 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				mini_set_inline_failure (cfg, "MethodBase:GetCurrentMethod ()");
 			return ins;
 		}
+
+		/* The stack-walk implementation also needs its caller to survive LLVM inlining. */
+		cfg->no_inline |= COMPILE_LLVM (cfg) && !strcmp (cmethod->name, "GetCurrentMethod");
 	} else if (cmethod->klass == mono_class_try_get_math_class ()) {
 		/*
 		 * There is general branchless code for Min/Max, but it does not work for

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github60486.cs
@@ -168,7 +168,8 @@ public class Program : ProgramBase<InputData>, TestItf2<InputData>
             int frameCount = 0;
             foreach (System.Diagnostics.StackFrame frame in new System.Diagnostics.StackTrace().GetFrames())
             {
-                if (frame.GetMethod().Name == nameof(ValidateRecursiveCurrentMethod))
+                // NativeAOT can omit reflection metadata for unrelated callers.
+                if (frame.GetMethod()?.Name == nameof(ValidateRecursiveCurrentMethod))
                 {
                     frameCount++;
                 }


### PR DESCRIPTION
## Summary

This fixes https://github.com/dotnet/runtime/issues/133798

Fix the two AOT failures exposed by the expanded `github60486` regression in dotnet/runtime#133707 and observed in CI for dotnet/runtime#133774.

- Preserve callers of the stack-walk implementation of `MethodBase.GetCurrentMethod` during Mono LLVM inlining. The LLVM-only intrinsic already prevents inlining; the stack-walk path needs the same protection. The test's inlineable helper remains unannotated.
- Allow unrelated NativeAOT stack frames to lack reflection metadata. A local diagnostic run identified `TestEntryPoint` as the frame returning null from `GetMethod`; all four recursive frames returned valid method metadata. Keep the exact four-frame assertion and all existing DIM, exception-stack, caller-identity, and GC-root checks.

Related caller-inlining report: dotnet/runtime#60334. Its iOS configuration was not tested here.

## Validation

Built Checked CoreCLR/NativeAOT and Release Mono with LLVM from a clean baseline in the same worktree.

| Windows x64 configuration | Before | After |
|---|---|---|
| NativeAOT Checked | Reported null-reference failure | Pass |
| Mono LLVM AOT Release | Expected `GetCurrentMethodInlineable`, actual `ValidateCurrentMethod` | Pass |
| CoreCLR Checked | Pass | Pass |
| Mono MiniJIT Release | Pass | Pass |

Each run executes the full standalone `github60486` regression. Mono LLVM AOT comparisons use identical test IL, and runtime logging confirms the fixed AOT image is loaded. LLVM IR adds `noinline` to the inlineable and generic wrappers; the optimized caller retains the helper call instead of inlining it. No performance claim is made.

The Windows Mono LLVM AOT reproduction matches the Linux CI failure signature. Linux and browser Wasm were not run locally. The Windows x64 JIT formatting check completed successfully.

> [!NOTE]
> This change and pull request description were developed with GitHub Copilot assistance.
