### PR TITLE
JIT: Fix zero-flag reuse for BSF/BSR

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -791,17 +791,23 @@ bool emitter::HasRegularWideImmediateForm(instruction ins)
 }
 
 //------------------------------------------------------------------------
-// DoesWriteZeroFlag: check if the instruction write the
-//     ZF flag.
+// DoesSetZeroFlagOnResult: check if the instruction sets ZF according to
+//     whether its result is zero.
 //
 // Arguments:
 //    ins - instruction to test
 //
 // Return Value:
-//    true if instruction writes the ZF flag, false otherwise.
+//    true if instruction sets ZF based on its result, false otherwise.
 //
-bool emitter::DoesWriteZeroFlag(instruction ins)
+bool emitter::DoesSetZeroFlagOnResult(instruction ins)
 {
+    // BSF/BSR set ZF based on the source, not the result.
+    if ((ins == INS_bsf) || (ins == INS_bsr))
+    {
+        return false;
+    }
+
     insFlags flags = CodeGenInterface::instInfo[ins];
     return (flags & Writes_ZF) != 0;
 }
@@ -1618,7 +1624,7 @@ bool emitter::AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, GenCondition 
     // Certain instruction like and, or and xor modifies exactly same flags
     // as "test" instruction.
     // They reset OF and CF to 0 and modifies SF, ZF and PF.
-    if (DoesResetOverflowAndCarryFlags(lastIns) && DoesWriteSignFlag(lastIns) && DoesWriteZeroFlag(lastIns) &&
+    if (DoesResetOverflowAndCarryFlags(lastIns) && DoesWriteSignFlag(lastIns) && DoesSetZeroFlagOnResult(lastIns) &&
         DoesWriteParityFlag(lastIns))
     {
         return id->idOpSize() == opSize;
@@ -1626,7 +1632,7 @@ bool emitter::AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, GenCondition 
 
     if ((cond.GetCode() == GenCondition::NE) || (cond.GetCode() == GenCondition::EQ))
     {
-        if (DoesWriteZeroFlag(lastIns) && IsFlagsAlwaysModified(id))
+        if (DoesSetZeroFlagOnResult(lastIns) && IsFlagsAlwaysModified(id))
         {
             return id->idOpSize() == opSize;
         }

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -721,7 +721,7 @@ bool        IsThreeOperandAVXInstruction(instruction ins) const;
 bool        IsAvxCommutative(instruction ins) const;
 static bool HasRegularWideForm(instruction ins);
 static bool HasRegularWideImmediateForm(instruction ins);
-static bool DoesWriteZeroFlag(instruction ins);
+static bool DoesSetZeroFlagOnResult(instruction ins);
 static bool DoesWriteParityFlag(instruction ins);
 static bool DoesWriteSignFlag(instruction ins);
 static bool DoesResetOverflowAndCarryFlags(instruction ins);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -22321,7 +22321,8 @@ bool GenTree::SupportsSettingZeroFlag()
     }
 
 #ifdef FEATURE_HW_INTRINSICS
-    if (OperIs(GT_HWINTRINSIC) && emitter::DoesWriteZeroFlag(HWIntrinsicInfo::lookupIns(AsHWIntrinsic(), nullptr)))
+    if (OperIs(GT_HWINTRINSIC) &&
+        emitter::DoesSetZeroFlagOnResult(HWIntrinsicInfo::lookupIns(AsHWIntrinsic(), nullptr)))
     {
         return true;
     }

--- a/src/tests/JIT/Regression_ro_2/Runtime_133783.cs
+++ b/src/tests/JIT/Regression_ro_2/Runtime_133783.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_133783
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        // DOTNET_EnableAVX2=0 exercises the BSF/BSR fallbacks on newer x86 CPUs.
+        for (uint value = 0; value <= 3; value++)
+        {
+            Assert.Equal(value < 2, Log2IsZero(value));
+            Assert.Equal(value >= 2, Log2NotZero(value));
+            Assert.Equal((value & 1) != 0, TzcIsZero(value));
+            Assert.Equal(value < 2, Log2IsZero((ulong)value));
+            Assert.Equal(value >= 2, Log2NotZero((ulong)value));
+            Assert.Equal((value & 1) != 0, TzcIsZero((ulong)value));
+        }
+
+        Assert.False(Log2IsZero(1UL << 32));
+        Assert.True(Log2NotZero(1UL << 63));
+        Assert.False(TzcIsZero(1UL << 32));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool Log2IsZero(uint value) => BitOperations.Log2(value) == 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool Log2NotZero(uint value) => BitOperations.Log2(value) != 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool TzcIsZero(uint value) => BitOperations.TrailingZeroCount(value) == 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool Log2IsZero(ulong value) => BitOperations.Log2(value) == 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool Log2NotZero(ulong value) => BitOperations.Log2(value) != 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static bool TzcIsZero(ulong value) => BitOperations.TrailingZeroCount(value) == 0;
+}


### PR DESCRIPTION
Fixes #133783

Don't reuse BSF/BSR zero flags for result comparisons.