### PR TITLE
JIT: Preserve receiver side effects in constrained GetType calls

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -5302,9 +5302,13 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                             assert(compDonotInline());
                             return nullptr;
                         }
+
                         GenTree* runtimeType =
                             gtNewHelperCallNode(CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE, TYP_REF, typeHandleOp);
-                        retNode = runtimeType;
+
+                        // Preserve receiver evaluation and the null check that boxing would perform.
+                        GenTree* sideEffects = fgAddrCouldBeNull(op1) ? gtNewNullCheck(op1) : op1;
+                        retNode              = gtWrapWithSideEffects(runtimeType, sideEffects, GTF_ALL_EFFECT);
                     }
                 }
 

--- a/src/tests/JIT/Regression_ro_2/Runtime_133715.cs
+++ b/src/tests/JIT/Regression_ro_2/Runtime_133715.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_133715
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Test<int>();
+        Test<Guid>();
+    }
+
+    private static void Test<T>()
+    {
+        T[] array = new T[1];
+        Assert.Equal(typeof(T), Get(array, 0));
+        Assert.Throws<IndexOutOfRangeException>(() => Get(array, -1));
+        Assert.Throws<IndexOutOfRangeException>(() => Get(array, 1));
+        Assert.Throws<NullReferenceException>(() => Get<T>(null, 0));
+        Assert.Throws<NullReferenceException>(() => Get(ref Unsafe.NullRef<T>()));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Type Get<T>(T[] array, int index) => array[index].GetType();
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static Type Get<T>(ref T value) => value.GetType();
+}


### PR DESCRIPTION
Fixes #133715.

The constrained `Object.GetType()` expansion discarded the receiver tree when replacing boxing with direct type construction, losing bounds checks and other side effects. Preserve receiver evaluation and the null check that boxing would perform, while retaining the boxing optimization.

