### PR TITLE
Honor ConfigurationKeyName in constructor binding

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -600,7 +600,7 @@ namespace Microsoft.Extensions.Configuration
 
                 for (int index = 0; index < parameters.Length; index++)
                 {
-                    parameterValues[index] = BindParameter(parameters[index], type, config, options);
+                    parameterValues[index] = BindParameter(parameters[index], FindMatchingProperty(parameters[index].Name!, properties)!, type, config, options);
                 }
 
                 constructorParameters = parameters;
@@ -624,23 +624,12 @@ namespace Microsoft.Extensions.Configuration
         private static bool DoAllParametersHaveEquivalentProperties(ParameterInfo[] parameters,
             List<PropertyInfo> properties, out string missing)
         {
-            HashSet<string> propertyNames = new(StringComparer.OrdinalIgnoreCase);
-            foreach (PropertyInfo prop in properties)
-            {
-                if (IsIgnoredProperty(prop))
-                {
-                    continue;
-                }
-
-                propertyNames.Add(prop.Name);
-            }
-
             List<string> missingParameters = new();
 
             foreach (ParameterInfo parameter in parameters)
             {
                 string name = parameter.Name!;
-                if (!propertyNames.Contains(name))
+                if (FindMatchingProperty(name, properties) is null)
                 {
                     missingParameters.Add(name);
                 }
@@ -649,6 +638,20 @@ namespace Microsoft.Extensions.Configuration
             missing = string.Join(",", missingParameters);
 
             return missing.Length == 0;
+        }
+
+        private static PropertyInfo? FindMatchingProperty(string name, List<PropertyInfo> properties)
+        {
+            foreach (PropertyInfo property in properties)
+            {
+                if (!IsIgnoredProperty(property) &&
+                    string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return property;
+                }
+            }
+
+            return null;
         }
 
         private static bool CanBindToTheseConstructorParameters(ParameterInfo[] constructorParameters, out string nameOfInvalidParameter)
@@ -1141,7 +1144,7 @@ namespace Microsoft.Extensions.Configuration
 
         [RequiresDynamicCode(DynamicCodeWarningMessage)]
         [RequiresUnreferencedCode(PropertyTrimmingWarningMessage)]
-        private static object? BindParameter(ParameterInfo parameter, Type type, IConfiguration config,
+        private static object? BindParameter(ParameterInfo parameter, PropertyInfo property, Type type, IConfiguration config,
             BinderOptions options)
         {
             string? parameterName = parameter.Name;
@@ -1156,7 +1159,7 @@ namespace Microsoft.Extensions.Configuration
             BindInstance(
                 parameter.ParameterType,
                 propertyBindingPoint,
-                config.GetSection(parameterName),
+                config.GetSection(GetPropertyName(property)),
                 options,
                 false);
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.cs
@@ -157,6 +157,20 @@ namespace Microsoft.Extensions
             public int Length { get; } = length;
         }
 
+        public class ClassWithPrimaryCtorAndConfigurationKeyName(string color, int length)
+        {
+            [ConfigurationKeyName("config-color")]
+            public string Color { get; } = color;
+            public int Length { get; } = length;
+        }
+
+        public class ClassWithPrimaryCtorAndConfigurationKeyNameOnNonMatchingProperty(string color, int length)
+        {
+            [ConfigurationKeyName("color")]
+            public string Shade { get; } = color;
+            public int Length { get; } = length;
+        }
+
         public class ClassWithPrimaryCtorAndIgnoredProperty(string color, int length)
         {
             [ConfigurationIgnore]

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -1692,6 +1692,42 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         [Fact]
+        public void CanBindClassWithPrimaryCtorAndConfigurationKeyName()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Length", "42"},
+                {"config-color", "Green"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = config.Get<ClassWithPrimaryCtorAndConfigurationKeyName>();
+            Assert.Equal(42, options.Length);
+            Assert.Equal("Green", options.Color);
+        }
+
+        [Fact]
+        public void ThrowOnClassWithPrimaryCtorAndConfigurationKeyNameOnNonMatchingProperty()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Length", "42"},
+                {"color", "Green"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => config.Get<ClassWithPrimaryCtorAndConfigurationKeyNameOnNonMatchingProperty>());
+
+            Assert.Equal(
+                SR.Format(SR.Error_ConstructorParametersDoNotMatchProperties, typeof(ClassWithPrimaryCtorAndConfigurationKeyNameOnNonMatchingProperty), "color"),
+                ex.Message);
+        }
+
+        [Fact]
         public void ThrowOnClassWithPrimaryCtorAndIgnoredProperty()
         {
             var dic = new Dictionary<string, string>


### PR DESCRIPTION
Constructor binding in `Microsoft.Extensions.Configuration.Binder` validated and read constructor parameters by CLR property/parameter name, so `[ConfigurationKeyName]` on a corresponding property could still fail for primary constructors and records. This updates the runtime binder to use the matched property's effective configuration key for parameter value lookup without changing constructor/property matching semantics.

- **Runtime binder**
  - Keep constructor parameter ↔ property matching based on CLR property names.
  - When a parameter matches a property, bind that parameter from the property's effective configuration key (`GetPropertyName(property)`), not the raw parameter name.

- **Validation / error behavior**
  - Preserve existing validation behavior for unannotated properties.
  - Preserve mismatch and ignored-property failures based on constructor parameter names rather than attributed configuration keys.

- **Source generator scope**
  - No source-generator implementation change.
  - The generator already carries a matched property's `ConfigurationKeyName` into constructor-parameter binding; this PR only closes the reflection-path parity gap.
  - Intentionally does not expand into separate init-only/source-generator feature work.

- **Tests**
  - Add a constructor-binding success case for a primary-constructor property annotated with `ConfigurationKeyNameAttribute`.
  - Keep coverage for the existing unannotated constructor-binding path.
  - Add a negative case proving validation is not widened to unrelated properties that only share the configuration key.

```csharp
public class Options(string secretKey)
{
    [ConfigurationKeyName("example-secret-key")]
    public string SecretKey { get; } = secretKey;
}
```

With this change, `secretKey` is populated from `example-secret-key` during constructor binding, while constructor/property equivalence checks continue to use `SecretKey`.