### PR TITLE
Align CompositeFormat index and width limits with string.Format

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/CompositeFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/CompositeFormat.cs
@@ -122,6 +122,9 @@ namespace System.Text
             // allows us to merge those segments back together easily prior to their being appended to the list.
             var vsb = new ValueStringBuilder(stackalloc char[string.StackallocCharBufferSizeLimit]);
 
+            const int IndexLimit = 1_000_000;
+            const int WidthLimit = 1_000_000;
+
             // Repeatedly find the next hole and process it.
             int pos = 0;
             char ch;
@@ -198,7 +201,7 @@ namespace System.Text
                 if (ch != '}')
                 {
                     // Continue consuming optional additional digits.
-                    while (char.IsAsciiDigit(ch))
+                    while (char.IsAsciiDigit(ch) && index < IndexLimit)
                     {
                         index = index * 10 + ch - '0';
                         if (!TryMoveNext(format, ref pos, out ch))
@@ -255,7 +258,7 @@ namespace System.Text
                         {
                             goto FailureUnclosedFormatItem;
                         }
-                        while (char.IsAsciiDigit(ch))
+                        while (char.IsAsciiDigit(ch) && width < WidthLimit)
                         {
                             width = width * 10 + ch - '0';
                             if (!TryMoveNext(format, ref pos, out ch))

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Text/CompositeFormatTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Text/CompositeFormatTests.cs
@@ -277,5 +277,50 @@ namespace System.Text.Tests
                     break;
             }
         }
+
+        [Theory]
+        [InlineData("{999999}", 1_000_000)]
+        [InlineData("{1000000}", 1_000_001)]
+        [InlineData("{1000001}", 1_000_002)]
+        [InlineData("{9999999}", 10_000_000)]
+        public static void Parse_ValidLargeIndex_MinimumArgumentCount(string format, int expectedMinArgs)
+        {
+            CompositeFormat cf = CompositeFormat.Parse(format);
+            Assert.NotNull(cf);
+            Assert.Equal(expectedMinArgs, cf.MinimumArgumentCount);
+        }
+
+        [Theory]
+        [InlineData("{0,999999}")]
+        [InlineData("{0,1000000}")]
+        [InlineData("{0,1000001}")]
+        [InlineData("{0,9999999}")]
+        [InlineData("{0,-9999999}")]
+        public static void Parse_ValidLargeAlignment_ParsesSuccessfully(string format)
+        {
+            CompositeFormat cf = CompositeFormat.Parse(format);
+            Assert.NotNull(cf);
+            Assert.Equal(1, cf.MinimumArgumentCount);
+        }
+
+        [Theory]
+        [InlineData("{10000000}")]
+        [InlineData("{10000001}")]
+        [InlineData("{9999999999999999999999}")]
+        [InlineData("{0,10000000}")]
+        [InlineData("{0,10000001}")]
+        [InlineData("{0,-10000000}")]
+        [InlineData("{0,-10000001}")]
+        [InlineData("{0,9999999999999999999999}")]
+        [InlineData("{0,-9999999999999999999999}")]
+        public static void Parse_InvalidIndexOrWidthExceedingLimits_ThrowsFormatException(string format)
+        {
+            // Verify CompositeFormat.Parse throws FormatException (and specifically not OverflowException)
+            Assert.Throws<FormatException>(() => CompositeFormat.Parse(format));
+
+            // Verify parity with string.Format / StringBuilder.AppendFormat
+            Assert.Throws<FormatException>(() => string.Format(null, format, 0));
+            Assert.Throws<FormatException>(() => new StringBuilder().AppendFormat(null, format, 0));
+        }
     }
 }


### PR DESCRIPTION
Fixes #119756

Fixes #133792

## Customer Impact

`CompositeFormat.Parse` had differing digit-boundary behavior compared to `string.Format` and `StringBuilder.AppendFormat`. In particular, format item indices and alignment widths above `9,999,999` could previously be parsed or overflow during parsing, potentially resulting in incorrect behavior or exceptions other than `FormatException`.

This change aligns `CompositeFormat.Parse` with the existing behavior of `string.Format` and `StringBuilder.AppendFormat` by rejecting values greater than `9,999,999` with `FormatException`.

## Description of Changes

* Added local constants `IndexLimit = 1_000_000` and `WidthLimit = 1_000_000` in `CompositeFormat.TryParseLiterals`.
* Bounded index parsing with `index < IndexLimit`.
* Bounded alignment-width parsing with `width < WidthLimit`.
* Added unit tests covering valid boundary values and values exceeding the supported limits.
* Added tests verifying `FormatException` behavior and parity with `string.Format` and `StringBuilder.AppendFormat`.

## Regression

This is an intentional behavior change for `CompositeFormat.Parse`. Format item indices and alignment widths greater than `9,999,999` now throw `FormatException` instead of being accepted or overflowing during parsing.

The limit is based on the numeric value, not the number of digits, so values with leading zeros such as `{00000005}` continue to parse successfully.

## Testing

* Added unit tests in `src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Text/CompositeFormatTests.cs`.
* Rebuilt `System.Private.CoreLib` cleanly with 0 warnings and 0 errors.
* Tests cover both boundary values and values exceeding the supported limit.

## Risk

Low. This aligns `CompositeFormat.Parse` with the established limits and exception behavior of `string.Format` and `StringBuilder.AppendFormat`.

The only compatibility impact is that inputs with an index or alignment value greater than `9,999,999` that previously parsed will now consistently throw `FormatException`.

This change also prevents integer overflow scenarios covered by #133792.
