### PR TITLE
JIT: Fix loop cloning with nested EH regions

### DIFF
--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2323,7 +2323,9 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
     unsigned const enclosingRegion = ehGetMostNestedRegionIndex(preheader, &inTry);
     if (!BasicBlock::sameEHRegion(beforeSlowPreheader, preheader))
     {
-        beforeSlowPreheader = fgFindInsertPoint(enclosingRegion, inTry, bottom, /* endBlk */ nullptr,
+        // The lexical bottom may be in a nested region, so start searching from the fast preheader,
+        // which is guaranteed to be in the target region.
+        beforeSlowPreheader = fgFindInsertPoint(enclosingRegion, inTry, fastPreheader, /* endBlk */ nullptr,
                                                 /* nearBlk */ bottom, /* jumpBlk */ nullptr, /* runRarely */ false);
     }
 

--- a/src/tests/JIT/opt/Cloning/loops_with_eh.cs
+++ b/src/tests/JIT/opt/Cloning/loops_with_eh.cs
@@ -1264,5 +1264,43 @@ public class LoopsWithEH
 
         return sum;
     }
-}
 
+    [Fact]
+    public static int Test_LoopBottomInNestedTry() => Sum_LoopBottomInNestedTry(data, data[64]) - 1923;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static int Sum_LoopBottomInNestedTry(int[] data, int n)
+    {
+        int sum = 0;
+        int i = 0;
+
+        try
+        {
+        loop:
+            sum += data[i];
+            try
+            {
+                if (data[i] == 42)
+                {
+                    sum += 7;
+                }
+
+                i++;
+                if (i < n)
+                {
+                    goto loop;
+                }
+            }
+            catch (Exception)
+            {
+                sum = -1;
+            }
+        }
+        catch (Exception)
+        {
+            sum = -2;
+        }
+
+        return sum;
+    }
+}


### PR DESCRIPTION
When placing the slow-loop preheader, the loop's lexically bottommost block
may lie in a nested EH region. So instead, use the fast-loop preheader for
placement, as it belongs to the correct region.

Fixes #133758

> [!NOTE]
> This pull request description was generated by GitHub Copilot.