### PR TITLE
[wip][Wasm] Emit R2R branch hints from profile data

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1425,6 +1425,8 @@ public:
     void instGen(instruction ins);
 #if defined(TARGET_XARCH)
     void inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock, bool isRemovableJmpCandidate = false);
+#elif defined(TARGET_WASM)
+    void inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock, WasmBranchHint branchHint = WasmBranchHint::None);
 #else
     void inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock);
 #endif

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1207,6 +1207,8 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 //
 void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
 {
+    static constexpr weight_t LikelyThreshold = 0.8;
+
     BasicBlock* const block = m_compiler->compCurBB;
     assert(block->KindIs(BBJ_COND));
 
@@ -1223,9 +1225,25 @@ void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
     //
     assert(trueTarget != block->Next());
 
+    WasmBranchHint branchHint = WasmBranchHint::None;
+    bool const     hasStaticProfile =
+        (m_compiler->fgPgoSource == ICorJitInfo::PgoSource::Static) && m_compiler->fgHaveSufficientProfileWeights();
+    if (hasStaticProfile || (JitConfig.JitWasmBranchHintStress() != 0))
+    {
+        weight_t const trueLikelihood = block->GetTrueEdge()->getLikelihood();
+        if (trueLikelihood >= LikelyThreshold)
+        {
+            branchHint = WasmBranchHint::LikelyTrue;
+        }
+        else if (trueLikelihood <= (1.0 - LikelyThreshold))
+        {
+            branchHint = WasmBranchHint::LikelyFalse;
+        }
+    }
+
     // br_if for true target
     //
-    inst_JMP(EJ_jmpif, trueTarget);
+    inst_JMP(EJ_jmpif, trueTarget, branchHint);
 
     // br for false target, if not fallthrough
     //
@@ -4278,11 +4296,11 @@ void CodeGen::genEmitEndBlock()
 //   jmp      - kind of jump to emit
 //   tgtBlock - target of the jump
 //
-void CodeGen::inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock)
+void CodeGen::inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock, WasmBranchHint branchHint)
 {
     instruction    instr = emitter::emitJumpKindToIns(jmp);
     unsigned const depth = findTargetDepth(tgtBlock) + wasmExtraControlFlowDepth;
-    GetEmitter()->emitIns_J(instr, EA_4BYTE, depth, tgtBlock);
+    GetEmitter()->emitIns_J(instr, EA_4BYTE, depth, tgtBlock, branchHint);
 }
 
 #if defined(DEBUG)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7220,6 +7220,10 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
     instrDesc* prevId = nullptr;
 #endif // defined(DEBUG) && defined(TARGET_ARM64)
 
+#ifdef TARGET_WASM
+    JitMetadata::report(m_compiler, JitMetadata::WasmBranchHintsReset, nullptr, 0);
+#endif
+
     for (insGroup* ig = emitIGlist; ig != nullptr; ig = ig->igNext)
     {
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1027,6 +1027,21 @@ protected:
 #define SMALL_IDSC_SIZE 8
 
     public:
+#ifdef TARGET_WASM
+        WasmBranchHint idWasmBranchHint() const
+        {
+            return static_cast<WasmBranchHint>((_idCustom3 << 1) | _idCustom2);
+        }
+
+        void idSetWasmBranchHint(WasmBranchHint hint)
+        {
+            unsigned const value = static_cast<unsigned>(hint);
+            assert(value <= static_cast<unsigned>(WasmBranchHint::LikelyTrue));
+            _idCustom2 = value & 1;
+            _idCustom3 = (value >> 1) & 1;
+        }
+#endif
+
         instrDescDebugInfo* idDebugOnlyInfo() const
         {
             const char* addr = reinterpret_cast<const char*>(this);

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -120,13 +120,15 @@ void emitter::emitIns_I(instruction ins, emitAttr attr, cnsval_ssize_t imm)
 //   imm         - immediate value (depth in control flow stack)
 //   targetBlock - block at that depth (may be null, in the case of jump table which doesn't target a real block)
 //
-void emitter::emitIns_J(instruction ins, emitAttr attr, cnsval_ssize_t imm, BasicBlock* targetBlock)
+void emitter::emitIns_J(
+    instruction ins, emitAttr attr, cnsval_ssize_t imm, BasicBlock* targetBlock, WasmBranchHint branchHint)
 {
     instrDesc* id  = emitNewInstrSC(attr, imm);
     insFormat  fmt = emitInsFormat(ins);
 
     id->idIns(ins);
     id->idInsFmt(fmt);
+    id->idSetWasmBranchHint(branchHint);
 
     if (m_debugInfoSize > 0 && targetBlock != nullptr)
     {
@@ -960,6 +962,40 @@ size_t emitter::emitOutputValtypeSig(uint8_t* destination, WasmValueType valtype
     }
 }
 
+//------------------------------------------------------------------------
+// emitReportBranchHint: Report a branch hint for the current Wasm function.
+//
+// Arguments:
+//   ig                 - Instruction group containing the branch
+//   id                 - Branch instruction descriptor
+//   instructionAddress - Address of the encoded branch opcode
+//
+void emitter::emitReportBranchHint(insGroup* ig, const instrDesc* id, const BYTE* instructionAddress)
+{
+    WasmBranchHint const branchHint = id->idWasmBranchHint();
+    if (branchHint == WasmBranchHint::None)
+    {
+        return;
+    }
+
+    FuncInfoDsc* const func                = m_compiler->funGetFunc(ig->igFuncIdx);
+    unsigned const     functionStartOffset = func->startLoc->CodeOffset(this);
+    unsigned const     instructionOffset   = emitCurCodeOffs(instructionAddress);
+    assert(instructionOffset >= functionStartOffset + PADDED_RELOC_SIZE);
+
+    uint32_t const offsetFromLocals = instructionOffset - functionStartOffset - PADDED_RELOC_SIZE;
+    uint8_t        metadata[9];
+
+    for (unsigned byteIndex = 0; byteIndex < sizeof(uint32_t); byteIndex++)
+    {
+        metadata[byteIndex]     = static_cast<uint8_t>(ig->igFuncIdx >> (byteIndex * 8));
+        metadata[byteIndex + 4] = static_cast<uint8_t>(offsetFromLocals >> (byteIndex * 8));
+    }
+    metadata[8] = branchHint == WasmBranchHint::LikelyTrue ? 1 : 0;
+
+    JitMetadata::report(m_compiler, JitMetadata::WasmBranchHint, metadata, sizeof(metadata));
+}
+
 size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 {
     const bool SIGNED   = true;
@@ -1197,6 +1233,8 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         emitDispIns(id, false, 0, true, emitCurCodeOffs(*dp), *dp, (dst - *dp), ig);
     }
 #endif
+
+    emitReportBranchHint(ig, id, *dp);
 
     *dp = dst;
     return sz;

--- a/src/coreclr/jit/emitwasm.h
+++ b/src/coreclr/jit/emitwasm.h
@@ -22,7 +22,11 @@ void emitIns_BlockTy(instruction ins, WasmValueType valType = WasmValueType::Inv
 void emitIns_I(instruction ins, emitAttr attr, cnsval_ssize_t imm);
 void emitIns_Ty_I(instruction ins, WasmValueType ty, unsigned int imm);
 void emitIns_I_Ty(instruction ins, unsigned int imm, WasmValueType valType, int offs);
-void emitIns_J(instruction ins, emitAttr attr, cnsval_ssize_t imm, BasicBlock* tgtBlock);
+void emitIns_J(instruction    ins,
+               emitAttr       attr,
+               cnsval_ssize_t imm,
+               BasicBlock*    tgtBlock,
+               WasmBranchHint branchHint = WasmBranchHint::None);
 void emitIns_S(instruction ins, emitAttr attr, int varx, int offs);
 void emitIns_R(instruction ins, emitAttr attr, regNumber reg);
 
@@ -80,6 +84,7 @@ size_t emitOutputOpcode(BYTE* dst, instruction ins);
 size_t emitOutputPaddedReloc(uint8_t* destination);
 size_t emitOutputConstant(uint8_t* destination, const instrDesc* id, bool isSigned, CorInfoReloc relocType);
 size_t emitOutputConstantFunclet(uint8_t* destination, const instrDesc* id, CorInfoReloc relocType);
+void   emitReportBranchHint(insGroup* ig, const instrDesc* id, const BYTE* instructionAddress);
 
 size_t emitOutputValtypeSig(uint8_t* destination, WasmValueType valtype);
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -920,6 +920,8 @@ RELEASE_CONFIG_INTEGER(JitWasmNyiToR2RUnsupported, "JitWasmNyiToR2RUnsupported",
 CONFIG_STRING(JitR2RUnsupportedRange, "JitR2RUnsupportedRange")
 // Enable processing methods with funclets. Set to 0 to bail to R2R unsupported before codegen.
 RELEASE_CONFIG_INTEGER(JitWasmFunclets, "JitWasmFunclets", 1)
+// Emit branch hints from any available profile weights, including synthesized weights.
+RELEASE_CONFIG_INTEGER(JitWasmBranchHintStress, "JitWasmBranchHintStress", 0)
 #endif // defined(TARGET_WASM)
 
 // Allow to enregister locals with struct type.

--- a/src/coreclr/jit/jitmetadatalist.h
+++ b/src/coreclr/jit/jitmetadatalist.h
@@ -27,6 +27,8 @@
 //              Name,                                    type              flags
 JITMETADATAINFO(MethodFullName,                          const char*,      0)
 JITMETADATAINFO(TieringName,                             const char*,      0)
+JITMETADATAINFO(WasmBranchHint,                          const void*,      0)
+JITMETADATAINFO(WasmBranchHintsReset,                    const void*,      0)
 JITMETADATAMETRIC(ActualCodeBytes,                       int,              JIT_METADATA_LOWER_IS_BETTER)
 JITMETADATAMETRIC(AllocatedHotCodeBytes,                 int,              JIT_METADATA_LOWER_IS_BETTER)
 JITMETADATAMETRIC(AllocatedColdCodeBytes,                int,              JIT_METADATA_LOWER_IS_BETTER)

--- a/src/coreclr/jit/targetwasm.h
+++ b/src/coreclr/jit/targetwasm.h
@@ -15,6 +15,13 @@
 
 #define WASM_THREAD_SUPPORT      0       // Codegen does not support WasmThreads yet
 
+enum class WasmBranchHint : uint8_t
+{
+    None,
+    LikelyFalse,
+    LikelyTrue,
+};
+
 #define CPU_LOAD_STORE_ARCH      1
 #define CPU_HAS_FP_SUPPORT       1
 #define CPU_HAS_BYTE_REGS        0

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmTypes.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmTypes.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Linq;
 
 using ILCompiler.ObjectWriter;
@@ -10,6 +11,25 @@ using Internal.JitInterface;
 
 namespace ILCompiler.DependencyAnalysis.Wasm
 {
+    public readonly struct WasmBranchHint
+    {
+        public WasmBranchHint(uint functionOrdinal, uint codeOffset, bool isLikelyTaken)
+        {
+            FunctionOrdinal = functionOrdinal;
+            CodeOffset = codeOffset;
+            IsLikelyTaken = isLikelyTaken;
+        }
+
+        public uint FunctionOrdinal { get; }
+        public uint CodeOffset { get; }
+        public bool IsLikelyTaken { get; }
+    }
+
+    public interface INodeWithWasmBranchHints
+    {
+        IReadOnlyList<WasmBranchHint> WasmBranchHints { get; }
+    }
+
     // For now, we only encode Wasm numeric value types.
     // These are encoded as a single byte. However,
     // not all value types can be encoded this way.

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmSection.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/Wasm/WasmSection.cs
@@ -145,6 +145,14 @@ namespace ILCompiler.ObjectWriter
         protected virtual int EncodeCustomPayloadPrefix(Span<byte> destination) => 0;
     }
 
+    internal sealed class NamedWasmCustomSection : WasmCustomSection
+    {
+        public NamedWasmCustomSection(Stream stream, Utf8String customSectionName, int sectionIndex)
+            : base(stream, customSectionName, sectionIndex)
+        {
+        }
+    }
+
     internal sealed class PaddingWasmSection : IWasmSection
     {
         private const int MinimumSectionSize = 3;

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -31,6 +31,7 @@ namespace ILCompiler.ObjectWriter
             { WasmObjectNodeSection.ImportSection, WasmSectionType.Import },
             { WasmObjectNodeSection.GlobalSection, WasmSectionType.Global },
             { ObjectNodeSection.WasmTypeSection, WasmSectionType.Type },
+            { WasmObjectNodeSection.BranchHintSection, WasmSectionType.Custom },
             { ObjectNodeSection.WasmCodeSection, WasmSectionType.Code },
             { WasmObjectNodeSection.DataCountSection, WasmSectionType.DataCount },
             { WasmObjectNodeSection.DataSection, WasmSectionType.Data },
@@ -49,6 +50,7 @@ namespace ILCompiler.ObjectWriter
             WasmObjectNodeSection.ExportSection.Name,
             WasmObjectNodeSection.ElementSection.Name,
             WasmObjectNodeSection.DataCountSection.Name,
+            WasmObjectNodeSection.BranchHintSection.Name,
             ObjectNodeSection.WasmCodeSection.Name,
             WasmObjectNodeSection.DataSection.Name,
         ];
@@ -63,12 +65,55 @@ namespace ILCompiler.ObjectWriter
         /// logical WebAssembly indices and must not be used to resolve index relocations.
         /// </summary>
         private protected Dictionary<Utf8String, SymbolDefinition> _definedSymbols;
+        private readonly List<PendingWasmBranchHint> _branchHints = new();
+        private int[] _branchHintRangeStarts;
         private int[] _sectionEmitOrder;
+
+        private readonly struct PendingWasmBranchHint
+        {
+            public PendingWasmBranchHint(int functionDefinitionIndex, uint codeOffset, bool isLikelyTaken)
+            {
+                FunctionDefinitionIndex = functionDefinitionIndex;
+                CodeOffset = codeOffset;
+                IsLikelyTaken = isLikelyTaken;
+            }
+
+            public int FunctionDefinitionIndex { get; }
+            public uint CodeOffset { get; }
+            public bool IsLikelyTaken { get; }
+        }
+
+        private protected readonly struct WasmCodeOffsetAdjustment
+        {
+            public WasmCodeOffsetAdjustment(uint offset, uint cumulativeShrink)
+            {
+                Offset = offset;
+                CumulativeShrink = cumulativeShrink;
+            }
+
+            public uint Offset { get; }
+            public uint CumulativeShrink { get; }
+        }
+
+        private readonly struct ResolvedWasmBranchHint
+        {
+            public ResolvedWasmBranchHint(int functionIndex, uint codeOffset, bool isLikelyTaken)
+            {
+                FunctionIndex = functionIndex;
+                CodeOffset = codeOffset;
+                IsLikelyTaken = isLikelyTaken;
+            }
+
+            public int FunctionIndex { get; }
+            public uint CodeOffset { get; }
+            public bool IsLikelyTaken { get; }
+        }
 
         /// <summary>
         /// The number of methods in the Function section.
         /// </summary>
         private protected int MethodCount => _wasmSymbolManager.GetDefinitionCount(WasmIndexSpace.Function);
+        private protected bool HasBranchHints => _branchHints.Count != 0;
 
         private protected int[] SectionEmitOrder
         {
@@ -107,6 +152,10 @@ namespace ILCompiler.ObjectWriter
             {
                 wasmSection = CreateDataSection(section, sectionIndex, sectionStream);
             }
+            else if (sectionType == WasmSectionType.Custom)
+            {
+                wasmSection = new NamedWasmCustomSection(sectionStream, new Utf8String(section.Name), sectionIndex);
+            }
             else
             {
                 Utf8String sectionName = new(section.Name);
@@ -144,10 +193,30 @@ namespace ILCompiler.ObjectWriter
         private protected override void RecordMethodDeclaration(INodeWithTypeSignature node)
         {
             WriteSignatureIndexForFunction(node);
-            RegisterFunctionSymbol(new Utf8String(node.GetMangledName(_nodeFactory.NameMangler)));
+            Utf8String mangledName = new(node.GetMangledName(_nodeFactory.NameMangler));
+            RegisterFunctionSymbol(mangledName);
+            int functionDefinitionIndex = MethodCount - 1;
             if (node is INodeWithFunclets nodeWithFunclets)
             {
                 RecordFunclets(nodeWithFunclets);
+            }
+
+            if (node is INodeWithWasmBranchHints nodeWithBranchHints)
+            {
+                RecordBranchHints(functionDefinitionIndex, nodeWithBranchHints);
+            }
+        }
+
+        private void RecordBranchHints(int functionDefinitionIndex, INodeWithWasmBranchHints node)
+        {
+            Debug.Assert(_branchHintRangeStarts is null);
+            foreach (WasmBranchHint hint in node.WasmBranchHints)
+            {
+                int hintFunctionDefinitionIndex = checked(functionDefinitionIndex + (int)hint.FunctionOrdinal);
+                _branchHints.Add(new PendingWasmBranchHint(
+                    hintFunctionDefinitionIndex,
+                    hint.CodeOffset,
+                    hint.IsLikelyTaken));
             }
         }
 
@@ -370,6 +439,137 @@ namespace ILCompiler.ObjectWriter
             _definedSymbols = new Dictionary<Utf8String, SymbolDefinition>(definedSymbols);
         }
 
+        private protected void AdjustBranchHintOffsets(
+            int functionDefinitionIndex,
+            IReadOnlyList<WasmCodeOffsetAdjustment> adjustments)
+        {
+            if (adjustments.Count == 0)
+            {
+                return;
+            }
+
+            EnsureBranchHintRanges();
+            Debug.Assert((uint)functionDefinitionIndex < (uint)MethodCount);
+            int hintStart = _branchHintRangeStarts[functionDefinitionIndex];
+            int hintEnd = _branchHintRangeStarts[functionDefinitionIndex + 1];
+            for (int hintIndex = hintStart; hintIndex < hintEnd; hintIndex++)
+            {
+                PendingWasmBranchHint hint = _branchHints[hintIndex];
+                uint cumulativeShrink = 0;
+                foreach (WasmCodeOffsetAdjustment adjustment in adjustments)
+                {
+                    if (hint.CodeOffset < adjustment.Offset)
+                    {
+                        break;
+                    }
+
+                    cumulativeShrink = adjustment.CumulativeShrink;
+                }
+
+                Debug.Assert(hint.CodeOffset >= cumulativeShrink);
+                _branchHints[hintIndex] = new PendingWasmBranchHint(
+                    hint.FunctionDefinitionIndex,
+                    hint.CodeOffset - cumulativeShrink,
+                    hint.IsLikelyTaken);
+            }
+        }
+
+        private void EnsureBranchHintRanges()
+        {
+            if (_branchHintRangeStarts is not null)
+            {
+                return;
+            }
+
+            _branchHintRangeStarts = new int[MethodCount + 1];
+            int hintIndex = 0;
+            for (int functionIndex = 0; functionIndex < MethodCount; functionIndex++)
+            {
+                _branchHintRangeStarts[functionIndex] = hintIndex;
+                while (hintIndex < _branchHints.Count &&
+                       _branchHints[hintIndex].FunctionDefinitionIndex == functionIndex)
+                {
+                    hintIndex++;
+                }
+            }
+
+            _branchHintRangeStarts[MethodCount] = hintIndex;
+            Debug.Assert(hintIndex == _branchHints.Count);
+        }
+
+        private protected void WriteBranchHints()
+        {
+            if (_branchHints.Count == 0)
+            {
+                return;
+            }
+
+            Debug.Assert(_sectionEmitOrder is null);
+            // https://webassembly.github.io/branch-hinting/core/appendix/custom.html#branch-hinting-section
+            List<ResolvedWasmBranchHint> hints = new(_branchHints.Count);
+            int functionImportCount = _wasmSymbolManager.GetImportCount(WasmIndexSpace.Function);
+            foreach (PendingWasmBranchHint hint in _branchHints)
+            {
+                if ((uint)hint.FunctionDefinitionIndex >= (uint)MethodCount)
+                {
+                    throw new InvalidOperationException(
+                        $"Wasm branch hint refers to function definition {hint.FunctionDefinitionIndex}, but only {MethodCount} functions are defined.");
+                }
+
+                hints.Add(new ResolvedWasmBranchHint(
+                    functionImportCount + hint.FunctionDefinitionIndex,
+                    hint.CodeOffset,
+                    hint.IsLikelyTaken));
+            }
+
+            hints.Sort(static (left, right) =>
+            {
+                int result = left.FunctionIndex.CompareTo(right.FunctionIndex);
+                return result != 0 ? result : left.CodeOffset.CompareTo(right.CodeOffset);
+            });
+
+            int functionCount = 1;
+            for (int i = 1; i < hints.Count; i++)
+            {
+                if (hints[i - 1].FunctionIndex != hints[i].FunctionIndex)
+                {
+                    functionCount++;
+                }
+            }
+
+            SectionWriter writer = GetOrCreateSection(WasmObjectNodeSection.BranchHintSection);
+            writer.WriteULEB128((ulong)functionCount);
+
+            int hintIndex = 0;
+            while (hintIndex < hints.Count)
+            {
+                int functionIndex = hints[hintIndex].FunctionIndex;
+                int functionEnd = hintIndex + 1;
+                while (functionEnd < hints.Count && hints[functionEnd].FunctionIndex == functionIndex)
+                {
+                    functionEnd++;
+                }
+
+                writer.WriteULEB128((ulong)functionIndex);
+                writer.WriteULEB128((ulong)(functionEnd - hintIndex));
+                for (; hintIndex < functionEnd; hintIndex++)
+                {
+                    ResolvedWasmBranchHint hint = hints[hintIndex];
+                    if (hintIndex > 0 &&
+                        hints[hintIndex - 1].FunctionIndex == hint.FunctionIndex &&
+                        hints[hintIndex - 1].CodeOffset == hint.CodeOffset)
+                    {
+                        throw new InvalidOperationException(
+                            $"Duplicate Wasm branch hint for function {hint.FunctionIndex} at offset {hint.CodeOffset}.");
+                    }
+
+                    writer.WriteULEB128(hint.CodeOffset);
+                    writer.WriteULEB128(1);
+                    writer.WriteULEB128(hint.IsLikelyTaken ? 1u : 0u);
+                }
+            }
+        }
+
         private protected abstract void WriteImports();
         private protected abstract void WriteGlobalSection();
         private protected abstract void WriteExports();
@@ -393,6 +593,7 @@ namespace ILCompiler.ObjectWriter
         // TODO-WASM: Consider alignment needs for data sections
         public static readonly ObjectNodeSection DataSection = new("wasm.data", SectionType.Writeable, needsAlign: false);
         public static readonly ObjectNodeSection DataCountSection = new("wasm.datacount", SectionType.ReadOnly, needsAlign: false);
+        public static readonly ObjectNodeSection BranchHintSection = new("metadata.code.branch_hint", SectionType.ReadOnly, needsAlign: false);
         public static readonly ObjectNodeSection CombinedDataSection = new("wasm.alldata", SectionType.Writeable, needsAlign: false);
         public static readonly ObjectNodeSection FunctionSection = new("wasm.function", SectionType.ReadOnly, needsAlign: false);
         public static readonly ObjectNodeSection ExportSection = new("wasm.export", SectionType.ReadOnly, needsAlign: false);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmRelocatableObjectWriter.cs
@@ -58,8 +58,9 @@ namespace ILCompiler.ObjectWriter
         {
             Debug.Assert(outputFileStream.CanSeek, $"EmitObjectFile requires seekable output stream");
 
-            FinalizeSectionEntryCounts();
             ResolveSectionRelocations();
+            Debug.Assert(!HasBranchHints, "Branch hints require final function indices and are not supported in relocatable output.");
+            FinalizeSectionEntryCounts();
 
             EmitWasmHeader(outputFileStream);
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmSymbolManager.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmSymbolManager.cs
@@ -95,6 +95,8 @@ internal sealed class WasmSymbolManager
 
     public int GetImportCount() => _importCounts.Values.Sum();
 
+    public int GetImportCount(WasmIndexSpace indexSpace) => _importCounts[indexSpace];
+
     public int GetDefinitionCount(WasmIndexSpace indexSpace) =>
         _definitionCounts[indexSpace];
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WebCilObjectWriter.cs
@@ -347,6 +347,9 @@ namespace ILCompiler.ObjectWriter
 
             // Writing our memory import <- size of the webcil segment (for an accurate minimum size)
             WriteMemoryImport((ulong)webcilPayloadSegment.ContentSize);
+            ResolveWasmSectionRelocations();
+            WriteBranchHints();
+
             FinalizeSectionEntryCounts();
 
            /*********************************************************************
@@ -361,19 +364,6 @@ namespace ILCompiler.ObjectWriter
             foreach (int index in SectionEmitOrder)
             {
                 SectionDataEmitter section = _sections[index];
-                if (_resolvableRelocations.TryGetValue(index, out List<SymbolicRelocation> relocations) &&
-                    section is WasmSection)
-                {
-                    using (Stream originalStream = section.ContentReadStream)
-                    {
-                        MemoryStream destStream = new MemoryStream((int)originalStream.Length);
-                        originalStream.Position = 0;
-                        ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0, shrink: true);
-                        section.ContentReadStream = destStream;
-                        // originalStream may be disposed, section.Stream now points to resolved stream
-                    }
-                }
-
                 if (index == codeSectionIndex)
                 {
                     // Function bodies begin after the section header and the (externally counted) entry-count prefix.
@@ -424,6 +414,25 @@ namespace ILCompiler.ObjectWriter
                 {
                     _outputInfoBuilder.RemapMethodNodeOffsets(codeSectionIndex, _codeOffsetMap);
                 }
+            }
+        }
+
+        private void ResolveWasmSectionRelocations()
+        {
+            for (int index = 0; index < _sections.Count; index++)
+            {
+                SectionDataEmitter section = _sections[index];
+                if (!_resolvableRelocations.TryGetValue(index, out List<SymbolicRelocation> relocations) ||
+                    section is not WasmSection)
+                {
+                    continue;
+                }
+
+                using Stream originalStream = section.ContentReadStream;
+                MemoryStream destStream = new((int)originalStream.Length);
+                originalStream.Position = 0;
+                ResolveRelocations(index, originalStream, destStream, relocations, sectionStart: 0, shrink: true);
+                section.ContentReadStream = destStream;
             }
         }
 
@@ -542,6 +551,7 @@ namespace ILCompiler.ObjectWriter
                 throw new InvalidDataException();
             }
 
+            Debug.Assert(blobs.Count == MethodCount);
             long maxBlobSize = blobs.Max(blob => blob.End - blob.Start);
             MemoryStream tempStream = new MemoryStream((int)maxBlobSize);
             byte[] relocScratchBuffer = new byte[Relocation.MaxSize];
@@ -561,6 +571,8 @@ namespace ILCompiler.ObjectWriter
             for (int b = 0; b < blobs.Count; b++)
             {
                 CodeBlob blob = blobs[b];
+                List<WasmCodeOffsetAdjustment>? branchHintAdjustments = null;
+                uint cumulativeBranchHintShrink = 0;
                 // writeCursor is the post-shrink offset where this entry's (new) size prefix will be written.
                 postEntryStart[b] = writeCursor;
                 Debug.Assert(writeCursor <= blobs[b].Start, $"Write cursor {writeCursor} is beyond the start of blob {blobs[b].Start}");
@@ -594,7 +606,16 @@ namespace ILCompiler.ObjectWriter
                         }
 
                         int size = ResolveReloc(sectionIndex, sectionStream, curReloc.Offset, tempStream, tempStream.Position, curReloc, relocScratchBuffer, shrink: shrink);
-                        blobShrink[b] += (int)Relocation.GetSize(curReloc.Type) - size;
+                        int relocationShrink = (int)Relocation.GetSize(curReloc.Type) - size;
+                        blobShrink[b] += relocationShrink;
+                        if (relocationShrink > 0)
+                        {
+                            cumulativeBranchHintShrink += (uint)relocationShrink;
+                            branchHintAdjustments ??= new List<WasmCodeOffsetAdjustment>();
+                            branchHintAdjustments.Add(new WasmCodeOffsetAdjustment(
+                                checked((uint)(curReloc.Offset + Relocation.GetSize(curReloc.Type) - blob.Start)),
+                                cumulativeBranchHintShrink));
+                        }
 
                         long nextStart = curReloc.Offset + Relocation.GetSize(curReloc.Type);
                         long nextEnd = nextReloc is not null ? nextReloc.Offset : blob.End;
@@ -632,6 +653,11 @@ namespace ILCompiler.ObjectWriter
 
                     CopyOnly(src: sectionStream, srcPos: blob.Start, dest: sectionStream, destPos: writeCursor, count: blob.Size);
                     writeCursor += blob.Size;
+                }
+
+                if (branchHintAdjustments is not null)
+                {
+                    AdjustBranchHintOffsets(b, branchHintAdjustments);
                 }
             }
             sectionStream.SetLength(writeCursor);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3478,11 +3478,12 @@ namespace Internal.JitInterface
             NativeMemory.Free(vars);
         }
 
-#pragma warning disable CA1822 // Mark members as static
         private void reportMetadata(byte* key, void* value, nuint length)
-#pragma warning restore CA1822 // Mark members as static
         {
+            HandleReportedMetadata(key, value, length);
         }
+
+        partial void HandleReportedMetadata(byte* key, void* value, nuint length);
 
 #pragma warning disable CA1822 // Mark members as static
         private void* allocateArray(nuint cBytes)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -112,7 +112,19 @@ public class R2RTestSuites
                 new(nameof(WasmWebcilModule), [new CrossgenAssembly(wasmWebcilModule)])
                 {
                     OutputFileExtension = ".wasm",
+                    AdditionalArgs =
+                    [
+                        "--codegenopt",
+                        "JitSynthesizeCounts=1",
+                        "--codegenopt",
+                        "JitWasmBranchHintStress=1",
+                    ],
                     Validate = Validate,
+                },
+                new($"{nameof(WasmWebcilModule)}NoHints", [new CrossgenAssembly(wasmWebcilModule)])
+                {
+                    OutputFileExtension = ".wasm",
+                    Validate = ValidateNoHints,
                 },
             ]));
 
@@ -153,6 +165,14 @@ public class R2RTestSuites
                 "Expected a 'global.get' of the wasm image-base well-known global in the emitted code.");
             Assert.True(WasmR2RAssert.WasmImageContainsWellKnownGlobalGet(webcilReader, TableBaseGlobal),
                 "Expected a 'global.get' of the wasm table-base well-known global in the emitted code.");
+            Assert.True(WasmR2RAssert.WasmBranchHintsAreValid(webcilReader, out string branchHintDiagnostic),
+                branchHintDiagnostic);
+        }
+
+        static void ValidateNoHints(ReadyToRunReader reader)
+        {
+            var webcilReader = Assert.IsType<WebcilImageReader>(reader.CompositeReader);
+            Assert.True(WasmR2RAssert.WasmBranchHintsAreAbsent(webcilReader, out string diagnostic), diagnostic);
         }
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/Webcil/WasmWebcilModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/Webcil/WasmWebcilModule.cs
@@ -17,6 +17,46 @@ public static class WasmWebcilModule
         return left + right;
     }
 
+    public static int SumTo(int limit)
+    {
+        int sum = 0;
+        for (int i = 0; i < limit; i++)
+        {
+            sum += i;
+        }
+
+        return sum;
+    }
+
+    public static int SumStaticDataTo(int limit)
+    {
+        int sum = 0;
+        for (int i = 0; i < limit; i++)
+        {
+            sum += s_primes[i % s_primes.Length];
+        }
+
+        return sum;
+    }
+
+    public static int SumInFinally(int limit)
+    {
+        int sum = 0;
+        try
+        {
+            sum = limit;
+        }
+        finally
+        {
+            for (int i = 0; i < limit; i++)
+            {
+                sum += i;
+            }
+        }
+
+        return sum;
+    }
+
     // Reads static data, which forces the JIT to materialize the imageBase address via a
     // 'global.get' of the wasm imageBase well-known global.
     public static int SumStaticData(int index)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/WasmR2RAssert.cs
@@ -51,6 +51,161 @@ internal static class WasmR2RAssert
     }
 
     /// <summary>
+    /// Verifies the WebAssembly branch-hint custom section and all referenced instructions.
+    /// </summary>
+    public static bool WasmBranchHintsAreValid(WebcilImageReader reader, out string diagnostic)
+    {
+        ReadOnlySpan<byte> image = reader.GetEntireImage().AsSpan();
+        if (!TryGetWasmCustomSection(image, "metadata.code.branch_hint", out int offset, out int sectionEnd, out int sectionStart))
+        {
+            diagnostic = "WASM image does not contain a 'metadata.code.branch_hint' custom section.";
+            return false;
+        }
+
+        if (!TryGetWasmSectionBounds(image, WasmSectionKind.Code, out int codeOffset, out _))
+        {
+            diagnostic = "WASM image does not contain a code section.";
+            return false;
+        }
+
+        if (sectionStart >= codeOffset)
+        {
+            diagnostic = "WASM branch-hint custom section must precede the code section.";
+            return false;
+        }
+
+        Dictionary<(string Module, string Name), WasmImportIndex> imports = ReadWasmImports(reader);
+        uint importedFunctionCount = CountWasmImports(imports, WasmImportKind.Function);
+        uint functionCount = ReadWasmUleb32(image, ref offset, sectionEnd);
+        if (functionCount == 0)
+        {
+            diagnostic = "WASM branch-hint custom section contains no function entries.";
+            return false;
+        }
+
+        long previousFunctionIndex = -1;
+        for (uint functionEntry = 0; functionEntry < functionCount; functionEntry++)
+        {
+            uint functionIndex = ReadWasmUleb32(image, ref offset, sectionEnd);
+            if (functionIndex <= previousFunctionIndex)
+            {
+                diagnostic = $"WASM branch-hint function index {functionIndex} is not strictly increasing.";
+                return false;
+            }
+
+            if (functionIndex < importedFunctionCount)
+            {
+                diagnostic = $"WASM branch hint refers to imported function index {functionIndex}.";
+                return false;
+            }
+
+            WebcilImageReader.WasmFunctionInfo? function =
+                reader.GetWasmFunctionBody(checked((int)(functionIndex - importedFunctionCount)));
+            if (function is null)
+            {
+                diagnostic = $"WASM branch hint refers to missing function index {functionIndex}.";
+                return false;
+            }
+
+            int localsSize = GetWasmLocalsEncodingSize(function.Value.Locals);
+            int localsOffset = function.Value.InstructionOffset - localsSize;
+            uint hintCount = ReadWasmUleb32(image, ref offset, sectionEnd);
+            if (hintCount == 0)
+            {
+                diagnostic = $"WASM branch-hint entry for function {functionIndex} contains no hints.";
+                return false;
+            }
+
+            long previousCodeOffset = -1;
+            for (uint hintIndex = 0; hintIndex < hintCount; hintIndex++)
+            {
+                uint branchOffset = ReadWasmUleb32(image, ref offset, sectionEnd);
+                uint metadataCount = ReadWasmUleb32(image, ref offset, sectionEnd);
+                uint likelyTaken = ReadWasmUleb32(image, ref offset, sectionEnd);
+
+                if (branchOffset <= previousCodeOffset)
+                {
+                    diagnostic = $"WASM branch offsets for function {functionIndex} are not strictly increasing.";
+                    return false;
+                }
+
+                if (metadataCount != 1 || likelyTaken > 1)
+                {
+                    diagnostic =
+                        $"WASM branch hint at function {functionIndex}, offset {branchOffset} has invalid metadata.";
+                    return false;
+                }
+
+                if (branchOffset < localsSize ||
+                    branchOffset > int.MaxValue ||
+                    branchOffset >= (uint)(localsSize + function.Value.InstructionLength))
+                {
+                    diagnostic =
+                        $"WASM branch hint at function {functionIndex}, offset {branchOffset} is outside the function body.";
+                    return false;
+                }
+
+                byte opcode = image[localsOffset + (int)branchOffset];
+                if (opcode is not 0x04 and not 0x0D)
+                {
+                    diagnostic =
+                        $"WASM branch hint at function {functionIndex}, offset {branchOffset} points to opcode 0x{opcode:X2}.";
+                    return false;
+                }
+
+                previousCodeOffset = branchOffset;
+            }
+
+            previousFunctionIndex = functionIndex;
+        }
+
+        if (offset != sectionEnd)
+        {
+            diagnostic = "WASM branch-hint custom section contains trailing data.";
+            return false;
+        }
+
+        diagnostic = $"Validated {functionCount} function entries in the WASM branch-hint custom section.";
+        return true;
+    }
+
+    public static bool WasmBranchHintsAreAbsent(WebcilImageReader reader, out string diagnostic)
+    {
+        ReadOnlySpan<byte> image = reader.GetEntireImage().AsSpan();
+        if (TryGetWasmCustomSection(image, "metadata.code.branch_hint", out _, out _, out _))
+        {
+            diagnostic = "WASM image unexpectedly contains a 'metadata.code.branch_hint' custom section.";
+            return false;
+        }
+
+        diagnostic = "WASM image does not contain a branch-hint custom section.";
+        return true;
+    }
+
+    private static int GetWasmLocalsEncodingSize(IReadOnlyList<(uint Count, byte ValType)> locals)
+    {
+        int size = GetWasmUleb32Size((uint)locals.Count);
+        foreach ((uint count, _) in locals)
+        {
+            size += GetWasmUleb32Size(count) + sizeof(byte);
+        }
+
+        return size;
+    }
+
+    private static int GetWasmUleb32Size(uint value)
+    {
+        int size = 1;
+        while (value >= 0x80)
+        {
+            value >>= 7;
+            size++;
+        }
+
+        return size;
+    }
+
+    /// <summary>
     /// Returns true if the default Webcil imports and defined section entries occupy the expected
     /// indices in their respective WASM external-kind index spaces.
     /// </summary>
@@ -331,6 +486,48 @@ internal static class WasmR2RAssert
         return false;
     }
 
+    private static bool TryGetWasmCustomSection(
+        ReadOnlySpan<byte> image,
+        string name,
+        out int payloadOffset,
+        out int sectionEnd,
+        out int sectionStart)
+    {
+        payloadOffset = 0;
+        sectionEnd = 0;
+        sectionStart = 0;
+
+        if (image.Length < 8)
+            throw new BadImageFormatException("WASM image is shorter than its magic and version header.");
+
+        int offset = 8;
+        while (offset < image.Length)
+        {
+            int currentSectionStart = offset;
+            byte sectionId = ReadWasmByte(image, ref offset, image.Length);
+            uint sectionSize = ReadWasmUleb32(image, ref offset, image.Length);
+            if (sectionSize > int.MaxValue || sectionSize > image.Length - offset)
+                throw new BadImageFormatException($"WASM section {sectionId} extends beyond the image boundary.");
+
+            int currentSectionEnd = offset + (int)sectionSize;
+            if (sectionId == 0)
+            {
+                int cursor = offset;
+                if (ReadWasmName(image, ref cursor, currentSectionEnd) == name)
+                {
+                    payloadOffset = cursor;
+                    sectionEnd = currentSectionEnd;
+                    sectionStart = currentSectionStart;
+                    return true;
+                }
+            }
+
+            offset = currentSectionEnd;
+        }
+
+        return false;
+    }
+
     private static Dictionary<(string Module, string Name), WasmImportIndex> ReadWasmImports(WebcilImageReader reader)
     {
         ReadOnlySpan<byte> image = reader.GetEntireImage().AsSpan();
@@ -578,6 +775,7 @@ internal static class WasmR2RAssert
         Global = 6,
         Export = 7,
         Element = 9,
+        Code = 10,
         Tag = 13,
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Buffers.Binary;
 using System.Linq;
+using ILCompiler.DependencyAnalysis.Wasm;
 using Internal.JitInterface;
 using Internal.Pgo;
 using Internal.Text;
@@ -14,7 +15,7 @@ using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
-    public class MethodWithGCInfo : ObjectNode, IMethodBodyNode, INodeWithFunclets, IMethodCodeNodeWithTypeSignature
+    public class MethodWithGCInfo : ObjectNode, IMethodBodyNode, INodeWithFunclets, IMethodCodeNodeWithTypeSignature, INodeWithWasmBranchHints
     {
         public readonly MethodGCInfoNode GCInfoNode;
 
@@ -32,6 +33,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private MethodDesc[] _inlinedMethods;
         private bool _lateTriggeredCompilation;
         private DependencyList _nonRelocationDependencies;
+        private List<WasmBranchHint> _wasmBranchHints;
 
         public MethodWithGCInfo(MethodDesc methodDesc)
         {
@@ -98,6 +100,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public int Size => _methodCode.Data.Length;
 
         public bool IsEmpty => _methodCode.Data.Length == 0;
+
+        public IReadOnlyList<WasmBranchHint> WasmBranchHints =>
+            _wasmBranchHints is null ? Array.Empty<WasmBranchHint>() : _wasmBranchHints;
+
+        public void AddWasmBranchHint(WasmBranchHint branchHint)
+        {
+            _wasmBranchHints ??= new List<WasmBranchHint>();
+            _wasmBranchHints.Add(branchHint);
+        }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -484,6 +485,7 @@ namespace Internal.JitInterface
         private UnboxingMethodDescFactory _unboxingThunkFactory = new UnboxingMethodDescFactory();
         private List<ISymbolNode> _precodeFixups;
         private List<MethodDesc> _ilBodiesNeeded;
+        private List<WasmBranchHint> _wasmBranchHints;
         private Dictionary<TypeDesc, bool> _preInitedTypes = new Dictionary<TypeDesc, bool>();
         private HashSet<MethodDesc> _synthesizedPgoDependencies;
         public bool HasColdCode { get; private set; }
@@ -785,6 +787,7 @@ namespace Internal.JitInterface
         {
             bool codeGotPublished = false;
             _methodCodeNode = methodCodeNodeNeedingCode;
+            _wasmBranchHints = null;
 
             try
             {
@@ -872,6 +875,14 @@ namespace Internal.JitInterface
 
                 var compilationResult = CompileMethodInternal(methodCodeNodeNeedingCode, methodIL);
                 codeGotPublished = true;
+
+                if (compilationResult == CompilationResult.CompilationComplete && _wasmBranchHints is not null)
+                {
+                    foreach (WasmBranchHint branchHint in _wasmBranchHints)
+                    {
+                        _methodCodeNode.AddWasmBranchHint(branchHint);
+                    }
+                }
 
                 if (compilationResult == CompilationResult.CompilationRetryRequested && logger.IsVerbose)
                 {
@@ -1624,6 +1635,49 @@ namespace Internal.JitInterface
             _methodCodeNode.SetCode(new ObjectNode.ObjectData(Array.Empty<byte>(), null, 1, Array.Empty<ISymbolDefinitionNode>()));
             _methodCodeNode.InitializeFrameInfos(Array.Empty<FrameInfo>());
             _methodCodeNode.InitializeColdFrameInfos(Array.Empty<FrameInfo>());
+        }
+
+        partial void HandleReportedMetadata(byte* key, void* value, nuint length)
+        {
+            if (!_compilation.NodeFactory.Target.IsWasm)
+            {
+                return;
+            }
+
+            ReadOnlySpan<byte> metadataKey = MemoryMarshal.CreateReadOnlySpanFromNullTerminated(key);
+            if (metadataKey.SequenceEqual("WasmBranchHintsReset"u8))
+            {
+                if (length != 0)
+                {
+                    throw new InvalidOperationException($"Unexpected Wasm branch hint reset metadata size: {length}.");
+                }
+
+                _wasmBranchHints = null;
+                return;
+            }
+
+            if (!metadataKey.SequenceEqual("WasmBranchHint"u8))
+            {
+                return;
+            }
+
+            const int WasmBranchHintMetadataSize = (2 * sizeof(uint)) + sizeof(byte);
+            if (length != WasmBranchHintMetadataSize)
+            {
+                throw new InvalidOperationException($"Unexpected Wasm branch hint metadata size: {length}.");
+            }
+
+            ReadOnlySpan<byte> metadata = new(value, WasmBranchHintMetadataSize);
+            uint functionOrdinal = BinaryPrimitives.ReadUInt32LittleEndian(metadata);
+            uint codeOffset = BinaryPrimitives.ReadUInt32LittleEndian(metadata.Slice(sizeof(uint)));
+            byte likelyTaken = metadata[2 * sizeof(uint)];
+            if (likelyTaken > 1)
+            {
+                throw new InvalidOperationException($"Unexpected Wasm branch hint value: {likelyTaken}.");
+            }
+
+            _wasmBranchHints ??= new List<WasmBranchHint>();
+            _wasmBranchHints.Add(new WasmBranchHint(functionOrdinal, codeOffset, likelyTaken != 0));
         }
 
         private CorInfoHelpFunc getCastingHelper(ref CORINFO_RESOLVED_TOKEN pResolvedToken, bool fThrowing)


### PR DESCRIPTION
## Summary

Emit the standardized WebAssembly `metadata.code.branch_hint` custom section from CoreCLR ReadyToRun compilation when static PGO identifies strongly biased conditional branches.

This is an experimental implementation for #133794. Engines that do not consume branch hints safely ignore the custom section.

## Design

- Select hints in RyuJIT after final Wasm CFG layout and condition reversal.
- Require static, sufficiently trustworthy PGO and an 80/20 likelihood threshold in production.
- Attach the final hint to the emitted `br_if` instruction descriptor.
- Report function-relative instruction offsets through the existing JIT metadata channel.
- Retain hints as ReadyToRun per-method side data and resolve final function indices in the Wasm object writer.
- Emit one sorted `metadata.code.branch_hint` custom section immediately before the code section.
- Adjust hint offsets when Webcil relocation resolution shrinks variable-length LEB encodings.
- Reset reported metadata on internal JIT retries so discarded compilation attempts cannot leak stale hints.
- Keep relocatable Wasm output explicitly unsupported because its function indices and code offsets are not final.

A `JitWasmBranchHintStress` switch permits deterministic tests using synthesized profile weights without changing production gating.

## Validation

- `./build.sh clr`
- `PATH=/opt/homebrew/bin:$PATH ./build.sh -os browser -c Debug -subset clr+libs`
- `python3 src/coreclr/scripts/jitformat.py -r <runtime> -o osx -a arm64 -b Checked --verbose --fix --projects dll`
- Full browser-wasm `ILCompiler.ReadyToRun.Tests`: **75 passed, 37 skipped, 0 failed**
- Independent Wasm parsing confirmed the custom section is present before the code section.
- Tests verify function and branch ordering, metadata shape, final function indices, funclet handling, relocation-adjusted offsets, and that each hint points to an actual `if` or `br_if` opcode.
- Tests also verify the section is absent without qualifying profile data or the test stress switch.

## Size impact

For the test module, identical synthesized profile input produced:

| Configuration | Size |
|---|---:|
| Profile data, branch hints disabled | 6,528 bytes |
| Profile data, branch hints enabled | 6,560 bytes |

The custom section and hints add **32 bytes** in this sample.

## Follow-up measurements

This draft establishes correct metadata generation. Before considering it ready to merge, it needs end-to-end measurements on Wasm engines that consume branch hints, including representative application startup/steady-state results, engine compilation time, generated native-code size, and broader R2R image-size impact.

> [!NOTE]
> This pull request description was drafted with GitHub Copilot.