### PR TITLE
[wasm] Bump wasmbrowser template precedence so it tracks the SDK version

### DIFF
--- a/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
+++ b/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
@@ -4,7 +4,9 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
 
     <PackageType>Template</PackageType>
-    <!-- when changing the net version also change it in template.json in the templates -->
+    <!-- Version-dependent values here and in the templates' template.json are validated by _ValidateTemplateVersions below.
+         When changing the net version, also change 'NetVersion' in Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj
+         and the package name in eng/Signing.props. -->
     <PackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net11</PackageId>
     <Title>WebAssembly Templates</Title>
     <Authors>Microsoft</Authors>
@@ -26,6 +28,46 @@
   <ItemGroup>
     <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
   </ItemGroup>
+
+  <!--
+    The version-dependent values in the templates are not generated at pack time because the templates are
+    also installed straight from source during development (see src/mono/browser/README.md), so they have to
+    stay valid on disk. They are validated against $(NetCoreAppCurrentVersion) instead.
+
+    'precedence' has to grow with the .NET version: when several versions of this package are installed side
+    by side, 'dotnet new' resolves a template group by precedence and only then evaluates constraints, so
+    equal values make 'dotnet new wasmbrowser' fail as ambiguous instead of picking the newest template.
+  -->
+  <Target Name="_ValidateTemplateVersions" BeforeTargets="Build;Pack">
+    <PropertyGroup>
+      <_NetCoreAppCurrentMajorVersion>$([System.String]::Copy('$(NetCoreAppCurrentVersion)').Split('.')[0])</_NetCoreAppCurrentMajorVersion>
+      <_ExpectedPackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net$(_NetCoreAppCurrentMajorVersion)</_ExpectedPackageId>
+      <_ExpectedPrecedence>$([MSBuild]::Multiply($(_NetCoreAppCurrentMajorVersion), 1000))</_ExpectedPrecedence>
+      <_ExpectedSdkConstraint>[$(_NetCoreAppCurrentMajorVersion).0.100-0,)</_ExpectedSdkConstraint>
+      <_NetCoreAppCurrentVersionRegex>$([System.Text.RegularExpressions.Regex]::Escape('$(NetCoreAppCurrentVersion)'))</_NetCoreAppCurrentVersionRegex>
+      <_NetCoreAppCurrentRegex>$([System.Text.RegularExpressions.Regex]::Escape('$(NetCoreAppCurrent)'))</_NetCoreAppCurrentRegex>
+    </PropertyGroup>
+
+    <Error Condition="'$(PackageId)' != '$(_ExpectedPackageId)'"
+           Text="PackageId is '$(PackageId)' but NetCoreAppCurrentVersion is '$(NetCoreAppCurrentVersion)'. Expected '$(_ExpectedPackageId)'." />
+
+    <ItemGroup>
+      <_TemplateConfigFile Include="templates\**\.template.config\template.json" />
+      <_TemplateConfigFile Text="$([System.IO.File]::ReadAllText('%(FullPath)'))" />
+    </ItemGroup>
+
+    <Error Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(_TemplateConfigFile.Text)', '&quot;precedence&quot;\s*:\s*$(_ExpectedPrecedence)\b'))"
+           Text="%(_TemplateConfigFile.Identity): 'precedence' does not match NetCoreAppCurrentVersion '$(NetCoreAppCurrentVersion)'. Expected $(_ExpectedPrecedence)." />
+
+    <Error Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(_TemplateConfigFile.Text)', '&quot;identity&quot;\s*:\s*&quot;[^&quot;]*\.$(_NetCoreAppCurrentVersionRegex)&quot;'))"
+           Text="%(_TemplateConfigFile.Identity): 'identity' does not end with NetCoreAppCurrentVersion '$(NetCoreAppCurrentVersion)'." />
+
+    <Error Condition="!$([System.String]::Copy('%(_TemplateConfigFile.Text)').Contains('$(_ExpectedSdkConstraint)'))"
+           Text="%(_TemplateConfigFile.Identity): the 'sdk-version' constraint does not match NetCoreAppCurrentVersion '$(NetCoreAppCurrentVersion)'. Expected '$(_ExpectedSdkConstraint)'." />
+
+    <Error Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(_TemplateConfigFile.Text)', '&quot;choice&quot;\s*:\s*&quot;$(_NetCoreAppCurrentRegex)&quot;')) or !$([System.Text.RegularExpressions.Regex]::IsMatch('%(_TemplateConfigFile.Text)', '&quot;defaultValue&quot;\s*:\s*&quot;$(_NetCoreAppCurrentRegex)&quot;'))"
+           Text="%(_TemplateConfigFile.Identity): the 'framework' choice does not match NetCoreAppCurrent '$(NetCoreAppCurrent)'." />
+  </Target>
 
   <Target Name="CreateManifestResourceNames" />
   <Target Name="CoreCompile" />

--- a/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
+++ b/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
@@ -36,6 +36,8 @@
     'precedence' has to grow with the .NET version: when several versions of this package are installed side
     by side, 'dotnet new' resolves a template group by precedence and only then evaluates constraints, so
     equal values make 'dotnet new wasmbrowser' fail as ambiguous instead of picking the newest template.
+    This is the same scheme the in-box SDK and ASP.NET Core templates use - both bump precedence by 1000 for
+    every major version, and the ASP.NET Core ones use these very values (net10 10000, net11 11000).
   -->
   <Target Name="_ValidateTemplateVersions" BeforeTargets="Build;Pack">
     <PropertyGroup>

--- a/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
+++ b/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
@@ -4,9 +4,8 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
 
     <PackageType>Template</PackageType>
-    <!-- Version-dependent values here and in the templates' template.json are validated by _ValidateTemplateVersions below.
-         When changing the net version, also change 'NetVersion' in Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj
-         and the package name in eng/Signing.props. -->
+    <!-- Version-dependent values here, in the templates' template.json, in eng/Signing.props and in the
+         workload manifest are validated against $(NetCoreAppCurrentVersion) by _ValidateTemplateVersions below. -->
     <PackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net11</PackageId>
     <Title>WebAssembly Templates</Title>
     <Authors>Microsoft</Authors>
@@ -50,6 +49,17 @@
 
     <Error Condition="'$(PackageId)' != '$(_ExpectedPackageId)'"
            Text="PackageId is '$(PackageId)' but NetCoreAppCurrentVersion is '$(NetCoreAppCurrentVersion)'. Expected '$(_ExpectedPackageId)'." />
+
+    <PropertyGroup>
+      <_SigningPropsText>$([System.IO.File]::ReadAllText('$([MSBuild]::NormalizePath('$(RepoRoot)eng/Signing.props'))'))</_SigningPropsText>
+      <_WorkloadManifestPkgprojText>$([System.IO.File]::ReadAllText('$([MSBuild]::NormalizePath('$(RepoRoot)src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj'))'))</_WorkloadManifestPkgprojText>
+    </PropertyGroup>
+
+    <Error Condition="!$([System.String]::Copy('$(_SigningPropsText)').Contains('$(PackageId).'))"
+           Text="eng/Signing.props does not reference '$(PackageId)', so the templates package would not be signed." />
+
+    <Error Condition="!$([System.String]::Copy('$(_WorkloadManifestPkgprojText)').Contains('&quot;NetVersion&quot; Value=&quot;net$(_NetCoreAppCurrentMajorVersion)&quot;'))"
+           Text="Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj 'NetVersion' does not match '$(PackageId)', so the workload would reference a non-existent templates pack." />
 
     <ItemGroup>
       <_TemplateConfigFile Include="templates\**\.template.config\template.json" />

--- a/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
+++ b/src/mono/wasm/templates/Microsoft.NET.Runtime.WebAssembly.Templates.csproj
@@ -4,8 +4,9 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
 
     <PackageType>Template</PackageType>
-    <!-- Version-dependent values here, in the templates' template.json, in eng/Signing.props and in the
-         workload manifest are validated against $(NetCoreAppCurrentVersion) by _ValidateTemplateVersions below. -->
+    <!-- When changing the net version, also change 'NetVersion' in
+         Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj and the package name in eng/Signing.props.
+         The values in the templates' template.json are validated by _ValidateTemplateVersions below. -->
     <PackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net11</PackageId>
     <Title>WebAssembly Templates</Title>
     <Authors>Microsoft</Authors>
@@ -29,39 +30,25 @@
   </ItemGroup>
 
   <!--
-    The version-dependent values in the templates are not generated at pack time because the templates are
-    also installed straight from source during development (see src/mono/browser/README.md), so they have to
-    stay valid on disk. They are validated against $(NetCoreAppCurrentVersion) instead.
+    'precedence' has to grow with the .NET version: when several versions of this package are visible to the
+    same SDK, 'dotnet new' resolves a template group by precedence, so equal values make 'dotnet new
+    wasmbrowser' fail as ambiguous instead of picking the newest template. This is the scheme the MAUI and
+    ASP.NET Core templates use - both are major * 1000 (net10 10000, net11 11000).
 
-    'precedence' has to grow with the .NET version: when several versions of this package are installed side
-    by side, 'dotnet new' resolves a template group by precedence and only then evaluates constraints, so
-    equal values make 'dotnet new wasmbrowser' fail as ambiguous instead of picking the newest template.
-    This is the same scheme the in-box SDK and ASP.NET Core templates use - both bump precedence by 1000 for
-    every major version, and the ASP.NET Core ones use these very values (net10 10000, net11 11000).
+    These values can't be generated at pack time because the templates are also installed straight from
+    source during development (see src/mono/browser/README.md), so they are validated instead.
   -->
   <Target Name="_ValidateTemplateVersions" BeforeTargets="Build;Pack">
     <PropertyGroup>
       <_NetCoreAppCurrentMajorVersion>$([System.String]::Copy('$(NetCoreAppCurrentVersion)').Split('.')[0])</_NetCoreAppCurrentMajorVersion>
       <_ExpectedPackageId>Microsoft.NET.Runtime.WebAssembly.Templates.net$(_NetCoreAppCurrentMajorVersion)</_ExpectedPackageId>
       <_ExpectedPrecedence>$([MSBuild]::Multiply($(_NetCoreAppCurrentMajorVersion), 1000))</_ExpectedPrecedence>
-      <_ExpectedSdkConstraint>[$(_NetCoreAppCurrentMajorVersion).0.100-0,)</_ExpectedSdkConstraint>
       <_NetCoreAppCurrentVersionRegex>$([System.Text.RegularExpressions.Regex]::Escape('$(NetCoreAppCurrentVersion)'))</_NetCoreAppCurrentVersionRegex>
       <_NetCoreAppCurrentRegex>$([System.Text.RegularExpressions.Regex]::Escape('$(NetCoreAppCurrent)'))</_NetCoreAppCurrentRegex>
     </PropertyGroup>
 
     <Error Condition="'$(PackageId)' != '$(_ExpectedPackageId)'"
            Text="PackageId is '$(PackageId)' but NetCoreAppCurrentVersion is '$(NetCoreAppCurrentVersion)'. Expected '$(_ExpectedPackageId)'." />
-
-    <PropertyGroup>
-      <_SigningPropsText>$([System.IO.File]::ReadAllText('$([MSBuild]::NormalizePath('$(RepoRoot)eng/Signing.props'))'))</_SigningPropsText>
-      <_WorkloadManifestPkgprojText>$([System.IO.File]::ReadAllText('$([MSBuild]::NormalizePath('$(RepoRoot)src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj'))'))</_WorkloadManifestPkgprojText>
-    </PropertyGroup>
-
-    <Error Condition="!$([System.String]::Copy('$(_SigningPropsText)').Contains('$(PackageId).'))"
-           Text="eng/Signing.props does not reference '$(PackageId)', so the templates package would not be signed." />
-
-    <Error Condition="!$([System.String]::Copy('$(_WorkloadManifestPkgprojText)').Contains('&quot;NetVersion&quot; Value=&quot;net$(_NetCoreAppCurrentMajorVersion)&quot;'))"
-           Text="Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj 'NetVersion' does not match '$(PackageId)', so the workload would reference a non-existent templates pack." />
 
     <ItemGroup>
       <_TemplateConfigFile Include="templates\**\.template.config\template.json" />
@@ -73,9 +60,6 @@
 
     <Error Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(_TemplateConfigFile.Text)', '&quot;identity&quot;\s*:\s*&quot;[^&quot;]*\.$(_NetCoreAppCurrentVersionRegex)&quot;'))"
            Text="%(_TemplateConfigFile.Identity): 'identity' does not end with NetCoreAppCurrentVersion '$(NetCoreAppCurrentVersion)'." />
-
-    <Error Condition="!$([System.String]::Copy('%(_TemplateConfigFile.Text)').Contains('$(_ExpectedSdkConstraint)'))"
-           Text="%(_TemplateConfigFile.Identity): the 'sdk-version' constraint does not match NetCoreAppCurrentVersion '$(NetCoreAppCurrentVersion)'. Expected '$(_ExpectedSdkConstraint)'." />
 
     <Error Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(_TemplateConfigFile.Text)', '&quot;choice&quot;\s*:\s*&quot;$(_NetCoreAppCurrentRegex)&quot;')) or !$([System.Text.RegularExpressions.Regex]::IsMatch('%(_TemplateConfigFile.Text)', '&quot;defaultValue&quot;\s*:\s*&quot;$(_NetCoreAppCurrentRegex)&quot;'))"
            Text="%(_TemplateConfigFile.Identity): the 'framework' choice does not match NetCoreAppCurrent '$(NetCoreAppCurrent)'." />

--- a/src/mono/wasm/templates/templates/browser/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/browser/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": [ "Web", "WebAssembly", "Browser" ],
   "generatorVersions": "[1.0.0.0-*)",
   "groupIdentity": "WebAssembly.Browser",
-  "precedence": 9000,
+  "precedence": 11000,
   "identity": "WebAssembly.Browser.11.0",
   "name": "WebAssembly Browser App",
   "description": "A project template for creating a .NET app that runs on WebAssembly in a browser",
@@ -14,6 +14,12 @@
   "tags": {
     "language": "C#",
     "type": "project"
+  },
+  "constraints": {
+    "sdk-version": {
+      "type": "sdk-version",
+      "args": "[11.0.100-0,)"
+    }
   },
   "symbols": {
     "kestrelHttpPortGenerated": {

--- a/src/mono/wasm/templates/templates/browser/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/browser/.template.config/template.json
@@ -15,12 +15,6 @@
     "language": "C#",
     "type": "project"
   },
-  "constraints": {
-    "sdk-version": {
-      "type": "sdk-version",
-      "args": "[11.0.100-0,)"
-    }
-  },
   "symbols": {
     "kestrelHttpPortGenerated": {
       "type": "generated",


### PR DESCRIPTION
Fixes: #83811

## Why

Every shipped version of the WebAssembly browser template declares `"precedence": 9000` and the same `groupIdentity`, with only `identity` differing. When an SDK can see more than one version of the template pack, the template engine has no way to break the tie, so `dotnet new wasmbrowser` fails outright:

```
Unable to resolve the template, the following installed templates are conflicting:
WebAssembly.Browser.10.0 ... Precedence: 9000
WebAssembly.Browser.9.0  ... Precedence: 9000
```

## How this relates to global.json

Worth being precise, because precedence alone is not the whole story.

What actually follows `global.json` is **visibility**, not precedence. `dotnet new` discovers workload template packs through `TemplateLocator.GetDotnetSdkTemplatePackages(sdkVersion, dotnetRoot, ...)`, which builds a `SdkDirectoryWorkloadManifestProvider(dotnetRootPath, sdkVersion, userProfileDir, globalJsonPath)` scoped to the *running* SDK, and the running SDK is the one `global.json` selected. So a pinned older SDK never sees a newer band's template pack.

What precedence does is break the tie among the packs that *are* visible. A newer SDK resolves its own band's pack plus older bands' packs, so it sees several. Making precedence grow with the version means the newest visible one wins, and that is exactly the band of the SDK `global.json` selected.

Measured on a private `DOTNET_ROOT` with SDK 9.0.305 and 10.0.101, `wasm-experimental` installed for both bands, and a `global.json` per directory:

| `global.json` pins | today (9000 / 9000) | with this change (9000 / 10000) |
|---|---|---|
| 9.0.305 | `net9.0` (correct) | `net9.0` (correct) |
| 10.0.101 | **exit 103, no project** | `net10.0` (correct) |

Both rows were re-run with freshly created, per-band `DOTNET_CLI_HOME` directories, so the conflict is genuine workload resolution and not stale template-engine cache. Note the older SDK is unaffected in both columns: it never sees the newer pack, so raising precedence on newer templates cannot drag it forward.

The practical impact today is therefore worse than the issue title suggests. On .NET 10 with two bands installed, the command does not pick the wrong TFM, it fails with exit code 103 and creates nothing.

**Caveat:** precedence only orders templates the SDK can see. Template packages a user installs by hand with `dotnet new install` are user-scoped rather than band-scoped, and there the highest precedence wins regardless of `global.json`. This change does not make `global.json` authoritative in that case; it makes the outcome deterministic instead of an error. MAUI and ASP.NET Core behave the same way.

## Approach

Bump `precedence` to `major * 1000` so it grows with the .NET version. Values pulled from the shipped nupkgs:

| Template family | Delivery | net9 | net10 | net11 | constraints |
|---|---|---|---|---|---|
| MAUI (`Microsoft.Maui.Templates.netN`) | workload | 9000 | 10000 | **11000** | none |
| ASP.NET Core (`Microsoft.DotNet.Web.ProjectTemplates.N.0`) | in-box | 9900 | 10000 | **11000** | none |
| SDK common (`Microsoft.DotNet.Common.ProjectTemplates.N.0`) | in-box | 11000 | 12000 | 13000 | none |
| wasm browser (before this PR) | workload | 9000 | 9000 | 9000 | none |

MAUI is the closest analogue, shipping the same way this package does (via a workload, with a per-major-version package id), and it uses exactly `major * 1000`. The wasm template was left at MAUI's net9 value and never bumped again.

The second commit adds `_ValidateTemplateVersions`, which fails the build when `precedence`, `identity`, or the `framework` choice in `template.json` drift from `$(NetCoreAppCurrentVersion)`. That drift is the actual bug here: the literal went unbumped across three releases. These values can't be generated at pack time because the templates are also installed straight from source during development (`src/mono/browser/README.md`), so they have to stay valid JSON on disk.

## Notes for review

- Net diff is one line in `template.json` plus the validation target. Happy to drop the target if you'd rather keep this to the single line, but without something like it there is nothing to stop the same drift recurring.
- I initially added an `sdk-version` constraint as defense in depth and then removed it: no in-box, ASP.NET Core, or MAUI template uses `constraints` at all, and the template engine resolves a template group by precedence *before* evaluating constraints, so it cannot drive `global.json` fallback anyway. The intermediate commits show that exploration.
- **A `release/10.0` backport is what actually unblocks users today**, since the shipped net10 pack is the one stuck at 9000. The value there should be `10000`, matching MAUI's net10.
- Separately, it's arguably a `dotnet/sdk` issue that `InstantiateCommand` resolves the group by precedence before constraints are evaluated. Happy to file it if you agree.

## Testing

Beyond the matrix above:

- Confirmed the same version-ordering mechanism works for the in-box templates: with SDK 9.0.318 and 10.0.401 in a shared root, `global.json` pinning yields `net9.0` and `net10.0` from `dotnet new console`.
- Build and pack succeed; the packed nupkg carries `"precedence": 11000`.
- Each of the three validation checks was individually confirmed to fail the build when its value is wrong.
- `dotnet new install` from source followed by `dotnet new wasmbrowser` produces a `net11.0` project.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.