### PR TITLE
JIT: Fix block-store address containment boundary

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -761,7 +761,9 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
         return;
     }
 #else  // !TARGET_ARM
-    if ((ClrSafeInt<int>(offset) + ClrSafeInt<int>(size)).IsOverflow())
+    // Keep offset + size strictly below INT32_MAX, as required by unrolled block codegen.
+    ClrSafeInt<int> endOffset = ClrSafeInt<int>(offset) + ClrSafeInt<int>(size);
+    if (endOffset.IsOverflow() || (endOffset.Value() == INT32_MAX))
     {
         return;
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -402,7 +402,8 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
     // up to 16 bytes lower than offset + size. But offsets large enough to hit this case are likely
     // to be extremely rare for this to ever be a CQ issue.
     // On x86 this shouldn't be needed but then again, offsets large enough to hit this are rare.
-    if (addrMode->Offset() > (INT32_MAX - static_cast<int>(size)))
+    // Keep offset + size strictly below INT32_MAX, as required by unrolled block codegen.
+    if (addrMode->Offset() >= (INT32_MAX - static_cast<int>(size)))
     {
         return;
     }

--- a/src/tests/JIT/Regression_ro_2/Runtime_133785.cs
+++ b/src/tests/JIT/Regression_ro_2/Runtime_133785.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_133785
+{
+    // On x64, the element offset is 16 + Index * 3 == int.MaxValue - 3.
+    private const int Index = 715827876;
+
+    private struct S3
+    {
+        public byte A, B, C;
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        S3[] array = new S3[1];
+        S3 value = new S3 { A = 1, B = 2, C = 3 };
+
+        Assert.Throws<IndexOutOfRangeException>(() => StoreInit(array));
+        Assert.Throws<IndexOutOfRangeException>(() => StoreCopy(array, value));
+        Assert.Throws<IndexOutOfRangeException>(() => LoadCopy(array, ref value));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static void StoreInit(S3[] array) => array[Index] = default;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static void StoreCopy(S3[] array, S3 value) => array[Index] = value;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static void LoadCopy(S3[] array, ref S3 value) => value = array[Index];
+}


### PR DESCRIPTION
Fixes #133785

Align block-store containment bounds with codegen assertions on xarch and ARM64; add regression coverage.